### PR TITLE
DB-2431: test code not transactionally valid. Allow drop routines to use...

### DIFF
--- a/splice_machine_test/src/test/java/com/splicemachine/derby/test/framework/SpliceSchemaWatcher.java
+++ b/splice_machine_test/src/test/java/com/splicemachine/derby/test/framework/SpliceSchemaWatcher.java
@@ -67,7 +67,15 @@ public class SpliceSchemaWatcher extends TestWatcher {
 		} catch (Exception e) {
 			LOG.error(tag("error Dropping " + e.getMessage(), schemaName));
 			e.printStackTrace();
-			throw new RuntimeException(e);
+            try {
+                if (connection != null) {
+                    connection.rollback();
+                }
+            } catch (SQLException e1) {
+                LOG.error(tag("error Rolling back " + e1.getMessage(), schemaName));
+                e1.printStackTrace();
+            }
+            throw new RuntimeException(e);
 		} finally {
 			DbUtils.commitAndCloseQuietly(connection);
 		}

--- a/splice_machine_test/src/test/java/com/splicemachine/derby/test/framework/SpliceTableWatcher.java
+++ b/splice_machine_test/src/test/java/com/splicemachine/derby/test/framework/SpliceTableWatcher.java
@@ -81,6 +81,15 @@ public class SpliceTableWatcher extends TestWatcher {
             connection.commit();
         } catch (Exception e) {
             LOG.error(tag("error Dropping " + e.getMessage(), schemaName, tableName),e);
+            e.printStackTrace();
+            try {
+                if (connection != null) {
+                    connection.rollback();
+                }
+            } catch (SQLException e1) {
+                LOG.error(tag("error Rolling back " + e1.getMessage(), schemaName, tableName), e1);
+                e1.printStackTrace();
+            }
             throw new RuntimeException(e);
         } finally {
             DbUtils.commitAndCloseQuietly(connection);


### PR DESCRIPTION
... a passed-in connection.

I was seeing txn write periodically errors when ITs start up and old schema was being dropped.  The problem was that we were using two different connection (thus, 2 diff txns) to drop schema and schema dependencies (tables, views, etc.).
