### PR TITLE
SPLICE-696 Fixing Small Memory Leak in Spark Stream Processing

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/stream/StreamListener.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/StreamListener.java
@@ -276,6 +276,7 @@ public class StreamListener<T> extends ChannelInboundHandlerAdapter implements I
         PartitionState ps = new PartitionState(currentQueue, 0);
         ps.messages.add(SENTINEL);
         partitionStateMap.putIfAbsent(currentQueue, ps);
+        close();
     }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,14 +39,22 @@
             <url>http://repo.hortonworks.com/content/repositories/jetty-hadoop/</url>
         </repository>
         <repository>
-            <id>splicemachine</id>
+            <id>splicemachine-public</id>
             <url>http://repository.splicemachine.com/nexus/content/groups/public</url>
+        </repository>
+        <repository>
+            <id>splicemachine</id>
+            <url>http://nexus.splicemachine.com/nexus/content/groups/developers</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
-            <id>splicemachine</id>
+            <id>splicemachine-public</id>
             <url>http://repository.splicemachine.com/nexus/content/groups/public</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>splicemachine</id>
+            <url>http://nexus.splicemachine.com/nexus/content/groups/developers</url>
         </pluginRepository>
     </pluginRepositories>
     <properties>


### PR DESCRIPTION
There is a path where close() may not have been called which will leak Streams.