### PR TITLE
DB-5011: pop statement context properly when a trigger fails

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -2286,7 +2286,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
 
                 parentStatementContext=statementContexts[0];
             }else{
-                parentStatementContext=getStatementContext();
+                parentStatementContext=(StatementContext)getContextManager().getContext(ContextId.LANG_STATEMENT);
                 statementContext=new GenericStatementContext(this);
             }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericStatementContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericStatementContext.java
@@ -624,7 +624,7 @@ final class GenericStatementContext
         // let outer contexts take corrective action for jvm errors, so 
         // return false as this will not be the last handler for such 
         // errors.
-		return inUse && !rollbackParentContext && 
+		return inUse && !rollbackParentContext && !parentInTrigger &&
             ( severity == ExceptionSeverity.STATEMENT_SEVERITY );
 	}
 


### PR DESCRIPTION
The code change is to fix two problems:
1) when a trigger throws an exception, we pop up all statement context for trigger on stack and clean them up. There could be more than one statement contexts because a trigger may fire another trigger for another table. Pop the stack until the parent statement is not in a trigger, which is the parent statement context(GenericStatementContext.java).
2) Always look at the context at the top of the stack(GenericLanguageConnectionContext.java).