### PR TITLE
SPLICE-700: Import requires write access to data file on HDFS

### DIFF
--- a/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
@@ -345,14 +345,14 @@ public class HNIOFileSystem extends DistributedFileSystem{
             try{
                 fs.access(path,FsAction.READ);
                 readable= true;
-            }catch(AccessDeniedException ade){
+            }catch(IOException ioe){
                readable = false;
             }
             boolean writable;
             try{
                 fs.access(path,FsAction.WRITE);
                 writable = true;
-            }catch(AccessDeniedException ade){
+            }catch(IOException ioe){
                 writable = false;
             }
             this.isReadable = readable;


### PR DESCRIPTION
We were catching the wrong exception from fs#access(path, mode).
We were catching AccessDeniedException but was throwing org.apache.hadoop.security.AccessControlException.
I changed to catch IOException which is the ancestor of all exceptions thrown by the method. The rational is that, if we get any IOException, the access mode we were checking is not available.