### PR TITLE
Bug Fixed SPLICE-701 : EXPLAINTRACE  obsolete when type help in ij.

### DIFF
--- a/db-tools-ij/src/main/grammar/ij.jj
+++ b/db-tools-ij/src/main/grammar/ij.jj
@@ -1219,102 +1219,6 @@ class ij {
 
     }
 
-    ijResult explainTrace(String sql, String format) throws SQLException{
-        haveConnection();
-        Statement	aStatement = theConnection.createStatement();
-        boolean runtimeStatistics = false;
-        boolean statisticsTiming = false;
-
-        try{
-            // Save the old state
-
-            ResultSet rs = aStatement.executeQuery("call SYSCS_UTIL.SYSCS_GET_RUNTIME_STATISTICS()");
-            if (rs.next()) {
-                runtimeStatistics = rs.getBoolean(1);
-            }
-            rs.close();
-
-            rs = aStatement.executeQuery("call SYSCS_UTIL.SYSCS_GET_STATISTICS_TIMING()");
-            if (rs.next()) {
-                statisticsTiming = rs.getBoolean(1);
-            }
-            rs.close();
-
-            // Turn on explain trace
-            aStatement.execute("call SYSCS_UTIL.SYSCS_SET_RUNTIMESTATISTICS(1)");
-            aStatement.execute("call SYSCS_UTIL.SYSCS_SET_STATISTICS_TIMING(1)");
-
-            // Execute the statement
-            boolean rowsReturned = aStatement.execute(sql);
-            if (rowsReturned) {
-                rs = aStatement.getResultSet();
-                while(rs.next()){
-                    // Consume all rows
-                }
-            }
-            // Get the statement ID
-            long statementId = 0;
-            rs = aStatement.executeQuery("call SYSCS_UTIL.SYSCS_GET_XPLAIN_STATEMENTID()");
-            if (rs.next()) {
-               statementId = rs.getLong(1);
-            }
-            rs.close();
-
-            // Wait until data is available
-            int count = 0;
-            String stmt = null;
-            while (count == 0) {
-                try{
-                    Thread.sleep(200);
-                } catch (InterruptedException e) {
-
-                }
-                stmt = "select count(*) from sys.sysstatementhistory where statementId = " + statementId;
-                rs = aStatement.executeQuery(stmt);
-                if (rs.next()){
-                    count = rs.getInt(1);
-                }
-            }
-
-            // Wait until all task data are written
-            int count_before = -1;
-            count = -1;
-            while (count_before != count && count > 0) {
-                try{
-                    Thread.sleep(200);
-                } catch (InterruptedException e) {
-
-                }
-                count_before = count;
-                stmt = "select count(*) from sys.systaskhistory where statementId = " + statementId;
-                rs = aStatement.executeQuery(stmt);
-                if (rs.next()){
-                    count = rs.getInt(1);
-                }
-            }
-
-            stmt = "call SYSCS_UTIL.SYSCS_GET_XPLAIN_TRACE(" + statementId + ", 0, '" + format + "')";
-            rs = aStatement.executeQuery(stmt);
-            return new ijResultSetResult(rs);
-
-        }finally {
-            // Restore the old state
-            Statement	anotherStatement = theConnection.createStatement();
-            if (runtimeStatistics){
-                anotherStatement.execute("call SYSCS_UTIL.SYSCS_SET_RUNTIMESTATISTICS(1)");
-            }
-            else {
-                anotherStatement.execute("call SYSCS_UTIL.SYSCS_SET_RUNTIMESTATISTICS(0)");
-            }
-
-            if (statisticsTiming){
-                anotherStatement.execute("call SYSCS_UTIL.SYSCS_SET_STATISTICS_TIMING(1)");
-            }
-            else {
-                anotherStatement.execute("call SYSCS_UTIL.SYSCS_SET_STATISTICS_TIMING(0)");
-            }
-        }
-    }
 }
 
 PARSER_END(ij)
@@ -1489,7 +1393,6 @@ TOKEN [IGNORE_CASE] :
 |	<CP_GETCONNECTION: "CP_getconnection">
 |	<CP_DISCONNECT: "CP_disconnect">
 |	<WORK : "work">
-|   <EXPLAINTRACE: "explaintrace">
 |   <JSON: "JSON">
 }
 
@@ -1837,7 +1740,6 @@ throws SQLException
 |	r=CP_ConnectStatement()
 |	r=CP_GetConnectionStatement()
 |	r=CP_DisconnectStatement()
-|   r=ExplainTraceStatement()
 )? <EOF>
 	{
 		return r;
@@ -4196,7 +4098,6 @@ keyword() :
 |	tok = <CP_GETCONNECTION>
 |	tok = <CP_DISCONNECT>
 |	tok = <WORK>
-|   tok = <EXPLAINTRACE>
 |   tok = <JSON>
 	)
 	{
@@ -4204,33 +4105,4 @@ keyword() :
 		return tok.image;
 
 	}
-}
-
-ijResult ExplainTraceStatement() throws SQLException
-:
-{
-	Token json=null;
-	Token t=null;
-	String sql = null;
-}
-{
-
-	<EXPLAINTRACE>
-	( <ON>
-	    {
-	        set_xplain_trace(true);
-            return null;
-	    }
-	| <OFF>
-	    {
-	        set_xplain_trace(false);
-            return null;
-	    }
-	| [<IN> json=<JSON>] <FOR> t=<STRING>
-	    {
-            sql = stringValue(t.image);
-            String format = (json == null ? "tree" : "Json");
-            return explainTrace(sql, format);
-	    }
-	)
 }

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages.properties
@@ -93,10 +93,6 @@ IJ_HelpText=\
 \                               -- sets the maximum display width for\n\
 \                               -- each column to integerValue\n\
 \ \n\
-\  EXPLAINTRACE [ ON | OFF ];   -- sets explain trace mode\n\
-\  EXPLAINTRACE [IN JSON] FOR ''SQL text'';\n\
-\                               -- display explain trace for the SQL text\n\
-\ \n\
 \  EXIT;                        -- exits splice\n\
 \  HELP;                        -- shows this message\n\
 \ \n\

--- a/docs/architecture/ExplainTracePlan.tex
+++ b/docs/architecture/ExplainTracePlan.tex
@@ -72,37 +72,6 @@ A splice machine developer can utilize explain trace to better understand perfor
 \end{itemize}
 
 \section{Design}
-\subsection{Explain Tables}
-If explain traced is turned on, runtime statistics are collected into the following three explain tables under SYS schema.
-\begin{itemize}
-  \item SYSSTATEMENTHISTORY: stores information for executed state
-  \item SYSOPERATIONHISTORY: stores information for executed splice operations
-  \item SYSTASKHISTORY: store information for tasks that execute splice operations
-\end{itemize}
-Once an EXPLAINTRACE for a SQL statement completes successfully, runtime statistics is stored in explain tables until the tables are purged. To purge explain tables, run the following command.
-\begin{lstlisting}
-CALL SYSCS_UTIL.PURGE_XPLAIN_TRACE();
-\end{lstlisting}
-\subsection{Enabling and Disabling Explain Trace}
-Explain trace can be turned manually for a connection by running the following command from ij console:
-\begin{lstlisting}
-EXPLAINTRACE ON;
-\end{lstlisting}
-Explain trace will be turned on to trace all subsequent SQL statements until a user turns off explain trace by running 
-\begin{lstlisting}
-EXPLAINTRACE OFF;
-\end{lstlisting}
-Explain trace can be turned on for a SQL statement by running the following command
-\begin{lstlisting}
-EXPLAINTRACE [IN JSON] FOR ?SQL Statement?; 
-\end{lstlisting}
-Explaintrace turns on runtime statistics, executes the SQL, collects runtime statistics, and stores statistics in explain tables under SYS schema. 
-
-\noindent
-A user can specify the output format for an execution plan. By default, splice outputs an execution plan in an annotated tree format. If \lq IN JASON\rq\,is specified, splice outputs the execution plan as a JSON string.
-
-\noindent
-When explaintrace command completes, runtime statistics is turned off automatically. The SQL statement and its unique ID can be found in SYS.SYSSTATEMENTHISTORY table.  
 \subsection{Auto Trace}
 To better trouble-shooting a long-running analytic SQL, explain trace will be automatically turned on if a query runs on a table with more than 3 regions. Auto trace is turned on by default. To disable it, run the following command:
 


### PR DESCRIPTION
I removed the EXPLAINTRACE reference  from the ij.jj grammar , the reference in the help documentation, and messages properties.

Now when we type help in ij, there is no reference left to EXPLAINTRACE