### PR TITLE
Fixed SPLICE-703 : Null Name on UI for Query in the Dag Spark Visualizer

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
@@ -108,6 +108,7 @@ public class TableScanOperation extends ScanOperation{
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException{
         super.readExternal(in);
         tableName=in.readUTF();
+        tableDisplayName=in.readUTF();
         tableNameBytes=Bytes.toBytes(tableName);
         indexColItem=in.readInt();
         if(in.readBoolean())
@@ -118,6 +119,7 @@ public class TableScanOperation extends ScanOperation{
     public void writeExternal(ObjectOutput out) throws IOException{
         super.writeExternal(out);
         out.writeUTF(tableName);
+        out.writeUTF(tableDisplayName);
         out.writeInt(indexColItem);
         out.writeBoolean(indexName!=null);
         if(indexName!=null)


### PR DESCRIPTION
The issue was a simple issue of serialization. I just added the tableDisplayName in the readExternal and writeExternal in TableScanOperation