### PR TITLE
DB-4198:throw an exception when aggregate function is applied to rowid Column

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AggregateNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AggregateNode.java
@@ -651,7 +651,17 @@ public class AggregateNode extends UnaryOperatorNode
 		** Create a result column with the aggrergate operand
 		** it.
 		*/
-		return getNullNode(getTypeServices());
+        DataTypeDescriptor type = null;
+		try {
+            type = getTypeServices();
+			return getNullNode(type);
+		}
+		catch (StandardException e) {
+			if (e.getSqlState().compareTo(SQLState.LANG_NONULL_DATATYPE) == 0) {
+                throw StandardException.newException(SQLState.LANG_INVALID_AGGREGATION_DATATYPE, type.getTypeId().getSQLTypeName());
+            }
+            else throw e;
+		}
 	}
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QueryTreeNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QueryTreeNode.java
@@ -677,10 +677,7 @@ public abstract class QueryTreeNode implements Node, Visitable{
                 if(type.getTypeId().userType()){
                     constantNodeType=C_NodeTypes.USERTYPE_CONSTANT_NODE;
                 }else{
-                    if(SanityManager.DEBUG)
-                        SanityManager.THROWASSERT("Unknown type "+
-                                type.getTypeId().getSQLTypeName()+" in getNullNode");
-                    return null;
+                    throw StandardException.newException(SQLState.LANG_NONULL_DATATYPE, type.getTypeId().getSQLTypeName());
                 }
         }
 

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -742,7 +742,8 @@ public interface SQLState {
     String LANG_MISSING_FIRST_LAST_VALUE_ARG                           = "2202A";
     String LANG_MISSING_LEAD_LAG_ARG                                   = "2202B";
     String LANG_MISSING_LEAD_LAG_DEFAULT                               = "2202C";
-
+	String LANG_NONULL_DATATYPE                                        = "2202D";
+	String LANG_INVALID_AGGREGATION_DATATYPE                           = "2202E";
 	/*
 	** Integrity violations.
 	*/

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -866,6 +866,18 @@ Guide.
             </msg>
 
             <msg>
+                <name>2202D</name>
+                <text>NULL value for data type {0} not supported.</text>
+                <arg>string</arg>
+            </msg>
+
+            <msg>
+                <name>2202E</name>
+                <text>A {0} column cannot be aggregated.</text>
+                <arg>string</arg>
+            </msg>
+
+            <msg>
                 <name>2201W</name>
                 <text>Row count for FIRST/NEXT/TOP must be >= 1 and row count for LIMIT must be >= 0.</text>
             </msg>

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/RowIdIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/RowIdIT.java
@@ -15,6 +15,8 @@
 
 package com.splicemachine.derby.impl.sql.execute.operations;
 
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.shared.common.reference.SQLState;
 import com.splicemachine.derby.test.framework.*;
 import org.junit.*;
 import org.junit.rules.RuleChain;
@@ -335,7 +337,7 @@ public class RowIdIT extends SpliceUnitTest {
     }
 
     @Test
-    public void testSuquery() throws Exception {
+    public void testSubquery() throws Exception {
         String sqlText = String.format("update %s set j=j+3 where rowid in (select rowid from %s)",
                 spliceTableWatcher4, spliceTableWatcher5);
         int n = methodWatcher.executeUpdate(sqlText);
@@ -345,5 +347,17 @@ public class RowIdIT extends SpliceUnitTest {
                 spliceTableWatcher4, spliceTableWatcher5);
         n = methodWatcher.executeUpdate(sqlText);
         Assert.assertEquals("Wrong number of rows updated", n, nRows);
+    }
+
+    @Test
+    public void testAggregateNotAllowed() throws Exception {
+        String sqlText = String.format("select min(rowid) from %s", spliceTableWatcher4);
+        try {
+            methodWatcher.executeQuery(sqlText);
+            Assert.assertTrue("An exception is expected to be thrown", false);
+        }
+        catch (Exception e) {
+            Assert.assertTrue(e.getLocalizedMessage().contains("A REF column cannot be aggregated"));
+        }
     }
 }


### PR DESCRIPTION
Throw an exception and return an error message to a client when an aggregate funciton is applied to a rowid column, instead of failing an assertion and dropping client connection.