### PR TITLE
SPLICE-714 NullPointerException when using more than one parameter in…

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CoalesceFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CoalesceFunctionNode.java
@@ -172,12 +172,9 @@ public class CoalesceFunctionNode extends ValueNode
 		setType(argumentsList.getDominantTypeServices());
 
 		//set all the parameter types to the type of the result type
-		for (int index = 0; index < argumentsListSize; index++)
-		{
-			if (((ValueNode) argumentsList.elementAt(index)).requiresTypeFromContext())
-			{
+		for (int index = 0; index < argumentsListSize; index++) {
+			if (((ValueNode) argumentsList.elementAt(index)).requiresTypeFromContext()) {
 				((ValueNode)argumentsList.elementAt(index)).setType(getTypeServices());
-				break;
 			}
 		}
 		return this;


### PR DESCRIPTION
NullPointerException when using more than one parameter in COALESCE.  This is another mindless vacation special.  

Corresponds to this derby bug fix.

https://issues.apache.org/jira/browse/DERBY-6273