### PR TITLE
Fix explain for spark

### DIFF
--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/ConstraintConstantOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/ConstraintConstantOperationIT.java
@@ -114,15 +114,15 @@ public class ConstraintConstantOperationIT {
         // insert good data
         statement.execute(
                 String.format("insert into %s (EmpId, dob, ssn, salary) values (101, '04/08', '999-22-1234', 10001)",
-                              empPrivTable));
+                        empPrivTable));
 
         // insert good data
         statement.execute(
                 String.format("insert into %s (EmpId, fname, lname) values (101, 'Jeff', 'Cunningham')",
-                              empNameTable));
+                        empNameTable));
 
         ResultSet resultSet = connection.createStatement().executeQuery(query);
-        Assert.assertTrue("Connection should see its own writes",resultSet.next());
+        Assert.assertTrue("Connection should see its own writes", resultSet.next());
     }
 
     /**
@@ -295,5 +295,21 @@ public class ConstraintConstantOperationIT {
                               TASK_TABLE_CONSTRAINT_NAME, schemaWatcher.schemaName, TASK_TABLE_NAME);
             Assert.assertEquals(exMsg+" Expected:\n"+ expectedMsg, expectedMsg, exMsg);
         }
+    }
+
+    @Test
+    public void testDropTableReferecedByFK() throws Exception {
+        methodWatcher.execute("create table P (a int, b int, constraint pk1 primary key(a))");
+        methodWatcher.execute("create table C (a int, CONSTRAINT fk1 FOREIGN KEY(a) REFERENCES P(a))");
+
+        try {
+            methodWatcher.execute("drop table P");
+        }
+        catch (Exception e) {
+            Assert.assertTrue(e.getLocalizedMessage().contains("Operation 'DROP CONSTRAINT' cannot be performed on object 'PK1' because CONSTRAINT 'FK1' is dependent on that object"));
+        }
+
+        methodWatcher.execute("drop table C");
+        methodWatcher.execute("drop table P");
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
@@ -25,9 +25,8 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 
 import java.math.BigDecimal;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.RowId;
+import java.sql.*;
+import java.util.Properties;
 
 import static java.lang.String.format;
 
@@ -141,6 +140,18 @@ public class ExplainPlanIT extends SpliceUnitTest  {
         rs  = methodWatcher.executeQuery(sql);
         Assert.assertTrue(rs.next());
         Assert.assertTrue("expect explain plan contains useSpark=true", rs.getString(1).contains("engine=Spark"));
+
+    }
+
+    @Test
+    public void testSparkConnection() throws Exception {
+        String url = "jdbc:splice://localhost:1527/splicedb;create=true;user=splice;password=admin;useSpark=true";
+        Connection connection = DriverManager.getConnection(url, new Properties());
+        connection.setSchema(CLASS_NAME.toUpperCase());
+        Statement s = connection.createStatement();
+        ResultSet rs = s.executeQuery("explain select * from A");
+        Assert.assertTrue(rs.next());
+        Assert.assertTrue("expect explain plan contains useSpark=false", rs.getString(1).contains("engine=Spark"));
 
     }
 }


### PR DESCRIPTION
Fixes two issues:
1) Pick up useSpark property in connection context
2) Serialize/deserialize explain plan when executing explain on spark, because it's stored in a ThreadLocal variable.