### PR TITLE
SPLICE-28: bad file creation broken on hdfs

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkOperationContext.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkOperationContext.java
@@ -454,8 +454,12 @@ public class SparkOperationContext<Op extends SpliceOperation> implements Operat
     public void setPermissive(String statusDirectory, String importFileName, long badRecordThreshold){
         this.permissive=true;
         this.badRecordThreshold = badRecordThreshold;
-        BadRecordsRecorder badRecordsRecorder = new BadRecordsRecorder(statusDirectory, importFileName, badRecordThreshold);
-        this.badRecordsAccumulator=SpliceSpark.getContext().accumulable(badRecordsRecorder,badRecordsRecorder.getUniqueName(), new BadRecordsAccumulator());
+        BadRecordsRecorder badRecordsRecorder = new BadRecordsRecorder(statusDirectory,
+                                                                       importFileName,
+                                                                       badRecordThreshold);
+        this.badRecordsAccumulator=SpliceSpark.getContext().accumulable(badRecordsRecorder,
+                                                                        badRecordsRecorder.getUniqueName(),
+                                                                        new BadRecordsAccumulator());
     }
 
     public ActivationHolder getActivationHolder() {

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsImportIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsImportIT.java
@@ -502,7 +502,7 @@ public class HdfsImportIT extends SpliceUnitTest {
         } catch (SQLException e) {
             assertEquals("Expected too many bad records, but got: "+e.getLocalizedMessage(), "SE009", e.getSQLState());
         }
-        assertTrue(new File(badFileName).exists());
+        assertTrue("Bad file " +badFileName+" does not exist.", new File(badFileName).exists());
     }
 
     @Test
@@ -1516,7 +1516,7 @@ public class HdfsImportIT extends SpliceUnitTest {
         }
         Assert.assertEquals(format("Expected %s row1 imported", insertRowsExpected), insertRowsExpected, results.size());
 
-        assertTrue("Files does not exist: " + badFile, badFile.exists());
+        assertTrue("Bad file " +badFile+" does not exist.", badFile.exists());
         List<String> badLines = Files.readAllLines(badFile.toPath(), Charset.defaultCharset());
         assertEquals("Expected 2 lines in bad file "+badFile.getCanonicalPath(), 2, badLines.size());
         assertContains(badLines, containsString("BONUS_CK"));


### PR DESCRIPTION
Bad record accumulators create ".bad" files in <bad_record_directory>/.tmp directory but do not merge.

In the case where there's only one bad record accumulator, accumulator#addInPlace(BadRecordsRecorder r1, BadRecordsRecorder r2), which forwards to merge(), never gets called by spark.
Removed the merge. Now BadRecordRecorder writes to only its uniquely named file.
Tested on cluster with small (10 record) file and with TPCC 1000 where import date format was changed to force import errors.

See more details in https://splice.atlassian.net/browse/SPLICE-28