### PR TITLE
SPLICE-128: Fix SYSCS_UTIL.SYSCS_PEEK_AT_SEQUENCE

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -7799,12 +7799,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
     public abstract void getCurrentValueAndAdvance(String sequenceUUIDstring,NumberDataValue returnValue, boolean useBatch) throws StandardException;
 
     @Override
-    public Long peekAtSequence(String schemaName,String sequenceName) throws StandardException{
-        String uuid=getSequenceID(schemaName, sequenceName);
-        if(uuid==null)
-            throw StandardException.newException(SQLState.LANG_OBJECT_NOT_FOUND_DURING_EXECUTION,"SEQUENCE",(schemaName+"."+sequenceName));
-        return dataDictionaryCache.sequenceGeneratorCacheFind(uuid).peekAtCurrentValue();
-    }
+    public abstract Long peekAtSequence(String schemaName,String sequenceName) throws StandardException;
 
     @Override
     public RowLocation getRowLocationTemplate(LanguageConnectionContext lcc,TableDescriptor td) throws StandardException{

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/AbstractSequence.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/AbstractSequence.java
@@ -52,6 +52,10 @@ public abstract class AbstractSequence implements Sequence, Externalizable{
         return currPosition.getAndAdd(incrementSteps);
     }
 
+    public long peekAtCurrentValue() throws StandardException {
+        return currPosition.get();
+    }
+
     protected abstract long getCurrentValue() throws IOException;
 
     protected abstract boolean atomicIncrement(long nextValue) throws IOException;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/Sequence.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/Sequence.java
@@ -18,5 +18,6 @@ package com.splicemachine.derby.impl.sql.execute.sequence;
 import com.splicemachine.db.iapi.error.StandardException;
 
 public interface Sequence {
-	   long getNext() throws StandardException;
+    long getNext() throws StandardException;
+    long peekAtCurrentValue() throws StandardException;
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/sequence/SpliceSequenceIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/sequence/SpliceSequenceIT.java
@@ -62,7 +62,8 @@ public class SpliceSequenceIT {
         methodWatcher.executeUpdate("create sequence SMALLSEQ AS smallint");
 
         Integer first = methodWatcher.query("values (next value for SMALLSEQ)");
-
+        assertEquals(new Long(first + 1), methodWatcher.query(
+                String.format("VALUES SYSCS_UTIL.SYSCS_PEEK_AT_SEQUENCE('%s', 'SMALLSEQ')",SCHEMA)));
         assertEquals(first + 1, methodWatcher.query("values (next value for SMALLSEQ)"));
         assertEquals(first + 2, methodWatcher.query("values (next value for SMALLSEQ)"));
         assertEquals(first + 3, methodWatcher.query("values (next value for SMALLSEQ)"));


### PR DESCRIPTION
DataDictionaryImpl.peekAtSequence() tries to peek next sequence number from SequenceUpdater, which is obsolete. The code changes make it work by peeking SpliceSequence.