### PR TITLE
Fixed SPLICE 709 - Use Kryo pools in result streamer / stream listener

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
@@ -24,6 +24,8 @@ import com.esotericsoftware.kryo.serializers.DefaultSerializers;
 import com.esotericsoftware.kryo.serializers.FieldSerializer;
 import com.esotericsoftware.kryo.serializers.MapSerializer;
 import com.google.common.collect.ArrayListMultimap;
+import com.splicemachine.EngineDriver;
+import com.splicemachine.SpliceKryoRegistry;
 import com.splicemachine.derby.ddl.DDLChangeType;
 import com.splicemachine.derby.ddl.TentativeAddColumnDesc;
 import com.splicemachine.derby.ddl.TentativeAddConstraintDesc;
@@ -53,6 +55,7 @@ import com.splicemachine.kvpair.KVPair;
 import com.splicemachine.pipeline.client.BulkWrite;
 import com.splicemachine.utils.ByteSlice;
 import com.splicemachine.utils.kryo.ExternalizableSerializer;
+import com.splicemachine.utils.kryo.KryoPool;
 import de.javakaffee.kryoserializers.UUIDSerializer;
 import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer;
 import com.splicemachine.db.catalog.types.*;
@@ -90,10 +93,39 @@ import java.util.*;
  * @author Scott Fines
  * Created on: 8/15/13
  */
-public class SpliceSparkKryoRegistrator implements KryoRegistrator {
+public class SpliceSparkKryoRegistrator implements KryoRegistrator, KryoPool.KryoRegistry {
     //ExternalizableSerializers are stateless, no need to create more than we need
     private static final ExternalizableSerializer EXTERNALIZABLE_SERIALIZER = ExternalizableSerializer.INSTANCE;
     private static final UnmodifiableCollectionsSerializer UNMODIFIABLE_COLLECTIONS_SERIALIZER = new UnmodifiableCollectionsSerializer();
+
+    private static volatile KryoPool spliceKryoPool;
+
+
+    public static KryoPool getInstance(){
+        KryoPool kp = spliceKryoPool;
+        if(kp==null){
+            synchronized(SpliceKryoRegistry.class){
+                kp = spliceKryoPool;
+                if(kp==null){
+                    EngineDriver driver = EngineDriver.driver();
+                    if(driver==null){
+                        kp = new KryoPool(2);
+                    }else{
+                        int kpSize = driver.getConfiguration().getKryoPoolSize();
+                        kp = spliceKryoPool = new KryoPool(kpSize);
+                    }
+                    kp.setKryoRegistry(new SpliceSparkKryoRegistrator());
+
+                }
+            }
+        }
+        return kp;
+    }
+
+    @Override
+    public void register(Kryo instance) {
+        registerClasses(instance);
+    }
 
     @Override
     public void registerClasses(Kryo instance) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SortOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SortOperation.java
@@ -207,7 +207,6 @@ public class SortOperation extends SpliceBaseOperation{
             try {
                 operationContext.pushScopeForOp(OperationContext.Scope.LOCATE);
                 dataSet = dataSet.map(new SetCurrentLocatedRowFunction(operationContext), true);
-                return dataSet;
             } finally {
                 operationContext.popScope();
             }


### PR DESCRIPTION
I didn't change ResultStreamer because this code is executed in Spark for each request by deserializing the class. It doesn't make sense then to spin up a pool each time.

 Made SpliceSparkKryoRegistrator to implement KryoPool.KryoRegistry so we can reuse the Kryo Pool.