### PR TITLE
SPLICE-726 Set start/stop keys properly in Spark

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/hbase/BytesCopyTaskSplitter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/BytesCopyTaskSplitter.java
@@ -28,32 +28,13 @@ import java.util.*;
  *         Date: 4/16/14
  */
 public class BytesCopyTaskSplitter {
-    private final HRegion region;
-    public BytesCopyTaskSplitter(HRegion region) {
-        this.region = region;
-    }
 
-    public Collection<SizedInterval> split(byte[] taskStart, byte[] taskStop) throws IOException {
-        List<byte[]> splits = getCutPoints(region, taskStart, taskStop);
-        List<SizedInterval> intervals =new ArrayList<>();
-        int length = splits.size();
-        if (length == 0)
-            return Collections.singletonList(new SizedInterval(taskStart,taskStop,0));
-        intervals.add(new SizedInterval(taskStart,splits.get(0),0));
-        for (int i=1; i < length; i++) {
-            //assert Bytes.compareTo(splits.get(i), splits.get(i-1)) > 0;
-            intervals.add(new SizedInterval(splits.get(i-1),splits.get(i),0));
-        }
-        intervals.add(new SizedInterval(splits.get(length-1),taskStop,0));
-        return intervals;
-    }
-
-    public static List<byte[]> getCutPoints(HRegion region, byte[] start, byte[] end) throws IOException {
+    public static List<byte[]> getCutPoints(HRegion region, byte[] start, byte[] end, byte[] expectedRegionEnd) throws IOException {
         Store store = null;
         try {
             store = region.getStore(SIConstants.DEFAULT_FAMILY_BYTES);
             HRegionUtil.lockStore(store);
-            return HRegionUtil.getCutpoints(store, start, end);
+            return HRegionUtil.getCutpoints(store, start, end, expectedRegionEnd);
         }catch (Throwable t) {
             throw Exceptions.getIOException(t);
         }finally{

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/RegionSizeEndpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/RegionSizeEndpoint.java
@@ -68,7 +68,8 @@ public class RegionSizeEndpoint extends SpliceMessage.SpliceDerbyCoprocessorServ
         try {
             ByteString beginKey = request.getBeginKey();
             ByteString endKey = request.getEndKey();
-            List<byte[]> splits = computeSplits(region, beginKey.toByteArray(), endKey.toByteArray());
+            ByteString expectedEndKey = request.getRegionEndKey();
+            List<byte[]> splits = computeSplits(region, beginKey.toByteArray(), endKey.toByteArray(), expectedEndKey.toByteArray());
             if (LOG.isDebugEnabled())
                 SpliceLogUtils.debug(LOG,"computeSplits with beginKey=%s, endKey=%s, numberOfSplits=%s",beginKey,endKey,splits.size());
             for (byte[] split : splits)
@@ -95,8 +96,8 @@ public class RegionSizeEndpoint extends SpliceMessage.SpliceDerbyCoprocessorServ
 
     /* ****************************************************************************************************************/
     /*private helper methods*/
-    private static List<byte[]> computeSplits(HRegion region, byte[] beginKey, byte[] endKey) throws IOException {
-        return BytesCopyTaskSplitter.getCutPoints(region, beginKey, endKey);
+    private static List<byte[]> computeSplits(HRegion region, byte[] beginKey, byte[] endKey, byte[] expectedRegionEnd) throws IOException {
+        return BytesCopyTaskSplitter.getCutPoints(region, beginKey, endKey, expectedRegionEnd);
     }
 
     /**

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/AbstractSMInputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/AbstractSMInputFormat.java
@@ -103,7 +103,7 @@ public abstract class AbstractSMInputFormat<K,V> extends InputFormat<K, V> imple
                     }
                 }
                 SubregionSplitter splitter = new HBaseSubregionSplitter();
-                List<InputSplit> results = splitter.getSubSplits(table, splits);
+                List<InputSplit> results = splitter.getSubSplits(table, splits, s.getStartRow(), s.getStopRow());
                 return results;
             } catch (HMissedSplitException e) {
                 // retry;

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/HBaseSubregionSplitter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/HBaseSubregionSplitter.java
@@ -16,6 +16,7 @@
 package com.splicemachine.mrio.api.core;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.ZeroCopyLiteralByteString;
 import com.splicemachine.access.HConfiguration;
 import com.splicemachine.access.hbase.HBaseTableInfoFactory;
 import com.splicemachine.coprocessor.SpliceMessage;
@@ -73,9 +74,9 @@ public class HBaseSubregionSplitter implements SubregionSplitter{
                                 }
 
                                 SpliceMessage.SpliceSplitServiceRequest message = SpliceMessage.SpliceSplitServiceRequest.newBuilder()
-                                        .setBeginKey(ByteString.copyFrom(scanStartRow))
-                                        .setEndKey(ByteString.copyFrom(scanStopRow))
-                                        .setRegionEndKey(ByteString.copyFrom(stopKey)).build();
+                                        .setBeginKey(ZeroCopyLiteralByteString.wrap(scanStartRow))
+                                        .setEndKey(ZeroCopyLiteralByteString.wrap(scanStopRow))
+                                        .setRegionEndKey(ZeroCopyLiteralByteString.wrap(stopKey)).build();
 
                                 BlockingRpcCallback<SpliceMessage.SpliceSplitServiceResponse> rpcCallback = new BlockingRpcCallback<>();
                                 instance.computeSplits(controller, message, rpcCallback);

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SubregionSplitter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SubregionSplitter.java
@@ -27,5 +27,5 @@ import java.util.List;
  * Used to compute a list of splits for a given table smaller than regions
  */
 public interface SubregionSplitter {
-    List<InputSplit> getSubSplits(Table table, List<Partition> splits) throws HMissedSplitException;
+    List<InputSplit> getSubSplits(Table table, List<Partition> splits, byte[] startRow, byte[] stopRow) throws HMissedSplitException;
 }

--- a/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -289,8 +289,10 @@ public class SplitRegionScanner implements RegionScanner {
                     refresh = true;
                     continue;
                 } else {
-                    // Not Good, partition missing...
-                    SpliceLogUtils.warn(LOG,"Couldn't find subpartitions in range for %s and scan %s",partition,scan);
+                    // Not Good, partition missing, bail out...
+                    String msg = String.format("Couldn't find subpartitions in range for %s and scan %s",partition,scan);
+                    SpliceLogUtils.error(LOG,msg);
+                    throw new IllegalStateException(msg);
                 }
             } else {
                 break;

--- a/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -297,8 +297,10 @@ public class SplitRegionScanner implements RegionScanner {
                     refresh = true;
                     continue;
                 } else {
-                    // Not Good, partition missing...
-                    SpliceLogUtils.warn(LOG,"Couldn't find subpartitions in range for %s and scan %s",partition,scan);
+                    // Not Good, partition missing, bail out...
+                    String msg = String.format("Couldn't find subpartitions in range for %s and scan %s",partition,scan);
+                    SpliceLogUtils.error(LOG,msg);
+                    throw new IllegalStateException(msg);
                 }
             } else {
                 break;

--- a/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -289,8 +289,10 @@ public class SplitRegionScanner implements RegionScanner {
                     refresh = true;
                     continue;
                 } else {
-                    // Not Good, partition missing...
-                    SpliceLogUtils.warn(LOG,"Couldn't find subpartitions in range for %s and scan %s",partition,scan);
+                    // Not Good, partition missing, bail out...
+                    String msg = String.format("Couldn't find subpartitions in range for %s and scan %s",partition,scan);
+                    SpliceLogUtils.error(LOG,msg);
+                    throw new IllegalStateException(msg);
                 }
             } else {
                 break;

--- a/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -289,8 +289,10 @@ public class SplitRegionScanner implements RegionScanner {
                     refresh = true;
                     continue;
                 } else {
-                    // Not Good, partition missing...
-                    SpliceLogUtils.warn(LOG,"Couldn't find subpartitions in range for %s and scan %s",partition,scan);
+                    // Not Good, partition missing, bail out...
+                    String msg = String.format("Couldn't find subpartitions in range for %s and scan %s",partition,scan);
+                    SpliceLogUtils.error(LOG,msg);
+                    throw new IllegalStateException(msg);
                 }
             } else {
                 break;

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -289,8 +289,10 @@ public class SplitRegionScanner implements RegionScanner {
                     refresh = true;
                     continue;
                 } else {
-                    // Not Good, partition missing...
-                    SpliceLogUtils.warn(LOG,"Couldn't find subpartitions in range for %s and scan %s",partition,scan);
+                    // Not Good, partition missing, bail out...
+                    String msg = String.format("Couldn't find subpartitions in range for %s and scan %s",partition,scan);
+                    SpliceLogUtils.error(LOG,msg);
+                    throw new IllegalStateException(msg);
                 }
             } else {
                 break;

--- a/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionUtil.java
+++ b/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionUtil.java
@@ -68,7 +68,7 @@ public class HRegionUtil extends BaseHRegionUtil{
         HBasePlatformUtils.updateReadRequests(region,numReads);
     }
 
-    public static List<byte[]> getCutpoints(Store store, byte[] start, byte[] end) throws IOException {
+    public static List<byte[]> getCutpoints(Store store, byte[] start, byte[] end, byte[] expectedRegionEnd) throws IOException {
         assert Bytes.compareTo(start, end) <= 0 || start.length == 0 || end.length == 0;
         if (LOG.isTraceEnabled())
             SpliceLogUtils.trace(LOG, "getCutpoints");
@@ -81,8 +81,8 @@ public class HRegionUtil extends BaseHRegionUtil{
         byte[] regionStart = store.getRegionInfo().getStartKey();
         byte[] regionEnd = store.getRegionInfo().getEndKey();
 
-        if ((end.length == 0 && regionEnd.length != 0)
-            || Bytes.compareTo(end, regionEnd) > 0) {
+        if ((expectedRegionEnd.length == 0 && regionEnd.length != 0)
+            || Bytes.compareTo(expectedRegionEnd, regionEnd) > 0) {
             throw new HMissedSplitException("Subplit computation missed region split");
         }
 

--- a/splice_protocol/src/main/protobuf/Splice.proto
+++ b/splice_protocol/src/main/protobuf/Splice.proto
@@ -142,6 +142,7 @@ service SpliceDerbyCoprocessorService {
 message SpliceSplitServiceRequest {
     optional bytes beginKey = 1;
     optional bytes endKey = 2;
+    optional bytes regionEndKey = 3;
 }
 
 message SpliceSplitServiceResponse {


### PR DESCRIPTION
This change makes sure we set start/stop keys properly on Spark scans when they are bounded, for instance when we have an inequality on an index access. Previously we would scan the whole region.

Furthermore, when computing cutpoints we didn't take into account the start/stop scan keys, so we could create more partitions than necessary that did no useful work.