### PR TITLE
Fixed SPLICE-724 : ORDER BY with UNION ignored

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SortOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SortOperation.java
@@ -207,7 +207,7 @@ public class SortOperation extends SpliceBaseOperation{
             try {
                 operationContext.pushScopeForOp(OperationContext.Scope.LOCATE);
                 dataSet = dataSet.map(new SetCurrentLocatedRowFunction(operationContext), true);
-                return dataSet;
+
             } finally {
                 operationContext.popScope();
             }


### PR DESCRIPTION
Should not return the operation if distinct is set to true but continue to traverse the execution tree.