### PR TITLE
SPLICE-731 Fix maven exclusions

### DIFF
--- a/hbase_pipeline/pom.xml
+++ b/hbase_pipeline/pom.xml
@@ -185,16 +185,16 @@
                     <artifactId>hadoop-core</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>org.mortbay.jetty</artifactId>
-                    <groupId>jetty-sslengine</groupId>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty-sslengine</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>org.mortbay.jetty</artifactId>
-                    <groupId>jsp-2.1</groupId>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jsp-2.1</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>org.mortbay.jetty</artifactId>
-                    <groupId>jsp-api-2.1</groupId>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jsp-api-2.1</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>tomcat</groupId>

--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -100,6 +100,16 @@
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-server</artifactId>
             <version>${hbase.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jsp-2.1</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jsp-api-2.1</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -147,6 +157,24 @@
             <version>${hbase.version}</version>
             <!--intentionally compile scope,we use this dependency at app compile and runtime-->
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jsp-2.1</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jsp-api-2.1</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>tomcat</groupId>
+                    <artifactId>jasper-compiler</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>tomcat</groupId>
+                    <artifactId>jasper-runtime</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!--
         <dependency>

--- a/hbase_storage/pom.xml
+++ b/hbase_storage/pom.xml
@@ -161,16 +161,16 @@
                     <artifactId>hadoop-core</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>org.mortbay.jetty</artifactId>
-                    <groupId>jetty-sslengine</groupId>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty-sslengine</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>org.mortbay.jetty</artifactId>
-                    <groupId>jsp-2.1</groupId>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jsp-2.1</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>org.mortbay.jetty</artifactId>
-                    <groupId>jsp-api-2.1</groupId>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jsp-api-2.1</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>tomcat</groupId>


### PR DESCRIPTION
Some exclusions were wrong (transposed artifactId/groupId) and some were missing. This caused the standalone version to sometimes fail to start, as reported on the user forum: http://community.splicemachine.com/community/forum/topic/getting-error-on-startup/