### PR TITLE
DB-5595: Parallelize backup/restore

### DIFF
--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -1938,6 +1938,7 @@ public interface SQLState {
     String INVALID_BACKUP_ID                                       = "BR007";
     String CHECKSUM_FILE_MISSING                                   = "BR008";
     String BAD_FILE_CHECKSUM                                       = "BR009";
-    String DATA_FILE_MISSING                                        = "BR010";
+    String DATA_FILE_MISSING                                       = "BR010";
+	String BACKUP_CANCELED                                         = "BR011";
 }
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -8825,6 +8825,10 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
                <text>A data file {0} is missing. The restored table may be corrupted.</text>
                <arg>fileName</arg>
            </msg>
+           <msg>
+               <name>BR011</name>
+               <text>Backup was canceled.</text>
+           </msg>
        </family>
     </section>
 

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupSystemProcedures.java
@@ -84,6 +84,7 @@ public class BackupSystemProcedures {
         } catch (Throwable t) {
             resultSets[0] = generateResult("Error", t.getLocalizedMessage());
             SpliceLogUtils.error(LOG, "Database backup error", t);
+            t.printStackTrace();
         }
     }
 
@@ -269,7 +270,7 @@ public class BackupSystemProcedures {
         }
     }
 
-    public static void CANCEL_BACKUP(ResultSet[] resultSets) throws StandardException, SQLException {
+    public static void SYSCS_CANCEL_BACKUP(ResultSet[] resultSets) throws StandardException, SQLException {
         try {
             BackupManager backupManager = EngineDriver.driver().manager().getBackupManager();
             backupManager.cancelBackup();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -629,7 +629,7 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                         .varchar("ownerName", 128)
                         .build());
 
-                    procedures.add(Procedure.newBuilder().name("CANCEL_BACKUP")
+                    procedures.add(Procedure.newBuilder().name("SYSCS_CANCEL_BACKUP")
                             .numOutputParams(0)
                             .numResultSets(1)
                             .ownerClass(BackupSystemProcedures.class.getCanonicalName())


### PR DESCRIPTION
The current backup/restore is not efficient because it backup/restore one table a time. The code changes parallelize backup/restore by creating callables and submitting to ExecutorCompletionService.  This speeds up backup/restore by 3-4 times on bare splice db.

I include some other minor changes in the commit:
1) rename cancel_backup to syscs_cancel_backup for naming consistency.
2) Add an error message for backup cancelation.
2) code clean up.

**Note: please review code changes on both spliceengine and spliceengine_ee.