### PR TITLE
Fixed SPLICE-735

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropTableConstantOperation.java
@@ -16,8 +16,6 @@
 package com.splicemachine.derby.impl.sql.execute.actions;
 
 import com.splicemachine.db.impl.services.uuid.BasicUUID;
-import com.splicemachine.db.impl.sql.catalog.DataDictionaryCache;
-import com.splicemachine.db.impl.sql.catalog.TableKey;
 import com.splicemachine.ddl.DDLMessage.*;
 import com.splicemachine.derby.ddl.DDLUtils;
 import com.splicemachine.derby.impl.store.access.SpliceTransactionManager;
@@ -31,9 +29,8 @@ import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.depend.DependencyManager;
 import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.derby.utils.DataDictionaryUtils;
 import com.splicemachine.protobuf.ProtoUtil;
-
-import java.util.List;
 
 
 /**
@@ -180,10 +177,7 @@ public class DropTableConstantOperation extends DDLSingleTableConstantOperation 
         } catch (Exception e) {
             // If dropping table fails, it could happen that the table object in cache has been modified.
             // Invalidate the table in cache.
-            DataDictionaryCache cache = dd.getDataDictionaryCache();
-            TableKey tableKey = new TableKey(td.getSchemaDescriptor().getUUID(), td.getName());
-            cache.nameTdCacheRemove(tableKey);
-            cache.oidTdCacheRemove(td.getUUID());
+            DataDictionaryUtils.invalidateTableCache(dd,td);
             throw e;
         }
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/DataDictionaryUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/DataDictionaryUtils.java
@@ -15,6 +15,8 @@
 
 package com.splicemachine.derby.utils;
 
+import com.splicemachine.db.impl.sql.catalog.DataDictionaryCache;
+import com.splicemachine.db.impl.sql.catalog.TableKey;
 import org.sparkproject.guava.collect.Lists;
 
 import com.splicemachine.derby.jdbc.SpliceTransactionResourceImpl;
@@ -33,6 +35,20 @@ import java.util.List;
  */
 public class DataDictionaryUtils {
 
+    /**
+     * Sometime ddl operations fails and return exceptions. The Table descriptor might
+     * be stall and need to be invalidate and clean up. Use this function if your code
+     * do such operation. Once the cache is clean up the Table Descriptor will be reload
+     * in the cache from the disk and will be in a consistent state.
+     * @param dd
+     * @param td
+     */
+    public static void invalidateTableCache(DataDictionary dd,  TableDescriptor td) throws StandardException{
+        DataDictionaryCache cache = dd.getDataDictionaryCache();
+        TableKey tableKey = new TableKey(td.getSchemaDescriptor().getUUID(), td.getName());
+        cache.nameTdCacheRemove(tableKey);
+        cache.oidTdCacheRemove(td.getUUID());
+    }
 
     public static TableDescriptor getTableDescriptor(LanguageConnectionContext lcc, UUID tableId) throws StandardException {
         DataDictionary dd = lcc.getDataDictionary();


### PR DESCRIPTION
Trying to drop a column with a trigger depending on that column will throw a error but behind the scene the column is effectively deleted and the table descriptor will become stall.
This fix makes sure we handling triggers and constraints before we effectively deleting the column.