### PR TITLE
SPLICE-739: Correcting WholeTextInputFormat.

### DIFF
--- a/hbase_sql/hbase1.0.0.x/src/test/java/com/splicemachine/derby/impl/spark/WholeTextInputFormatTest.java
+++ b/hbase_sql/hbase1.0.0.x/src/test/java/com/splicemachine/derby/impl/spark/WholeTextInputFormatTest.java
@@ -1,0 +1,100 @@
+package com.splicemachine.derby.impl.spark;
+
+import com.splicemachine.access.HConfiguration;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.mapred.TaskAttemptID;
+import org.apache.hadoop.mapreduce.*;
+import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit;
+import org.apache.hadoop.mapreduce.task.JobContextImpl;
+import org.apache.hadoop.mapreduce.task.MapContextImpl;
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Scott Fines
+ *         Date: 8/4/16
+ */
+public class WholeTextInputFormatTest{
+
+    @Test
+    public void testGetsStreamForDirectory() throws Exception{
+        /*
+         * This test failed before changes to WholeTextInputFormat(hooray for test-driven development!),
+         * so this constitutes an effective regression test for SPLICE-739. Of course, we'll be certain
+         * about it by ALSO writing an IT, but this is a nice little Unit test of the same thing.
+         */
+        Configuration configuration =HConfiguration.unwrapDelegate();
+        String dirPath =SpliceUnitTest.getResourceDirectory()+"multiLineDirectory";
+        configuration.set("mapred.input.dir",dirPath);
+
+        WholeTextInputFormat wtif = new WholeTextInputFormat();
+        wtif.setConf(configuration);
+
+        JobContext ctx = new JobContextImpl(configuration,new JobID("test",1));
+        List<InputSplit> splits=wtif.getSplits(ctx);
+
+        int i=0;
+        Set<String> files = readFileNames(dirPath);
+
+        Set<String> readFiles = new HashSet<>();
+        for(InputSplit is:splits){
+            TaskAttemptContext tac = new TaskAttemptContextImpl(configuration,new TaskAttemptID("test",1,true,i,1));
+            RecordReader<String, InputStream> recordReader=wtif.createRecordReader(is,tac);
+            CombineFileSplit cfs = (CombineFileSplit)is;
+            System.out.println(cfs);
+
+            long c = collectRecords(readFiles,recordReader);
+            Assert.assertEquals("did not read all data!",28,c);
+            i++;
+        }
+
+        Assert.assertEquals("Did not read all files!",files.size(),readFiles.size());
+        for(String expectedFile:files){
+            Assert.assertTrue("Did not read file <"+expectedFile+">",readFiles.contains(expectedFile));
+        }
+    }
+
+    /* ****************************************************************************************************************/
+    /*private helper methods*/
+    private Set<String> readFileNames(String dirPath){
+        Set<String> fileNames = new HashSet<>();
+        File d = new File(dirPath);
+        //we can assume that d exists, but let's be safe
+        Assert.assertTrue("Programmer error: missing directory <"+dirPath+">",d.exists());
+        Assert.assertTrue("Programmer error: not a directory <"+dirPath+">",d.isDirectory());
+        File[] files=d.listFiles();
+        Assert.assertNotNull("Programmer error: did not list files properly <"+dirPath+">",files);
+        for(File file:files){
+            //CombineFileSplit prepends the file: to the front of all of its paths, so we need to do the same for equality checking
+            fileNames.add("file:"+file.getAbsolutePath());
+        }
+        return fileNames;
+    }
+
+    private long collectRecords(Set<String> fileNames,RecordReader<String, InputStream> recordReader) throws IOException, InterruptedException{
+        long count = 0L;
+        while(recordReader.nextKeyValue()){
+            String key = recordReader.getCurrentKey();
+            Assert.assertTrue("Seen the same file twice!",fileNames.add(key));
+
+            InputStream is = recordReader.getCurrentValue();
+            try(BufferedReader br = new BufferedReader(new InputStreamReader(is))){
+                String n;
+                while((n = br.readLine())!=null){
+                   count++;
+                }
+            }
+        }
+        return count;
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/BadRecordsRecorder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/BadRecordsRecorder.java
@@ -239,4 +239,9 @@ public class BadRecordsRecorder implements Externalizable, Closeable {
         numberOfBadRecords = in.readLong();
         badRecordMasterPath = fileSystem.getPath(in.readUTF());
     }
+
+    @Override
+    public String toString(){
+        return Long.toString(numberOfBadRecords);
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/FileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/FileFunction.java
@@ -59,7 +59,7 @@ public class FileFunction extends AbstractFileFunction<String> {
     @Override
     public Iterable<LocatedRow> call(final String s) throws Exception {
         if (operationContext.isFailed())
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         if (!initialized) {
             Reader reader = new StringReader(s);
             checkPreference();
@@ -69,11 +69,11 @@ public class FileFunction extends AbstractFileFunction<String> {
         try {
             tokenizer.setLine(s);
             LocatedRow lr =  call(tokenizer.read());
-            return lr==null?Collections.EMPTY_LIST:Collections.singletonList(lr);
+            return lr==null?Collections.<LocatedRow>emptyList():Collections.singletonList(lr);
         } catch (Exception e) {
             if (operationContext.isPermissive()) {
                 operationContext.recordBadRecord(e.getLocalizedMessage(), e);
-                return Collections.EMPTY_LIST;
+                return Collections.emptyList();
             }
             throw StandardException.plainWrapException(e);
         }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/StreamFileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/StreamFileFunction.java
@@ -59,7 +59,7 @@ import java.util.NoSuchElementException;
     @Override
     public Iterable<LocatedRow> call(final InputStream s) throws Exception {
         if (operationContext.isFailed())
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         checkPreference();
 
         return new Iterable<LocatedRow>() {

--- a/splice_machine/src/test/test-data/multiLineDirectory/mytable.dat
+++ b/splice_machine/src/test/test-data/multiLineDirectory/mytable.dat
@@ -1,0 +1,7 @@
+12,test12,2004-03-23 19:45:00,"this just 
+two lines", 100001
+1,test1,2014-03-23 19:45:00,oneline,20000001
+13,test13,2004-06-23 19:45:00,"this just 
+three lines 
+now", 100013
+2,test1,2000-03-23 19:45:00,oneline,20000011

--- a/splice_machine/src/test/test-data/multiLineDirectory/mytable1.dat
+++ b/splice_machine/src/test/test-data/multiLineDirectory/mytable1.dat
@@ -1,0 +1,7 @@
+22,test12,2004-03-23 19:45:00,"this just 
+two lines", 100001
+2,test1,2014-03-23 19:45:00,oneline,20000001
+23,test13,2004-06-23 19:45:00,"this just 
+three lines 
+now", 100013
+21,test1,2000-03-23 19:45:00,oneline,20000011

--- a/splice_machine/src/test/test-data/multiLineDirectory/mytable2.dat
+++ b/splice_machine/src/test/test-data/multiLineDirectory/mytable2.dat
@@ -1,0 +1,7 @@
+32,test12,2004-03-23 19:45:00,"this just 
+two lines", 100001
+3,test1,2014-03-23 19:45:00,oneline,20000001
+33,test13,2004-06-23 19:45:00,"this just 
+three lines 
+now", 100013
+32,test1,2000-03-23 19:45:00,oneline,20000011

--- a/splice_machine/src/test/test-data/multiLineDirectory/mytable3.dat
+++ b/splice_machine/src/test/test-data/multiLineDirectory/mytable3.dat
@@ -1,0 +1,7 @@
+42,test12,2004-03-23 19:45:00,"this just 
+two lines", 100001
+4,test1,2014-03-23 19:45:00,oneline,20000001
+43,test13,2004-06-23 19:45:00,"this just 
+three lines 
+now", 100013
+42,test1,2000-03-23 19:45:00,oneline,20000011


### PR DESCRIPTION
WholeTextInputFormat was only processing a single path out of a combined
list, which meant that multiple files were not being processed. This is
easily detected in a UT(WholeTextInputFormatTest), and corrected here.

It also includes an IT because why not.

I also included a few (minor) code cleanups, but it passes ITs on my box.