### PR TITLE
DB-5473: fix distcp dependencies

### DIFF
--- a/db-engine/pom.xml
+++ b/db-engine/pom.xml
@@ -41,6 +41,12 @@
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-common</artifactId>
             <version>1.0.0-cdh5.4.10</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -94,6 +94,10 @@
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-common</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-core</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -108,6 +112,10 @@
                 <exclusion>
                     <groupId>org.mortbay.jetty</groupId>
                     <artifactId>jsp-api-2.1</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-core</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -174,15 +182,22 @@
                     <groupId>tomcat</groupId>
                     <artifactId>jasper-runtime</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-core</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
-        <!--
         <dependency>
             <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-core</artifactId>
+            <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
         </dependency>
--->
+	<dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-distcp</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
@@ -290,21 +305,6 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-tools</artifactId>
-            <version>${hadoop.tools.version}</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>hadoop-core</artifactId>
-                    <groupId>org.apache.hadoop</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>hadoop-common</artifactId>
-                    <groupId>org.apache.hadoop</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.splicemachine</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -772,7 +772,6 @@
                 <envClassifier>cdh5.4.10</envClassifier>
                 <envHbase>hbase1.0.0</envHbase>
                 <hadoop.version>2.6.0-cdh5.4.10</hadoop.version>
-                <hadoop.tools.version>2.6.0-mr1-cdh5.4.10</hadoop.tools.version>
                 <hbase.version>1.0.0-cdh5.4.10</hbase.version>
                 <hive.version>1.1.0-cdh5.4.10</hive.version>
                 <zookeeper.version>3.4.5-cdh5.4.10</zookeeper.version>
@@ -799,7 +798,6 @@
                 <envClassifier>cdh5.5.2</envClassifier>
                 <envHbase>hbase1.0.0.x</envHbase>
                 <hadoop.version>2.6.0-cdh5.5.2</hadoop.version>
-                <hadoop.tools.version>2.6.0-mr1-cdh5.5.2</hadoop.tools.version>
                 <hbase.version>1.0.0-cdh5.5.2</hbase.version>
                 <hive.version>1.1.0-cdh5.5.2</hive.version>
                 <zookeeper.version>3.4.5-cdh5.5.2</zookeeper.version>
@@ -826,7 +824,6 @@
                 <envClassifier>cdh5.6.0</envClassifier>
                 <envHbase>hbase1.0.0.x</envHbase>
                 <hadoop.version>2.6.0-cdh5.6.0</hadoop.version>
-                <hadoop.tools.version>2.6.0-mr1-cdh5.6.0</hadoop.tools.version>
                 <hbase.version>1.0.0-cdh5.6.0</hbase.version>
                 <hive.version>1.1.0-cdh5.6.0</hive.version>
                 <zookeeper.version>3.4.5-cdh5.6.0</zookeeper.version>
@@ -853,7 +850,6 @@
                 <envClassifier>cdh5.7.2</envClassifier>
                 <envHbase>hbase1.2.0</envHbase>
                 <hadoop.version>2.6.0-cdh5.7.2</hadoop.version>
-                <hadoop.tools.version>2.6.0-mr1-cdh5.7.2</hadoop.tools.version>
                 <hbase.version>1.2.0-cdh5.7.2</hbase.version>
                 <hive.version>1.1.0-cdh5.7.2</hive.version>
                 <zookeeper.version>3.4.5-cdh5.7.2</zookeeper.version>
@@ -880,7 +876,6 @@
                 <envClassifier>cdh5.8.0</envClassifier>
                 <envHbase>hbase1.2.0</envHbase>
                 <hadoop.version>2.6.0-cdh5.8.0</hadoop.version>
-                <hadoop.tools.version>2.6.0-mr1-cdh5.8.0</hadoop.tools.version>
                 <hbase.version>1.2.0-cdh5.8.0</hbase.version>
                 <hive.version>1.1.0-cdh5.8.0</hive.version>
                 <zookeeper.version>3.4.5-cdh5.8.0</zookeeper.version>


### PR DESCRIPTION
Removed hadoop-tools and hadoop-core, pulled in  hadoop-distcp and hadoop-common. Please also review https://github.com/splicemachine/spliceengine-ee/pull/3