### PR TITLE
 SPLICE 741

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
@@ -24,6 +24,8 @@ import com.esotericsoftware.kryo.serializers.DefaultSerializers;
 import com.esotericsoftware.kryo.serializers.FieldSerializer;
 import com.esotericsoftware.kryo.serializers.MapSerializer;
 import com.google.common.collect.ArrayListMultimap;
+import com.splicemachine.EngineDriver;
+import com.splicemachine.SpliceKryoRegistry;
 import com.splicemachine.derby.ddl.DDLChangeType;
 import com.splicemachine.derby.ddl.TentativeAddColumnDesc;
 import com.splicemachine.derby.ddl.TentativeAddConstraintDesc;
@@ -53,6 +55,7 @@ import com.splicemachine.kvpair.KVPair;
 import com.splicemachine.pipeline.client.BulkWrite;
 import com.splicemachine.utils.ByteSlice;
 import com.splicemachine.utils.kryo.ExternalizableSerializer;
+import com.splicemachine.utils.kryo.KryoPool;
 import de.javakaffee.kryoserializers.UUIDSerializer;
 import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer;
 import com.splicemachine.db.catalog.types.*;
@@ -90,10 +93,39 @@ import java.util.*;
  * @author Scott Fines
  * Created on: 8/15/13
  */
-public class SpliceSparkKryoRegistrator implements KryoRegistrator {
+public class SpliceSparkKryoRegistrator implements KryoRegistrator, KryoPool.KryoRegistry {
     //ExternalizableSerializers are stateless, no need to create more than we need
     private static final ExternalizableSerializer EXTERNALIZABLE_SERIALIZER = ExternalizableSerializer.INSTANCE;
     private static final UnmodifiableCollectionsSerializer UNMODIFIABLE_COLLECTIONS_SERIALIZER = new UnmodifiableCollectionsSerializer();
+
+    private static volatile KryoPool spliceKryoPool;
+
+
+    public static KryoPool getInstance(){
+        KryoPool kp = spliceKryoPool;
+        if(kp==null){
+            synchronized(SpliceKryoRegistry.class){
+                kp = spliceKryoPool;
+                if(kp==null){
+                    EngineDriver driver = EngineDriver.driver();
+                    if(driver==null){
+                        kp = new KryoPool(1000);
+                    }else{
+                        int kpSize = driver.getConfiguration().getKryoPoolSize();
+                        kp = spliceKryoPool = new KryoPool(kpSize);
+                    }
+                    kp.setKryoRegistry(new SpliceSparkKryoRegistrator());
+
+                }
+            }
+        }
+        return kp;
+    }
+
+    @Override
+    public void register(Kryo instance) {
+        registerClasses(instance);
+    }
 
     @Override
     public void registerClasses(Kryo instance) {

--- a/hbase_sql/src/main/java/com/splicemachine/stream/KryoDecoder.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/KryoDecoder.java
@@ -17,6 +17,8 @@ package com.splicemachine.stream;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
+import com.splicemachine.derby.impl.SpliceSparkKryoRegistrator;
+import com.splicemachine.utils.kryo.KryoPool;
 import org.apache.log4j.Logger;
 import org.sparkproject.io.netty.buffer.ByteBuf;
 import org.sparkproject.io.netty.channel.ChannelHandlerContext;
@@ -26,12 +28,7 @@ import java.util.List;
 
 public class KryoDecoder extends ByteToMessageDecoder {
     private static final Logger LOG = Logger.getLogger(KryoDecoder.class);
-    
-    private final Kryo kryo;
-
-    public KryoDecoder(Kryo kryo) {
-        this.kryo = kryo;
-    }
+    static private KryoPool kp = SpliceSparkKryoRegistrator.getInstance();
 
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
@@ -58,8 +55,17 @@ public class KryoDecoder extends ByteToMessageDecoder {
         byte[] buf = new byte[len];
         in.readBytes(buf);
         Input input = new Input(buf);
-        Object object = kryo.readClassAndObject(input);
-        out.add(object);
+
+        Kryo decoder = kp.get();
+        try {
+            Object object = decoder.readClassAndObject(input);
+            out.add(object);
+        }
+        finally {
+            kp.returnInstance(decoder);
+
+        }
+
 
 //        LOG.warn("Decoded " + object);
     }

--- a/hbase_sql/src/main/java/com/splicemachine/stream/StreamListenerServer.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/StreamListenerServer.java
@@ -15,20 +15,21 @@
 
 package com.splicemachine.stream;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.util.DefaultClassResolver;
-import com.esotericsoftware.kryo.util.MapReferenceResolver;
+
 import com.google.common.net.HostAndPort;
 import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.derby.impl.SpliceSparkKryoRegistrator;
 import com.splicemachine.pipeline.Exceptions;
+import com.splicemachine.stream.handlers.OpenHandler;
 import org.apache.log4j.Logger;
-import org.apache.spark.serializer.KryoRegistrator;
 import org.sparkproject.guava.util.concurrent.ThreadFactoryBuilder;
 import org.sparkproject.io.netty.bootstrap.ServerBootstrap;
-import org.sparkproject.io.netty.channel.*;
+import org.sparkproject.io.netty.channel.Channel;
+import org.sparkproject.io.netty.channel.ChannelFuture;
+import org.sparkproject.io.netty.channel.ChannelHandler;
+import org.sparkproject.io.netty.channel.ChannelHandlerContext;
+import org.sparkproject.io.netty.channel.ChannelInboundHandlerAdapter;
+import org.sparkproject.io.netty.channel.ChannelOption;
 import org.sparkproject.io.netty.channel.nio.NioEventLoopGroup;
-import org.sparkproject.io.netty.channel.socket.SocketChannel;
 import org.sparkproject.io.netty.channel.socket.nio.NioServerSocketChannel;
 import org.sparkproject.io.netty.handler.logging.LogLevel;
 import org.sparkproject.io.netty.handler.logging.LoggingHandler;
@@ -36,11 +37,9 @@ import org.sparkproject.io.netty.handler.logging.LoggingHandler;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ThreadFactory;
 
 
@@ -50,7 +49,6 @@ import java.util.concurrent.ThreadFactory;
 @ChannelHandler.Sharable
 public class StreamListenerServer<T> extends ChannelInboundHandlerAdapter {
     private static final Logger LOG = Logger.getLogger(StreamListenerServer.class);
-    private static final KryoRegistrator registry = new SpliceSparkKryoRegistrator();
     private final int port;
 
     private Channel serverChannel;
@@ -83,19 +81,7 @@ public class StreamListenerServer<T> extends ChannelInboundHandlerAdapter {
             b.group(bossGroup, workerGroup)
                     .channel(NioServerSocketChannel.class)
                     .handler(new LoggingHandler(LogLevel.INFO))
-                    .childHandler(new ChannelInitializer<SocketChannel>() {
-                        @Override
-                        public void initChannel(SocketChannel ch) throws Exception {
-                            Kryo encoder =  new Kryo(new DefaultClassResolver(),new MapReferenceResolver());
-                            registry.registerClasses(encoder);
-                            Kryo decoder =  new Kryo(new DefaultClassResolver(),new MapReferenceResolver());
-                            registry.registerClasses(decoder);
-                            ch.pipeline().addLast(
-                                    new KryoEncoder(encoder),
-                                    new KryoDecoder(decoder),
-                                    StreamListenerServer.this);
-                        }
-                    })
+                    .childHandler(new OpenHandler(this))
                     .option(ChannelOption.SO_BACKLOG, 128)
                     .childOption(ChannelOption.SO_KEEPALIVE, true);
 

--- a/hbase_sql/src/main/java/com/splicemachine/stream/handlers/OpenHandler.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/handlers/OpenHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012 - 2016 Splice Machine, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.splicemachine.stream.handlers;
+
+import com.splicemachine.stream.KryoDecoder;
+import com.splicemachine.stream.KryoEncoder;
+import org.sparkproject.io.netty.channel.ChannelHandler;
+import org.sparkproject.io.netty.channel.ChannelInboundHandlerAdapter;
+import org.sparkproject.io.netty.channel.ChannelInitializer;
+import org.sparkproject.io.netty.channel.socket.SocketChannel;
+
+
+/**
+ * We are using Kryo for serialization message between spark and the Olap Server.
+ * This handler is going to simply take the current pipeline and add 2 standard channels
+ * to encode a kryo object and decode a kryo object.
+ * Also it is going to add the main channel handler in the pipleline
+ * @see com.splicemachine.stream.StreamListenerServer
+ * @see com.splicemachine.stream.ResultStreamer
+ */
+
+@ChannelHandler.Sharable
+public class OpenHandler extends ChannelInitializer<SocketChannel> {
+
+    private ChannelInboundHandlerAdapter listener;
+
+    public OpenHandler(ChannelInboundHandlerAdapter listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public void initChannel(SocketChannel ch) throws Exception {
+
+        ch.pipeline().addLast(
+                new KryoEncoder(),
+                new KryoDecoder(),
+                listener);
+    }
+
+}

--- a/splice_encoding/src/main/java/com/splicemachine/utils/kryo/KryoPool.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/kryo/KryoPool.java
@@ -20,8 +20,8 @@ import com.esotericsoftware.kryo.util.DefaultClassResolver;
 import com.esotericsoftware.kryo.util.MapReferenceResolver;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * Simple Pool of Kryo objects that allows a core of Kryo objects to remain
@@ -32,12 +32,14 @@ import java.util.concurrent.BlockingQueue;
  * Created on: 8/15/13
  */
 public class KryoPool {
-    private final BlockingQueue<Kryo> instances;
+    private final Queue<Kryo> instances;
 
     private volatile KryoRegistry kryoRegistry;
+    private int poolSize;
 
     public KryoPool(int poolSize) {
-        this.instances =new ArrayBlockingQueue<>(poolSize);
+        this.poolSize = poolSize;
+        this.instances =new ConcurrentLinkedQueue<>();
     }
 
     public void setKryoRegistry(KryoRegistry kryoRegistry){
@@ -63,7 +65,10 @@ public class KryoPool {
          * which will allow the GC to collect it. Thus, we can suppress
          * the findbugs warning
          */
-        instances.offer(kryo);
+        if(instances.size()< this.poolSize){
+            instances.offer(kryo);
+        }
+
     }
     public interface KryoRegistry{
         void register(Kryo instance);


### PR DESCRIPTION
 Use Kryo pools in result streamer   stream listener
 Added Kryo Pool master
 This version added  ThreadLocal to avoid race condition with multiple handlers used with Netty.
 It should now use  different kryo objects by thread basis and then the kryo object will be return when the thread close and perform a clean of its ThreadLocal