### PR TITLE
DB-4457: incremental backup

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/BackupDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/BackupDescriptor.java
@@ -30,7 +30,9 @@ package com.splicemachine.db.iapi.sql.dictionary;
  */
 import org.joda.time.DateTime;
 
-public class BackupDescriptor extends TupleDescriptor {
+import java.io.*;
+
+public class BackupDescriptor extends TupleDescriptor{
 
     private long backupId;
     private DateTime beginTimestamp;
@@ -41,6 +43,8 @@ public class BackupDescriptor extends TupleDescriptor {
     private boolean isIncremental;
     private long parentId;
     private int items;
+
+    public BackupDescriptor() {}
 
     public BackupDescriptor(long backupId,
                             DateTime beginTimestamp,
@@ -96,5 +100,29 @@ public class BackupDescriptor extends TupleDescriptor {
 
     public int getItems() {
         return items;
+    }
+
+    public void writeExternal(DataOutput out) throws IOException {
+        out.writeLong(backupId);
+        out.writeLong(beginTimestamp.getMillis());
+        out.writeLong(endTimestamp.getMillis());
+        out.writeUTF(status);
+        out.writeUTF(fileSystem);
+        out.writeUTF(scope);
+        out.writeBoolean(isIncremental);
+        out.writeLong(parentId);
+        out.writeInt(items);
+    }
+
+    public void readExternal(DataInput in) throws IOException {
+        backupId = in.readLong();
+        beginTimestamp = new DateTime(in.readLong());
+        endTimestamp = new DateTime(in.readLong());
+        status = in.readUTF();
+        fileSystem = in.readUTF();
+        scope = in.readUTF();
+        isIncremental = in.readBoolean();
+        parentId = in.readLong();
+        items = in.readInt();
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -2069,4 +2069,18 @@ public interface DataDictionary{
     public boolean canUseCache(TransactionController xactMgr) throws StandardException;
 
     boolean canUseSPSCache() throws StandardException;
+
+    void addBackup(TupleDescriptor descriptor, TransactionController tc) throws StandardException;
+
+    void deleteBackup(long backupId, TransactionController tc) throws StandardException;
+
+    List<BackupDescriptor> getBackupDescriptorList() throws StandardException;
+
+    void addBackupItem(TupleDescriptor descriptor, TransactionController tc) throws StandardException;
+
+    void deleteAllBackupItems(long backupId, TransactionController tc) throws StandardException;
+
+    void addBackupJob(TupleDescriptor descriptor, TransactionController tc) throws StandardException;
+
+    void deleteBackupJob(long jobId, TransactionController tc) throws StandardException;
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSBACKUPITEMSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSBACKUPITEMSRowFactory.java
@@ -49,20 +49,23 @@ public class SYSBACKUPITEMSRowFactory extends CatalogRowFactory {
     private static final int END_TIMESTAMP = 4;
 
     protected static final int SYSBACKUPITEMS_INDEX1_ID = 0;
+    protected static final int SYSBACKUPITEMS_INDEX2_ID = 1;
 
     private	static	final	boolean[]	uniqueness = {
-            true
+            false, true
     };
 
     private static final int[][] indexColumnPositions = {
-                    {BACKUP_ID, ITEM}
-            };
+            {BACKUP_ID},
+            {BACKUP_ID, ITEM}
+    };
 
 
     private static String uuids[] = {
             "a0527143-4f6e-42df-98ab-b1dff6bea7db",
             "a0527143-4f6c-42df-98ab-b1dff6bea7db",
-            "a0527143-4f6z-42df-98ab-b1dff6bea7db"
+            "a0527143-4f6d-42df-98ab-b1dff6bea7db",
+            "a0527143-4f6e-42df-98ab-b1dff6bea7db"
     };
 
     public SYSBACKUPITEMSRowFactory(UUIDFactory uuidf, ExecutionFactory ef, DataValueFactory dvf) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSBACKUPJOBSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSBACKUPJOBSRowFactory.java
@@ -58,7 +58,6 @@ public class SYSBACKUPJOBSRowFactory extends CatalogRowFactory {
 
 
     protected static final int SYSBACKUPJOBS_INDEX1_ID = 0;
-    protected static final int SYSBACKUPJOBS_INDEX2_ID = 1;
 
     private	static	final	boolean[]	uniqueness = {
             true

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSBACKUPRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSBACKUPRowFactory.java
@@ -37,6 +37,11 @@ import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.sql.execute.ExecutionFactory;
 import com.splicemachine.db.iapi.types.*;
 import org.joda.time.DateTime;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.sql.Types;
 
 public class SYSBACKUPRowFactory extends CatalogRowFactory {
@@ -55,7 +60,6 @@ public class SYSBACKUPRowFactory extends CatalogRowFactory {
 
 
     protected static final int SYSBACKUP_INDEX1_ID = 0;
-    protected static final int SYSBACKUP_INDEX2_ID = 1;
 
     private	static	final	boolean[]	uniqueness = {
             true,
@@ -65,7 +69,6 @@ public class SYSBACKUPRowFactory extends CatalogRowFactory {
     private static final int[][] indexColumnPositions =
             {
                     {BACKUP_ID},
-                    {INCREMENTAL_PARENT_BACKUP_ID}
             };
 
 
@@ -118,7 +121,7 @@ public class SYSBACKUPRowFactory extends CatalogRowFactory {
         row.setColumn(FILESYSTEM, new SQLVarchar(fileSystem));
         row.setColumn(SCOPE, new SQLVarchar(scope));
         row.setColumn(IS_INCREMENTAL_BACKUP, new SQLBoolean(isIncremental));
-        row.setColumn(INCREMENTAL_PARENT_BACKUP_ID, new SQLDouble(parentId));
+        row.setColumn(INCREMENTAL_PARENT_BACKUP_ID, new SQLLongint(parentId));
         row.setColumn(ITEMS, new SQLInteger(items));
 
         return row;
@@ -170,7 +173,7 @@ public class SYSBACKUPRowFactory extends CatalogRowFactory {
         return new SystemColumn[]{
                 SystemColumnImpl.getColumn("BACKUP_ID", Types.BIGINT, false),
                 SystemColumnImpl.getColumn("BEGIN_TIMESTAMP",Types.TIMESTAMP,false),
-                SystemColumnImpl.getColumn("END_TIMESTAMP",Types.TIMESTAMP,true),
+                SystemColumnImpl.getColumn("END_TIMESTAMP",Types.TIMESTAMP,false),
                 SystemColumnImpl.getColumn("STATUS",Types.VARCHAR,false,20),
                 SystemColumnImpl.getColumn("FILESYSTEM",Types.VARCHAR,false,32642),
                 SystemColumnImpl.getColumn("SCOPE",Types.VARCHAR,false,10),

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceHFileCleaner.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceHFileCleaner.java
@@ -1,0 +1,51 @@
+package com.splicemachine.hbase;
+
+import com.splicemachine.EngineDriver;
+import com.splicemachine.access.HConfiguration;
+import com.splicemachine.backup.BackupManager;
+import com.splicemachine.backup.BackupUtils;
+import com.splicemachine.db.iapi.error.StandardException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.master.cleaner.BaseHFileCleanerDelegate;
+import org.apache.hadoop.hbase.util.FSUtils;
+import org.apache.log4j.Logger;
+
+/**
+ * Created by jyuan on 1/29/15.
+ */
+public class SpliceHFileCleaner extends BaseHFileCleanerDelegate {
+
+    private static final Logger LOG = Logger.getLogger(SpliceHFileCleaner.class);
+
+    @Override
+    public void setConf(Configuration conf) {
+        super.setConf(conf);
+    }
+
+    @Override
+    public synchronized boolean isFileDeletable(FileStatus fStat) {
+
+        boolean deletable = true;
+        try {
+            Configuration conf = HConfiguration.unwrapDelegate();
+            Path rootDir = FSUtils.getRootDir(conf);
+            FileSystem fs = FSUtils.getCurrentFileSystem(conf);
+            /**An archived HFile is reserved for an incremental backup if
+             * 1) There exists a successful full/incremental backup for the database
+             * 2) An empty file with the same name exists in backup directory.
+            */
+            if (BackupUtils.existsDatabaseBackup(fs, rootDir)) {
+                String p = BackupUtils.getBackupFilePath(fStat.getPath().toString());
+                if (fs.exists(new Path(p)))
+                    deletable = false;
+            }
+        }
+        catch(Exception e) {
+            //ignores any exception
+        }
+        return deletable;
+    }
+}

--- a/hbase_sql/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
+++ b/hbase_sql/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
@@ -68,6 +68,7 @@ class SpliceTestPlatformConfig {
             SpliceMasterObserver.class);
 
     private static final List<Class<?>> HFILE_CLEANERS = ImmutableList.<Class<?>>of(
+            SpliceHFileCleaner.class,
             TimeToLiveHFileCleaner.class);
 
     /*

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupRestoreConstants.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupRestoreConstants.java
@@ -1,0 +1,16 @@
+package com.splicemachine.backup;
+
+/**
+ * Created by jyuan on 8/8/16.
+ */
+import org.apache.hadoop.hbase.util.Bytes;
+
+public class BackupRestoreConstants {
+
+    public static String BACKUP_DIR = "backup";
+    public static final String BACKUP_RECORD_FILE_NAME = "SYSBACKUP";
+    public static final String REGION_FILE_NAME = ".regioninfo";
+    public static final String ARCHIVE_DIR = "archive";
+    public static final byte[] BACKUP_TYPE_FULL_BYTES = Bytes.toBytes("FULL");
+    public static final byte[] BACKUP_TYPE_INCR_BYTES = Bytes.toBytes("INCR");
+}

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupUtils.java
@@ -1,0 +1,57 @@
+package com.splicemachine.backup;
+
+import com.splicemachine.db.iapi.sql.dictionary.BackupDescriptor;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+
+/**
+ * Created by jyuan on 8/10/16.
+ */
+public class BackupUtils {
+
+    /**
+     *
+     * @param fs HBase file system
+     * @param rootPath HBase root directory
+     * @return True if there exists a successful database backup
+     * @throws IOException
+     */
+    public static boolean existsDatabaseBackup(FileSystem fs, Path rootPath) throws IOException {
+        boolean ret = false;
+        FSDataInputStream in = null;
+        try {
+            // Open backup record file from file system
+            Path backupPath = new Path(rootPath, BackupRestoreConstants.BACKUP_DIR);
+            Path p = new Path(backupPath, BackupRestoreConstants.BACKUP_RECORD_FILE_NAME);
+            if (fs.exists(p)) {
+                in = fs.open(p);
+                int n = in.readInt();  // number of records
+                BackupDescriptor bd = new BackupDescriptor();
+                while (n-- > 0) {
+                    bd.readExternal(in);
+                    if (bd.getScope().compareToIgnoreCase("DATABASE") == 0) {
+                        ret = true;
+                        break;
+                    }
+                }
+            }
+            return ret;
+        }
+        finally {
+            if (in != null)
+                in.close();
+        }
+    }
+
+    /**
+     * Given a file path for an archived HFile, return the corresponding file path in backup metadata directory
+     * @param p file path for archived HFile
+     * @return orresponding file path in backup metadata directory
+     */
+    public static String getBackupFilePath(String p) {
+        return p.replace(BackupRestoreConstants.ARCHIVE_DIR, BackupRestoreConstants.BACKUP_DIR);
+    }
+}


### PR DESCRIPTION
First checkin for incremental backup
1) As soon as an HFile is flushed to disk, record its name in backup medata directory by creating an empty file with the same name. The file indicates that an HFile with the same name in either archived directory or data directory should be included in next incremental backup
2) During incremental backup, for each region, look for HFile names in the backup medata directory, and copy HFiles from hbase data directory or archived directory.
3) Prevent an archived HFile from being purged if there is a file with the same name in backup metadata directory.

Also included are code cleanup, refactoring, backup system table cleanup. Please review code changes in both spliceengin and spliceengine-ee repositories.