### PR TITLE
DB-5620: add splice.backup.parallelism parameter

### DIFF
--- a/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
@@ -86,6 +86,8 @@ public interface SConfiguration {
 
     String getBackupPath();
 
+    int getBackupParallelism();
+
     String getCompressionAlgorithm();
 
     String getNamespace();

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
@@ -87,6 +87,7 @@ public class ConfigurationBuilder {
     public String spliceRootPath;
     public String hbaseSecurityAuthorization;
     public boolean hbaseSecurityAuthentication;
+    public int backupParallelism;
 
     // SQLConfiguration
     public boolean debugDumpBindTree;

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/HBaseConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/HBaseConfiguration.java
@@ -119,6 +119,8 @@ public class HBaseConfiguration implements ConfigurationDefault {
     protected static final String REGION_MAX_FILE_SIZE = StorageConfiguration.REGION_MAX_FILE_SIZE;
     protected static final String TRANSACTION_LOCK_STRIPES = SIConfigurations.TRANSACTION_LOCK_STRIPES;
 
+    public static final String SPLICE_BACKUP_PARALLELISM = "splice.backup.parallelism";
+    public static final int DEFAULT_SPLICE_BACKUP_PARALLELISM = 16;
     /**
      * The Path in zookeeper for storing the maximum reserved timestamp
      * from the ZkTimestampSource implementation.
@@ -175,6 +177,8 @@ public class HBaseConfiguration implements ConfigurationDefault {
         builder.hbaseSecurityAuthentication = configurationSource.getBoolean(HBASE_SECURITY_AUTHENTICATION, false);
         builder.hbaseSecurityAuthorization = configurationSource.getString(HBASE_SECURITY_AUTHORIZATION,
                                                                            DEFAULT_HBASE_SECURITY_AUTHORIZATION);
+
+        builder.backupParallelism = configurationSource.getInt(SPLICE_BACKUP_PARALLELISM, DEFAULT_SPLICE_BACKUP_PARALLELISM);
 
     }
 }

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
@@ -74,6 +74,7 @@ public final class SConfigurationImpl implements SConfiguration {
     private final  String spliceRootPath;
     private final  String hbaseSecurityAuthorization;
     private final  boolean hbaseSecurityAuthentication;
+    private final int backupParallelism;
 
     // OperationConfiguration
     private final  int sequenceBlockSize;
@@ -248,6 +249,10 @@ public final class SConfigurationImpl implements SConfiguration {
     @Override
     public String getBackupPath() {
         return backupPath;
+    }
+    @Override
+    public int getBackupParallelism() {
+        return backupParallelism;
     }
     @Override
     public String getCompressionAlgorithm() {
@@ -613,6 +618,7 @@ public final class SConfigurationImpl implements SConfiguration {
         timestampBlockSize = builder.timestampBlockSize;
         regionLoadUpdateInterval = builder.regionLoadUpdateInterval;
         backupPath = builder.backupPath;
+        backupParallelism = builder.backupParallelism;
         compressionAlgorithm = builder.compressionAlgorithm;
         namespace = builder.namespace;
         spliceRootPath = builder.spliceRootPath;


### PR DESCRIPTION
Add a parameter splice.backup.parallelism to allow a user to tune backup parallelism.