### PR TITLE
SPLICE-835 Mapping TEXT column creation to CLOB

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -770,6 +770,7 @@ public class SQLParser
 		  case NCLOB:
 		  case BINARY: // LARGE OBJECT
 		  case XML:
+		  case TEXT:
 			retval = true;
 			break;
 
@@ -2905,6 +2906,7 @@ TOKEN [IGNORE_CASE] :
 |	<RTRIM: "rtrim">
 |	<SUBSTR:	"substr">
 |	<XML:	"xml">
+|   <TEXT:	"text">
 |	<XMLEXISTS:	"xmlexists">
 |	<XMLPARSE:	"xmlparse">
 |	<XMLQUERY:	"xmlquery">
@@ -4856,6 +4858,11 @@ LOBType() throws StandardException :
 		}
 	|
 		<CLOB> [ length = lengthAndModifier() ]
+		{
+			type = TypeId.CLOB_NAME;
+		}
+	|
+		<TEXT> [ length = lengthAndModifier() ]
 		{
 			type = TypeId.CLOB_NAME;
 		}

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/TableConstantOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/TableConstantOperationIT.java
@@ -33,6 +33,7 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -332,4 +333,14 @@ public class TableConstantOperationIT extends SpliceUnitTest {
             methodWatcher.closeAll();
         }
     }
+
+    @Test
+    public void createTableWithTextField() throws Exception {
+        methodWatcher.execute(format("create table %s.%s (col1 text)",CLASS_NAME,"FOO"));
+        methodWatcher.execute(format("insert into %s.%s values ('1232')",CLASS_NAME,"FOO"));
+        ResultSet rs = methodWatcher.getOrCreateConnection().getMetaData().getColumns(null,CLASS_NAME,"FOO","COL1");
+        Assert.assertTrue("Could not find column",rs.next());
+        Assert.assertEquals("type conversion did not work","CLOB",rs.getString("TYPE_NAME"));
+    }
+
 }


### PR DESCRIPTION
Adding Text datatype so Spark JDBC lib works easily with Splice Machine.