### PR TITLE
SPLICE-838: Making olap server tick time configurable

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/olap/AsyncOlapNIOLayer.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/AsyncOlapNIOLayer.java
@@ -17,6 +17,7 @@ package com.splicemachine.olap;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.ExtensionRegistry;
+import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.derby.iapi.sql.olap.DistributedJob;
 import com.splicemachine.derby.iapi.sql.olap.OlapResult;
 import com.splicemachine.pipeline.Exceptions;

--- a/hbase_sql/src/main/java/com/splicemachine/olap/MappedJobRegistry.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/MappedJobRegistry.java
@@ -31,9 +31,11 @@ public class MappedJobRegistry implements OlapJobRegistry{
     private final ConcurrentMap<String/*jobName*/,OlapJobStatus/*jobStatus*/> registry;
     private final ScheduledExecutorService registryCleaner;
     private final long tickTime;
+    private final int numTicks;
 
-    public MappedJobRegistry(long tickTime,TimeUnit unit){
+    public MappedJobRegistry(long tickTime,int numTicks,TimeUnit unit){
         this.tickTime=unit.toMillis(tickTime);
+        this.numTicks = numTicks;
         this.registry = new ConcurrentHashMap<>();
         this.registryCleaner =Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder().setDaemon(true).setNameFormat("jobRegistryCleaner").build());
         this.registryCleaner.scheduleWithFixedDelay(new Cleaner(),1l,10l,unit);
@@ -50,7 +52,7 @@ public class MappedJobRegistry implements OlapJobRegistry{
          */
         OlapJobStatus status = registry.get(uniqueJobName);
         if(status!=null) return status;
-        status = new OlapJobStatus(tickTime);
+        status = new OlapJobStatus(tickTime,numTicks);
         OlapJobStatus old = registry.putIfAbsent(uniqueJobName,status);
         if(old!=null)
             status = old;

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapJobStatus.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapJobStatus.java
@@ -37,9 +37,9 @@ public class OlapJobStatus implements OlapStatus{
     private volatile AtomicReference<OlapStatus.State> currentState = new AtomicReference<>(State.NOT_SUBMITTED);
     private volatile OlapResult results;
 
-    public OlapJobStatus(long tickTime){
+    public OlapJobStatus(long tickTime,int numTicks){
         //TODO -sf- remove the constants
-        FiniteDuration maxHeartbeatInterval = FiniteDuration.apply(10*tickTime,TimeUnit.MILLISECONDS);
+        FiniteDuration maxHeartbeatInterval = FiniteDuration.apply(numTicks*tickTime,TimeUnit.MILLISECONDS);
         FiniteDuration stdDev = FiniteDuration.apply(2*tickTime,TimeUnit.MILLISECONDS);
         FiniteDuration firstTick = FiniteDuration.apply(tickTime,TimeUnit.MILLISECONDS);
 

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapServer.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapServer.java
@@ -56,7 +56,9 @@ public class OlapServer {
         ServerBootstrap bootstrap = new ServerBootstrap(factory);
 
         // Instantiate handler once and share it
-        OlapJobRegistry registry = new MappedJobRegistry(1L,TimeUnit.SECONDS); //TODO -sf- make this tick time configurable
+        OlapJobRegistry registry = new MappedJobRegistry(config.getOlapClientTickTime(),
+                config.getOlapServerTickLimit(),
+                TimeUnit.MILLISECONDS);
         ChannelHandler submitHandler = new OlapRequestHandler(config,
                 registry,clock,config.getOlapClientTickTime());
         ChannelHandler statusHandler = new OlapStatusHandler(registry);

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
@@ -253,4 +253,6 @@ public interface SConfiguration {
     int getCompactionReservedSlots();
 
     int getReservedSlotsTimeout();
+
+    int getOlapServerTickLimit();
 }

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
@@ -106,6 +106,7 @@ public class ConfigurationBuilder {
     public int olapClientTickTime;
     public int olapServerBindPort;
     public int olapServerThreads;
+    public int olapServerTickLimit;
     public int partitionserverJmxPort;
     public int partitionserverPort;
     public long broadcastRegionMbThreshold;

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
@@ -107,6 +107,7 @@ public final class SConfigurationImpl implements SConfiguration {
     private final int olapClientTickTime;
     private final int olapServerBindPort;
     private final int olapServerThreads;
+    private final int olapServerTickLimit;
     private final  int readResolverQueueSize;
     private final  int readResolverThreads;
     private final  int timestampClientWaitTime;
@@ -663,6 +664,7 @@ public final class SConfigurationImpl implements SConfiguration {
         olapClientTickTime = builder.olapClientTickTime;
         olapServerBindPort = builder.olapServerBindPort;
         olapServerThreads = builder.olapServerThreads;
+        olapServerTickLimit = builder.olapServerTickLimit;
         sparkResultStreamingBatches = builder.sparkResultStreamingBatches;
         sparkResultStreamingBatchSize = builder.sparkResultStreamingBatchSize;
         compactionReservedSlots = builder.compactionReservedSlots;
@@ -706,6 +708,11 @@ public final class SConfigurationImpl implements SConfiguration {
     @Override
     public int getReservedSlotsTimeout() {
         return reservedSlotsTimeout;
+    }
+
+    @Override
+    public int getOlapServerTickLimit(){
+        return olapServerTickLimit;
     }
 
 }

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SIConfigurations.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SIConfigurations.java
@@ -143,6 +143,9 @@ public class SIConfigurations implements ConfigurationDefault {
     public static final String OLAP_SERVER_THREADS = "splice.olap_server.threads";
     private static final int DEFAULT_OLAP_SERVER_THREADS = 16;
 
+    public static final String OLAP_SERVER_TICK_LIMIT = "splice.olap_server.tickLimit";
+    private static final int DEFAULT_OLAP_SERVER_TICK_LIMIT = 10;
+
     public static final String ACTIVE_TRANSACTION_CACHE_SIZE="splice.txn.activeCacheSize";
     private static final int DEFAULT_ACTIVE_TRANSACTION_CACHE_SIZE = 1<<12;
 
@@ -161,6 +164,7 @@ public class SIConfigurations implements ConfigurationDefault {
         builder.olapClientWaitTime  = configurationSource.getInt(OLAP_CLIENT_WAIT_TIME, DEFAULT_OLAP_CLIENT_WAIT_TIME);
         builder.olapClientTickTime  = configurationSource.getInt(OLAP_CLIENT_TICK_TIME, DEFAULT_OLAP_CLIENT_TICK_TIME);
         builder.olapServerThreads = configurationSource.getInt(OLAP_SERVER_THREADS, DEFAULT_OLAP_SERVER_THREADS);
+        builder.olapServerTickLimit = configurationSource.getInt(OLAP_SERVER_TICK_LIMIT,DEFAULT_OLAP_SERVER_TICK_LIMIT);
 
         builder.transactionTimeout = configurationSource.getLong(TRANSACTION_TIMEOUT, DEFAULT_TRANSACTION_TIMEOUT);
         builder.transactionKeepAliveInterval = configurationSource.getLong(TRANSACTION_KEEP_ALIVE_INTERVAL, DEFAULT_TRANSACTION_KEEP_ALIVE_INTERVAL);


### PR DESCRIPTION
This makes the olap server tick time configurable, so that we can wait longer if we need to.