### PR TITLE
SPLICE-836: Removing recursive cogroups.

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AntiJoinRestrictionFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AntiJoinRestrictionFlatMapFunction.java
@@ -54,7 +54,7 @@ public class AntiJoinRestrictionFlatMapFunction<Op extends SpliceOperation> exte
             op.setCurrentRow(mergedRow);
             if (op.getRestriction().apply(mergedRow)) { // Has Row, abandon
                 operationContext.recordFilter();
-                return Collections.EMPTY_LIST;
+                return Collections.emptyList();
             }
         }
         // No Rows Matched...

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CogroupAntiJoinRestrictionFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CogroupAntiJoinRestrictionFlatMapFunction.java
@@ -18,17 +18,20 @@ package com.splicemachine.derby.stream.function;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.LocatedRow;
 import com.splicemachine.derby.stream.iapi.OperationContext;
+import com.splicemachine.derby.stream.utils.ConcatenatedIterable;
 import org.sparkproject.guava.collect.Iterables;
 import org.sparkproject.guava.collect.Sets;
 import scala.Tuple2;
 import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
 
 /**
  * Created by jleach on 4/30/15.
  */
 public class CogroupAntiJoinRestrictionFlatMapFunction<Op extends SpliceOperation> extends SpliceJoinFlatMapFunction<Op, Tuple2<Iterable<LocatedRow>,Iterable<LocatedRow>>,LocatedRow> {
-    protected AntiJoinRestrictionFlatMapFunction antiJoinRestrictionFlatMapFunction;
+    private AntiJoinRestrictionFlatMapFunction<Op> antiJoinRestrictionFlatMapFunction;
     protected LocatedRow leftRow;
     public CogroupAntiJoinRestrictionFlatMapFunction() {
         super();
@@ -41,18 +44,20 @@ public class CogroupAntiJoinRestrictionFlatMapFunction<Op extends SpliceOperatio
     @Override
     public Iterable<LocatedRow> call(Tuple2<Iterable<LocatedRow>, Iterable<LocatedRow>> tuple) throws Exception {
         checkInit();
-        Set<LocatedRow> rightSide = Sets.newHashSet(tuple._2); // Memory Issue, HashSet ?
-        Iterable<LocatedRow> returnRows = new ArrayList<>();
+//        Iterable<LocatedRow> rightSide = Sets.newHashSet(tuple._2); // Memory Issue, HashSet ?
+        Iterable<LocatedRow> rightSide = tuple._2;
+        //LinkedList has better memory behavior here.
+        List<Iterable<LocatedRow>> returnRows = new LinkedList<>();
         for(LocatedRow a_1 : tuple._1){
-            returnRows= Iterables.concat(returnRows, antiJoinRestrictionFlatMapFunction.call(new Tuple2<>(a_1, rightSide)));
+            returnRows.add(antiJoinRestrictionFlatMapFunction.call(new Tuple2<>(a_1,rightSide)));
         }
-        return returnRows;
+        return new ConcatenatedIterable<>(returnRows);
     }
 
     @Override
     protected void checkInit() {
         if (!initialized)
-            antiJoinRestrictionFlatMapFunction = new AntiJoinRestrictionFlatMapFunction(operationContext);
+            antiJoinRestrictionFlatMapFunction = new AntiJoinRestrictionFlatMapFunction<>(operationContext);
         super.checkInit();
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ConcatenatedIterable.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ConcatenatedIterable.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2012 - 2016 Splice Machine, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.splicemachine.derby.stream.utils;
+
+
+import java.util.*;
+
+/**
+ * @author Scott Fines
+ *         Date: 8/18/16
+ */
+public class ConcatenatedIterable<E> implements Iterable<E>{
+    /*
+     * This represents a concatenation of multiple iterables together without needing a lot of
+     * stack allocations (see SPLICE-836).
+     *
+     * The initial implementation was to make use of guava's Iterable.concat() implementation. However,
+     * each time you use Iterables.concat(), you create a new wrapper iterable around what we are concatenating,
+     * which means that, for each row on the left, we would be creating a new Iterable wrapper around the
+     * previous row's results. This is a fine recursive algorithm when we have tail-call optimizations, but
+     * alas Java is not Scala, and tail-call optimizations don't exist, so we end up overflowing the stack
+     * whenever the size of the left hand side is large enough.
+     *
+     * This implementation avoids the extra wrapper objects, resulting in a flat iterative algorithm for
+     * concatenating all the values together. This should not only avoid StackOverflow problems, but in most cases
+     * it should perform significantly better as well(since it will avoid creating millions of extraneous
+     * Iterable objects).
+     */
+    private final List<Iterable<E>> iterables;
+
+    public ConcatenatedIterable(List<Iterable<E>> iterables){
+        this.iterables=iterables;
+    }
+
+    @Override
+    public Iterator<E> iterator(){
+        Queue<Iterator<E>> iterators=new LinkedList<>();
+        for(Iterable<E> iterable : iterables){
+            iterators.add(iterable.iterator());
+        }
+
+        return new ConcatenatedIterator<>(iterators);
+    }
+
+    private static class ConcatenatedIterator<E> implements Iterator<E>{
+        private final Queue<Iterator<E>> iterators;
+        private Iterator<E> currentIterator;
+
+        ConcatenatedIterator(Queue<Iterator<E>> iterators){
+            this.iterators=iterators;
+        }
+
+        @Override
+        public boolean hasNext(){
+            while(currentIterator==null || !currentIterator.hasNext()){
+                currentIterator=iterators.poll();
+                if(currentIterator==null) return false;
+            }
+            return true;
+        }
+
+        @Override
+        public E next(){
+            if(!hasNext()) throw new NoSuchElementException();
+            return currentIterator.next();
+        }
+
+        @Override
+        public void remove(){
+            throw new UnsupportedOperationException("Removes not supported");
+        }
+    }
+}
+


### PR DESCRIPTION
The implementation of cogrouping was (accidentally?) recursive: it
created a wrapper Iterable around each pair of iterables, resulting in a
wrapper Iterable around each row on the left-hand side. If you get
enough such rows, you'll blow off with a StackOverflowError
(SPLICE-836).

This removes the recursive implementation and uses an iterative approach
instead by flattening out the excess Iterables and using just a single
while() loop. This should have the added benefit of reducing extraneous
object creation, reducing memory overhead and improving performance (in
a pretty small way, to be sure, but still).