### PR TITLE
SPLICE-848 Fixing tests that used text as column name now that it is …

### DIFF
--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SortOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SortOperationIT.java
@@ -47,7 +47,7 @@ public class SortOperationIT extends SpliceUnitTest {
 	protected static SpliceTableWatcher spliceTableWatcher1 = new SpliceTableWatcher(TABLE_NAME_1,CLASS_NAME,"(name varchar(255),value1 varchar(255),value2 varchar(255))");
 	protected static SpliceTableWatcher spliceTableWatcher2 = new SpliceTableWatcher(TABLE_NAME_2,CLASS_NAME,"(name varchar(255), age float,created_time timestamp)");
 	protected static SpliceTableWatcher spliceTableWatcher3 = new SpliceTableWatcher(TABLE_NAME_3,CLASS_NAME,"(col boolean)");
-	protected static SpliceTableWatcher spliceTableWatcher4 = new SpliceTableWatcher(TABLE_NAME_4,CLASS_NAME,"(id int, text char(20))");
+	protected static SpliceTableWatcher spliceTableWatcher4 = new SpliceTableWatcher(TABLE_NAME_4,CLASS_NAME,"(id int, text2 char(20))");
 	protected static SpliceTableWatcher spliceTableWatcher5 = new SpliceTableWatcher(TABLE_NAME_5,CLASS_NAME,"(id int)");
 	protected static SpliceTableWatcher spliceTableWatcher6 = new SpliceTableWatcher(TABLE_NAME_6,CLASS_NAME,"(id int)");
 
@@ -73,8 +73,8 @@ public class SortOperationIT extends SpliceUnitTest {
 				spliceClassWatcher.executeUpdate(format("insert into %s.%s values (2,'d2w')",CLASS_NAME,TABLE_NAME_4));
 				spliceClassWatcher.executeUpdate(format("insert into %s.%s(id) values (3)",CLASS_NAME,TABLE_NAME_4));
 					spliceClassWatcher.executeUpdate(format("insert into %s.%s(id) values (4)",CLASS_NAME,TABLE_NAME_4));
-				spliceClassWatcher.executeUpdate(format("insert into %s.%s(text) values ('4')",CLASS_NAME,TABLE_NAME_4));
-				spliceClassWatcher.executeUpdate(format("insert into %s.%s(text) values ('45')",CLASS_NAME,TABLE_NAME_4));
+				spliceClassWatcher.executeUpdate(format("insert into %s.%s(text2) values ('4')",CLASS_NAME,TABLE_NAME_4));
+				spliceClassWatcher.executeUpdate(format("insert into %s.%s(text2) values ('45')",CLASS_NAME,TABLE_NAME_4));
 
 
 				Triplet triple = new Triplet("jzhang","pickles","greens");
@@ -509,16 +509,16 @@ public class SortOperationIT extends SpliceUnitTest {
 
 	@Test
 	public void testNullsFirstPartial() throws Exception {
-		ResultSet rs = methodWatcher.executeQuery(format("select text, id from %s.%s order by id nulls first,text",CLASS_NAME,TABLE_NAME_4));
-		String test = "TEXT | ID  |\n" +
-				"------------\n" +
-				"  4  |NULL |\n" +
-				" 45  |NULL |\n" +
-				"NULL |  3  |\n" +
-				"NULL |  4  |\n" +
-				" d2w |  1  |\n" +
-				" d2w |  2  |\n" +
-				" dw  |  1  |";
+		ResultSet rs = methodWatcher.executeQuery(format("select text2, id from %s.%s order by id nulls first,text2",CLASS_NAME,TABLE_NAME_4));
+		String test = "TEXT2 | ID  |\n" +
+				"--------------\n" +
+				"   4   |NULL |\n" +
+				"  45   |NULL |\n" +
+				" NULL  |  3  |\n" +
+				" NULL  |  4  |\n" +
+				"  d2w  |  1  |\n" +
+				"  d2w  |  2  |\n" +
+				"  dw   |  1  |";
 		assertEquals(test, TestUtils.FormattedResult.ResultFactory.toString(rs));
 	}
 

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Row_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Row_IT.java
@@ -77,7 +77,7 @@ public class Trigger_Row_IT {
         Connection c = classWatcher.createConnection();
         try(Statement s = c.createStatement()){
             s.executeUpdate("create table T (a int, b int, c int)");
-            s.executeUpdate("create table RECORD (text varchar(99))");
+            s.executeUpdate("create table RECORD (text2 varchar(99))");
             s.executeUpdate("insert into T values(1,1,1),(2,2,2),(3,3,3),(4,4,4),(5,5,5),(6,6,6)");
         }
     }
@@ -240,8 +240,8 @@ public class Trigger_Row_IT {
             s.executeUpdate("create table T3391 (a bigint primary key, b bigint unique, c bigint)");
             s.executeUpdate("insert into T3391 values(1,1,1),(2,2,2)");
             s.executeUpdate("insert into RECORD values('aaa'), ('bbb')");
-            createTrigger(tb.named("t3391a").after().delete().on("T3391").row().then("delete from RECORD where text='aaa'"));
-            createTrigger(tb.named("t3391b").after().delete().on("T3391").row().then("delete from RECORD where text='bbb'"));
+            createTrigger(tb.named("t3391a").after().delete().on("T3391").row().then("delete from RECORD where text2='aaa'"));
+            createTrigger(tb.named("t3391b").after().delete().on("T3391").row().then("delete from RECORD where text2='bbb'"));
             assertRecordCount(s,"aaa",1);
             assertRecordCount(s,"bbb",1);
 
@@ -471,7 +471,7 @@ public class Trigger_Row_IT {
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     private void assertRecordCount(Statement s,String tag,long expectedCount) throws Exception {
-        long actualCount = StatementUtils.onlyLong(s, "select count(*) from RECORD where text='" + tag + "'");
+        long actualCount = StatementUtils.onlyLong(s, "select count(*) from RECORD where text2='" + tag + "'");
         assertEquals("Didn't find expected number of rows:", expectedCount, actualCount);
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Statement_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Statement_IT.java
@@ -74,7 +74,7 @@ public class Trigger_Statement_IT {
     @BeforeClass
     public static void createSharedTables() throws Exception {
         classWatcher.executeUpdate("create table T (a int, b int, c int)");
-        classWatcher.executeUpdate("create table RECORD (text varchar(99))");
+        classWatcher.executeUpdate("create table RECORD (text2 varchar(99))");
     }
 
     @Before
@@ -100,14 +100,14 @@ public class Trigger_Statement_IT {
         // when - update
         methodWatcher.executeUpdate("update T set b = b * 2 where a <= 4");
         // then - verify trigger has fired
-        Assert.assertEquals(1L,methodWatcher.query("select count(*) from RECORD where text = 'update'"));
+        Assert.assertEquals(1L,methodWatcher.query("select count(*) from RECORD where text2 = 'update'"));
 
         // when -- update twice more
         methodWatcher.executeUpdate("update T set b = b * 2 where a <= 2");
         methodWatcher.executeUpdate("update T set b = b * 2 where a <= 2");
 
         // then - verify trigger has fired twice more
-        Assert.assertEquals(3L,methodWatcher.query("select count(*) from RECORD where text = 'update'"));
+        Assert.assertEquals(3L,methodWatcher.query("select count(*) from RECORD where text2 = 'update'"));
     }
 
     /* When an update succeeds but the trigger action fails then the changes from the triggering statement should be rolled back. */
@@ -139,7 +139,7 @@ public class Trigger_Statement_IT {
         }
 
         // then - verify trigger has fired
-        Assert.assertEquals(32L,methodWatcher.query("select count(*) from RECORD where text = 'update'"));
+        Assert.assertEquals(32L,methodWatcher.query("select count(*) from RECORD where text2 = 'update'"));
     }
 
     /* Trigger on subset of columns */
@@ -150,13 +150,13 @@ public class Trigger_Statement_IT {
         // when - update
         methodWatcher.executeUpdate("update T set a = a * 2");
         // then - verify trigger has fired
-        Assert.assertEquals(0L,methodWatcher.query("select count(*) from RECORD where text = 'update'"));
+        Assert.assertEquals(0L,methodWatcher.query("select count(*) from RECORD where text2 = 'update'"));
 
         // when -- update twice more
         methodWatcher.executeUpdate("update T set b = b * 2");
-        Assert.assertEquals(1L,methodWatcher.query("select count(*) from RECORD where text = 'update'"));
+        Assert.assertEquals(1L,methodWatcher.query("select count(*) from RECORD where text2 = 'update'"));
         methodWatcher.executeUpdate("update T set c = c * 2");
-        Assert.assertEquals(2L,methodWatcher.query("select count(*) from RECORD where text = 'update'"));
+        Assert.assertEquals(2L,methodWatcher.query("select count(*) from RECORD where text2 = 'update'"));
     }
 
     @Test
@@ -165,16 +165,16 @@ public class Trigger_Statement_IT {
 
         // one insert
         methodWatcher.executeUpdate("insert into T select * from T");
-        Assert.assertEquals(1L,methodWatcher.query("select count(*) from RECORD where text='insert'"));
+        Assert.assertEquals(1L,methodWatcher.query("select count(*) from RECORD where text2='insert'"));
 
         // two more inserts
         methodWatcher.executeUpdate("insert into T select * from T");
         methodWatcher.executeUpdate("insert into T select * from T");
-        Assert.assertEquals(3L,methodWatcher.query("select count(*) from RECORD where text='insert'"));
+        Assert.assertEquals(3L,methodWatcher.query("select count(*) from RECORD where text2='insert'"));
 
         // Insert VALUES - a special case in splice at the time of writing, different code is executed.
         methodWatcher.executeUpdate("insert into T values (1,1,1),(2,2,2),(3,3,3)");
-        Assert.assertEquals(4L,methodWatcher.query("select count(*) from RECORD where text='insert'"));
+        Assert.assertEquals(4L,methodWatcher.query("select count(*) from RECORD where text2='insert'"));
     }
 
     @Test
@@ -186,8 +186,8 @@ public class Trigger_Statement_IT {
 
         // one insert
         methodWatcher.executeUpdate("insert into T select * from T");
-        Assert.assertEquals(1L,methodWatcher.query("select count(*) from RECORD where text='insert01'"));
-        Assert.assertEquals(1L,methodWatcher.query("select count(*) from RECORD where text='insert02'"));
+        Assert.assertEquals(1L,methodWatcher.query("select count(*) from RECORD where text2='insert01'"));
+        Assert.assertEquals(1L,methodWatcher.query("select count(*) from RECORD where text2='insert02'"));
     }
 
     @Test
@@ -196,11 +196,11 @@ public class Trigger_Statement_IT {
 
         // trigger fires on single delete
         methodWatcher.executeUpdate("delete from T where a = 4");
-        Assert.assertEquals(1L,methodWatcher.query("select count(*) from RECORD where text = 'delete'"));
+        Assert.assertEquals(1L,methodWatcher.query("select count(*) from RECORD where text2 = 'delete'"));
 
         // delete two rows, trigger still fires once
         methodWatcher.executeUpdate("delete from T where a = 5 or a = 6");
-        Assert.assertEquals(2L,methodWatcher.query("select count(*) from RECORD where text = 'delete'"));
+        Assert.assertEquals(2L,methodWatcher.query("select count(*) from RECORD where text2 = 'delete'"));
     }
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Fixing failing tests.  _Text_ is now a reserved keyword.  As a reminder, this is so Spark Integration works with create table foo (col1 text);