### PR TITLE
2.0 version of SPLICE-856 fix

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
@@ -357,6 +357,7 @@ public class StatisticsAdmin extends BaseAdminProcedures {
 
     private static DataScan createScan (TxnView txn) {
         DataScan scan=SIDriver.driver().getOperationFactory().newDataScan(txn);
+        scan.returnAllVersions(); //make sure that we read all versions of the data
         return scan.startKey(new byte[0]).stopKey(new byte[0]);
     }
 


### PR DESCRIPTION
This is the 2.0 version of SPLICE-856. 

Updates push multiple versions into a cell. When scanning, HBase
defaults to only scanning a single version of the cell. Thus, if you do
an update, you have to make sure that any subsequent scans are using
non-default hbase behavior (i.e. reading all versions). There is a
method on DataScan to provide this, but statistics collection was not
calling it. This resulted in statistics collections only reading the
updates, and not the underlying insertions (or past updates), instead of
constructing the entire row.

This corrects that issue, and adds an IT for verification. Note that the
IT would only fail in the HBase architecture, as the memory architecture
ignores version limits.