### PR TITLE
SPLICE-859 Having System Tables Compact Outside of Spark Since we Loo…

### DIFF
--- a/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
+++ b/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
@@ -82,7 +82,7 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
 
     @Override
     public List<Path> compact(CompactionRequest request, CompactionThroughputController compactionThroughputController, User user) throws IOException {
-        if(!allowSpark)
+        if(!allowSpark || store.getRegionInfo().isSystemTable())
             return super.compact(request,compactionThroughputController,user);
         if (LOG.isTraceEnabled())
             SpliceLogUtils.trace(LOG, "compact(): request=%s", request);


### PR DESCRIPTION
The UI lookup for the region location causes compaction to fail for the meta table since it cannot perform a meta lookup on itself.  This is a catastrophic failure during splits of meta.