### PR TITLE
Splice 726 - More Efficient Cutpoints for Spark

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/hbase/BytesCopyTaskSplitter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/BytesCopyTaskSplitter.java
@@ -28,32 +28,12 @@ import java.util.*;
  *         Date: 4/16/14
  */
 public class BytesCopyTaskSplitter {
-    private final HRegion region;
-    public BytesCopyTaskSplitter(HRegion region) {
-        this.region = region;
-    }
-
-    public Collection<SizedInterval> split(byte[] taskStart, byte[] taskStop) throws IOException {
-        List<byte[]> splits = getCutPoints(region, taskStart, taskStop);
-        List<SizedInterval> intervals =new ArrayList<>();
-        int length = splits.size();
-        if (length == 0)
-            return Collections.singletonList(new SizedInterval(taskStart,taskStop,0));
-        intervals.add(new SizedInterval(taskStart,splits.get(0),0));
-        for (int i=1; i < length; i++) {
-            //assert Bytes.compareTo(splits.get(i), splits.get(i-1)) > 0;
-            intervals.add(new SizedInterval(splits.get(i-1),splits.get(i),0));
-        }
-        intervals.add(new SizedInterval(splits.get(length-1),taskStop,0));
-        return intervals;
-    }
-
-    public static List<byte[]> getCutPoints(HRegion region, byte[] start, byte[] end) throws IOException {
+    public static List<byte[]> getCutPoints(HRegion region, byte[] start, byte[] end,byte[] expectedRegionEnd) throws IOException {
         Store store = null;
         try {
             store = region.getStore(SIConstants.DEFAULT_FAMILY_BYTES);
             HRegionUtil.lockStore(store);
-            return HRegionUtil.getCutpoints(store, start, end);
+            return HRegionUtil.getCutpoints(store, start, end, expectedRegionEnd);
         }catch (Throwable t) {
             throw Exceptions.getIOException(t);
         }finally{

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/RegionSizeEndpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/RegionSizeEndpoint.java
@@ -68,7 +68,9 @@ public class RegionSizeEndpoint extends SpliceMessage.SpliceDerbyCoprocessorServ
         try {
             ByteString beginKey = request.getBeginKey();
             ByteString endKey = request.getEndKey();
-            List<byte[]> splits = computeSplits(region, beginKey.toByteArray(), endKey.toByteArray());
+            ByteString expectedEndKey = request.getRegionEndKey();
+            List<byte[]> splits = computeSplits(region, beginKey.toByteArray(), endKey.toByteArray(), expectedEndKey.toByteArray());
+
             if (LOG.isDebugEnabled())
                 SpliceLogUtils.debug(LOG,"computeSplits with beginKey=%s, endKey=%s, numberOfSplits=%s",beginKey,endKey,splits.size());
             for (byte[] split : splits)
@@ -95,8 +97,8 @@ public class RegionSizeEndpoint extends SpliceMessage.SpliceDerbyCoprocessorServ
 
     /* ****************************************************************************************************************/
     /*private helper methods*/
-    private static List<byte[]> computeSplits(HRegion region, byte[] beginKey, byte[] endKey) throws IOException {
-        return BytesCopyTaskSplitter.getCutPoints(region, beginKey, endKey);
+    private static List<byte[]> computeSplits(HRegion region, byte[] beginKey, byte[] endKey, byte[] expectedRegionEnd) throws IOException {
+        return BytesCopyTaskSplitter.getCutPoints(region, beginKey, endKey, expectedRegionEnd);
     }
 
     /**

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/AbstractSMInputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/AbstractSMInputFormat.java
@@ -103,7 +103,8 @@ public abstract class AbstractSMInputFormat<K,V> extends InputFormat<K, V> imple
                     }
                 }
                 SubregionSplitter splitter = new HBaseSubregionSplitter();
-                List<InputSplit> results = splitter.getSubSplits(table, splits);
+                List<InputSplit> results = splitter.getSubSplits(table, splits, s.getStartRow(), s.getStopRow());
+
                 return results;
             } catch (HMissedSplitException e) {
                 // retry;

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/HBaseSubregionSplitter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/HBaseSubregionSplitter.java
@@ -16,6 +16,7 @@
 package com.splicemachine.mrio.api.core;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.ZeroCopyLiteralByteString;
 import com.splicemachine.access.HConfiguration;
 import com.splicemachine.access.hbase.HBaseTableInfoFactory;
 import com.splicemachine.coprocessor.SpliceMessage;
@@ -43,7 +44,7 @@ import java.util.Map;
 public class HBaseSubregionSplitter implements SubregionSplitter{
     private static final Logger LOG = Logger.getLogger(HBaseSubregionSplitter.class);
     @Override
-    public List<InputSplit> getSubSplits(Table table, List<Partition> splits) throws HMissedSplitException {
+    public List<InputSplit> getSubSplits(Table table, List<Partition> splits, final byte[] scanStartRow, final byte[] scanStopRow) throws HMissedSplitException {
         List<InputSplit> results = new ArrayList<>();
         final HBaseTableInfoFactory infoFactory = HBaseTableInfoFactory.getInstance(HConfiguration.getConfiguration());
         for (final Partition split : splits) {
@@ -67,11 +68,16 @@ public class HBaseSubregionSplitter implements SubregionSplitter{
                                 byte[] stopKey = split.getEndKey();
 
                                 if (LOG.isDebugEnabled()) {
-                                    LOG.debug(String.format("Original split [%s,%s]", CellUtils.toHex(startKey), CellUtils.toHex(stopKey)));
+                                    LOG.debug(String.format("Original split [%s,%s] with scan [%s,%s]",
+                                            CellUtils.toHex(startKey), CellUtils.toHex(stopKey),
+                                            CellUtils.toHex(scanStartRow), CellUtils.toHex(scanStopRow)));
+
                                 }
 
                                 SpliceMessage.SpliceSplitServiceRequest message = SpliceMessage.SpliceSplitServiceRequest.newBuilder()
-                                        .setBeginKey(ByteString.copyFrom(startKey)).setEndKey(ByteString.copyFrom(stopKey)).build();
+                                        .setBeginKey(ZeroCopyLiteralByteString.wrap(scanStartRow))
+                                        .setEndKey(ZeroCopyLiteralByteString.wrap(scanStopRow))
+                                        .setRegionEndKey(ZeroCopyLiteralByteString.wrap(stopKey)).build();
 
                                 BlockingRpcCallback<SpliceMessage.SpliceSplitServiceResponse> rpcCallback = new BlockingRpcCallback<>();
                                 instance.computeSplits(controller, message, rpcCallback);

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMRecordReaderImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMRecordReaderImpl.java
@@ -27,6 +27,7 @@ import com.splicemachine.derby.stream.ActivationHolder;
 import com.splicemachine.derby.stream.spark.SparkOperationContext;
 import com.splicemachine.metrics.Metrics;
 import com.splicemachine.mrio.MRConstants;
+import com.splicemachine.primitives.Bytes;
 import com.splicemachine.si.api.server.TransactionalRegion;
 import com.splicemachine.si.api.txn.Txn;
 import com.splicemachine.si.api.txn.TxnView;
@@ -88,11 +89,20 @@ public class SMRecordReaderImpl extends RecordReader<RowLocation, ExecRow> {
 				SpliceLogUtils.trace(LOG, "config loaded builder=%s",builder);
 			TableSplit tSplit = ((SMSplit)split).getSplit();
 			DataScan scan = builder.getScan();
-			scan.startKey(tSplit.getStartRow()).stopKey(tSplit.getEndRow());
+			if (Bytes.startComparator.compare(scan.getStartKey(), tSplit.getStartRow()) < 0) {
+				// the split itself is more restrictive
+				scan.startKey(tSplit.getStartRow());
+			}
+			if (Bytes.endComparator.compare(scan.getStopKey(), tSplit.getEndRow()) > 0) {
+				// the split itself is more restrictive
+				scan.stopKey(tSplit.getEndRow());
+			}
+
             this.scan = ((HScan)scan).unwrapDelegate();
             // TODO (wjk): this seems weird (added with DB-4483)
             this.statisticsRun = AbstractSMInputFormat.oneSplitPerRegion(config);
-            restart(tSplit.getStartRow());
+			restart(scan.getStartKey());
+
             SparkOperationContext operationContext = (SparkOperationContext)builder.getOperationContext();
             if (operationContext != null) {
                 activationHolder = operationContext.getActivationHolder();

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SubregionSplitter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SubregionSplitter.java
@@ -27,5 +27,5 @@ import java.util.List;
  * Used to compute a list of splits for a given table smaller than regions
  */
 public interface SubregionSplitter {
-    List<InputSplit> getSubSplits(Table table, List<Partition> splits) throws HMissedSplitException;
+    List<InputSplit> getSubSplits(Table table, List<Partition> splits, byte[] startRow, byte[] stopRow) throws HMissedSplitException;
 }

--- a/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionUtil.java
+++ b/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionUtil.java
@@ -68,7 +68,7 @@ public class HRegionUtil extends BaseHRegionUtil{
         HBasePlatformUtils.updateReadRequests(region,numReads);
     }
 
-    public static List<byte[]> getCutpoints(Store store, byte[] start, byte[] end) throws IOException {
+    public static List<byte[]> getCutpoints(Store store, byte[] start, byte[] end, byte[] expectedRegionEnd) throws IOException {
         assert Bytes.compareTo(start, end) <= 0 || start.length == 0 || end.length == 0;
         if (LOG.isTraceEnabled())
             SpliceLogUtils.trace(LOG, "getCutpoints");
@@ -81,8 +81,8 @@ public class HRegionUtil extends BaseHRegionUtil{
         byte[] regionStart = store.getRegionInfo().getStartKey();
         byte[] regionEnd = store.getRegionInfo().getEndKey();
 
-        if ((end.length == 0 && regionEnd.length != 0)
-            || Bytes.compareTo(end, regionEnd) > 0) {
+        if ((expectedRegionEnd.length == 0 && regionEnd.length != 0)
+                || Bytes.compareTo(expectedRegionEnd, regionEnd) > 0) {
             throw new HMissedSplitException("Subplit computation missed region split");
         }
 

--- a/splice_protocol/src/main/protobuf/Splice.proto
+++ b/splice_protocol/src/main/protobuf/Splice.proto
@@ -142,6 +142,7 @@ service SpliceDerbyCoprocessorService {
 message SpliceSplitServiceRequest {
     optional bytes beginKey = 1;
     optional bytes endKey = 2;
+    optional bytes regionEndKey = 3;
 }
 
 message SpliceSplitServiceResponse {


### PR DESCRIPTION
Currently, spark would scan the entire Region even on a small range scan.  Daniel worked on this a while back but introduced a bug by throwing exceptions where a retry was needed.  Nice work Daniel...  