### PR TITLE
DB-5550 - removing unused parameter from SpliceSpark default config

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
@@ -146,7 +146,6 @@ public class SpliceSpark {
             Application Properties
          */
         conf.set("spark.app.name", System.getProperty("splice.spark.app.name", "SpliceMachine"));
-        conf.set("spark.driver.cores",System.getProperty("splice.spark.driver.cores", "8"));
         conf.set("spark.driver.maxResultSize", System.getProperty("splice.spark.driver.maxResultSize", "1g"));
         conf.set("spark.driver.memory", System.getProperty("splice.spark.driver.memory", "1g"));
         conf.set("spark.executor.memory", System.getProperty("splice.spark.executor.memory", "2g"));


### PR DESCRIPTION
this parameter is only applicable for "cluster" modes, we run in yarn-client mode. 