### PR TITLE
SPLICE-868: Correcting Race condition around splits.

### DIFF
--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/SpliceIndexEndpoint.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/SpliceIndexEndpoint.java
@@ -42,8 +42,10 @@ import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.hbase.Coprocessor;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.coprocessor.CoprocessorService;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.regionserver.RegionServerServices;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.log4j.Logger;
 
@@ -57,21 +59,20 @@ import java.io.IOException;
  * @author Scott Fines
  *         Created on: 3/11/13
  */
-public class SpliceIndexEndpoint extends SpliceMessage.SpliceIndexService implements BatchProtocol,Coprocessor, IndexEndpoint{
+public class SpliceIndexEndpoint extends SpliceMessage.SpliceIndexService implements CoprocessorService,Coprocessor{
     private static final Logger LOG=Logger.getLogger(SpliceIndexEndpoint.class);
 
     private PartitionWritePipeline writePipeline;
     private PipelineWriter pipelineWriter;
     private PipelineCompressor compressor;
+
     private volatile PipelineLoadService<TableName> service;
-
-
 
     @Override
     @SuppressWarnings("unchecked")
     public void start(final CoprocessorEnvironment env) throws IOException{
         RegionCoprocessorEnvironment rce=((RegionCoprocessorEnvironment)env);
-        final ServerControl serverControl=new RegionServerControl((HRegion) rce.getRegion());
+        final ServerControl serverControl=new RegionServerControl((HRegion) rce.getRegion(),rce.getRegionServerServices());
 
         String tableName=rce.getRegion().getTableDesc().getTableName().getQualifierAsString();
         TableType table=EnvUtils.getTableType(HConfiguration.getConfiguration(),(RegionCoprocessorEnvironment)env);
@@ -126,7 +127,7 @@ public class SpliceIndexEndpoint extends SpliceMessage.SpliceIndexService implem
         }
     }
 
-    @Override
+//    @Override
     public SpliceIndexEndpoint getBaseIndexEndpoint(){
         return this;
     }
@@ -168,12 +169,12 @@ public class SpliceIndexEndpoint extends SpliceMessage.SpliceIndexService implem
             }
     }
 
-    @Override
+//    @Override
     public BulkWritesResult bulkWrite(BulkWrites bulkWrites) throws IOException{
         return pipelineWriter.bulkWrite(bulkWrites);
     }
 
-    @Override
+//    @Override
     public byte[] bulkWrites(byte[] bulkWriteBytes) throws IOException{
         assert bulkWriteBytes!=null;
         BulkWrites bulkWrites=compressor.decompress(bulkWriteBytes,BulkWrites.class);

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/SpliceIndexObserver.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/SpliceIndexObserver.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.regionserver.RegionCoprocessorHost;
+import org.apache.hadoop.hbase.regionserver.RegionServerServices;
 import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.log4j.Logger;
@@ -93,7 +94,7 @@ public class SpliceIndexObserver extends BaseRegionObserver {
 
         final long cId = conglomId;
         final RegionPartition baseRegion=new RegionPartition((HRegion)rce.getRegion());
-        ServerControl sc = new RegionServerControl((HRegion)rce.getRegion());
+        ServerControl sc = new RegionServerControl((HRegion)rce.getRegion(),rce.getRegionServerServices());
         try{
             if(service==null){
                 service=new PipelineLoadService<TableName>(sc,baseRegion,cId){

--- a/hbase_pipeline/src/test/java/com/splicemachine/pipeline/testsetup/HPipelineTestEnv.java
+++ b/hbase_pipeline/src/test/java/com/splicemachine/pipeline/testsetup/HPipelineTestEnv.java
@@ -31,8 +31,6 @@ import com.splicemachine.derby.hbase.SpliceIndexObserver;
 import org.apache.log4j.Level;
 
 import java.io.IOException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * @author Scott Fines
@@ -50,6 +48,7 @@ public class HPipelineTestEnv extends HBaseSITestEnv implements PipelineTestEnv{
             }
         };
         ContextFactoryDriverService.setDriver(ctxFactoryLoader);
+        //pass in rsServices = null because we don't need the extra safety for these tests
         this.env = HBasePipelineEnvironment.loadEnvironment(super.getClock(),ctxFactoryLoader);
         DatabaseLifecycleManager.manager().start(); //start the database
     }

--- a/hbase_sql/src/main/java/com/splicemachine/compactions/PoolSlotBooker.java
+++ b/hbase_sql/src/main/java/com/splicemachine/compactions/PoolSlotBooker.java
@@ -53,7 +53,13 @@ public class PoolSlotBooker implements Runnable {
     @Override
     public void run() {
         try {
-            DistributedDataSetProcessor dsp = EngineDriver.driver().processorFactory().distributedProcessor();
+            EngineDriver driver=EngineDriver.driver();
+            /*
+             * If the driver is null, then we haven't finished booting yet. This means that we can't really
+             * get access to the distributed processor either (since it isn't alive yet)
+             */
+            if(driver==null) return;
+            DistributedDataSetProcessor dsp = driver.processorFactory().distributedProcessor();
             dsp.setJobGroup(group + "-" + counter++, "Ignore, reserved slot for " + pool);
             dsp.setSchedulerPool(pool);
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
@@ -91,6 +91,7 @@ public class SpliceSpark {
                 //boot the pipeline components
                 final Clock clock = driver.getClock();
                 ContextFactoryDriver cfDriver =ContextFactoryDriverService.loadDriver();
+                //we specify rsServices = null here because we don't actually use the receiving side of the Pipeline environment
                 HBasePipelineEnvironment pipelineEnv=HBasePipelineEnvironment.loadEnvironment(clock,cfDriver);
                 PipelineDriver.loadDriver(pipelineEnv);
                 HBaseRegionLoads.INSTANCE.startWatching();

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/TxnLifecycleEndpoint.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/TxnLifecycleEndpoint.java
@@ -71,10 +71,11 @@ public class TxnLifecycleEndpoint extends TxnMessage.TxnLifecycleService impleme
 
     @Override
     public void start(CoprocessorEnvironment env) throws IOException{
-        HRegion region=(HRegion)((RegionCoprocessorEnvironment)env).getRegion();
+        RegionCoprocessorEnvironment rce=(RegionCoprocessorEnvironment)env;
+        HRegion region=(HRegion)rce.getRegion();
         HBaseSIEnvironment siEnv = HBaseSIEnvironment.loadEnvironment(new SystemClock(),ZkUtils.getRecoverableZooKeeper());
         SConfiguration configuration=siEnv.configuration();
-        TableType table=EnvUtils.getTableType(configuration,(RegionCoprocessorEnvironment)env);
+        TableType table=EnvUtils.getTableType(configuration,rce);
         if(table.equals(TableType.TRANSACTION_TABLE)){
             TransactionResolver resolver=resolverRef.get();
             SIDriver driver=siEnv.getSIDriver();
@@ -88,7 +89,7 @@ public class TxnLifecycleEndpoint extends TxnMessage.TxnLifecycleService impleme
             TimestampSource timestampSource=driver.getTimestampSource();
             int txnLockStrips = configuration.getTransactionLockStripes();
             lifecycleStore = new StripedTxnLifecycleStore(txnLockStrips,regionStore,
-                    new RegionServerControl(region),timestampSource);
+                    new RegionServerControl(region,rce.getRegionServerServices()),timestampSource);
             isTxnTable=true;
         }
     }

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/region/RegionServerControl.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/region/RegionServerControl.java
@@ -20,6 +20,7 @@ import org.apache.hadoop.hbase.ipc.CallerDisconnectedException;
 import org.apache.hadoop.hbase.ipc.RpcCallContext;
 import org.apache.hadoop.hbase.ipc.RpcServer;
 import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.RegionServerServices;
 
 import java.io.IOException;
 
@@ -28,11 +29,13 @@ import java.io.IOException;
  *         Date: 12/14/15
  */
 public class RegionServerControl implements ServerControl{
+    private final RegionServerServices rsServices;
     private final HRegion region;
     private String regionNameAsString;
 
-    public RegionServerControl(HRegion region){
+    public RegionServerControl(HRegion region,RegionServerServices rsServices){
         this.region=region;
+        this.rsServices = rsServices;
         this.regionNameAsString = region.getRegionInfo().getRegionNameAsString();
     }
 
@@ -49,6 +52,11 @@ public class RegionServerControl implements ServerControl{
     @Override
     public void ensureNetworkOpen() throws IOException{
         checkCallerDisconnect(region,regionNameAsString);
+    }
+
+    @Override
+    public boolean isAvailable(){
+        return rsServices.getFromOnlineRegions(region.getRegionInfo().getEncodedName())!=null;
     }
 
     private static void checkCallerDisconnect(HRegion region, String task) throws CallerDisconnectedException{

--- a/mem_pipeline/src/main/java/com/splicemachine/pipeline/MPipelineEnv.java
+++ b/mem_pipeline/src/main/java/com/splicemachine/pipeline/MPipelineEnv.java
@@ -23,6 +23,7 @@ import com.splicemachine.concurrent.Clock;
 import com.splicemachine.pipeline.api.BulkWriterFactory;
 import com.splicemachine.pipeline.api.PipelineExceptionFactory;
 import com.splicemachine.pipeline.api.PipelineMeter;
+import com.splicemachine.pipeline.api.WritePipelineFactory;
 import com.splicemachine.pipeline.context.NoOpPipelineMeter;
 import com.splicemachine.pipeline.contextfactory.ContextFactoryDriver;
 import com.splicemachine.pipeline.mem.DirectBulkWriterFactory;
@@ -54,6 +55,7 @@ public class MPipelineEnv  implements PipelineEnvironment{
     private SIEnvironment siEnv;
     private BulkWriterFactory writerFactory;
     private ContextFactoryDriver ctxFactoryDriver;
+    private final WritePipelineFactory pipelineFactory= new MappedPipelineFactory();
 
     public MPipelineEnv(SIEnvironment siEnv) throws IOException{
         super();
@@ -172,6 +174,11 @@ public class MPipelineEnv  implements PipelineEnvironment{
     @Override
     public PipelineMeter pipelineMeter(){
         return NoOpPipelineMeter.INSTANCE;
+    }
+
+    @Override
+    public WritePipelineFactory pipelineFactory(){
+        return pipelineFactory;
     }
 
     @Override

--- a/mem_storage/src/main/java/com/splicemachine/storage/MServerControl.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MServerControl.java
@@ -30,4 +30,9 @@ public class MServerControl implements ServerControl{
     @Override public void startOperation() throws IOException{ }
     @Override public void stopOperation() throws IOException{ }
     @Override public void ensureNetworkOpen() throws IOException{ }
+
+    @Override
+    public boolean isAvailable(){
+        return true;
+    }
 }

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/MappedPipelineFactory.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/MappedPipelineFactory.java
@@ -33,7 +33,8 @@ public class MappedPipelineFactory implements WritePipelineFactory{
         return map.get(partitionName);
     }
 
-    public PartitionWritePipeline registerPipeline(String name,PartitionWritePipeline pipelineWriter){
+    @Override
+    public void registerPipeline(String name,PartitionWritePipeline pipelineWriter){
         if(LOG.isDebugEnabled()){
             LOG.debug("Registering pipeline for region "+ name);
         }
@@ -41,9 +42,9 @@ public class MappedPipelineFactory implements WritePipelineFactory{
         if(LOG.isDebugEnabled() && partitionWritePipeline!=null){
             LOG.debug("Region "+ name+" was already registered");
         }
-        return partitionWritePipeline;
     }
 
+    @Override
     public void deregisterPipeline(String name){
         if(LOG.isDebugEnabled())
             LOG.debug("De-registering region "+ name);

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineDriver.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineDriver.java
@@ -32,6 +32,7 @@ import com.splicemachine.concurrent.Clock;
 import com.splicemachine.pipeline.api.BulkWriterFactory;
 import com.splicemachine.pipeline.api.PipelineExceptionFactory;
 import com.splicemachine.pipeline.api.PipelineMeter;
+import com.splicemachine.pipeline.api.WritePipelineFactory;
 import com.splicemachine.pipeline.client.WriteCoordinator;
 import com.splicemachine.pipeline.contextfactory.ContextFactoryDriver;
 import com.splicemachine.pipeline.contextfactory.ContextFactoryLoader;
@@ -48,7 +49,7 @@ public class PipelineDriver{
     private static PipelineDriver INSTANCE;
 
     private final SpliceWriteControl writeControl;
-    private final MappedPipelineFactory writePipelineFactory=new MappedPipelineFactory();
+    private final WritePipelineFactory writePipelineFactory;
     private final PipelineMeter pipelineMeter;
     private final PipelineWriter pipelineWriter;
     private final PipelineCompressor compressor;
@@ -66,8 +67,9 @@ public class PipelineDriver{
         PipelineCompressor compressor = env.pipelineCompressor();
         BulkWriterFactory writerFactory = env.writerFactory();
         PipelineMeter meter = env.pipelineMeter();
+        WritePipelineFactory pipelineFactory = env.pipelineFactory();
 
-        INSTANCE = new PipelineDriver(config,ctxFactoryDriver,pef,partitionFactory,compressor,writerFactory,meter,env.systemClock());
+        INSTANCE = new PipelineDriver(config,ctxFactoryDriver,pef,partitionFactory,compressor,writerFactory,pipelineFactory,meter,env.systemClock());
         writerFactory.setWriter(INSTANCE.pipelineWriter);
     }
 
@@ -79,12 +81,14 @@ public class PipelineDriver{
                            PartitionFactory partitionFactory,
                            PipelineCompressor compressor,
                            BulkWriterFactory channelFactory,
+                           WritePipelineFactory writePipelineFactory,
                            PipelineMeter meter,
                            Clock clock){
         this.ctxFactoryDriver = ctxFactoryDriver;
         this.pef = pef;
         this.compressor = compressor;
         this.pipelineMeter= meter;
+        this.writePipelineFactory = writePipelineFactory;
 
         int ipcThreads = config.getIpcThreads();
         int maxIndependentWrites = config.getMaxIndependentWrites();

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineEnvironment.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineEnvironment.java
@@ -18,6 +18,7 @@ package com.splicemachine.pipeline;
 import com.splicemachine.pipeline.api.BulkWriterFactory;
 import com.splicemachine.pipeline.api.PipelineExceptionFactory;
 import com.splicemachine.pipeline.api.PipelineMeter;
+import com.splicemachine.pipeline.api.WritePipelineFactory;
 import com.splicemachine.pipeline.contextfactory.ContextFactoryDriver;
 import com.splicemachine.pipeline.utils.PipelineCompressor;
 import com.splicemachine.si.impl.driver.SIEnvironment;
@@ -38,4 +39,6 @@ public interface PipelineEnvironment extends SIEnvironment{
     BulkWriterFactory writerFactory();
 
     PipelineMeter pipelineMeter();
+
+    WritePipelineFactory pipelineFactory();
 }

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineWriter.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineWriter.java
@@ -57,6 +57,7 @@ public class PipelineWriter{
         this.pipelineMeter = pipelineMeter;
     }
 
+
     public BulkWritesResult bulkWrite(@Nonnull BulkWrites bulkWrites) throws IOException{
         Collection<BulkWrite> bws = bulkWrites.getBulkWrites();
         int numBulkWrites = bulkWrites.getBulkWrites().size();
@@ -201,6 +202,15 @@ public class PipelineWriter{
         return writeCoordinator;
     }
 
+    public BulkWritesResult rejectAll(BulkWrites bulkWrites,WriteResult globalStatus) {
+        Collection<BulkWriteResult> results = new ArrayList<>(bulkWrites.numRegions());
+        for(int i=0;i<bulkWrites.numRegions();i++){
+            BulkWriteResult result=new BulkWriteResult();
+            result.setGlobalStatus(globalStatus);
+            results.add(result);
+        }
+        return new BulkWritesResult(results);
+    }
     /* ****************************************************************************************************************/
     /*private helper methods*/
     private void rejectAll(Collection<BulkWrite> writes, Collection<BulkWriteResult> result, Code status,String msg) {

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/api/WritePipelineFactory.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/api/WritePipelineFactory.java
@@ -24,4 +24,8 @@ import com.splicemachine.pipeline.PartitionWritePipeline;
 public interface WritePipelineFactory{
 
     PartitionWritePipeline getPipeline(String partitionName);
+
+    void registerPipeline(String name,PartitionWritePipeline writePipeline);
+
+    void deregisterPipeline(String partitionName);
 }

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/ServerControl.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/ServerControl.java
@@ -53,5 +53,15 @@ public interface ServerControl{
      */
     void ensureNetworkOpen() throws IOException;
 
-
+    /**
+     * Determine if we should treat the "server" as available or not. If true, then this server
+     * can be considered active and actions can be taken against it. If false, then actions should
+     * not be taken.
+     *
+     * This is particularly prevalent in systems where a "server" is differentiated by sub-units (such as with
+     * HBase, where a "server" is really a region + network layer).
+     *
+     * @return {@code true} if the server should be considered available, {@code false} otherwise.
+     */
+    boolean isAvailable();
 }

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/TxnRegion.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/TxnRegion.java
@@ -148,4 +148,9 @@ public class TxnRegion<InternalScanner> implements TransactionalRegion<InternalS
     public Partition unwrap(){
         return region;
     }
+
+    @Override
+    public String toString(){
+        return region.getName();
+    }
 }

--- a/splice_si_api/src/test/java/com/splicemachine/si/testenv/TestServerControl.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/testenv/TestServerControl.java
@@ -27,4 +27,9 @@ public class TestServerControl implements ServerControl{
     @Override public void startOperation() throws IOException{ }
     @Override public void stopOperation() throws IOException{ }
     @Override public void ensureNetworkOpen() throws IOException{ }
+
+    @Override
+    public boolean isAvailable(){
+        return true;
+    }
 }


### PR DESCRIPTION
It turns out that a Region is not to be considered "available" until it
is added to the HBase RegionServerServices, instead of when a
coprocessor start() is called. For most operations this doesn't matter,
because RegionServerServices is where the HBase network layer determines
if the Region is present or not; if you sent an operation to that region
and it wasn't in RegionServerServices, you'd get a
NotServingRegionException instead of allowing through an operation.

However, in the Write Pipeline we send writes to multiple regions
simultaneously in a single network call (if there's a network call at
all--in some cases we send the data directly to the same JVM where we
are writing data). Therefore, we allow the possibility of bypassing the
network stack and its protections.

When operating outside the stack, there is a race condition around
splits where a daughter region starts all of its coprocessors up before
it is finished fully initializing (in fact, start() is called on all
coprocessors BEFORE preOpen() is called on any RegionObserver). This
means that we were allowing some writes to proceed to a daughter region
before it was fully opening, leading to a race condition and (in turn)
causing the abort sequence to occur.

This corrects that issue by requiring that the region be present in the
RegionServerServices before allowing a BulkWrite to proceed.

The awkward raciness of this prevents a decent IT; thankfully, Jenkins
will fail periodically with an ABORT message during builds if this
regresses, which will serve as a decent IT (since it breaks the build).