### PR TITLE
SPLICE-892: Correcting NPE during boot compactions.

### DIFF
--- a/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
+++ b/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
@@ -81,7 +81,8 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
 
     @Override
     public List<Path> compact(CompactionRequest request, CompactionThroughputController throughputController) throws IOException {
-        if(!allowSpark || store.getRegionInfo().isSystemTable())
+        EngineDriver driver = EngineDriver.driver();
+        if(!allowSpark || store.getRegionInfo().isSystemTable()|| driver==null)
             return super.compact(request, throughputController);
         if (LOG.isTraceEnabled())
             SpliceLogUtils.trace(LOG, "compact(): request=%s", request);
@@ -106,7 +107,7 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
                 getScope(request),
                 regionLocation);
         CompactionResult result = null;
-        Future<CompactionResult> futureResult = EngineDriver.driver().getOlapClient().submit(jobRequest);
+        Future<CompactionResult> futureResult = driver.getOlapClient().submit(jobRequest);
         SConfiguration config = HConfiguration.getConfiguration();
         while(result == null) {
             try {

--- a/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
+++ b/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
@@ -81,7 +81,8 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
 
     @Override
     public List<Path> compact(CompactionRequest request, CompactionThroughputController throughputController) throws IOException {
-        if(!allowSpark || store.getRegionInfo().isSystemTable())
+        EngineDriver driver = EngineDriver.driver();
+        if(!allowSpark || store.getRegionInfo().isSystemTable()|| driver==null)
             return super.compact(request, throughputController);
         if (LOG.isTraceEnabled())
             SpliceLogUtils.trace(LOG, "compact(): request=%s", request);
@@ -106,7 +107,7 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
                 getScope(request),
                 regionLocation);
         CompactionResult result = null;
-        Future<CompactionResult> futureResult = EngineDriver.driver().getOlapClient().submit(jobRequest);
+        Future<CompactionResult> futureResult = driver.getOlapClient().submit(jobRequest);
         SConfiguration config = HConfiguration.getConfiguration();
         while(result == null) {
             try {

--- a/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
+++ b/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
@@ -81,7 +81,8 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
 
     @Override
     public List<Path> compact(CompactionRequest request, CompactionThroughputController throughputController) throws IOException {
-        if(!allowSpark || store.getRegionInfo().isSystemTable())
+        EngineDriver driver = EngineDriver.driver();
+        if(!allowSpark || store.getRegionInfo().isSystemTable()|| driver==null)
             return super.compact(request, throughputController);
         if (LOG.isTraceEnabled())
             SpliceLogUtils.trace(LOG, "compact(): request=%s", request);
@@ -106,7 +107,7 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
                 getScope(request),
                 regionLocation);
         CompactionResult result = null;
-        Future<CompactionResult> futureResult = EngineDriver.driver().getOlapClient().submit(jobRequest);
+        Future<CompactionResult> futureResult = driver.getOlapClient().submit(jobRequest);
         SConfiguration config = HConfiguration.getConfiguration();
         while(result == null) {
             try {

--- a/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
+++ b/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
@@ -82,7 +82,8 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
 
     @Override
     public List<Path> compact(CompactionRequest request, CompactionThroughputController compactionThroughputController, User user) throws IOException {
-        if(!allowSpark || store.getRegionInfo().isSystemTable())
+        EngineDriver driver = EngineDriver.driver();
+        if(!allowSpark || store.getRegionInfo().isSystemTable()|| driver==null)
             return super.compact(request,compactionThroughputController,user);
         if (LOG.isTraceEnabled())
             SpliceLogUtils.trace(LOG, "compact(): request=%s", request);
@@ -107,7 +108,7 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
                 getScope(request),
                 regionLocation);
         CompactionResult result = null;
-        Future<CompactionResult> futureResult = EngineDriver.driver().getOlapClient().submit(jobRequest);
+        Future<CompactionResult> futureResult = driver.getOlapClient().submit(jobRequest);
         SConfiguration config = HConfiguration.getConfiguration();
         while(result == null) {
             try {


### PR DESCRIPTION
If the EngineDriver has not yet booted, then we can't use Spark for
compactions (because we don't know where the OlapServer is). This
ensures that we default back to HBase's default compaction strategy when
a compaction is requested during this time, rather than failing.