### PR TITLE
SPLICE-886 Don't wait indefinetely for subpartitions

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/HregionDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/HregionDataSetProcessor.java
@@ -69,7 +69,7 @@ public class HregionDataSetProcessor extends ControlDataSetProcessor {
                     SplitRegionScanner srs = new SplitRegionScanner(hscan,
                             ((ClientPartition)partition).unwrapDelegate(),
                             clock,
-                            partition);
+                            partition, driver.getConfiguration());
                     final HRegion hregion = srs.getRegion();
                     ExecRow template = SMSQLUtil.getExecRow(getExecRowTypeFormatIds());
                     spliceOperation.registerCloseable(new AutoCloseable() {

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMRecordReaderImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMRecordReaderImpl.java
@@ -27,6 +27,7 @@ import com.splicemachine.derby.stream.ActivationHolder;
 import com.splicemachine.derby.stream.spark.SparkOperationContext;
 import com.splicemachine.metrics.Metrics;
 import com.splicemachine.mrio.MRConstants;
+import com.splicemachine.primitives.Bytes;
 import com.splicemachine.si.api.server.TransactionalRegion;
 import com.splicemachine.si.api.txn.Txn;
 import com.splicemachine.si.api.txn.TxnView;
@@ -89,7 +90,7 @@ public class SMRecordReaderImpl extends RecordReader<RowLocation, ExecRow> {
 			TableSplit tSplit = ((SMSplit)split).getSplit();
 			DataScan scan = builder.getScan();
 			scan.startKey(tSplit.getStartRow()).stopKey(tSplit.getEndRow());
-            this.scan = ((HScan)scan).unwrapDelegate();
+            setScan(((HScan)scan).unwrapDelegate());
             // TODO (wjk): this seems weird (added with DB-4483)
             this.statisticsRun = AbstractSMInputFormat.oneSplitPerRegion(config);
             restart(tSplit.getStartRow());
@@ -178,6 +179,10 @@ public class SMRecordReaderImpl extends RecordReader<RowLocation, ExecRow> {
 	}
 	
 	public void setScan(Scan scan) {
+		if (Bytes.equals(scan.getStartRow(), scan.getStopRow()) && !Bytes.empty(scan.getStartRow()))
+			throw new IllegalArgumentException("Start/stop rows cannot be equal for scan " + scan.toString());
+		if (Bytes.startComparator.compare(scan.getStartRow(), scan.getStopRow()) < 0)
+			throw new IllegalArgumentException("Start row must come before stop row for scan " + scan.toString());
 		this.scan = scan;
 	}
 	
@@ -189,7 +194,7 @@ public class SMRecordReaderImpl extends RecordReader<RowLocation, ExecRow> {
 	public void restart(byte[] firstRow) throws IOException {		
 		Scan newscan = scan;
 		newscan.setStartRow(firstRow);
-        scan = newscan;
+        setScan(newscan);
 		if(htable != null) {
 			SIDriver driver=SIDriver.driver();
 
@@ -202,7 +207,9 @@ public class SMRecordReaderImpl extends RecordReader<RowLocation, ExecRow> {
 			SplitRegionScanner srs = new SplitRegionScanner(scan,
 					htable,
 					clock,
-                    clientPartition);
+					clientPartition,
+					driver.getConfiguration()
+			);
 			this.hregion = srs.getRegion();
 			this.mrs = srs;
 			ExecRow template = SMSQLUtil.getExecRow(builder.getExecRowTypeFormatIds());

--- a/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SplitRegionScannerIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SplitRegionScannerIT.java
@@ -34,14 +34,12 @@ import com.splicemachine.storage.SplitRegionScanner;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.log4j.Logger;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -160,7 +158,7 @@ public class SplitRegionScannerIT  extends BaseMRIOTest {
             Scan scan = new Scan(subPartition.getStartKey(),subPartition.getEndKey());
             SplitRegionScanner srs = new SplitRegionScanner(scan,
                     htable,
-                    clock,subPartition);
+                    clock,subPartition, driver.getConfiguration());
             while (srs.next(newCells)) {
                 i++;
                 simpleScan.add(CellUtils.toHex(newCells.get(0).getRow()));
@@ -185,7 +183,7 @@ public class SplitRegionScannerIT  extends BaseMRIOTest {
             Scan scan = new Scan(subPartition.getStartKey(),subPartition.getEndKey());
             SplitRegionScanner srs = new SplitRegionScanner(scan,
                     htable,
-                    clock,subPartition);
+                    clock,subPartition, driver.getConfiguration());
             while (srs.next(newCells)) {
                 i++;
                 newCells.clear();
@@ -210,7 +208,7 @@ public class SplitRegionScannerIT  extends BaseMRIOTest {
         Scan scan = new Scan();
         SplitRegionScanner srs = new SplitRegionScanner(scan,
                 htable,
-                clock,partition);
+                clock,partition, driver.getConfiguration());
         while (srs.next(newCells)) {
             i++;
             newCells.clear();
@@ -240,7 +238,7 @@ public class SplitRegionScannerIT  extends BaseMRIOTest {
             Scan scan = new Scan(subPartition.getStartKey(),subPartition.getEndKey());
             SplitRegionScanner srs = new SplitRegionScanner(scan,
                     htable,
-                    clock,subPartition);
+                    clock,subPartition, driver.getConfiguration());
             while (srs.next(newCells)) {
                 i++;
                 newCells.clear();
@@ -267,7 +265,7 @@ public class SplitRegionScannerIT  extends BaseMRIOTest {
             Scan scan = new Scan(subPartition.getStartKey(),subPartition.getEndKey());
             SplitRegionScanner srs = new SplitRegionScanner(scan,
                     htable,
-                    clock,subPartition);
+                    clock,subPartition, driver.getConfiguration());
             while (srs.next(newCells)) {
                 i++;
                 if (i==ITERATIONS/2)
@@ -296,7 +294,7 @@ public class SplitRegionScannerIT  extends BaseMRIOTest {
             Scan scan = new Scan(subPartition.getStartKey(),subPartition.getEndKey());
             SplitRegionScanner srs = new SplitRegionScanner(scan,
                     htable,
-                    clock,subPartition);
+                    clock,subPartition, driver.getConfiguration());
             while (srs.next(newCells)) {
                 i++;
                 if (i==ITERATIONS/2)
@@ -327,7 +325,7 @@ public class SplitRegionScannerIT  extends BaseMRIOTest {
             Scan scan = new Scan(subPartition.getStartKey(),subPartition.getEndKey());
             SplitRegionScanner srs = new SplitRegionScanner(scan,
                                                             htable,
-                                                            clock,subPartition);
+                                                            clock,subPartition, driver.getConfiguration());
             while (srs.next(newCells)) {
                 i++;
                 if (i==ITERATIONS/2) {
@@ -360,7 +358,7 @@ public class SplitRegionScannerIT  extends BaseMRIOTest {
             Scan scan = new Scan();
             SplitRegionScanner srs = new SplitRegionScanner(scan,
                     htable,
-                    clock,partition);
+                    clock,partition, driver.getConfiguration());
             while (srs.next(newCells)) {
                 i++;
                 if (i==ITERATIONS/2) {
@@ -392,7 +390,7 @@ public class SplitRegionScannerIT  extends BaseMRIOTest {
         Scan scan = new Scan();
         SplitRegionScanner srs = new SplitRegionScanner(scan,
                 htable,
-                clock,partition);
+                clock,partition, driver.getConfiguration());
         while (srs.next(newCells)) {
             i++;
             if (i==ITERATIONS/2) {
@@ -420,7 +418,7 @@ public class SplitRegionScannerIT  extends BaseMRIOTest {
 
             List<Cell> newCells = new ArrayList<>();
             Scan scan = new Scan();
-            SplitRegionScanner srs = new SplitRegionScanner(scan, htable, clock, partition);
+            SplitRegionScanner srs = new SplitRegionScanner(scan, htable, clock, partition, driver.getConfiguration());
             while (srs.next(newCells)) {
                 if (i++ == ITERATIONS / 2) {
                     // JL - TODO Now that we are blocking moves, this hangs.

--- a/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SplitRegionScannerStressIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SplitRegionScannerStressIT.java
@@ -42,7 +42,6 @@ import org.junit.rules.TestRule;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 
@@ -307,7 +306,7 @@ public class SplitRegionScannerStressIT extends BaseMRIOTest {
         Scan scan = new Scan();
         SplitRegionScanner srs = new SplitRegionScanner(scan,
                 htable,
-                clock,partition);
+                clock,partition, driver.getConfiguration());
         while (srs.next(newCells)) {
             i++;
             newCells.clear();

--- a/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -19,7 +19,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.hbase.CellUtils;
+import com.splicemachine.pipeline.utils.PipelineUtils;
 import org.apache.hadoop.hbase.regionserver.ScannerContext;
 import org.spark_project.guava.base.Throwables;
 import com.splicemachine.access.client.HBase10ClientSideRegionScanner;
@@ -46,6 +49,7 @@ import com.splicemachine.utils.SpliceLogUtils;
  */
 public class SplitRegionScanner implements RegionScanner {
     protected static final Logger LOG = Logger.getLogger(SplitRegionScanner.class);
+    private final int maxRetries;
     protected List<RegionScanner> regionScanners = new ArrayList<>(2);
     protected RegionScanner currentScanner;
     protected HRegion region;
@@ -63,7 +67,7 @@ public class SplitRegionScanner implements RegionScanner {
     public SplitRegionScanner(Scan scan,
                               Table table,
                               Clock clock,
-                              Partition clientPartition) throws IOException {
+                              Partition clientPartition, SConfiguration configuration) throws IOException {
         this.scan = scan;
         this.initialScan = new Scan(scan);
         this.htable = table;
@@ -72,6 +76,7 @@ public class SplitRegionScanner implements RegionScanner {
         totalScannerCount = 0;
         reInitCount = 0;
         scanExceptionCount = 0;
+        maxRetries = configuration.getMaxRetries();
         init(false);
     }
 
@@ -281,8 +286,10 @@ public class SplitRegionScanner implements RegionScanner {
      */
     public List<Partition> getPartitionsInRange(Partition partition, Scan scan, boolean refresh) throws IOException {
         List<Partition> partitions;
-        while (true) {
+        int tries = 0;
+        while (tries < maxRetries) {
             partitions = partition.subPartitions(scan.getStartRow(), scan.getStopRow(), refresh);
+            tries++;
             if (partitions == null || partitions.isEmpty()) {
                 if (!refresh) {
                     // try again with a refresh
@@ -291,12 +298,18 @@ public class SplitRegionScanner implements RegionScanner {
                 } else {
                     // Not Good, partition missing...
                     SpliceLogUtils.warn(LOG,"Couldn't find subpartitions in range for %s and scan %s",partition,scan);
+                    try {
+                        clock.sleep(PipelineUtils.getPauseTime(tries,10),TimeUnit.MILLISECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException(e);
+                    }
                 }
             } else {
-                break;
+                return partitions;
             }
         }
-        return partitions;
+        throw new IOException("Couldn't find subpartitions in range");
     }
 
     @Override

--- a/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import com.splicemachine.hbase.CellUtils;
 import org.spark_project.guava.base.Throwables;
+import com.splicemachine.access.api.SConfiguration;
+import com.splicemachine.pipeline.utils.PipelineUtils;
 import com.splicemachine.access.client.HBase10ClientSideRegionScanner;
 import com.splicemachine.access.client.SkeletonClientSideRegionScanner;
 import com.splicemachine.concurrent.Clock;
@@ -45,6 +47,7 @@ import com.splicemachine.utils.SpliceLogUtils;
  */
 public class SplitRegionScanner implements RegionScanner {
     protected static final Logger LOG = Logger.getLogger(SplitRegionScanner.class);
+    private final int maxRetries;
     protected List<RegionScanner> regionScanners = new ArrayList<>(2);
     protected RegionScanner currentScanner;
     protected HRegion region;
@@ -62,7 +65,7 @@ public class SplitRegionScanner implements RegionScanner {
     public SplitRegionScanner(Scan scan,
                               Table table,
                               Clock clock,
-                              Partition clientPartition) throws IOException {
+                              Partition clientPartition, SConfiguration configuration) throws IOException {
         this.scan = scan;
         this.initialScan = new Scan(scan);
         this.htable = table;
@@ -71,6 +74,7 @@ public class SplitRegionScanner implements RegionScanner {
         totalScannerCount = 0;
         reInitCount = 0;
         scanExceptionCount = 0;
+        maxRetries = configuration.getMaxRetries();
         init(false);
     }
 
@@ -289,8 +293,10 @@ public class SplitRegionScanner implements RegionScanner {
      */
     public List<Partition> getPartitionsInRange(Partition partition, Scan scan, boolean refresh) throws IOException {
         List<Partition> partitions;
-        while (true) {
+        int tries = 0;
+        while (tries < maxRetries) {
             partitions = partition.subPartitions(scan.getStartRow(), scan.getStopRow(), refresh);
+            tries++;
             if (partitions == null || partitions.isEmpty()) {
                 if (!refresh) {
                     // try again with a refresh
@@ -299,12 +305,18 @@ public class SplitRegionScanner implements RegionScanner {
                 } else {
                     // Not Good, partition missing...
                     SpliceLogUtils.warn(LOG,"Couldn't find subpartitions in range for %s and scan %s",partition,scan);
+                    try {
+                        clock.sleep(PipelineUtils.getPauseTime(tries,10),TimeUnit.MILLISECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException(e);
+                    }
                 }
             } else {
-                break;
+                return partitions;
             }
         }
-        return partitions;
+        throw new IOException("Couldn't find subpartitions in range");
     }
 
 

--- a/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -19,7 +19,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.hbase.CellUtils;
+import com.splicemachine.pipeline.utils.PipelineUtils;
 import org.apache.hadoop.hbase.regionserver.ScannerContext;
 import org.spark_project.guava.base.Throwables;
 import com.splicemachine.access.client.HBase10ClientSideRegionScanner;
@@ -46,6 +49,7 @@ import com.splicemachine.utils.SpliceLogUtils;
  */
 public class SplitRegionScanner implements RegionScanner {
     protected static final Logger LOG = Logger.getLogger(SplitRegionScanner.class);
+    private final int maxRetries;
     protected List<RegionScanner> regionScanners = new ArrayList<>(2);
     protected RegionScanner currentScanner;
     protected HRegion region;
@@ -63,7 +67,7 @@ public class SplitRegionScanner implements RegionScanner {
     public SplitRegionScanner(Scan scan,
                               Table table,
                               Clock clock,
-                              Partition clientPartition) throws IOException {
+                              Partition clientPartition, SConfiguration configuration) throws IOException {
         this.scan = scan;
         this.initialScan = new Scan(scan);
         this.htable = table;
@@ -72,6 +76,7 @@ public class SplitRegionScanner implements RegionScanner {
         totalScannerCount = 0;
         reInitCount = 0;
         scanExceptionCount = 0;
+        maxRetries = configuration.getMaxRetries();
         init(false);
     }
 
@@ -281,8 +286,10 @@ public class SplitRegionScanner implements RegionScanner {
      */
     public List<Partition> getPartitionsInRange(Partition partition, Scan scan, boolean refresh) throws IOException {
         List<Partition> partitions;
-        while (true) {
+        int tries = 0;
+        while (tries < maxRetries) {
             partitions = partition.subPartitions(scan.getStartRow(), scan.getStopRow(), refresh);
+            tries++;
             if (partitions == null || partitions.isEmpty()) {
                 if (!refresh) {
                     // try again with a refresh
@@ -291,12 +298,18 @@ public class SplitRegionScanner implements RegionScanner {
                 } else {
                     // Not Good, partition missing...
                     SpliceLogUtils.warn(LOG,"Couldn't find subpartitions in range for %s and scan %s",partition,scan);
+                    try {
+                        clock.sleep(PipelineUtils.getPauseTime(tries,10),TimeUnit.MILLISECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException(e);
+                    }
                 }
             } else {
-                break;
+                return partitions;
             }
         }
-        return partitions;
+        throw new IOException("Couldn't find subpartitions in range");
     }
 
     @Override

--- a/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -19,7 +19,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.hbase.CellUtils;
+import com.splicemachine.pipeline.utils.PipelineUtils;
 import org.apache.hadoop.hbase.regionserver.ScannerContext;
 import org.spark_project.guava.base.Throwables;
 import com.splicemachine.access.client.HBase10ClientSideRegionScanner;
@@ -46,6 +49,7 @@ import com.splicemachine.utils.SpliceLogUtils;
  */
 public class SplitRegionScanner implements RegionScanner {
     protected static final Logger LOG = Logger.getLogger(SplitRegionScanner.class);
+    private final int maxRetries;
     protected List<RegionScanner> regionScanners = new ArrayList<>(2);
     protected RegionScanner currentScanner;
     protected HRegion region;
@@ -63,7 +67,7 @@ public class SplitRegionScanner implements RegionScanner {
     public SplitRegionScanner(Scan scan,
                               Table table,
                               Clock clock,
-                              Partition clientPartition) throws IOException {
+                              Partition clientPartition, SConfiguration configuration) throws IOException {
         this.scan = scan;
         this.initialScan = new Scan(scan);
         this.htable = table;
@@ -72,6 +76,7 @@ public class SplitRegionScanner implements RegionScanner {
         totalScannerCount = 0;
         reInitCount = 0;
         scanExceptionCount = 0;
+        maxRetries = configuration.getMaxRetries();
         init(false);
     }
 
@@ -281,8 +286,10 @@ public class SplitRegionScanner implements RegionScanner {
      */
     public List<Partition> getPartitionsInRange(Partition partition, Scan scan, boolean refresh) throws IOException {
         List<Partition> partitions;
-        while (true) {
+        int tries = 0;
+        while (tries < maxRetries) {
             partitions = partition.subPartitions(scan.getStartRow(), scan.getStopRow(), refresh);
+            tries++;
             if (partitions == null || partitions.isEmpty()) {
                 if (!refresh) {
                     // try again with a refresh
@@ -291,12 +298,18 @@ public class SplitRegionScanner implements RegionScanner {
                 } else {
                     // Not Good, partition missing...
                     SpliceLogUtils.warn(LOG,"Couldn't find subpartitions in range for %s and scan %s",partition,scan);
+                    try {
+                        clock.sleep(PipelineUtils.getPauseTime(tries,10),TimeUnit.MILLISECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException(e);
+                    }
                 }
             } else {
-                break;
+                return partitions;
             }
         }
-        return partitions;
+        throw new IOException("Couldn't find subpartitions in range");
     }
 
     @Override

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -19,7 +19,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.hbase.CellUtils;
+import com.splicemachine.pipeline.utils.PipelineUtils;
 import org.apache.hadoop.hbase.regionserver.ScannerContext;
 import org.spark_project.guava.base.Throwables;
 import com.splicemachine.access.client.HBase10ClientSideRegionScanner;
@@ -46,6 +49,7 @@ import com.splicemachine.utils.SpliceLogUtils;
  */
 public class SplitRegionScanner implements RegionScanner {
     protected static final Logger LOG = Logger.getLogger(SplitRegionScanner.class);
+    private final int maxRetries;
     protected List<RegionScanner> regionScanners = new ArrayList<>(2);
     protected RegionScanner currentScanner;
     protected HRegion region;
@@ -63,7 +67,7 @@ public class SplitRegionScanner implements RegionScanner {
     public SplitRegionScanner(Scan scan,
                               Table table,
                               Clock clock,
-                              Partition clientPartition) throws IOException {
+                              Partition clientPartition, SConfiguration configuration) throws IOException {
         this.scan = scan;
         this.initialScan = new Scan(scan);
         this.htable = table;
@@ -72,6 +76,7 @@ public class SplitRegionScanner implements RegionScanner {
         totalScannerCount = 0;
         reInitCount = 0;
         scanExceptionCount = 0;
+        maxRetries = configuration.getMaxRetries();
         init(false);
     }
 
@@ -281,8 +286,10 @@ public class SplitRegionScanner implements RegionScanner {
      */
     public List<Partition> getPartitionsInRange(Partition partition, Scan scan, boolean refresh) throws IOException {
         List<Partition> partitions;
-        while (true) {
+        int tries = 0;
+        while (tries < maxRetries) {
             partitions = partition.subPartitions(scan.getStartRow(), scan.getStopRow(), refresh);
+            tries++;
             if (partitions == null || partitions.isEmpty()) {
                 if (!refresh) {
                     // try again with a refresh
@@ -291,12 +298,18 @@ public class SplitRegionScanner implements RegionScanner {
                 } else {
                     // Not Good, partition missing...
                     SpliceLogUtils.warn(LOG,"Couldn't find subpartitions in range for %s and scan %s",partition,scan);
+                    try {
+                        clock.sleep(PipelineUtils.getPauseTime(tries,10),TimeUnit.MILLISECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException(e);
+                    }
                 }
             } else {
-                break;
+                return partitions;
             }
         }
-        return partitions;
+        throw new IOException("Couldn't find subpartitions in range");
     }
 
     @Override


### PR DESCRIPTION
Make sure we don't retry indefinitely looking for subpartitions and raise an exception if we ever construct a Scan that doesn't make sense in SMRecordReaderImpl.

Fixed other platforms.