### PR TITLE
SPLICE-838 Increase OlapClient timeout

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/olap/MappedJobRegistry.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/MappedJobRegistry.java
@@ -92,8 +92,7 @@ public class MappedJobRegistry implements OlapJobRegistry{
             while(regIterator.hasNext()){
                 Map.Entry<String,OlapJobStatus> entry = regIterator.next();
                 if(!entry.getValue().isAvailable()){
-                    if(LOG.isTraceEnabled())
-                        LOG.trace("Job with id "+ entry.getKey()+" does not have an available client, removing");
+                    LOG.warn("Job " + entry.getValue() + " with id "+ entry.getKey()+" does not have an available client, removing");
                     regIterator.remove();
                     entry.getValue().cancel();
                 }

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapJobStatus.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapJobStatus.java
@@ -20,6 +20,7 @@ import akka.remote.FailureDetector$;
 import akka.remote.PhiAccrualFailureDetector;
 import com.splicemachine.derby.iapi.sql.olap.OlapResult;
 import com.splicemachine.derby.iapi.sql.olap.OlapStatus;
+import org.apache.log4j.Logger;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.util.concurrent.TimeUnit;
@@ -31,6 +32,8 @@ import java.util.concurrent.atomic.AtomicReference;
  *         Date: 4/1/16
  */
 public class OlapJobStatus implements OlapStatus{
+    private static final Logger LOG = Logger.getLogger(OlapJobStatus.class);
+
     private final FailureDetector failureDetector;
     private final long tickTime;
 
@@ -43,7 +46,7 @@ public class OlapJobStatus implements OlapStatus{
         FiniteDuration stdDev = FiniteDuration.apply(2*tickTime,TimeUnit.MILLISECONDS);
         FiniteDuration firstTick = FiniteDuration.apply(tickTime,TimeUnit.MILLISECONDS);
 
-        failureDetector = new PhiAccrualFailureDetector(0.1d,128,stdDev,maxHeartbeatInterval,firstTick,
+        failureDetector = new PhiAccrualFailureDetector(10,128,stdDev,maxHeartbeatInterval,firstTick,
                 FailureDetector$.MODULE$.defaultClock());
         this.tickTime = tickTime;
     }
@@ -178,5 +181,11 @@ public class OlapJobStatus implements OlapStatus{
         return curState;
     }
 
-
+    @Override
+    public String toString() {
+        return "OlapJobStatus{" +
+                "currentState=" + currentState +
+                ", failureDetector.phi =" + ((PhiAccrualFailureDetector)failureDetector).phi() +
+                '}';
+    }
 }

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SIConfigurations.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SIConfigurations.java
@@ -144,7 +144,7 @@ public class SIConfigurations implements ConfigurationDefault {
     private static final int DEFAULT_OLAP_SERVER_THREADS = 16;
 
     public static final String OLAP_SERVER_TICK_LIMIT = "splice.olap_server.tickLimit";
-    private static final int DEFAULT_OLAP_SERVER_TICK_LIMIT = 10;
+    private static final int DEFAULT_OLAP_SERVER_TICK_LIMIT = 120;
 
     public static final String ACTIVE_TRANSACTION_CACHE_SIZE="splice.txn.activeCacheSize";
     private static final int DEFAULT_ACTIVE_TRANSACTION_CACHE_SIZE = 1<<12;


### PR DESCRIPTION
Add logging when cancelling an Olap job

I've increased the Phi failure detector's threshold since 0.1 seems to be too conservative. 
As taken from http://doc.akka.io/docs/akka/snapshot/scala/remoting.html and http://fubica.lsd.ufcg.edu.br/hp/cursos/cfsc/papers/hayashibara04theaccrual.pdf a more reasonable threshold seems to be 10. We can revisit this based on the logged information when cancelling running jobs.
