### PR TITLE
SPLICE-909 Remove wrong preconditions

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMRecordReaderImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMRecordReaderImpl.java
@@ -179,10 +179,6 @@ public class SMRecordReaderImpl extends RecordReader<RowLocation, ExecRow> {
 	}
 	
 	public void setScan(Scan scan) {
-		if (Bytes.equals(scan.getStartRow(), scan.getStopRow()) && !Bytes.empty(scan.getStartRow()))
-			throw new IllegalArgumentException("Start/stop rows cannot be equal for scan " + scan.toString());
-		if (Bytes.startComparator.compare(scan.getStartRow(), scan.getStopRow()) < 0)
-			throw new IllegalArgumentException("Start row must come before stop row for scan " + scan.toString());
 		this.scan = scan;
 	}
 	


### PR DESCRIPTION
This fixes some test failures on the recent builds. The preconditions were wrong, sometimes we build scans with a startRow greater than a stopRow, for instance if we do

`create table a ( i int primary key);
select * from a where i > 3 and i < 1;`

We can't raise an exception in that case.