### PR TITLE
SPLICE-915 Don't expect read() to return more than 1 byte

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLClob.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLClob.java
@@ -782,6 +782,7 @@ public class SQLClob
                 srcIn.mark(MAX_STREAM_HEADER_LENGTH);
             }
             byte[] header = new byte[MAX_STREAM_HEADER_LENGTH];
+            // TODO fix this, read() isn't guaranteed to return more than 1 byte, see SPLICE-915
             int read = in.read(header);
             // Expect at least two header bytes.
             if (SanityManager.DEBUG) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/SpliceSequence.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/SpliceSequence.java
@@ -93,7 +93,6 @@ public class SpliceSequence extends AbstractSequence{
         super.readExternal(in);
         int size=in.readInt();
         sysColumnsRow=new byte[size];
-        int read=in.read(sysColumnsRow);
-        assert read==size: "Did not read entire byte array!";
+        in.readFully(sysColumnsRow);
     }
 }

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnOperationFactory.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnOperationFactory.java
@@ -150,8 +150,7 @@ public class SimpleTxnOperationFactory implements TxnOperationFactory{
     public TxnView readTxn(ObjectInput oi) throws IOException{
         int size=oi.readInt();
         byte[] txnData=new byte[size];
-        int readAmt = oi.read(txnData);
-        if(readAmt!=size) throw new IOException("Did not read enough bytes!");
+        oi.readFully(txnData);
 
         return decode(txnData,0,txnData.length);
     }


### PR DESCRIPTION
SQLClob.readExternal still uses read(), complicated code path

Should I try to fix SQLClob.readExternal too? I'm not so sure about the invariants there, or whether that method is used at all. If we assume the header will always have a 10.5 format we can just read 5 bytes and be done with it.