### PR TITLE
SPLICE-924 Fixing Ternary Operator Node so it chooses it's variant ty…

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
@@ -277,14 +277,11 @@ public class TernaryOperatorNode extends OperatorNode
 	 * @exception StandardException	thrown on error
 	 */
 	protected int getOrderableVariantType() throws StandardException {
-
-        return Qualifier.VARIANT;
-      /*
-      int leftType = leftOperand.getOrderableVariantType();
-      return rightOperand == null ?
-               leftType : Math.min(leftType, rightOperand.getOrderableVariantType());
-
-      */
+		if (operator != null && operator.equals("trim") && rightOperand == null)
+			return Qualifier.VARIANT;
+		int leftType = leftOperand.getOrderableVariantType();
+		return rightOperand == null ?
+				leftType : Math.min(leftType, rightOperand.getOrderableVariantType());
 	}
 	
 	/**


### PR DESCRIPTION
Using Variants correctly for TernaryOperatorNodes so qualifiers do not have to be recomputed when they are in fact constants.  

This impacts query 1 in TPCH significantly.

l_shipdate <= date({fn TIMESTAMPADD(SQL_TSI_DAY, -90, cast('1998-12-01 00:00:00'