### PR TITLE
DB-5633: fix timestamp column for system tables

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/BaseDataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/BaseDataDictionary.java
@@ -52,6 +52,9 @@ public abstract class BaseDataDictionary implements DataDictionary, ModuleContro
 	protected static final int		SYSCOLUMNS_CORE_NUM = 2;
 	protected	static final int		SYSSCHEMAS_CORE_NUM = 3;
 	protected static final int        NUM_CORE = 4;
+	// NOTE: JC - When adding a new sys table, this
+	// number will need to be increased in BOTH places.
+	public static final long FIRST_USER_TABLE_NUMBER = 1458;
 	/**
 	* SYSFUN functions. Table of functions that automatically appear
 	* in the SYSFUN schema. These functions are resolved to directly

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -1362,8 +1362,13 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
             return retval;
         }
         retval = getTableDescriptorIndex1Scan(tableName,schemaUUID.toString());
-        if (retval!=null)
-            dataDictionaryCache.nameTdCacheAdd(tableKey,retval);
+        if (retval!=null) {
+            ConglomerateDescriptor[] conglomerateDescriptors = retval.getConglomerateDescriptors();
+            if (conglomerateDescriptors.length > 0 &&
+                    conglomerateDescriptors[0].getConglomerateNumber() < DataDictionaryImpl.FIRST_USER_TABLE_NUMBER)
+                retval.setVersion(SYSTABLESRowFactory.ORIGINAL_TABLE_VERSION);
+            dataDictionaryCache.nameTdCacheAdd(tableKey, retval);
+        }
         return retval;
     }
 

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -1942,5 +1942,6 @@ public interface SQLState {
 	String BACKUP_CANCELED                                         = "BR011";
 	String BACKUP_DOESNOT_EXIST                                    = "BR012";
 	String PARENT_BACKUP_MISSING                                   = "BR013";
+	String EXISTS_CONCURRENT_BACKUP                                = "BR014";
 }
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -8841,6 +8841,11 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
                <arg>backupId</arg>
                <arg>parentBackupId</arg>
            </msg>
+           <msg>
+               <name>BR014</name>
+               <text>A concurrent {0} backup is running.</text>
+               <arg>backupType</arg>
+           </msg>
        </family>
     </section>
 

--- a/hbase_storage/src/main/java/com/splicemachine/constants/EnvUtils.java
+++ b/hbase_storage/src/main/java/com/splicemachine/constants/EnvUtils.java
@@ -17,6 +17,7 @@ package com.splicemachine.constants;
 
 import com.splicemachine.access.HConfiguration;
 import com.splicemachine.access.api.SConfiguration;
+import com.splicemachine.db.impl.sql.catalog.DataDictionaryImpl;
 import com.splicemachine.si.data.hbase.coprocessor.TableType;
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.hbase.TableName;
@@ -26,9 +27,6 @@ import org.apache.log4j.Logger;
 
 public class EnvUtils {
 	private static Logger LOG = Logger.getLogger(EnvUtils.class);
-    // NOTE: JC - this constant is also defined in DataDictionary. When adding a new sys table, this
-    // number will need to be increased in BOTH places.
-	private static final long FIRST_USER_TABLE_NUMBER = 1458;
 
     public static TableType getTableType(SConfiguration config,RegionCoprocessorEnvironment e) {
         return EnvUtils.getTableType(config,e.getRegion().getTableDesc().getTableName());
@@ -51,7 +49,7 @@ public class EnvUtils {
         else {
 			try {
 				long tableNumber = Long.parseLong(tableName.getQualifierAsString());
-				if (tableNumber < FIRST_USER_TABLE_NUMBER)
+				if (tableNumber < DataDictionaryImpl.FIRST_USER_TABLE_NUMBER)
 					return TableType.DERBY_SYS_TABLE;
 			} catch(NumberFormatException nfe){
                 return TableType.HBASE_TABLE;


### PR DESCRIPTION
Timestamp column for system tables is encoded by V1 serializer, but is decoded by v2 serializer. In general, you get incorrect values for a timestamp column if you do a select on the column. Fix this problem by using a V1 serializer to decode system tables.