### PR TITLE
SPLICE-923 Fixing GenericQualifier.getOrderable to be more performant

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericQualifier.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericQualifier.java
@@ -127,8 +127,7 @@ public class GenericQualifier implements Qualifier
 		if (variantType != VARIANT) {
 			if (orderableCache == null) {
 				try {
-					Method method = activation.getClass().getMethod(orderableGetter.getMethodName(), null);
-					orderableCache = (DataValueDescriptor) (method.invoke(activation,null));
+					orderableCache = (DataValueDescriptor) (orderableGetter.invoke(activation));
 				} catch (Exception e) {
 					throw StandardException.unexpectedUserException(e);
 				}
@@ -136,8 +135,7 @@ public class GenericQualifier implements Qualifier
 			return orderableCache;
 		}
 		try {
-			Method method = activation.getClass().getMethod(orderableGetter.getMethodName(), null);
-			return (DataValueDescriptor) (method.invoke(activation,null));
+			return (DataValueDescriptor) (orderableGetter.invoke(activation));
 		} catch (Exception e) {
 			throw StandardException.unexpectedUserException(e);
 		}


### PR DESCRIPTION
Removing the continued reflection calls.  This was there due to issues in our old task framework.