### PR TITLE
DB-5633: fix timestamp column for system tables

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -1362,8 +1362,13 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
             return retval;
         }
         retval = getTableDescriptorIndex1Scan(tableName,schemaUUID.toString());
-        if (retval!=null)
-            dataDictionaryCache.nameTdCacheAdd(tableKey,retval);
+        if (retval!=null) {
+            ConglomerateDescriptor[] conglomerateDescriptors = retval.getConglomerateDescriptors();
+            if (conglomerateDescriptors.length > 0 &&
+                    conglomerateDescriptors[0].getConglomerateNumber() < DataDictionary.FIRST_USER_TABLE_NUMBER)
+                retval.setVersion(SYSTABLESRowFactory.ORIGINAL_TABLE_VERSION);
+            dataDictionaryCache.nameTdCacheAdd(tableKey, retval);
+        }
         return retval;
     }
 

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -1942,5 +1942,6 @@ public interface SQLState {
 	String BACKUP_CANCELED                                         = "BR011";
 	String BACKUP_DOESNOT_EXIST                                    = "BR012";
 	String PARENT_BACKUP_MISSING                                   = "BR013";
+	String EXISTS_CONCURRENT_BACKUP                                = "BR014";
 }
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -8841,6 +8841,11 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
                <arg>backupId</arg>
                <arg>parentBackupId</arg>
            </msg>
+           <msg>
+               <name>BR014</name>
+               <text>A concurrent {0} backup is running.</text>
+               <arg>backupType</arg>
+           </msg>
        </family>
     </section>
 


### PR DESCRIPTION
Timestamp column for system tables is encoded by V1 serializer, but is decoded by v2 serializer. In general, you get incorrect values for a timestamp column if you do a select on the column. Fix this problem by using a V1 serializer to decode system tables.