### PR TITLE
SPLICE-869 Make sure operation context is properly setup on index job

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkScanSetBuilder.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkScanSetBuilder.java
@@ -62,7 +62,7 @@ public class SparkScanSetBuilder<V> extends TableScannerBuilder<V> {
     public DataSet<V> buildDataSet(Object caller) throws StandardException {
         if (op != null)
             operationContext = dsp.createOperationContext(op);
-        else if (activation != null)
+        else // this call works even if activation is null
             operationContext = dsp.createOperationContext(activation);
 
         JavaSparkContext ctx = SpliceSpark.getContext();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/IndexConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/IndexConstantOperation.java
@@ -148,7 +148,7 @@ public abstract class IndexConstantOperation extends DDLSingleTableConstantOpera
             DistributedDataSetProcessor dsp =EngineDriver.driver().processorFactory().distributedProcessor();
 
             childTxn = beginChildTransaction(indexTransaction, tentativeIndex.getIndex().getConglomerate());
-			ScanSetBuilder<LocatedRow> builder = dsp.newScanSet(null,Long.toString(tentativeIndex.getTable().getConglomerate()));
+			ScanSetBuilder<LocatedRow> builder = dsp.newScanSet(null, Long.toString(tentativeIndex.getTable().getConglomerate()));
 			builder.tableDisplayName(tableName)
 			.demarcationPoint(demarcationPoint)
 			.transaction(indexTransaction)
@@ -156,7 +156,6 @@ public abstract class IndexConstantOperation extends DDLSingleTableConstantOpera
 			.keyColumnEncodingOrder(Ints.toArray(tentativeIndex.getTable().getColumnOrderingList()))
 			.execRowTypeFormatIds(indexFormatIds)
 			.reuseRowLocation(false)
-			.operationContext(dsp.createOperationContext(activation))
 			.rowDecodingMap(rowDecodingMap)
 			.keyColumnTypes(ScanOperation.getKeyFormatIds(
 					Ints.toArray(tentativeIndex.getTable().getColumnOrderingList()),


### PR DESCRIPTION
Spark was failing to access Accumulators because the SparkOperationContext wasn't being properly set up.

