### PR TITLE
Fixed SPLICE-742

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLChar.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLChar.java
@@ -1955,16 +1955,16 @@ public class SQLChar
         {
             if (!(this instanceof SQLVarchar))
             {
-                StringBuffer    strbuf;
+                StringBuilder    strBuilder;
 
-                strbuf = new StringBuffer(getString());
+                strBuilder = new StringBuilder(getString());
     
-                for ( ; sourceWidth < desiredWidth; sourceWidth++)
+                for ( ; sourceWidth < desiredWidth-1; sourceWidth++)
                 {
-                    strbuf.append(' ');
+                    strBuilder.append(' ');
                 }
     
-                setValue(new String(strbuf));
+                setValue(new String(strBuilder));
             }
         }
         else if (sourceWidth > desiredWidth && desiredWidth > 0)

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/JoinWithFunctionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/JoinWithFunctionIT.java
@@ -79,6 +79,16 @@ public class JoinWithFunctionIT extends SpliceUnitTest {
                 .withCreate("create table c (d double, j int)")
                 .withInsert("insert into c values(?,?)")
                 .withRows(rows(row(1.1, 1), row(2.2, 2), row(-3.3, 3), row(-4.4, 4))).create();
+
+        new TableCreator(spliceClassWatcher.getOrCreateConnection())
+                .withCreate("create table d (i int)")
+                .withInsert("insert into d values(?)")
+                .withRows(rows(row(1), row(2), row(3), row(4))).create();
+
+        new TableCreator(spliceClassWatcher.getOrCreateConnection())
+                .withCreate("create table e (c char(10))")
+                .withInsert("insert into e values(?)")
+                .withRows(rows(row("1"), row("2"), row("3"), row("4"))).create();
     }
 
     @Test
@@ -174,6 +184,25 @@ public class JoinWithFunctionIT extends SpliceUnitTest {
                 "----------------\n" +
                 " 1 | 1 | 2 | 2 |\n" +
                 " 2 | 2 |-4 | 4 |";
+        assertEquals(s, expected, s);
+    }
+
+    @Test
+    public void testCharFunction()  throws Exception {
+        String sql = String.format("select * from --SPLICE-PROPERTIES joinOrder=FIXED\n" +
+                "d\n" +
+                ", e --SPLICE-PROPERTIES joinStrategy=%s\n" +
+                " where CHAR(d.i) = e.c", joinStrategy);
+        ResultSet rs = methodWatcher.executeQuery(sql);
+        String s = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+        rs.close();
+        String expected =
+                "I | C |\n" +
+                        "--------\n" +
+                        " 1 | 1 |\n" +
+                        " 2 | 2 |\n" +
+                        " 3 | 3 |\n" +
+                        " 4 | 4 |";
         assertEquals(s, expected, s);
     }
 }


### PR DESCRIPTION
In EntryPredicateFilter.java; line 79  we remove 1 to the limit.
When we build the Table Hash Key in a join , we end up with a hash key desalign between the left operand and the right operand.