### PR TITLE
SPLICE-942 SmallScanners bug in HBase where they return extra row

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScanOperation.java
@@ -169,11 +169,12 @@ public abstract class ScanOperation extends SpliceBaseOperation{
             s = s.cacheRows(2).batchCells(-1);
         }
         // Makes it a small scan for 100 rows of fewer
-        else if (this.getEstimatedRowCount()<100) {
-            s = s.cacheRows(100).batchCells(-1);
-        } else {
-            s.cacheRows(1000);
-        }
+        // Bug where splits return 1 extra row
+//        else if (this.getEstimatedRowCount()<100) {
+//            s = s.cacheRows(100).batchCells(-1);
+//        } else {
+            s.cacheRows(1000).batchCells(-1);
+//        }
         deSiify(s);
         return s;
     }


### PR DESCRIPTION
This is causing SelfInsertIT to add an extra row.  This could hit us on Batch NLJ...