### PR TITLE
SPLICE-428 Support for With Clause Array above a select

### DIFF
--- a/db-client/src/main/java/com/splicemachine/db/client/am/Statement.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Statement.java
@@ -2371,6 +2371,7 @@ public class Statement implements java.sql.Statement, StatementCallbackInterface
 
         if (firstToken.equalsIgnoreCase("select") || // captures <subselect> production
                 firstToken.equalsIgnoreCase("explain") ||
+                firstToken.equalsIgnoreCase("with") ||
                 firstToken.equalsIgnoreCase("export") ||
                 firstToken.equalsIgnoreCase("values")) // captures <values-clause> production
         {

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -1296,4 +1296,29 @@ public interface LanguageConnectionContext extends Context {
 
     CompilerContext.DataSetProcessorType getDataSetProcessorType();
 
+	/**
+	 *
+	 * Setting the dynamic withDescriptors
+	 *
+	 * @param withDescriptors
+     */
+	void setWithStack(Map<String,TableDescriptor> withDescriptors);
+
+	/**
+	 *
+	 * Checking for with clause handling
+	 *
+	 * @param name
+	 * @return
+     */
+	TableDescriptor getWithDescriptor(String name);
+
+	/**
+	 *
+	 * Null out the with stack.
+	 *
+	 */
+	void popWithStack();
+
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableDescriptor.java
@@ -593,7 +593,7 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
      * @param viewDescriptor The view descriptor to cache.
      */
     public void setViewDescriptor(ViewDescriptor viewDescriptor){
-        assert tableType==TableDescriptor.VIEW_TYPE:"tableType expected to be TableDescriptor.VIEW_TYPE";
+//        assert tableType==TableDescriptor.VIEW_TYPE:"tableType expected to be TableDescriptor.VIEW_TYPE";
         this.viewDescriptor=viewDescriptor;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableDescriptor.java
@@ -100,6 +100,9 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
     public static final int GLOBAL_TEMPORARY_TABLE_TYPE=3;
     public static final int SYNONYM_TYPE=4;
     public static final int VTI_TYPE=5;
+    /* Supports with clauses for TPCDS*/
+    public static final int WITH_TYPE=6;
+
 
     public static final char ROW_LOCK_GRANULARITY='R';
     public static final char TABLE_LOCK_GRANULARITY='T';

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
@@ -760,7 +760,7 @@ public class CompilerContextImpl extends ContextImpl
 			return;
 
 		if (td.getTableType() ==
-				TableDescriptor.GLOBAL_TEMPORARY_TABLE_TYPE) {
+				TableDescriptor.GLOBAL_TEMPORARY_TABLE_TYPE || td.getTableType() == TableDescriptor.WITH_TYPE) {
 			return; // no priv needed, it is per session anyway
 		}
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CursorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CursorNode.java
@@ -39,9 +39,8 @@ import com.splicemachine.db.iapi.sql.execute.ConstantAction;
 import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.impl.sql.CursorInfo;
 import com.splicemachine.db.impl.sql.CursorTableReference;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Vector;
+
+import java.util.*;
 
 /**
  * A CursorNode represents a result set that can be returned to a client.
@@ -208,6 +207,19 @@ public class CursorNode extends DMLStatementNode{
 
 			/* Check for ? parameters directly under the ResultColums */
             resultSet.rejectParameters();
+
+            // Bind and Optimize Real Time Views (OK, That is a made up name).
+            if (this.withParameterList != null) {
+                Map<String,TableDescriptor> withMap = new HashMap<>(withParameterList.size());
+                for (int i = 0; i<withParameterList.size(); i++) {
+                    CreateViewNode createViewNode = (CreateViewNode) withParameterList.get(i);
+                    createViewNode.bindStatement();
+                    createViewNode.optimizeStatement();
+                    withMap.put(createViewNode.getRelativeName(),createViewNode.createDynamicView());
+                }
+                this.getLanguageConnectionContext().setWithStack(withMap);
+            }
+
 
             super.bind(dataDictionary);
 
@@ -446,6 +458,7 @@ public class CursorNode extends DMLStatementNode{
             acb.rememberCursor(mb);
             acb.addCursorPositionCode();
         }
+        getLanguageConnectionContext().popWithStack();
     }
 
     public String getUpdateBaseTableName(){

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CursorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CursorNode.java
@@ -216,8 +216,8 @@ public class CursorNode extends DMLStatementNode{
                     createViewNode.bindStatement();
                     createViewNode.optimizeStatement();
                     withMap.put(createViewNode.getRelativeName(),createViewNode.createDynamicView());
+                    this.getLanguageConnectionContext().setWithStack(withMap);
                 }
-                this.getLanguageConnectionContext().setWithStack(withMap);
             }
 
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DDLStatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DDLStatementNode.java
@@ -72,7 +72,7 @@ abstract class DDLStatementNode extends StatementNode
 	//
 	/////////////////////////////////////////////////////////////////////////
 
-	private TableName	objectName;
+	protected TableName	objectName;
 	private boolean		initOk;
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -998,7 +998,10 @@ public class FromBaseTable extends FromTable {
 
             try{
 				/* This represents a view - query is dependent on the ViewDescriptor */
-                compilerContext.createDependency(vd);
+                // Removes with clause dependency creation.
+                // No reason to create dependency.
+                if (vd.getUUID() != null)
+                    compilerContext.createDependency(vd);
 
                 if(SanityManager.DEBUG){
                     //noinspection ConstantConditions

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -974,7 +974,7 @@ public class FromBaseTable extends FromTable {
         templateColumns=resultColumns;
 
 		/* Resolve the view, if this is a view */
-        if(tableDescriptor.getTableType()==TableDescriptor.VIEW_TYPE){
+        if(tableDescriptor.getTableType()==TableDescriptor.VIEW_TYPE || tableDescriptor.getTableType()==TableDescriptor.WITH_TYPE){
             FromSubquery fsq;
             ResultSetNode rsn;
             ViewDescriptor vd;
@@ -1290,6 +1290,12 @@ public class FromBaseTable extends FromTable {
         SchemaDescriptor sd=getSchemaDescriptor(schemaName);
 
         tableDescriptor=getTableDescriptor(tableName.getTableName(),sd);
+
+        // Find With Descriptors
+        if (tableDescriptor==null && getLanguageConnectionContext().getWithDescriptor(tableName.tableName) !=null) {
+            tableDescriptor = getLanguageConnectionContext().getWithDescriptor(tableName.tableName);
+        }
+
         if(tableDescriptor==null){
             // Check if the reference is for a synonym.
             TableName synonymTab=resolveTableToSynonym(tableName);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StatementNode.java
@@ -42,6 +42,7 @@ import com.splicemachine.db.iapi.util.ByteArray;
 
 import java.lang.reflect.Modifier;
 import java.util.Collection;
+import java.util.Vector;
 
 /**
  * A StatementNode represents a single statement in the language.  It is
@@ -338,5 +339,10 @@ public abstract class StatementNode extends QueryTreeNode{
 
     abstract int activationKind();
 
+    protected Vector withParameterList;
+
+    public void setWithVector(Vector withParameterList) {
+        this.withParameterList = withParameterList;
+    }
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -3428,6 +3428,7 @@ StatementPart(Token[] tokenHolder) throws StandardException :
 		statementNode = execStatement() |
 		statementNode = explainStatement() |
 		statementNode = exportStatement()
+		//statementNode = withStatement()
         // statementNode = SQLTransactionStatement()
     )
     {
@@ -3926,6 +3927,7 @@ preparableSelectStatement(boolean checkParams) throws StandardException :
 {
 	ResultSetNode	  queryExpression;
 	Vector  updateColumns = new Vector();
+	Vector parameterList = new Vector();
 	int               forUpdateState = CursorNode.UNSPECIFIED;
 	int				  isolationLevel = ExecutionContext.UNSPECIFIED_ISOLATION_LEVEL;
 	CursorNode		  retval;
@@ -3935,7 +3937,8 @@ preparableSelectStatement(boolean checkParams) throws StandardException :
     boolean     hasJDBClimitClause = false;
 }
 {
-	queryExpression = queryExpression(null, NO_SET_OP, topNOut)
+    [ <WITH> withClauseList(parameterList) ]
+    queryExpression = queryExpression(null, NO_SET_OP, topNOut)
 		[ orderCols = orderByClause(queryExpression) ]
         hasJDBClimitClause = offsetFetchFirstClause( offsetClauses )
 		[ <FOR> forUpdateState = forUpdateClause(updateColumns) ]
@@ -3966,7 +3969,7 @@ preparableSelectStatement(boolean checkParams) throws StandardException :
 		{
 			setUpAndLinkParameters();
 		}
-
+        retval.setWithVector(parameterList.size()>0?parameterList:null);
 		/* Set the isolation levels for the scans if specified */
 		if (isolationLevel != ExecutionContext.UNSPECIFIED_ISOLATION_LEVEL)
 		{
@@ -8606,6 +8609,7 @@ void methodCallParameterList(Vector parameterList) throws StandardException :
 	<RIGHT_PAREN>
 }
 
+
 /*
  * <A NAME="routineInvocation">routineInvocation</A>
  */
@@ -12244,6 +12248,76 @@ aggregateDefinition() throws StandardException :
                 AliasInfo.ALIAS_TYPE_AGGREGATE_AS_CHAR
             );
 		}
+}
+
+/**
+ * WITH... with_query_1 [(col_name[,...])]AS (SELECT ...),
+ *  ... with_query_2 [(col_name[,...])]AS (SELECT ...[with_query_1]),
+ *  .
+ *  .
+ *  .
+ *  ... with_query_n [(col_name[,...])]AS (SELECT ...[with_query1, with_query_2, with_query_n [,...]])
+ *  SELECT
+ *
+ * <A NAME="methodCallParameterList">methodCallParameterList</A>
+*/
+
+void withClauseList(Vector parameterList) throws StandardException :
+{
+}
+{
+[ withClause(parameterList)
+			( <COMMA> withClause(parameterList) )* ]
+}
+
+void withClause(Vector parameterList) throws StandardException :
+{
+    	int					checkOptionType;
+    	ResultColumnList	resultColumns = null;
+    	ResultSetNode		queryExpression;
+    	TableName			tableName;
+        Token beginToken = null;
+       	Token				checkTok = null;
+    	Token				endToken;
+    	OrderByList         orderCols = null;
+        ValueNode[] offsetClauses = new ValueNode[ OFFSET_CLAUSE_COUNT ];
+        ValueNode[] topNOut = new ValueNode[ 1 ];
+        boolean     hasJDBClimitClause = false;
+    }
+    {
+    	tableName = qualifiedName(Limits.MAX_IDENTIFIER_LENGTH)
+    		beginToken = <AS>
+    		queryExpression = queryExpression(null, NO_SET_OP, topNOut)
+    		[ orderCols = orderByClause(queryExpression) ]
+            hasJDBClimitClause = offsetFetchFirstClause( offsetClauses )
+    	{
+    		checkOptionType = ViewDescriptor.NO_CHECK_OPTION;
+    		endToken = getToken(0);
+    		/* Parameters not allowed in create view */
+    		HasNodeVisitor visitor = new HasNodeVisitor(ParameterNode.class);
+    		queryExpression.accept(visitor);
+    		if (visitor.hasNode()) {
+    			throw StandardException.newException(SQLState.LANG_NO_PARAMS_IN_VIEWS);
+    		}
+    	    if (topNOut[0] != null) {
+    	        hasJDBClimitClause = true;
+                offsetClauses[ FETCH_FIRST_CLAUSE ] = topNOut[0];
+    	    }
+    		parameterList.add(nodeFactory.getNode(
+    								C_NodeTypes.CREATE_VIEW_NODE,
+    								tableName,
+    								resultColumns,
+    								queryExpression,
+    								ReuseFactory.getInteger(checkOptionType),
+    								StringUtil.slice(statementSQLText,
+    												beginToken.beginOffset,
+    												endToken.endOffset,false),
+    								orderCols,
+                                    offsetClauses[ OFFSET_CLAUSE ],
+                                    offsetClauses[ FETCH_FIRST_CLAUSE ],
+                                    Boolean.valueOf( hasJDBClimitClause ),
+    								getContextManager()));
+    }
 }
 
 StatementNode

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -3483,4 +3483,23 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     }
 
     public void materialize() throws StandardException {}
+
+    protected Map<String,TableDescriptor> withDescriptors;
+
+    @Override
+    public void setWithStack(Map<String,TableDescriptor> withDescriptors) {
+        this.withDescriptors = withDescriptors;
+    }
+
+    @Override
+    public TableDescriptor getWithDescriptor(String name) {
+        if (withDescriptors==null)
+            return null;
+        return withDescriptors.get(name);
+    }
+
+    @Override
+    public void popWithStack() {
+        withDescriptors = null;
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicDependencyManager.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicDependencyManager.java
@@ -189,7 +189,8 @@ public class BasicDependencyManager implements DependencyManager {
         }
 
         // Dependency should have been added to both or neither.
-        if (SanityManager.DEBUG) {
+		// No Longer the case due to with clauses
+/*        if (SanityManager.DEBUG) {
             if (addedToDeps != addedToProvs) {
                 SanityManager.THROWASSERT(
                     "addedToDeps (" + addedToDeps +
@@ -197,7 +198,7 @@ public class BasicDependencyManager implements DependencyManager {
                     addedToProvs + ") are expected to agree");
             }
         }
-
+*/
         // Add the dependency to the StatementContext, so that
         // it can be cleared on a pre-execution error.
         StatementContext sc = (StatementContext) cm.getContext(

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicDependencyManager.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicDependencyManager.java
@@ -929,7 +929,8 @@ public class BasicDependencyManager implements DependencyManager {
 			UUID depKey = dy.getDependent().getObjectID();
 
             for (Dependency curDY : deps) {
-                if (curDY.getProvider().getObjectID().equals(provKey) && curDY.getDependent().getObjectID().equals(depKey)) {
+				// Check for dupes and dynamic with clauses
+                if (curDY.getProvider().getObjectID() == null || (curDY.getProvider().getObjectID().equals(provKey) && curDY.getDependent().getObjectID().equals(depKey))) {
                     return false;
                 }
             }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WithStatementIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WithStatementIT.java
@@ -1,0 +1,117 @@
+package com.splicemachine.derby.impl.sql.execute.operations;
+
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.derby.test.framework.TestConnection;
+import com.splicemachine.homeless.TestUtils;
+import com.splicemachine.test_tools.TableCreator;
+import org.junit.*;
+import java.sql.ResultSet;
+import static com.splicemachine.test_tools.Rows.row;
+import static com.splicemachine.test_tools.Rows.rows;
+
+/**
+ *
+ *
+ * Test for flushing out Splice Machine handling of with clauses
+ *
+ * WITH... with_query_1 [(col_name[,...])]AS (SELECT ...),
+ *  ... with_query_2 [(col_name[,...])]AS (SELECT ...[with_query_1]),
+ *  .
+ *  .
+ *  .
+ *  ... with_query_n [(col_name[,...])]AS (SELECT ...[with_query1, with_query_2, with_query_n [,...]])
+ *  SELECT
+ *
+ *
+ */
+public class WithStatementIT extends SpliceUnitTest {
+        private static final String SCHEMA = WithStatementIT.class.getSimpleName().toUpperCase();
+        private static SpliceWatcher spliceClassWatcher = new SpliceWatcher(SCHEMA);
+
+        @ClassRule
+        public static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(SCHEMA);
+
+        @Rule
+        public SpliceWatcher methodWatcher = new SpliceWatcher(SCHEMA);
+
+        @BeforeClass
+        public static void createSharedTables() throws Exception {
+            TestConnection connection = spliceClassWatcher.getOrCreateConnection();
+            new TableCreator(connection)
+                    .withCreate("create table FOO (col1 int primary key, col2 int)")
+                    .withInsert("insert into FOO values(?,?)")
+                    .withRows(rows(row(1, 1), row(2, 1), row(3, 1), row(4, 1), row(5, 1))).create();
+
+            new TableCreator(connection)
+                    .withCreate("create table FOO2 (col1 int primary key, col2 int)")
+                    .withInsert("insert into FOO2 values(?,?)")
+                    .withRows(rows(row(1, 5), row(3, 7), row(5, 9))).create();
+
+            new TableCreator(connection)
+                    .withCreate("create table FOO3 (col1 int primary key, col2 int)")
+                    .withInsert("insert into FOO3 values(?,?)")
+                    .withRows(rows(row(1, 5), row(3, 7))).create();
+
+        }
+
+    @Test
+    public void testSimpleWithStatementWithAggregate() throws Exception {
+        ResultSet rs = methodWatcher.executeQuery("with footest as " +
+                "(select count(*) as count, col2 from foo group by col2) " +
+                "select foo2.col1, count from foo2 " +
+                "inner join footest on foo2.col1 = footest.col2"
+        );
+        Assert.assertTrue("with join algebra incorrect",rs.next());
+        Assert.assertEquals("Wrong Count", 1, rs.getInt(1));
+        Assert.assertEquals("Wrong Join Column" , 5, rs.getInt(2));
+        Assert.assertFalse("with join algebra incorrect",rs.next());
+    }
+
+    @Test
+    public void testSimpleWithStatementWithAggregateExplain() throws Exception {
+        String query = "explain with footest as " +
+                "(select count(*) as count, col2 from foo group by col2) " +
+                "select foo2.col1, count from foo2 " +
+                "inner join footest on foo2.col1 = footest.col2";
+        ResultSet rs = methodWatcher.executeQuery(query);
+        Assert.assertEquals("explain plan incorrect",9,this.resultSetSize(rs));
+    }
+
+
+    @Test
+    public void testMultipleWithStatementsWithAggregates() throws Exception {
+        ResultSet rs = methodWatcher.executeQuery("with footest as " +
+                "(select count(*) as count, col2 from foo group by col2), " +
+                "footest1 as (select sum(col1) as sum_col1, col2 from foo group by col2)" +
+                "select foo2.col1, count, sum_col1 from foo2 " +
+                "inner join footest on foo2.col1 = footest.col2 " +
+                "inner join footest1 on foo2.col1 = footest1.col2"
+        );
+        Assert.assertTrue("with join algebra incorrect",rs.next());
+        Assert.assertEquals("Wrong Join Column", 1, rs.getInt(1));
+        Assert.assertEquals("Wrong Count" , 5, rs.getInt(2));
+        Assert.assertEquals("Wrong Sum" , 15, rs.getInt(3));
+        Assert.assertFalse("with join algebra incorrect",rs.next());
+    }
+
+    @Test
+    public void testMultipleWithStatementsWithUnderlyingJoins() throws Exception {
+        ResultSet rs = methodWatcher.executeQuery("with footest as " +
+                "(select count(*) as count, foo.col2 from foo " +
+                "inner join foo3 on foo.col1 = foo3.col1 group by foo.col2), " +
+                "footest1 as (select sum(foo.col1) as sum_col1, foo.col2 from foo " +
+                "inner join foo3 on foo.col1 = foo3.col1 group by foo.col2)" +
+                "select foo2.col1, count, sum_col1 from foo2 " +
+                "inner join footest on foo2.col1 = footest.col2 " +
+                "inner join footest1 on foo2.col1 = footest1.col2"
+        );
+        Assert.assertTrue("with join algebra incorrect",rs.next());
+        Assert.assertEquals("Wrong Join Column", 1, rs.getInt(1));
+        Assert.assertEquals("Wrong Count" , 2, rs.getInt(2));
+        Assert.assertEquals("Wrong Sum" , 4, rs.getInt(3));
+        Assert.assertFalse("with join algebra incorrect",rs.next());
+    }
+
+}


### PR DESCRIPTION
2.0 Version of 3.0 Commit...

This covers with clause support for analytical queries. It supports an array of with clauses prior to the query and under the covers it behaves like a view. I went with the view decision (Inline) since that is the default of most competitors (Oracle, Vertica).