### PR TITLE
SPLICE-948 Intersect Error Not Implemented on the wrong case

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -5645,37 +5645,40 @@ nonJoinQueryTerm(ResultSetNode leftSide, int operatorType, ValueNode[] topNOut) 
                 getContextManager());
 
         case EXCEPT_ALL_OP:
-            return (ResultSetNode) nodeFactory.getNode(
-                C_NodeTypes.INTERSECT_OR_EXCEPT_NODE,
-                ReuseFactory.getInteger( IntersectOrExceptNode.EXCEPT_OP),
-                leftSide,
-                term,
-                Boolean.TRUE,
-                null,
-                getContextManager());
+                    StandardException e = StandardException.newException("0A000 Feature not implemented: EXCEPT ALL");
+                    e.setSqlState("0A000");
+                    throw e;
+//            return (ResultSetNode) nodeFactory.getNode(
+//                C_NodeTypes.INTERSECT_OR_EXCEPT_NODE,
+//                ReuseFactory.getInteger( IntersectOrExceptNode.EXCEPT_OP),
+//                leftSide,
+//                term,
+//                Boolean.TRUE,
+//                null,
+//                getContextManager());
 
         case INTERSECT_OP:
-            StandardException e = StandardException.newException("0A000 Feature not implemented: INTERSECT");
-            e.setSqlState("0A000");
-            throw e;
-            //return (ResultSetNode) nodeFactory.getNode(
-            //    C_NodeTypes.INTERSECT_OR_EXCEPT_NODE,
-            //    ReuseFactory.getInteger( IntersectOrExceptNode.INTERSECT_OP),
-            //    leftSide,
-            //    term,
-            //    Boolean.FALSE,
-            //    null,
-            //    getContextManager());
-
-        case INTERSECT_ALL_OP:
             return (ResultSetNode) nodeFactory.getNode(
                 C_NodeTypes.INTERSECT_OR_EXCEPT_NODE,
                 ReuseFactory.getInteger( IntersectOrExceptNode.INTERSECT_OP),
                 leftSide,
                 term,
-                Boolean.TRUE,
+                Boolean.FALSE,
                 null,
                 getContextManager());
+
+        case INTERSECT_ALL_OP:
+                    StandardException ie = StandardException.newException("0A000 Feature not implemented: INTERSECT ALL");
+                    ie.setSqlState("0A000");
+                    throw ie;
+//            return (ResultSetNode) nodeFactory.getNode(
+//                C_NodeTypes.INTERSECT_OR_EXCEPT_NODE,
+//                ReuseFactory.getInteger( IntersectOrExceptNode.INTERSECT_OP),
+//                leftSide,
+//                term,
+//                Boolean.TRUE,
+//                null,
+//                getContextManager());
 
 
         default:

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SetOpOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SetOpOperationIT.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2012 - 2016 Splice Machine, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.splicemachine.derby.impl.sql.execute.operations;
 
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
@@ -6,10 +20,8 @@ import com.splicemachine.derby.test.framework.SpliceWatcher;
 import com.splicemachine.derby.test.framework.TestConnection;
 import com.splicemachine.test_tools.TableCreator;
 import org.junit.*;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
-
 import static com.splicemachine.test_tools.Rows.row;
 import static com.splicemachine.test_tools.Rows.rows;
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SetOpOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SetOpOperationIT.java
@@ -1,0 +1,92 @@
+package com.splicemachine.derby.impl.sql.execute.operations;
+
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.derby.test.framework.TestConnection;
+import com.splicemachine.test_tools.TableCreator;
+import org.junit.*;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static com.splicemachine.test_tools.Rows.row;
+import static com.splicemachine.test_tools.Rows.rows;
+
+/**
+ *
+ *
+ * Test for flushing out Splice Machine handling of with clauses
+ *
+ * WITH... with_query_1 [(col_name[,...])]AS (SELECT ...),
+ *  ... with_query_2 [(col_name[,...])]AS (SELECT ...[with_query_1]),
+ *  .
+ *  .
+ *  .
+ *  ... with_query_n [(col_name[,...])]AS (SELECT ...[with_query1, with_query_2, with_query_n [,...]])
+ *  SELECT
+ *
+ *
+ */
+public class SetOpOperationIT extends SpliceUnitTest {
+        private static final String SCHEMA = SetOpOperationIT.class.getSimpleName().toUpperCase();
+        private static SpliceWatcher spliceClassWatcher = new SpliceWatcher(SCHEMA);
+
+        @ClassRule
+        public static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(SCHEMA);
+
+        @Rule
+        public SpliceWatcher methodWatcher = new SpliceWatcher(SCHEMA);
+
+        @BeforeClass
+        public static void createSharedTables() throws Exception {
+            TestConnection connection = spliceClassWatcher.getOrCreateConnection();
+            new TableCreator(connection)
+                    .withCreate("create table FOO (col1 int primary key, col2 int)")
+                    .withInsert("insert into FOO values(?,?)")
+                    .withRows(rows(row(1, 1), row(2, 1), row(3, 1), row(4, 1), row(5, 1))).create();
+
+            new TableCreator(connection)
+                    .withCreate("create table FOO2 (col1 int primary key, col2 int)")
+                    .withInsert("insert into FOO2 values(?,?)")
+                    .withRows(rows(row(1, 5), row(3, 7), row(5, 9))).create();
+
+        }
+
+    @Test
+    public void testIntercept() throws Exception {
+        ResultSet rs = methodWatcher.executeQuery("select count(*), max(col1), min(col1) from (" +
+                "select col1 from foo intersect select col1 from foo2) argh"
+        );
+        Assert.assertTrue("intersect incorrect",rs.next());
+        Assert.assertEquals("Wrong Count", 3, rs.getInt(1));
+        Assert.assertEquals("Wrong Max", 5, rs.getInt(2));
+        Assert.assertEquals("Wrong Min", 1, rs.getInt(3));
+    }
+
+    @Test(expected = SQLException.class)
+    public void testInterceptAll() throws Exception {
+        ResultSet rs = methodWatcher.executeQuery("select count(*), max(col1), min(col1) from (" +
+                "select col1 from foo intersect all select col1 from foo2) argh"
+        );
+    }
+
+    @Test
+    public void testExcept() throws Exception {
+        ResultSet rs = methodWatcher.executeQuery("select count(*), max(col1), min(col1) from (" +
+                "select col1 from foo except select col1 from foo2) argh"
+        );
+        Assert.assertTrue("intersect incorrect",rs.next());
+        Assert.assertEquals("Wrong Count", 2, rs.getInt(1));
+        Assert.assertEquals("Wrong Max", 4, rs.getInt(2));
+        Assert.assertEquals("Wrong Min", 2, rs.getInt(3));
+    }
+
+    @Test(expected = SQLException.class)
+    public void testExceptAll() throws Exception {
+        ResultSet rs = methodWatcher.executeQuery("select count(*), max(col1), min(col1) from (" +
+                "select col1 from foo except all select col1 from foo2) argh"
+        );
+    }
+
+}


### PR DESCRIPTION
We do not currently support  
intersect all,
 except all  
but we do support
 intersect,
 except.
This commit attempts to straighten that out.  Branch-2.0 version.
