### PR TITLE
DB-5636

### DIFF
--- a/splice_machine_test/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctGroupedAggregateOperationIT.java
+++ b/splice_machine_test/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctGroupedAggregateOperationIT.java
@@ -1,5 +1,7 @@
 package com.splicemachine.derby.impl.sql.execute.operations;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.Arrays;
@@ -25,42 +27,70 @@ public class DistinctGroupedAggregateOperationIT extends SpliceUnitTest {
 	public static final String CLASS_NAME = DistinctGroupedAggregateOperationIT.class.getSimpleName().toUpperCase();
     protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);
 	public static final String TABLE_NAME_1 = "A";
+    public static final String TABLE_NAME_2 = "B";
 	private static Logger LOG = Logger.getLogger(DistinctGroupedAggregateOperationIT.class);
 	protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
 	protected static SpliceTableWatcher spliceTableWatcher = new SpliceTableWatcher(TABLE_NAME_1,CLASS_NAME,"(oid int, quantity int)");
-	
+    protected static SpliceTableWatcher spliceTableWatcher2 = new SpliceTableWatcher(TABLE_NAME_2,CLASS_NAME,"(BD_NAME CHAR(2), ACCOUNT_TYPE VARCHAR(20), ACCOUNT_NUMBER VARCHAR(20))");
+
 	@ClassRule 
 	public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
-		.around(spliceSchemaWatcher)
-		.around(spliceTableWatcher)
-		.around(new SpliceDataWatcher(){
-			@Override
-			protected void starting(Description description) {
-				try {
-				Statement s = spliceClassWatcher.getStatement();
-				s.execute(format("insert into %s.%s values(1, 5)",CLASS_NAME,TABLE_NAME_1));
-				s.execute(format("insert into %s.%s values(2, 2)",CLASS_NAME,TABLE_NAME_1));
-				s.execute(format("insert into %s.%s values(2, 1)",CLASS_NAME,TABLE_NAME_1));
-				s.execute(format("insert into %s.%s values(3, 10)",CLASS_NAME,TABLE_NAME_1));
-				s.execute(format("insert into %s.%s values(3, 5)",CLASS_NAME,TABLE_NAME_1));
-				s.execute(format("insert into %s.%s values(3, 1)",CLASS_NAME,TABLE_NAME_1));
-				s.execute(format("insert into %s.%s values(3, 1)",CLASS_NAME,TABLE_NAME_1));				
-				} catch (Exception e) {
-					e.printStackTrace();
-					throw new RuntimeException(e);
-				}
-				finally {
-					spliceClassWatcher.closeAll();
-				}
-			}
+            .around(spliceSchemaWatcher)
+            .around(spliceTableWatcher)
+            .around(new SpliceDataWatcher(){
+                @Override
+                protected void starting(Description description) {
+                    try {
+                        Statement s = spliceClassWatcher.getStatement();
+                        s.execute(format("insert into %s.%s values(1, 5)",CLASS_NAME,TABLE_NAME_1));
+                        s.execute(format("insert into %s.%s values(2, 2)",CLASS_NAME,TABLE_NAME_1));
+                        s.execute(format("insert into %s.%s values(2, 1)",CLASS_NAME,TABLE_NAME_1));
+                        s.execute(format("insert into %s.%s values(3, 10)",CLASS_NAME,TABLE_NAME_1));
+                        s.execute(format("insert into %s.%s values(3, 5)",CLASS_NAME,TABLE_NAME_1));
+                        s.execute(format("insert into %s.%s values(3, 1)",CLASS_NAME,TABLE_NAME_1));
+                        s.execute(format("insert into %s.%s values(3, 1)",CLASS_NAME,TABLE_NAME_1));
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        throw new RuntimeException(e);
+                    }
+                    finally {
+                        spliceClassWatcher.closeAll();
+                    }
+                }
 
-		})
-        .around(TestUtils
+            })
+            .around(spliceTableWatcher2)
+            .around(new SpliceDataWatcher(){
+                @Override
+                protected void starting(Description description) {
+                    try {
+                        Statement s = spliceClassWatcher.getStatement();
+                        s.execute(format("insert into %s.%s values('CA','QUALIFIED','1')",CLASS_NAME,TABLE_NAME_2));
+                        s.execute(format("insert into %s.%s values('CA','NON-QUALIFIED','2')",CLASS_NAME,TABLE_NAME_2));
+                        s.execute(format("insert into %s.%s values('CA','NON-QUALIFIED','3')",CLASS_NAME,TABLE_NAME_2));
+                        s.execute(format("insert into %s.%s values('CA','NON-QUALIFIED','4')",CLASS_NAME,TABLE_NAME_2));
+                        s.execute(format("insert into %s.%s values('CA','QUALIFIED','5')",CLASS_NAME,TABLE_NAME_2));
+                        s.execute(format("insert into %s.%s values('CA','QUALIFIED','6')",CLASS_NAME,TABLE_NAME_2));
+                        s.execute(format("insert into %s.%s values('CA','QUALIFIED','7')",CLASS_NAME,TABLE_NAME_2));
+                        s.execute(format("insert into %s.%s values('CA','QUALIFIED','8')",CLASS_NAME,TABLE_NAME_2));
+                        s.execute(format("insert into %s.%s values('CA','NON-QUALIFIED','9')",CLASS_NAME,TABLE_NAME_2));
+                        s.execute(format("insert into %s.%s values('CA','QUALIFIED','10')",CLASS_NAME,TABLE_NAME_2));
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        throw new RuntimeException(e);
+                    }
+                    finally {
+                        spliceClassWatcher.closeAll();
+                    }
+                }
+
+            })
+            .around(TestUtils
                     .createStringDataWatcher(spliceClassWatcher,
-                                                "create table t1 (c1 int, c2 int); " +
-                                                    "insert into t1 values (null, null), (1,1), " +
-                                                    "(null, null), (2,1), (3,1), (10,10);",
-                                                CLASS_NAME));
+                            "create table t1 (c1 int, c2 int); " +
+                                    "insert into t1 values (null, null), (1,1), " +
+                                    "(null, null), (2,1), (3,1), (10,10);",
+                            CLASS_NAME));
 
     public SpliceWatcher methodWatcher = new SpliceWatcher(CLASS_NAME);
 
@@ -135,5 +165,26 @@ public class DistinctGroupedAggregateOperationIT extends SpliceUnitTest {
                                                                                                "from t1 group by c2 " +
                                                                                                "order by 1"));
         Assert.assertArrayEquals(bothSumsExpected.toArray(), bothSumsRows.toArray());
+    }
+
+    //DB-5636
+    @Test
+    public void testDistinctAndNonDistinctAggregate2() throws Exception {
+        String sql = String.format("select BD_NAME\n" +
+                ",SUM(case when account_type <>'QUALIFIED' THEN 1 ELSE 0 END)\n" +
+                ",COUNT(DISTINCT ACCOUNT_NUMBER) AS TOTAL_ACCOUNTS\n" +
+                ",COUNT(DISTINCT case when account_type ='QUALIFIED' THEN ACCOUNT_NUMBER ELSE NULL END)\n" +
+                "FROM %s.%s\n" +
+                "GROUP BY BD_NAME", CLASS_NAME, TABLE_NAME_2);
+        Connection connection = methodWatcher.getOrCreateConnection();
+        PreparedStatement ps = connection.prepareStatement(sql);
+        for (int i = 0; i < 10; ++i) {
+            ResultSet rs = ps.executeQuery();
+            Assert.assertTrue(rs.next());
+            Assert.assertEquals(10, rs.getInt(3));
+            Assert.assertEquals(6, rs.getInt(4));
+            rs.close();
+        }
+        ps.close();
     }
 }


### PR DESCRIPTION
This fix is for 1.5.x only.

When calculating grouped distinct and non-distinct aggregation in one query, a row is emitted from non-distinct buffer in first phase. The columns that are involved in distinct aggregation in this row should be null out. Otherwise, they may be accidentally impact distinct aggregation.