### PR TITLE
SPLICE-950 Make activation classes eligible for GC

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
@@ -29,7 +29,11 @@ import com.google.common.base.Optional;
 import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.Property;
+import com.splicemachine.db.iapi.services.context.ContextService;
 import com.splicemachine.db.iapi.services.property.PropertyUtil;
+import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
+import com.splicemachine.db.iapi.sql.depend.DependencyManager;
+import com.splicemachine.db.iapi.sql.depend.Dependent;
 import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.store.access.conglomerate.Conglomerate;
@@ -38,6 +42,8 @@ import com.splicemachine.db.impl.sql.GenericStorablePreparedStatement;
 import org.apache.log4j.Logger;
 import org.spark_project.guava.cache.Cache;
 import org.spark_project.guava.cache.CacheBuilder;
+import org.spark_project.guava.cache.RemovalListener;
+import org.spark_project.guava.cache.RemovalNotification;
 
 import javax.management.MXBean;
 import java.util.List;
@@ -84,16 +90,28 @@ public class DataDictionaryCache {
         permissionsCacheSize=PropertyUtil.intPropertyValue(Property.LANG_PERMISSIONS_CACHE_SIZE, value,
                 0, Integer.MAX_VALUE, Property.LANG_PERMISSIONS_CACHE_SIZE_DEFAULT);
 
+        RemovalListener<Object,Dependent> dependentInvalidator = new RemovalListener<Object, Dependent>() {
+            @Override
+            public void onRemoval(RemovalNotification<Object, Dependent> removalNotification) {
+                LanguageConnectionContext lcc=(LanguageConnectionContext)
+                        ContextService.getContextOrNull(LanguageConnectionContext.CONTEXT_ID);
+                try {
+                    removalNotification.getValue().makeInvalid(DependencyManager.INTERNAL_RECOMPILE_REQUEST, lcc);
+                } catch (StandardException e) {
+                    LOG.error("Failed to invalidate " + removalNotification.getValue(), e);
+                }
+            }
+        };
         oidTdCache = CacheBuilder.newBuilder().maximumSize(tdCacheSize).build();
         nameTdCache = CacheBuilder.newBuilder().maximumSize(tdCacheSize).build();
         if(stmtCacheSize>0){
-            spsNameCache = CacheBuilder.newBuilder().maximumSize(stmtCacheSize).build();
-            storedPreparedStatementCache = CacheBuilder.newBuilder().maximumSize(stmtCacheSize).build();
+            spsNameCache = CacheBuilder.newBuilder().maximumSize(stmtCacheSize).removalListener(dependentInvalidator).build();
+            storedPreparedStatementCache = CacheBuilder.newBuilder().maximumSize(stmtCacheSize).removalListener(dependentInvalidator).build();
         }
         sequenceGeneratorCache=CacheBuilder.newBuilder().maximumSize(seqgenCacheSize).build();
         partitionStatisticsCache = CacheBuilder.newBuilder().maximumSize(8092).build();
         conglomerateCache = CacheBuilder.newBuilder().maximumSize(1024).build();
-        statementCache = CacheBuilder.newBuilder().maximumSize(1024).build();
+        statementCache = CacheBuilder.newBuilder().maximumSize(1024).removalListener(dependentInvalidator).build();
         schemaCache = CacheBuilder.newBuilder().maximumSize(1024).build();
         roleCache = CacheBuilder.newBuilder().maximumSize(100).build();
         permissionsCache=CacheBuilder.newBuilder().maximumSize(permissionsCacheSize).build();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicDependency.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicDependency.java
@@ -31,6 +31,8 @@ import com.splicemachine.db.iapi.sql.depend.Provider;
 
 import com.splicemachine.db.catalog.UUID;
 
+import java.lang.ref.WeakReference;
+
 /**
 	A dependency represents a reliance of the dependent on
 	the provider for some information the dependent contains
@@ -66,14 +68,14 @@ class BasicDependency implements Dependency {
 		@return the dependent for this dependency
 	 */
 	public Dependent getDependent() {
-		return dependent;
+		return dependent.get();
 	}
 
 	//
 	// class interface
 	//
 	BasicDependency(Dependent d, Provider p) {
-		dependent = d;
+		dependent = new WeakReference<Dependent>(d);
 		provider = p;
 	}
 
@@ -81,5 +83,5 @@ class BasicDependency implements Dependency {
 	// class implementation
 	//
 	private final Provider	provider;
-	private final Dependent	dependent;
+	private final WeakReference<Dependent>	dependent;
 }


### PR DESCRIPTION
Invalidate statements when pushed out of the statement cache and store
only weak references on the DependencyManager

I've tested this running a script similar to what Gene uploaded concurrently with an IT run. A test for it will be added to the QA runs.

Tested it against JDK 7 & 8.