### PR TITLE
SPLICE-954: fix an issue with BatchOnceOperation

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/batchonce/BatchOnceOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/batchonce/BatchOnceOperation.java
@@ -228,7 +228,7 @@ public class BatchOnceOperation extends SpliceBaseOperation {
 
         ExecRow sourceRow;
         ExecRow newRow;
-        while ((sourceRow = source.nextRow(spliceRuntimeContext)) != null && rowQueue.size() < BATCH_SIZE) {
+        while (rowQueue.size() < BATCH_SIZE && (sourceRow = source.nextRow(spliceRuntimeContext)) != null) {
             sourceRow = sourceRow.getClone();
             DataValueDescriptor sourceKey = sourceRow.getColumn(sourceCorrelatedColumnPosition);
             DataValueDescriptor sourceOldValue = sourceRow.getColumn(sourceCorrelatedColumnPosition == 1 ? 2 : 1);


### PR DESCRIPTION
BatchOnceOperation pulls a batch of rows to a buffer until the buffer is full (by default 50000). There is a bug that caused the operation to lose one row for each batch, because it pulls a row first and then check whether the buffer is full. If the buffer is full, the row that it just pulled will be ignored. 

The fix is very straightforward: check whether the buffer is full first. If not full, pull a row and buffer it.