### PR TITLE
SPLICE-960 close parent scanner

### DIFF
--- a/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -153,6 +153,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
 			if (LOG.isDebugEnabled()) {
 				SpliceLogUtils.debug(LOG, "close");
 			}
+			super.close();
 			boolean shouldC;
 			do{
 				MemstoreAware latest = memstoreAware.get();

--- a/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -155,6 +155,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
 			if (LOG.isDebugEnabled()) {
 				SpliceLogUtils.debug(LOG, "close");
 			}
+			super.close();
 			boolean shouldC;
 			do{
 				MemstoreAware latest = memstoreAware.get();

--- a/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -153,6 +153,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
         if (LOG.isDebugEnabled()) {
             SpliceLogUtils.debug(LOG, "close");
         }
+        super.close();
         boolean shouldC;
         do{
             MemstoreAware latest = memstoreAware.get();

--- a/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -153,6 +153,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
         if (LOG.isDebugEnabled()) {
             SpliceLogUtils.debug(LOG, "close");
         }
+        super.close();
         boolean shouldC;
         do{
             MemstoreAware latest = memstoreAware.get();

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -160,6 +160,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
         if (LOG.isDebugEnabled()) {
             SpliceLogUtils.debug(LOG, "close");
         }
+        super.close();
         boolean shouldC;
         do{
             MemstoreAware latest = memstoreAware.get();


### PR DESCRIPTION
We were leaking resources in StoreScanner, which MemStoreFlushAwareScanner inherits from. We must close it properly.