### PR TITLE
SPLICE-938 : Splice Machine 3.0 on a cluster with Spark 2.0.0

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -79,6 +79,7 @@
                         </goals>
                         <configuration>
                             <includeArtifactIds><!-- third party libs -->
+                                akka-remote_2.11,
                                 concurrentlinkedhashmap-lru,
                                 disruptor,
                                 ehcache-core,

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -79,7 +79,7 @@
                         </goals>
                         <configuration>
                             <includeArtifactIds><!-- third party libs -->
-                                akka-remote_2.11,
+                                akka-remote_${scala.binary.version},
                                 concurrentlinkedhashmap-lru,
                                 disruptor,
                                 ehcache-core,

--- a/db-engine/pom.xml
+++ b/db-engine/pom.xml
@@ -76,12 +76,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-catalyst_2.11</artifactId>
+            <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-unsafe_2.11</artifactId>
+            <artifactId>spark-unsafe_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
         </dependency>
 

--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -48,23 +48,23 @@
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-remote_2.11</artifactId>
+            <artifactId>akka-remote_${scala.binary.version}</artifactId>
             <version>2.4.8</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-network-common_2.11</artifactId>
+            <artifactId>spark-network-common_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-network-yarn_2.11</artifactId>
+            <artifactId>spark-network-yarn_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-yarn_2.11</artifactId>
+            <artifactId>spark-yarn_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <exclusions>
                 <exclusion>
@@ -85,12 +85,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-mllib_2.11</artifactId>
+            <artifactId>spark-mllib_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.11</artifactId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
         </dependency>
 
@@ -222,14 +222,14 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_${scala.binary.version}</artifactId>
             <version>${kafka.version}</version>
             <classifier>test</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_${scala.binary.version}</artifactId>
             <version>${kafka.version}</version>
         </dependency>
 
@@ -449,7 +449,7 @@
                     <artifactSet>
                         <includes>
                             <include>io.netty:netty-all</include>
-                            <!-- <include>com.typesafe.akka:akka-remote_2.11</include> -->
+                            <!-- <include>com.typesafe.akka:akka-remote_${scala.binary.version}</include> -->
                         </includes>
                     </artifactSet>
             <filters>

--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -446,12 +446,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
-<!--                    <shadedArtifactAttached>false</shadedArtifactAttached>
-                    <outputFile>${shuffle.jar}</outputFile> -->
                     <artifactSet>
                         <includes>
                             <include>io.netty:netty-all</include>
-                            <include>com.typesafe.akka:akka-remote_2.11</include>
+                            <!-- <include>com.typesafe.akka:akka-remote_2.11</include> -->
                         </includes>
                     </artifactSet>
             <filters>
@@ -472,13 +470,13 @@
                         <include>io.netty.**</include>
                     </includes>
                 </relocation>
-                <relocation>
+                <!-- <relocation>
                     <pattern>akka.remote</pattern>
                     <shadedPattern>splice.akka.remote</shadedPattern>
                     <includes>
                         <include>akka.remote.**</include>
                     </includes>
-                </relocation>
+                </relocation> -->
             </relocations>
         </configuration>
         <executions>

--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -441,6 +441,48 @@
     </dependencies>
     <build>
         <plugins>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+<!--                    <shadedArtifactAttached>false</shadedArtifactAttached>
+                    <outputFile>${shuffle.jar}</outputFile> -->
+                    <artifactSet>
+                        <includes>
+                            <include>io.netty:netty-all</include>
+                        </includes>
+                    </artifactSet>
+            <filters>
+                <filter>
+                    <artifact>*:*</artifact>
+                    <excludes>
+                        <exclude>META-INF/*.SF</exclude>
+                        <exclude>META-INF/*.DSA</exclude>
+                        <exclude>META-INF/*.RSA</exclude>
+                    </excludes>
+                </filter>
+            </filters>
+            <relocations>
+                <relocation>
+                    <pattern>io.netty</pattern>
+                    <shadedPattern>splice.io.netty</shadedPattern>
+                    <includes>
+                        <include>io.netty.**</include>
+                    </includes>
+                </relocation>
+            </relocations>
+        </configuration>
+        <executions>
+            <execution>
+                <phase>package</phase>
+                <goals>
+                    <goal>shade</goal>
+                </goals>
+            </execution>
+        </executions>
+    </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -451,6 +451,7 @@
                     <artifactSet>
                         <includes>
                             <include>io.netty:netty-all</include>
+                            <include>com.typesafe.akka:akka-remote_2.11</include>
                         </includes>
                     </artifactSet>
             <filters>
@@ -469,6 +470,13 @@
                     <shadedPattern>splice.io.netty</shadedPattern>
                     <includes>
                         <include>io.netty.**</include>
+                    </includes>
+                </relocation>
+                <relocation>
+                    <pattern>akka.remote</pattern>
+                    <shadedPattern>splice.akka.remote</shadedPattern>
+                    <includes>
+                        <include>akka.remote.**</include>
                     </includes>
                 </relocation>
             </relocations>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <skip.staticanalysis>${skip.sa}</skip.staticanalysis>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <scala.version>2.11</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
         <spark.version>2.0.0</spark.version>
     </properties>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <skip.staticanalysis>${skip.sa}</skip.staticanalysis>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <scala.version>2.11</scala.version>
         <spark.version>2.0.0</spark.version>
     </properties>
     <scm>

--- a/utilities/pom.xml
+++ b/utilities/pom.xml
@@ -26,7 +26,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-network-common_2.11</artifactId>
+            <artifactId>spark-network-common_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
         </dependency>
 


### PR DESCRIPTION
- resolves some io.netty startup issues
- include akka-remote dependency in our assembly since it was pulled out of Spark 2.0.0
- make Scala binary version a property instead of hard-coding