### PR TITLE
SPLICE-993 Make shared INSTANCE fields volatile

### DIFF
--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/HBasePipelineEnvironment.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/HBasePipelineEnvironment.java
@@ -76,7 +76,7 @@ public class HBasePipelineEnvironment implements PipelineEnvironment{
                 env = INSTANCE;
                 if(env==null){
                     SIEnvironment siEnv =HBaseSIEnvironment.loadEnvironment(systemClock,ZkUtils.getRecoverableZooKeeper());
-                    env= INSTANCE = new HBasePipelineEnvironment(siEnv,ctxFactoryLoader,HPipelineExceptionFactory.INSTANCE);
+                    env = INSTANCE = new HBasePipelineEnvironment(siEnv,ctxFactoryLoader,HPipelineExceptionFactory.INSTANCE);
                     PipelineDriver.loadDriver(env);
                 }
             }

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineDriver.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineDriver.java
@@ -46,7 +46,7 @@ import com.splicemachine.pipeline.utils.PipelineCompressor;
  */
 public class PipelineDriver{
     private static final int ipcReserved=10;
-    private static PipelineDriver INSTANCE;
+    private static volatile PipelineDriver INSTANCE;
 
     private final SpliceWriteControl writeControl;
     private final WritePipelineFactory writePipelineFactory;

--- a/splice_machine/src/main/java/com/splicemachine/EngineDriver.java
+++ b/splice_machine/src/main/java/com/splicemachine/EngineDriver.java
@@ -39,7 +39,7 @@ import com.splicemachine.uuid.UUIDGenerator;
  *         Date: 1/6/16
  */
 public class EngineDriver{
-    private static EngineDriver INSTANCE;
+    private static volatile EngineDriver INSTANCE;
 
     private final Connection internalConnection;
     private final Snowflake uuidGen;

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLDriver.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLDriver.java
@@ -22,7 +22,7 @@ import com.splicemachine.access.api.SConfiguration;
  *         Date: 12/31/15
  */
 public class DDLDriver{
-    private static DDLDriver INSTANCE;
+    private static volatile DDLDriver INSTANCE;
 
     private final DDLController ddlController;
     private final DDLWatcher ddlWatcher;


### PR DESCRIPTION
I got an NPE while accessing these fields a couple of times during the boot process. We might be accessing the field before initializing it, but if we are sharing it across threads it has to be volatile or have a synchronized access, I opted for the former.