### PR TITLE
SPLICE-983: Carrying defaults through imports.

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/load/SpliceCsvTokenizer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/load/SpliceCsvTokenizer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012 - 2016 Splice Machine, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.splicemachine.derby.impl.load;
+
+import com.splicemachine.derby.stream.function.QuoteTrackingTokenizer;
+import org.supercsv.prefs.CsvPreference;
+
+import java.io.Reader;
+
+/**
+ * @author Scott Fines
+ *         Date: 9/29/16
+ */
+public class SpliceCsvTokenizer extends QuoteTrackingTokenizer{
+
+    /**
+     * Constructs a new <tt>Tokenizer</tt>, which reads the CSV file, line by line.
+     *
+     * @param reader      the reader
+     * @param preferences the CSV preferences
+     * @throws NullPointerException if reader or preferences is null
+     */
+    public SpliceCsvTokenizer(Reader reader,CsvPreference preferences){
+        super(reader,preferences);
+    }
+
+
+
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/FileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/FileFunction.java
@@ -19,12 +19,14 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.derby.impl.sql.execute.operations.LocatedRow;
 import com.splicemachine.derby.stream.iapi.OperationContext;
+import com.splicemachine.derby.stream.utils.BooleanList;
 import org.apache.commons.collections.iterators.SingletonIterator;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.*;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  *
@@ -70,7 +72,9 @@ public class FileFunction extends AbstractFileFunction<String> {
         }
         try {
             tokenizer.setLine(s);
-            LocatedRow lr =  call(tokenizer.read());
+            List<String> read=tokenizer.read();
+            BooleanList quotedColumns=tokenizer.getQuotedColumns();
+            LocatedRow lr =  call(read,quotedColumns);
             return lr==null?Collections.<LocatedRow>emptyList().iterator():new SingletonIterator(lr);
         } catch (Exception e) {
             if (operationContext.isPermissive()) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MutableCSVTokenizer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MutableCSVTokenizer.java
@@ -15,6 +15,7 @@
 
 package com.splicemachine.derby.stream.function;
 
+import com.splicemachine.derby.stream.utils.BooleanList;
 import org.supercsv.io.Tokenizer;
 import org.supercsv.prefs.CsvPreference;
 
@@ -31,10 +32,11 @@ import java.util.List;
  * to bypass the synchronized lineNumber implementation in SuperCSV.
  *
  */
-public class MutableCSVTokenizer extends Tokenizer {
+public class MutableCSVTokenizer extends QuoteTrackingTokenizer {
 
     private String line;
-    private final List<String> columns = new ArrayList<String>();
+    private final List<String> columns =new ArrayList<>();
+    private final BooleanList quotedColumns = new BooleanList();
     public MutableCSVTokenizer(Reader reader, CsvPreference preferences) {
         super(reader, preferences);
     }
@@ -75,9 +77,13 @@ public class MutableCSVTokenizer extends Tokenizer {
      */
     public List<String> read() throws IOException {
         if( readRow() ) {
-            return new ArrayList<String>(getColumns()); // Do we need to array copy here?
+            return new ArrayList<>(getColumns()); // Do we need to array copy here?
         }
         return null; // EOF
+    }
+
+    public BooleanList getQuotedColumns(){
+        return new BooleanList(quotedColumns); //do we need this array copy?
     }
 
     /**
@@ -87,7 +93,7 @@ public class MutableCSVTokenizer extends Tokenizer {
      * @throws IOException
      */
     protected boolean readRow() throws IOException {
-        if( readColumns(columns) ) {
+        if( readColumns(columns,quotedColumns) ) {
             return true;
         }
         return false;

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/QuoteTrackingTokenizer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/QuoteTrackingTokenizer.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2012 - 2016 Splice Machine, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.splicemachine.derby.stream.function;
+
+import com.splicemachine.derby.stream.utils.BooleanList;
+import org.supercsv.comment.CommentMatcher;
+import org.supercsv.exception.SuperCsvException;
+import org.supercsv.io.AbstractTokenizer;
+import org.supercsv.prefs.CsvPreference;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.List;
+
+/**
+ * A Tokenizer which keeps track of which columns were quoted and which were not.
+ * This allows us to make a distinction between columns with value {@code Foo}
+ * versus columns with values {@code "Foo"}.
+ *
+ * @author Scott Fines
+ *         Date: 9/29/16
+ */
+public class QuoteTrackingTokenizer extends AbstractTokenizer{
+
+    private static final char NEWLINE='\n';
+
+    private static final char SPACE=' ';
+
+    private final StringBuilder currentColumn=new StringBuilder();
+
+    /* the raw, untokenized CSV row (may span multiple lines) */
+    private final StringBuilder currentRow=new StringBuilder();
+
+    private final int quoteChar;
+
+    private final int delimeterChar;
+
+    private final boolean surroundingSpacesNeedQuotes;
+
+    private final boolean ignoreEmptyLines;
+
+    private final CommentMatcher commentMatcher;
+
+    private final int maxLinesPerRow;
+
+    /**
+     * Enumeration of tokenizer states. QUOTE_MODE is activated between quotes.
+     */
+    private enum TokenizerState{
+        NORMAL,QUOTE_MODE;
+    }
+
+    /**
+     * Constructs a new <tt>Tokenizer</tt>, which reads the CSV file, line by line.
+     *
+     * @param reader      the reader
+     * @param preferences the CSV preferences
+     * @throws NullPointerException if reader or preferences is null
+     */
+    public QuoteTrackingTokenizer(final Reader reader,final CsvPreference preferences){
+        super(reader,preferences);
+        this.quoteChar=preferences.getQuoteChar();
+        this.delimeterChar=preferences.getDelimiterChar();
+        this.surroundingSpacesNeedQuotes=preferences.isSurroundingSpacesNeedQuotes();
+        this.ignoreEmptyLines=preferences.isIgnoreEmptyLines();
+        this.commentMatcher=preferences.getCommentMatcher();
+        this.maxLinesPerRow=preferences.getMaxLinesPerRow();
+    }
+
+    @Override
+    public boolean readColumns(final List<String> columns) throws IOException{
+        return readColumns(columns,null);
+    }
+
+    public boolean readColumns(final List<String> columns,final BooleanList quotedColumns) throws IOException{
+        if(columns==null){
+            throw new NullPointerException("columns should not be null");
+        }
+        boolean recordQuotes = quotedColumns!=null;
+
+        // clear the reusable List and StringBuilders
+        columns.clear();
+        if(recordQuotes) quotedColumns.clear();
+        currentColumn.setLength(0);
+        currentRow.setLength(0);
+
+        // read a line (ignoring empty lines/comments if necessary)
+        String line;
+        do{
+            line=readLine();
+            if(line==null){
+                return false; // EOF
+            }
+        }
+        while(ignoreEmptyLines && line.length()==0 || (commentMatcher!=null && commentMatcher.isComment(line)));
+
+        // update the untokenized CSV row
+        currentRow.append(line);
+
+        // process each character in the line, catering for surrounding quotes (QUOTE_MODE)
+        TokenizerState state=TokenizerState.NORMAL;
+        int quoteScopeStartingLine=-1; // the line number where a potential multi-line cell starts
+        int potentialSpaces=0; // keep track of spaces (so leading/trailing space can be removed if required)
+        int charIndex=0;
+        boolean wasQuoted = false;
+        while(true){
+            boolean endOfLineReached=charIndex==line.length();
+
+            if(endOfLineReached){
+                if(TokenizerState.NORMAL.equals(state)){
+                    /*
+					 * Newline. Add any required spaces (if surrounding spaces don't need quotes) and return (we've read
+					 * a line!).
+					 */
+                    if(!surroundingSpacesNeedQuotes){
+                        appendSpaces(currentColumn,potentialSpaces);
+                    }
+                    columns.add(currentColumn.length()>0?currentColumn.toString():null); // "" -> null
+                    if(recordQuotes) quotedColumns.add(wasQuoted);
+                    wasQuoted = false;
+                    return true;
+                }else{
+					/*
+					 * Newline. Doesn't count as newline while in QUOTESCOPE. Add the newline char, reset the charIndex
+					 * (will update to 0 for next iteration), read in the next line, then then continue to next
+					 * character.
+					 */
+                    currentColumn.append(NEWLINE);
+                    currentRow.append(NEWLINE); // specific line terminator lost, \n will have to suffice
+
+                    charIndex=0;
+
+                    if(maxLinesPerRow>0 && getLineNumber()-quoteScopeStartingLine+1>=maxLinesPerRow){
+						/*
+						 * The quoted section that is being parsed spans too many lines, so to avoid excessive memory
+						 * usage parsing something that is probably human error anyways, throw an exception. If each
+						 * row is suppose to be a single line and this has been exceeded, throw a more descriptive
+						 * exception
+						 */
+                        String msg=maxLinesPerRow==1?
+                                String.format("unexpected end of line while reading quoted column on line %d",
+                                        getLineNumber()):
+                                String.format("max number of lines to read exceeded while reading quoted column"+
+                                                " beginning on line %d and ending on line %d",
+                                        quoteScopeStartingLine,getLineNumber());
+                        throw new SuperCsvException(msg);
+                    }else if((line=readLine())==null){
+                        throw new SuperCsvException(
+                                String.format(
+                                                "unexpected end of file while reading quoted column beginning on line %d and ending on line %d",
+                                                quoteScopeStartingLine,getLineNumber()));
+                    }
+
+                    currentRow.append(line); // update untokenized CSV row
+
+                    if(line.length()==0){
+                        // consecutive newlines
+                        continue;
+                    }
+                }
+            }
+
+            final char c=line.charAt(charIndex);
+
+            if(TokenizerState.NORMAL.equals(state)){
+                if(c==delimeterChar){
+					/*
+					 * Delimiter. Save the column (trim trailing space if required) then continue to next character.
+					 */
+                    if(!surroundingSpacesNeedQuotes){
+                        appendSpaces(currentColumn,potentialSpaces);
+                    }
+                    columns.add(currentColumn.length()>0?currentColumn.toString():null); // "" -> null
+                    potentialSpaces=0;
+                    currentColumn.setLength(0);
+                    if(recordQuotes){
+                        quotedColumns.append(wasQuoted);
+                    }
+                    wasQuoted = false;
+                }else if(c==SPACE){
+					/*
+					 * Space. Remember it, then continue to next character.
+					 */
+                    potentialSpaces++;
+
+                }else if(c==quoteChar){
+					/*
+					 * A single quote ("). Update to QUOTESCOPE (but don't save quote), then continue to next character.
+					 */
+                    state=TokenizerState.QUOTE_MODE;
+                    wasQuoted = true;
+                    quoteScopeStartingLine=getLineNumber();
+
+                    // cater for spaces before a quoted section (be lenient!)
+                    if(!surroundingSpacesNeedQuotes || currentColumn.length()>0){
+                        appendSpaces(currentColumn,potentialSpaces);
+                    }
+                    potentialSpaces=0;
+
+                }else{
+					/*
+					 * Just a normal character. Add any required spaces (but trim any leading spaces if surrounding
+					 * spaces need quotes), add the character, then continue to next character.
+					 */
+                    if(!surroundingSpacesNeedQuotes || currentColumn.length()>0){
+                        appendSpaces(currentColumn,potentialSpaces);
+                    }
+
+                    potentialSpaces=0;
+                    currentColumn.append(c);
+                }
+
+            }else{
+				/*
+				 * QUOTE_MODE (within quotes).
+				 */
+                if(c==quoteChar){
+                    int nextCharIndex=charIndex+1;
+                    boolean availableCharacters=nextCharIndex<line.length();
+                    boolean nextCharIsQuote=availableCharacters && line.charAt(nextCharIndex)==quoteChar;
+                    if(nextCharIsQuote){
+						/*
+						 * An escaped quote (""). Add a single quote, then move the cursor so the next iteration of the
+						 * loop will read the character following the escaped quote.
+						 */
+                        currentColumn.append(c);
+                        charIndex++;
+
+                    }else{
+						/*
+						 * A single quote ("). Update to NORMAL (but don't save quote), then continue to next character.
+						 */
+                        state=TokenizerState.NORMAL;
+                        quoteScopeStartingLine=-1; // reset ready for next multi-line cell
+                    }
+                }else{
+					/*
+					 * Just a normal character, delimiter (they don't count in QUOTESCOPE) or space. Add the character,
+					 * then continue to next character.
+					 */
+                    currentColumn.append(c);
+                }
+            }
+
+            charIndex++; // read next char of the line
+        }
+    }
+
+    /**
+     * Appends the required number of spaces to the StringBuilder.
+     *
+     * @param sb     the StringBuilder
+     * @param spaces the required number of spaces to append
+     */
+    private static void appendSpaces(final StringBuilder sb,final int spaces){
+        for(int i=0;i<spaces;i++){
+            sb.append(SPACE);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getUntokenizedRow(){
+        return currentRow.toString();
+    }
+
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/StreamFileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/StreamFileFunction.java
@@ -20,9 +20,12 @@ import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.derby.impl.load.SpliceCsvReader;
 import com.splicemachine.derby.impl.sql.execute.operations.LocatedRow;
 import com.splicemachine.derby.stream.iapi.OperationContext;
+import com.splicemachine.derby.stream.utils.BooleanList;
+
 import java.io.*;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 /**
@@ -85,7 +88,9 @@ import java.util.NoSuchElementException;
                                             hasNext = false;
                                             return false;
                                         }
-                                        nextRow = call(spliceCsvReader.next());
+                                        List<String> next=spliceCsvReader.next();
+                                        BooleanList quotedColumns = spliceCsvReader.nextQuotedColumns();
+                                        nextRow = call(next,quotedColumns);
                                         if (nextRow != null) {
                                             stale = true;
                                             hasNext = true;

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/BooleanList.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/BooleanList.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2012 - 2016 Splice Machine, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.splicemachine.derby.stream.utils;
+
+import java.util.AbstractList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * A list of booleans.
+ *
+ * @author Scott Fines
+ *         Date: 9/29/16
+ */
+public class BooleanList extends AbstractList<Boolean>{
+    private boolean[] list;
+    private int size;
+
+    public BooleanList(){
+        this(10);
+    }
+
+    public BooleanList(int initialSize){
+        this.list = new boolean[initialSize];
+        size = 0;
+    }
+
+    public BooleanList(BooleanList bl){
+        this.list = Arrays.copyOf(bl.list,bl.list.length);
+        this.size = bl.size;
+    }
+
+    private BooleanList(boolean[] array){
+        this.list = array;
+        this.size= array.length;
+    }
+
+    @Override
+    public boolean add(Boolean aBoolean){
+        return append(aBoolean);
+    }
+
+    @Override
+    public void add(int index,Boolean element){
+        appendAt(index,element);
+    }
+
+    public boolean append(boolean bool){
+        if(expandIfNecessary()) return false;
+
+        list[size]=bool;
+        size++;
+        return true;
+    }
+
+    public void appendAt(int index,boolean element){
+        if(index>=size) {
+            append(element);
+            return;
+        }else if(index<0) throw new IndexOutOfBoundsException(Integer.toString(index));
+
+        if(!expandIfNecessary()) throw new IndexOutOfBoundsException("List is too large!");
+        System.arraycopy(list,index,list,index+1,size-index);
+        list[index] = element;
+        size++;
+    }
+
+    public boolean valueAt(int index){
+        if(index<0 || index>=size) throw new IndexOutOfBoundsException(Integer.toString(index));
+        return list[index];
+    }
+
+    @Override
+    public void clear(){
+        size = 0;
+    }
+
+    @Override
+    public Boolean get(int index){
+        return valueAt(index);
+    }
+
+    @Override
+    public int size(){
+        return size;
+    }
+
+    @Override
+    public Iterator<Boolean> iterator(){
+        return new BoolIter();
+    }
+
+    public BoolIter primitiveIterator(){
+        return new BoolIter();
+    }
+
+    @Override
+    public boolean equals(Object o){
+        if(o==this) return true;
+        if(!(o instanceof BooleanList)) return false;
+
+        BooleanList other = (BooleanList)o;
+        if(other.size!=size) return false;
+        for(int i=0;i<size;i++){
+            if(other.list[i]!=list[i]) return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode(){
+        int hC = 17;
+        for(int i=0;i<size;i++){
+            hC=31*hC +(list[i]?1:0);
+        }
+        return hC;
+    }
+
+    public static BooleanList wrap(boolean... array){
+        return new BooleanList(Arrays.copyOf(array,array.length));
+    }
+
+    public void trimToSize(){
+        list = Arrays.copyOf(list,size);
+    }
+
+    /* ***************************************************************************************************************/
+    /*private helper methods*/
+    private boolean expandIfNecessary(){
+        if(size>=list.length){
+            int newSize = Math.min(Integer.MAX_VALUE,3*size/2);
+            if(newSize!=list.length)
+                list = Arrays.copyOf(list,newSize);
+            else return true;
+        }
+        return false;
+    }
+
+    public class BoolIter implements Iterator<Boolean>{
+        private int pos = 0;
+
+        @Override
+        public boolean hasNext(){
+            return pos<size;
+        }
+
+        @Override
+        public Boolean next(){
+            return nextBoolean();
+        }
+
+        public boolean nextBoolean(){
+            if(!hasNext()) throw new NoSuchElementException();
+            boolean b = list[pos];
+            pos++;
+            return b;
+        }
+    }
+}

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/ImportDefaultValueIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/ImportDefaultValueIT.java
@@ -133,9 +133,9 @@ public class ImportDefaultValueIT {
 
         SpliceUnitTest.ResultList map = SpliceUnitTest.ResultList.create()
                                                                    .toFileRow("1", "ac").expected("1", "ac")
-                                                                   .toFileRow("2", "NULL").expected("2", "NULL")
+                                                                   .toFileRow("2", "NULL").expected("2", "abc")
                                                                    .toFileRow("3", "ab").expected("3", "ab")
-                                                                   .toFileRow("4", "NULL").expected("4", "NULL")
+                                                                   .toFileRow("4", "NULL").expected("4", "abc")
                                                                    .fill(writer);
 
         writer.close();
@@ -191,9 +191,9 @@ public class ImportDefaultValueIT {
 
         SpliceUnitTest.ResultList map = SpliceUnitTest.ResultList.create()
                                                                    .toFileRow("1", "ac").expected("1", "ac")
-                                                                   .toFileRow("2", "").expected("2", "NULL")
+                                                                   .toFileRow("2", "").expected("2", "abc")
                                                                    .toFileRow("3", "ab").expected("3", "ab")
-                                                                   .toFileRow("4", "").expected("4", "NULL")
+                                                                   .toFileRow("4", "").expected("4", "abc")
                                                                    .fill(writer);
         writer.close();
 
@@ -270,9 +270,9 @@ public class ImportDefaultValueIT {
         PrintWriter writer = new PrintWriter(fileName, UTF_8_CHAR_SET_STR);
 
         SpliceUnitTest.ResultList map = SpliceUnitTest.ResultList.create()
-                                                                   .toFileRow("1", "", "ac").expected("1", "NULL", "ac")
+                                                                   .toFileRow("1", "", "ac").expected("1", "2011-03-17 15:52:25.0", "ac")
                                                                    .toFileRow("2", "2016-01-29 15:38:45", "").expected("2", "2016-01-29 15:38:45.0", "NULL")
-                                                                   .toFileRow("3", "", "ab").expected("3", "NULL", "ab")
+                                                                   .toFileRow("3", "", "ab").expected("3", "2011-03-17 15:52:25.0", "ab")
                                                                    .toFileRow("4", "2016-01-29 15:38:45", "ca").expected("4", "2016-01-29 15:38:45.0", "ca")
                                                                    .fill(writer);
         writer.close();
@@ -311,10 +311,10 @@ public class ImportDefaultValueIT {
         PrintWriter writer = new PrintWriter(fileName, UTF_8_CHAR_SET_STR);
 
         SpliceUnitTest.ResultList map = SpliceUnitTest.ResultList.create()
-                                                                   .toFileRow("1", "", "ac").expected("1", "NULL", "ac")
-                                                                   .toFileRow("2", "", "").expected("2", "NULL", "NULL")
-                                                                   .toFileRow("3", "", "ab").expected("3", "NULL", "ab")
-                                                                   .toFileRow("4", "", "ca").expected("4", "NULL", "ca")
+                                                                   .toFileRow("1", "", "ac").expected("1", "2011-03-17 15:52:25.0", "ac")
+                                                                   .toFileRow("2", "", "").expected("2", "2011-03-17 15:52:25.0", "NULL")
+                                                                   .toFileRow("3", "", "ab").expected("3", "2011-03-17 15:52:25.0", "ab")
+                                                                   .toFileRow("4", "", "ca").expected("4", "2011-03-17 15:52:25.0", "ca")
                                                                    .fill(writer);
         writer.close();
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/ImportNullityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/ImportNullityIT.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2012 - 2016 Splice Machine, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.splicemachine.derby.impl.load;
+
+import com.splicemachine.derby.test.framework.RuledConnection;
+import com.splicemachine.derby.test.framework.SchemaRule;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.TableRule;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.io.File;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Scott Fines
+ *         Date: 9/30/16
+ */
+public class ImportNullityIT{
+    public static final String SCHEMA_NAME=ImportNullityIT.class.getSimpleName();
+    private final RuledConnection conn = new RuledConnection(null);
+
+    private final TableRule withDefault = new TableRule(conn,"T","(a varchar(10),b varchar(10),c varchar(20) NOT NULL default 'nullDefault')");
+
+    @Rule public final TestRule rules =RuleChain.outerRule(conn)
+            .around(new SchemaRule(conn,SCHEMA_NAME))
+            .around(withDefault);
+
+    private static File BADDIR;
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        BADDIR = SpliceUnitTest.createBadLogDirectory(SCHEMA_NAME);
+        assertNotNull(BADDIR);
+    }
+
+    @Test
+    public void importsWithDefaultValue() throws Exception{
+        String file =SpliceUnitTest.getResourceDirectory()+"/import/nullity.csv";
+        try(Statement s = conn.createStatement()){
+            s.execute(String.format("call SYSCS_UTIL.IMPORT_DATA(" +
+                            "'%s'," +  // schema name
+                            "'%s'," +  // table name
+                            "null," +  // insert column list
+                            "'%s'," +  // file path
+                            "','," +   // column delimiter
+                            "null," +  // character delimiter
+                            "null," +  // timestamp format
+                            "null," +  // date format
+                            "null," +  // time format
+                            "0," +    // max bad records
+                            "'%s'," +  // bad record dir
+                            "'false'," +  // has one line records
+                            "null)",   // char set
+                    SCHEMA_NAME,withDefault, file,
+                    BADDIR.getCanonicalPath()));
+            int expectedRowCount= 9; //9 total rows
+            int expectedNullCount = 2; //a and b column should have 2 null values
+            int[] nullCounts=  new int[3];
+            try(ResultSet rs = s.executeQuery("select * from "+withDefault)){
+                int count = 0;
+                while(rs.next()){
+                    String aStr = rs.getString(1); //a value
+                    if(rs.wasNull()){
+                        Assert.assertNull("Did not return a null value!",aStr);
+                        nullCounts[0]++;
+                    }else Assert.assertNotNull("Unexpected null",aStr);
+
+                    String bStr = rs.getString(2); //b value
+                    if(rs.wasNull()){
+                        Assert.assertNull("Did not return a null value!",bStr);
+                        nullCounts[1]++;
+                    }else Assert.assertNotNull("Unexpected null",bStr);
+
+                    String cStr = rs.getString(3); //c value
+                    //c value should never be null
+                    Assert.assertFalse("C should never have a null value!",rs.wasNull());
+                    Assert.assertNotNull("C should never have a null value!",cStr);
+
+                    count++;
+                }
+                Assert.assertEquals("Incorrect number of rows imported!",expectedRowCount,count);
+                Assert.assertEquals("Incorrect null count for column a!",expectedNullCount,nullCounts[0]);
+                Assert.assertEquals("Incorrect null count for column b!",expectedNullCount,nullCounts[1]);
+            }
+        }
+    }
+}

--- a/splice_machine/src/test/java/com/splicemachine/derby/stream/function/QuoteTrackingTokenizerTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/stream/function/QuoteTrackingTokenizerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2012 - 2016 Splice Machine, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.splicemachine.derby.stream.function;
+
+import com.splicemachine.derby.stream.utils.BooleanList;
+import org.junit.Assert;
+import org.junit.Test;
+import org.supercsv.prefs.CsvPreference;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Scott Fines
+ *         Date: 9/29/16
+ */
+public class QuoteTrackingTokenizerTest{
+
+    @Test
+    public void ignoresUnquotedColumns() throws Exception{
+        String column = "hello,goodbye,parseThis!,boots\n";
+        List<String> correctCols = Arrays.asList("hello","goodbye","parseThis!","boots");
+        BooleanList correctQuotes = BooleanList.wrap(new boolean[4]);
+
+        checkResults(column,correctCols,correctQuotes,4);
+    }
+
+    @Test
+    public void catchesQuotedFirstColumn() throws Exception{
+        String column = "\"hello\",goodbye,parseThis!,boots\n";
+        List<String> correctCols = Arrays.asList("hello","goodbye","parseThis!","boots");
+        BooleanList correctQuotes = BooleanList.wrap(true,false,false,false);
+
+        checkResults(column,correctCols,correctQuotes,4);
+    }
+
+    @Test
+    public void recordsQuotesAcrossLineBreaks() throws Exception{
+        String column = "\"hello\",goodbye,parseThis!,\"boots\nmagoo\"";
+        List<String> correctCols = Arrays.asList("hello","goodbye","parseThis!","boots\nmagoo");
+        BooleanList correctQuotes = BooleanList.wrap(true,false,false,true);
+
+        checkResults(column,correctCols,correctQuotes,4);
+    }
+
+    /* ****************************************************************************************************************/
+    /*private helper methods*/
+    private void checkResults(String column,List<String> correctCols,BooleanList correctQuotes,int size) throws IOException{
+        QuoteTrackingTokenizer qtt = new QuoteTrackingTokenizer(new StringReader(column),CsvPreference.STANDARD_PREFERENCE);
+        List<String> cols = new ArrayList<>(size);
+        BooleanList quoteCols = new BooleanList(size);
+        Assert.assertTrue("Did not properly read the columns!",qtt.readColumns(cols,quoteCols));
+        Assert.assertEquals("Did not return correct column information",correctCols, cols);
+        Assert.assertEquals("Did not return correct quoted column information",correctQuotes,quoteCols);
+    }
+}

--- a/splice_machine/src/test/test-data/import/nullity.csv
+++ b/splice_machine/src/test/test-data/import/nullity.csv
@@ -1,0 +1,9 @@
+null,b1,c1
+a1,null,c2
+a2,b2,null
+,b3,c3
+a3,,c4
+a4,b4,
+"null",b5,c5
+a5,"null",c6
+a6,b6,"null"


### PR DESCRIPTION
It turns out, Imports are really just inserts over subselects; to
support default value during the import, we can just re-write the import
SQL clauses to include a case statement which replaces null entries with
default values.

However, in order to support this case statement effectively, we also
need to make sure that we properly treat NULL strings within the parsing
stage. Per customer request, we treat null, NULL, nUll, etc. as actually
being null; we treat "null" as the string 'null'.

An IT was added to confirm overall behavior.