### PR TITLE
SPLICE-1036 Predicates are not being pushed underneath the projection…

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
@@ -673,8 +673,11 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
             Predicate[] preds=new Predicate[size];
             for(int index=0;index<size;index++){
                 Predicate pred=elementAt(index);
-                if(!isHashableJoin && isQualifier(pred,optTable,pushPreds) ||
-                        isHashableJoin && isQualifierForHashableJoin(pred, optTable, pushPreds)){
+                if(isQualifier(pred,optTable,pushPreds) ||
+                        (isHashableJoin && isQualifierForHashableJoin(pred, optTable, pushPreds))
+                        ) {
+//                if(!isHashableJoin && isQualifier(pred,optTable,pushPreds) ||
+//                        isHashableJoin && isQualifierForHashableJoin(pred, optTable, pushPreds)){
                     pred.markQualifier();
                     if(SanityManager.DEBUG){
                         if(pred.isInListProbePredicate()){

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
@@ -601,20 +601,7 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
             }
         }
 
-        // If we're doing a hash join with _this_ PRN (as opposed to
-        // with this PRN's child) then we don't attempt to push
-        // predicates down.  There are two reasons for this: 1)
-        // we don't want to push the equijoin predicate that is
-        // required for the hash join, and 2) if we're doing a
-        // hash join then we're going to materialize this node,
-        // but if we push predicates before materialization, we
-        // can end up with incorrect results (esp. missing rows).
-        // So don't push anything in this case.
-        boolean hashJoinWithThisPRN=hasTrulyTheBestAccessPath &&
-                (trulyTheBestAccessPath.getJoinStrategy()!=null) &&
-                trulyTheBestAccessPath.getJoinStrategy().isHashJoin();
-
-        if((restrictionList!=null) && !alreadyPushed && !hashJoinWithThisPRN){
+        if((restrictionList!=null) && !alreadyPushed){
             restrictionList.pushUsefulPredicates((Optimizable)childResult);
         }
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/TPCHIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/TPCHIT.java
@@ -34,7 +34,7 @@ import static com.splicemachine.subquery.SubqueryITUtil.*;
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 
-public class TPCHIT {
+public class TPCHIT extends SpliceUnitTest {
 
     private static final String SCHEMA_NAME = "TPCH1X";
     private static final String LINEITEM = "LINEITEM";
@@ -239,6 +239,13 @@ public class TPCHIT {
         String sql = getContent("22.sql");
         executeQuery(sql, getContent("22.expected.txt"), true);
         assertSubqueryNodeCount(conn(), sql, ZERO_SUBQUERY_NODES);
+    }
+
+    @Test
+    public void testPredicatePushdownOnRightSideOfJoin() throws Exception {
+        rowContainsQuery(7,"explain select count(*) from --splice-properties joinOrder=fixed\n" +
+                " ORDERS, LINEITEM --splice-properties joinStrategy=BROADCAST\n" +
+                " where l_orderkey = o_orderkey and l_shipdate > date('1995-03-15') and o_orderdate > date('1995-03-15')","preds=[(L_SHIPDATE[2:2] > 1995-03-15)]",methodWatcher);
     }
 
     @Test(expected = SQLException.class)


### PR DESCRIPTION
Allows predicates to be pushed down to TableScan on the right side of a hashable join.