### PR TITLE
Attempt to fix DB-5653( branch 2 version ) :

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
@@ -124,6 +124,14 @@ public class SpliceSpark {
         }
         conf.set("executor.source.splice-machine.class", "com.splicemachine.derby.stream.spark.SpliceMachineSource");
         conf.set("driver.source.splice-machine.class", "com.splicemachine.derby.stream.spark.SpliceMachineSource");
+        // pull out Kerberos and set Yarn properties
+        if(HConfiguration.unwrapDelegate().get("hbase.regionserver.kerberos.principal") != null){
+             conf.set("spark.yarn.keytab", HConfiguration.unwrapDelegate().get("hbase.regionserver.kerberos.principal"));
+        }
+
+        if(HConfiguration.unwrapDelegate().get("hbase.regionserver.keytab.file") != null){
+            conf.set("spark.yarn.principal", HConfiguration.unwrapDelegate().get("hbase.regionserver.keytab.file"));
+        }
 
         // set all spark props that start with "splice.".  overrides are set below.
         for (Object sysPropertyKey : System.getProperties().keySet()) {


### PR DESCRIPTION
Attempt to fix DB-5653( branch 2 version ) :

Pulling up hbase.regionserver.kerberos.principal and hbase.regionserver.keytab.file from HBase configuration
and set spark.yarn.keytab and spark.yarn.principal for Spark