### PR TITLE
WIndow Functions on top of Dataset.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/AggregateDefinition.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/AggregateDefinition.java
@@ -28,6 +28,8 @@ package com.splicemachine.db.iapi.sql.compile;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 
+import static java.lang.String.format;
+
 /**
  * An AggregateDefinition defines an aggregate.
  * 
@@ -48,7 +50,48 @@ import com.splicemachine.db.iapi.types.DataTypeDescriptor;
  *
  * @see com.splicemachine.db.catalog.TypeDescriptor
  */
+
+
+
 public interface AggregateDefinition {
+
+	static FunctionType fromString(String function) {
+			for (FunctionType type : FunctionType.values()) {
+				if (type.getName().equals(function)) {
+					return type;
+				}
+			}
+			throw new UnsupportedOperationException(format("%s aggregation function not implemented",function));
+	}
+
+	 enum FunctionType {
+
+		MAX_FUNCTION("MAX"),
+		MIN_FUNCTION("MIN"),
+		SUM_FUNCTION("SUM"),
+		LAST_VALUE_FUNCTION("LAST_VALUE"),
+		AVG_FUNCTION("AVG"),
+		COUNT_FUNCTION("COUNT"),
+		//no need to over complicate with sub type functions, treat count as count star
+		COUNT_STAR_FUNCTION("COUNT(*)"),
+		DENSE_RANK_FUNCTION("DENSE_RANK"),
+		RANK_FUNCTION("RANK"),
+		FIRST_VALUE_FUNCTION("FIRST_VALUE"),
+		LAG_FUNCTION("LAG"),
+		LEAD_FUNCTION("LEAD"),
+		ROW_NUMBER_FUNCTION("ROW_NUMBER");
+
+		private final String name;
+
+		FunctionType(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
 	/**
 	 * Get the aggregator that performs the aggregation on the
 	 * input datatype at execution time.  If the input type can be handled, 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/WindowFunctionVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/WindowFunctionVisitor.java
@@ -1,0 +1,64 @@
+/*
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified this file.
+ *
+ * All Splice Machine modifications are Copyright 2012 - 2016 Splice Machine, Inc.,
+ * and are licensed to you under the License; you may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+package com.splicemachine.db.impl.ast;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.compile.Visitable;
+import com.splicemachine.db.impl.sql.compile.FromTable;
+import com.splicemachine.db.impl.sql.compile.WindowFunctionNode;
+import org.apache.log4j.Logger;
+
+import static com.splicemachine.db.iapi.sql.compile.CompilerContext.DataSetProcessorType.FORCED_SPARK;
+
+import java.util.List;
+
+
+
+/**
+ * Created by jfilali on 10/10/16.
+ * This visitor will force the dataSetProcessor To Spark if one the operator
+ * is a window function.
+ * Currently window function will be supported by spark only
+ */
+public class WindowFunctionVisitor extends AbstractSpliceVisitor{
+
+    public static List<FromTable> getSourceNode(WindowFunctionNode node) throws StandardException {
+        return CollectingVisitorBuilder.forClass(FromTable.class).collect(node);
+    }
+
+    private static Logger LOG = Logger.getLogger(WindowFunctionVisitor.class);
+
+    @Override
+    public Visitable visit(WindowFunctionNode node) throws StandardException {
+        getSourceNode(node)
+        .forEach( source -> source.setDataSetProcessorType(FORCED_SPARK));
+
+        LOG.info("Window Function can only be executed on top of Spark, " +
+                "therefore dataSetProcessorType has been set to FORCED_SPARK");
+
+        return node;
+    }
+
+}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AggregateNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AggregateNode.java
@@ -25,6 +25,7 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
+import java.util.Arrays;
 import java.util.List;
 
 import com.splicemachine.db.catalog.AliasInfo;
@@ -41,7 +42,7 @@ import com.splicemachine.db.iapi.sql.dictionary.AliasDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
-
+import static com.splicemachine.db.iapi.sql.compile.AggregateDefinition.*;
 /**
  * An Aggregate Node is a node that reprsents a set function/aggregate.
  * It used for all system aggregates as well as user defined aggregates.
@@ -59,6 +60,7 @@ public class AggregateNode extends UnaryOperatorNode
 	private Class					aggregateDefinitionClass;
     protected ClassInspector			classInspector;
 	protected String					aggregateName;
+	protected FunctionType				type;
 
 	/*
 	** We wind up pushing all aggregates into a different
@@ -95,6 +97,9 @@ public class AggregateNode extends UnaryOperatorNode
 	{
 		super.init(operand);
 		this.aggregateName = (String) aggregateName;
+
+
+		this.type = fromString((String) aggregateName);
 
 		if ( uadClass instanceof UserAggregateDefinition )
 		{
@@ -742,4 +747,8 @@ public class AggregateNode extends UnaryOperatorNode
     public boolean isWindowFunction() {
         return this.isWindowFunction;
     }
+
+    public FunctionType getType(){
+		return  this.type;
+	}
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -133,7 +133,7 @@ public class FromBaseTable extends FromTable {
     private FormatableBitSet referencedCols;
     private ResultColumnList templateColumns;
 
-    protected CompilerContext.DataSetProcessorType dataSetProcessorType = CompilerContext.DataSetProcessorType.DEFAULT_CONTROL;
+
     /* A 0-based array of column names for this table used
      * for optimizer trace.
      */

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
@@ -69,6 +69,8 @@ public abstract class FromTable extends ResultSetNode implements Optimizable{
 
     protected String userSpecifiedJoinStrategy;
 
+    protected CompilerContext.DataSetProcessorType dataSetProcessorType = CompilerContext.DataSetProcessorType.DEFAULT_CONTROL;
+
     protected CostEstimate bestCostEstimate;
 
     private double perRowUsage=-1;
@@ -338,6 +340,9 @@ public abstract class FromTable extends ResultSetNode implements Optimizable{
             switch(key){
                 case "joinStrategy":
                     userSpecifiedJoinStrategy=StringUtil.SQLToUpperCase(value);
+                    break;
+                case "useSpark":
+                    dataSetProcessorType = Boolean.parseBoolean(StringUtil.SQLToUpperCase(value))? CompilerContext.DataSetProcessorType.FORCED_SPARK:CompilerContext.DataSetProcessorType.FORCED_CONTROL;
                     break;
                 default:
                     // No other "legal" values at this time
@@ -1123,5 +1128,13 @@ public abstract class FromTable extends ResultSetNode implements Optimizable{
 
     public ResultColumn getRowIdColumn(){
         return null;
+    }
+
+    public CompilerContext.DataSetProcessorType getDataSetProcessorType() {
+        return dataSetProcessorType;
+    }
+
+    public void setDataSetProcessorType(CompilerContext.DataSetProcessorType dataSetProcessorType) {
+        this.dataSetProcessorType = dataSetProcessorType;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowResultSetNode.java
@@ -30,6 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
+import com.splicemachine.db.iapi.sql.compile.*;
 import org.apache.log4j.Logger;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.ClassName;
@@ -40,14 +42,6 @@ import com.splicemachine.db.iapi.services.io.FormatableArrayHolder;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.LanguageFactory;
 import com.splicemachine.db.iapi.sql.ResultColumnDescriptor;
-import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
-import com.splicemachine.db.iapi.sql.compile.CostEstimate;
-import com.splicemachine.db.iapi.sql.compile.NodeFactory;
-import com.splicemachine.db.iapi.sql.compile.Optimizable;
-import com.splicemachine.db.iapi.sql.compile.OptimizablePredicate;
-import com.splicemachine.db.iapi.sql.compile.OptimizablePredicateList;
-import com.splicemachine.db.iapi.sql.compile.Optimizer;
-import com.splicemachine.db.iapi.sql.compile.RowOrdering;
 import com.splicemachine.db.iapi.sql.dictionary.ColumnDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
@@ -765,6 +759,7 @@ public class WindowResultSetNode extends SingleChildResultSetNode {
             FormatableArrayHolder keyCols = createColumnOrdering(wdn.getKeyColumns(), "Key");
             windowInfoList.addElement(new WindowFunctionInfo(
                 windowFunctionNode.getAggregateName(),
+                windowFunctionNode.getType(),
                 windowFunctionNode.getAggregatorClassName(),
                 inputVIDs,       // windowFunctionNode input columns
                 fnResultVID,    // the windowFunctionNode result column

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WrappedAggregateFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WrappedAggregateFunctionNode.java
@@ -37,6 +37,8 @@ import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import org.spark_project.guava.collect.Lists;
 
+import static com.splicemachine.db.iapi.sql.compile.AggregateDefinition.fromString;
+
 /**
  * @author Jeff Cunningham
  *         Date: 10/2/14
@@ -54,6 +56,7 @@ public class WrappedAggregateFunctionNode extends WindowFunctionNode {
         super.init(arg1, null);
         aggregateFunction = (AggregateNode) arg2;
         this.aggregateName = aggregateFunction.aggregateName;
+        this.type = fromString(aggregateFunction.aggregateName);
         this.operator = aggregateFunction.operator;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/WindowFunctionInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/WindowFunctionInfo.java
@@ -34,8 +34,9 @@ import com.splicemachine.db.iapi.services.io.FormatableArrayHolder;
 import com.splicemachine.db.iapi.services.io.FormatableHashtable;
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 import com.splicemachine.db.iapi.sql.ResultDescription;
+import com.splicemachine.db.iapi.sql.compile.AggregateDefinition;
 import com.splicemachine.db.iapi.store.access.ColumnOrdering;
-
+import static com.splicemachine.db.iapi.sql.compile.AggregateDefinition.*;
 /**
  * This is a simple class used to store the run time information
  * needed to invoke a window function.  This class is serializable
@@ -77,6 +78,7 @@ public class WindowFunctionInfo implements Formatable
     FormatableArrayHolder keyInfo;
     FormatableHashtable frameInfo;
     FormatableHashtable functionSpecificArgs;
+	FunctionType type;
 
     /**
 	 * Niladic constructor for Formattable
@@ -100,6 +102,7 @@ public class WindowFunctionInfo implements Formatable
 	 *
 	 */
 	public WindowFunctionInfo(String functionName,
+							  FunctionType type,
                               String functionClassName,
                               int[] operandColNumns,
                               int outputColNum,
@@ -111,6 +114,7 @@ public class WindowFunctionInfo implements Formatable
                               FormatableHashtable frameInfo,
                               FormatableHashtable functionSpecificArgs) {
 		this.functionName	= functionName;
+		this.type = type;
 		this.functionClassName = functionClassName;
 		this.operandColNums = operandColNumns;
 		this.outputColumn	= outputColNum;
@@ -297,6 +301,7 @@ public class WindowFunctionInfo implements Formatable
 		out.writeInt(outputColumn);
 		out.writeInt(aggregatorColumn);
 		out.writeObject(functionClassName);
+		out.writeObject(type);
 		out.writeObject(resultDescription);
         out.writeObject(partitionInfo);
         out.writeObject(orderByInfo);
@@ -324,6 +329,7 @@ public class WindowFunctionInfo implements Formatable
         outputColumn = in.readInt();
 		aggregatorColumn = in.readInt();
 		functionClassName = (String)in.readObject();
+		type = (FunctionType) in.readObject();
 		resultDescription = (ResultDescription)in.readObject();
         partitionInfo = (FormatableArrayHolder) in.readObject();
         orderByInfo = (FormatableArrayHolder) in.readObject();
@@ -338,4 +344,8 @@ public class WindowFunctionInfo implements Formatable
 	 *	@return	the formatID of this class
 	 */
 	public int	getTypeFormatId()	{ return StoredFormatIds.WINDOW_FUNCTION_INFO_V01_ID; }
+
+	public FunctionType getType() {
+		return type;
+	}
 }

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
@@ -16,13 +16,14 @@
 package com.splicemachine.derby.stream.spark;
 
 import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.SpliceSpark;
 import com.splicemachine.derby.impl.sql.execute.operations.JoinOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.LocatedRow;
 import com.splicemachine.derby.impl.sql.execute.operations.export.ExportExecRowWriter;
 import com.splicemachine.derby.impl.sql.execute.operations.export.ExportOperation;
+import com.splicemachine.derby.impl.sql.execute.operations.window.WindowAggregator;
+import com.splicemachine.derby.impl.sql.execute.operations.window.WindowContext;
 import com.splicemachine.derby.stream.function.*;
 import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.OperationContext;
@@ -42,11 +43,12 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.security.TokenCache;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.Column;
+import org.apache.spark.sql.types.DataType;
 import org.apache.spark.storage.StorageLevel;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.*;
@@ -248,6 +250,52 @@ public class SparkDataSet<V> implements DataSet<V> {
         return intersect(dataSet,"Intersect Operator",null,false,null);
     }
 
+    /**
+     * Spark implementation of Window function,
+     * We convert the derby specification using SparkWindow helper
+     * Most of the specifications is identical to Spark except the one position index
+     * and some specific functions. Look at SparkWindow for more
+     * @param windowContext
+     * @param context
+     * @param pushScope
+     * @param scopeDetail
+     * @return
+     */
+    public DataSet<V> windows(WindowContext windowContext, OperationContext context,  boolean pushScope, String scopeDetail) {
+        pushScopeIfNeeded(context, pushScope, scopeDetail);
+        try {
+            Dataset<Row> dataset = toSparkRow(this,context);
+
+            for(WindowAggregator aggregator : windowContext.getWindowFunctions()) {
+                // we need to remove to convert resultColumnId from a 1 position index to a 0position index
+                DataType resultDataType = dataset.schema().fields()[aggregator.getResultColumnId()-1].dataType();
+                // We define the window specification and we get a back a spark.
+                // Simply provide all the information and spark window will build it for you
+                Column col = SparkWindow.partitionBy(aggregator.getPartitions())
+                        .function(aggregator.getType())
+                        .inputs(aggregator.getInputColumnIds())
+                        .orderBy(aggregator.getOrderings())
+                        .frameBoundary(aggregator.getFrameDefinition())
+                        .specificArgs(aggregator.getFunctionSpecificArgs())
+                        .resultColumn(aggregator.getResultColumnId())
+                        .resultDataType(resultDataType)
+                        .toColumn();
+
+                // Now we replace the result column by the spark specification.
+                // the result column is already define by derby. We need to replace it
+                dataset = dataset.withColumn(String.valueOf(aggregator.getResultColumnId()-1),col);
+            }
+            //Convert back to Splice Row
+           return  toSpliceLocatedRow(dataset, context);
+
+        } catch (Exception se){
+            throw new RuntimeException(se);
+        }finally {
+            if (pushScope) context.popScope();
+        }
+
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public DataSet< V> intersect(DataSet< V> dataSet, String name, OperationContext context, boolean pushScope, String scopeDetail) {
@@ -347,7 +395,7 @@ public class SparkDataSet<V> implements DataSet<V> {
 
         JavaRDD<V> rdd2 = rdd1.coalesce(1, false);
         rdd2.setName("Coalesce 1 partition");
-        RDDUtils.setAncestorRDDNames(rdd2, 3, new String[]{"Coalesce Data", "Shuffle Data", "Map For Coalesce"}, null);
+        SparkUtils.setAncestorRDDNames(rdd2, 3, new String[]{"Coalesce Data", "Shuffle Data", "Map For Coalesce"}, null);
 
         JavaRDD<V> rdd3 = rdd2.mapPartitions(new SparkFlatMapFunction<>(takeFunction));
         rdd3.setName(takeFunction.getSparkName());
@@ -452,7 +500,7 @@ public class SparkDataSet<V> implements DataSet<V> {
     public DataSet<V> coalesce(int numPartitions, boolean shuffle) {
         JavaRDD rdd1 = rdd.coalesce(numPartitions, shuffle);
         rdd1.setName(String.format("Coalesce %d partitions", numPartitions));
-        RDDUtils.setAncestorRDDNames(rdd1, 3, new String[]{"Coalesce Data", "Shuffle Data", "Map For Coalesce"}, null);
+        SparkUtils.setAncestorRDDNames(rdd1, 3, new String[]{"Coalesce Data", "Shuffle Data", "Map For Coalesce"}, null);
         return new SparkDataSet<>(rdd1);
     }
 
@@ -463,7 +511,7 @@ public class SparkDataSet<V> implements DataSet<V> {
         try {
             JavaRDD rdd1 = rdd.coalesce(numPartitions, shuffle);
             rdd1.setName(String.format("Coalesce %d partitions", numPartitions));
-            RDDUtils.setAncestorRDDNames(rdd1, 3, new String[]{"Coalesce Data", "Shuffle Data", "Map For Coalesce"}, null);
+            SparkUtils.setAncestorRDDNames(rdd1, 3, new String[]{"Coalesce Data", "Shuffle Data", "Map For Coalesce"}, null);
             return new SparkDataSet<V>(rdd1);
         } finally {
             if (pushScope) context.popScope();

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -180,7 +180,6 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                     String.class,
                     InputStream.class,
                     HConfiguration.unwrapDelegate());
-            // RDDUtils.setAncestorRDDNames(rdd, 1, new String[] {fileInfo.toSummary()}, null);
             return new SparkPairDataSet<>(rdd,OperationContext.Scope.READ_TEXT_FILE.displayName());
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);
@@ -218,7 +217,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                             return o.toString();
                         }
                     });
-            RDDUtils.setAncestorRDDNames(rdd, 1, new String[] {fileInfo.toSummary()}, null);
+            SparkUtils.setAncestorRDDNames(rdd, 1, new String[] {fileInfo.toSummary()}, null);
             return new SparkDataSet<>(rdd,OperationContext.Scope.READ_TEXT_FILE.displayName());
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkPairDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkPairDataSet.java
@@ -112,7 +112,6 @@ public class SparkPairDataSet<K,V> implements PairDataSet<K, V>{
     public PairDataSet< K, V> sortByKey(Comparator<K> comparator, String name) {
         JavaPairRDD rdd2 = rdd.sortByKey(comparator);
         rdd2.setName(name);
-        // RDDUtils.setAncestorRDDNames(rdd2, 2, new String[]{"tbd", "tbd"}, new String[] {"MapPartitionsRDD", "MapPartitionsRDD"});
         return new SparkPairDataSet<>(rdd2);
     }
 
@@ -134,7 +133,7 @@ public class SparkPairDataSet<K,V> implements PairDataSet<K, V>{
     public PairDataSet<K, Iterable<V>> groupByKey(String name) {
         JavaPairRDD rdd1 = rdd.groupByKey();
         rdd1.setName(name);
-        RDDUtils.setAncestorRDDNames(rdd1, 1, new String[]{"Shuffle Data"}, null);
+        SparkUtils.setAncestorRDDNames(rdd1, 1, new String[]{"Shuffle Data"}, null);
         return new SparkPairDataSet<>(rdd1);
     }
 
@@ -157,7 +156,7 @@ public class SparkPairDataSet<K,V> implements PairDataSet<K, V>{
     public <W> PairDataSet<K, Tuple2<V, W>> hashJoin(PairDataSet<K, W> rightDataSet,String name){
         JavaPairRDD<K, Tuple2<V, W>> rdd1=rdd.join(((SparkPairDataSet<K, W>)rightDataSet).rdd);
         rdd1.setName(name);
-        RDDUtils.setAncestorRDDNames(rdd1,2,new String[]{"Map Left to Right","Coalesce"}, null);
+        SparkUtils.setAncestorRDDNames(rdd1,2,new String[]{"Map Left to Right","Coalesce"}, null);
         return new SparkPairDataSet<>(rdd1);
     }
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkUtils.java
@@ -20,6 +20,7 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.ResultColumnDescriptor;
 import com.splicemachine.db.iapi.sql.ResultDescription;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
+import com.splicemachine.db.iapi.store.access.ColumnOrdering;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.impl.jdbc.EmbedResultSet40;
@@ -30,7 +31,6 @@ import com.splicemachine.derby.impl.sql.execute.operations.LocatedRow;
 import com.splicemachine.derby.impl.sql.execute.operations.SpliceBaseOperation;
 
 import org.apache.log4j.Logger;
-import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.Function;
@@ -39,15 +39,22 @@ import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import scala.collection.JavaConversions;
 
 import java.sql.ResultSet;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
-public class RDDUtils {
-    public static final Logger LOG = Logger.getLogger(RDDUtils.class);
+import static org.apache.spark.sql.functions.asc;
+import static org.apache.spark.sql.functions.col;
+import static org.apache.spark.sql.functions.desc;
+
+public class SparkUtils {
+    public static final Logger LOG = Logger.getLogger(SparkUtils.class);
 
     public static JavaPairRDD<ExecRow, LocatedRow> getKeyedRDD(JavaRDD<LocatedRow> rdd, final int[] keyColumns)
             throws StandardException {
@@ -197,7 +204,7 @@ public class RDDUtils {
 
         @Override
         public ExecRow call(LocatedRow row) throws Exception {
-            return RDDUtils.getKey(row.getRow(), keyColumns);
+            return SparkUtils.getKey(row.getRow(), keyColumns);
         }
     }
 
@@ -278,5 +285,28 @@ public class RDDUtils {
             default:
                 return DataTypes.NullType;
         }
+    }
+
+
+
+    public static scala.collection.mutable.Buffer<Column> convertSortColumns(ColumnOrdering[] sortColumns){
+        return Arrays
+                .stream(sortColumns)
+                .map(column -> column.getIsAscending() ? asc(String.valueOf(column.getColumnId()-1)) : desc(String.valueOf(column.getColumnId()-1)))
+                .collect(Collectors.collectingAndThen(Collectors.toList(), JavaConversions::asScalaBuffer));
+    }
+
+    /**
+     * Convert partition to Spark dataset columns
+     * Ignoring partition
+     * @param sortColumns
+     * @return
+     */
+
+    public static scala.collection.mutable.Buffer<Column> convertPartitions(ColumnOrdering[] sortColumns){
+        return Arrays
+                .stream(sortColumns)
+                .map(column -> col(String.valueOf(column.getColumnId()-1)))
+                .collect(Collectors.collectingAndThen(Collectors.toList(), JavaConversions::asScalaBuffer));
     }
 }

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkWindow.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkWindow.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2012 - 2016 Splice Machine, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.splicemachine.derby.stream.spark;
+
+import com.splicemachine.db.iapi.services.io.FormatableHashtable;
+import com.splicemachine.db.iapi.store.access.ColumnOrdering;
+import com.splicemachine.derby.impl.sql.execute.operations.window.FrameDefinition;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.expressions.Window;
+import org.apache.spark.sql.expressions.WindowSpec;
+import org.apache.spark.sql.types.DataType;
+import scala.collection.JavaConversions;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static com.splicemachine.derby.stream.spark.SparkUtils.convertPartitions;
+import static com.splicemachine.derby.stream.spark.SparkUtils.convertSortColumns;
+import static org.apache.spark.sql.functions.*;
+import static com.splicemachine.db.iapi.sql.compile.AggregateDefinition.*;
+/**
+ * Created by jfilali on 10/4/16.
+ * Spark Window Builder.
+ * Start by providing a partition and then use a set of convenient
+ * method to specify the Spark Window
+ */
+public class SparkWindow {
+
+    private WindowSpec spec;
+    private int[] inputColumnIds;
+    private ColumnOrdering[] partitionIds;
+    private FunctionType functionType;
+    private int resultColumn;
+    private  DataType resultDataType;
+    private FormatableHashtable specificArgs;
+
+    private SparkWindow(ColumnOrdering[] partitionIds) {
+        this.partitionIds = partitionIds;
+        this.spec = Window.partitionBy(convertPartitions(partitionIds));
+    }
+
+    /**
+     * Define the Window Partition and initiate that builder
+     * @param partitionIds
+     * @return
+     */
+    public static SparkWindow partitionBy(ColumnOrdering[] partitionIds) {
+        return new SparkWindow(partitionIds);
+    }
+
+    /**
+     * Specify the window ordering
+     * @param sortColumns
+     * @return
+     */
+
+    public SparkWindow orderBy(ColumnOrdering[] sortColumns) {
+        //not  ordering provided but spark need one,
+        // for backward compatibility order by partition
+        // Current IT except that not to fail but is not possible to
+        // have nor ordering with Spark.
+        if(sortColumns.length == 0){
+            spec = spec.orderBy(convertSortColumns(partitionIds));
+            return this;
+        }
+        spec = spec.orderBy(convertSortColumns(sortColumns));
+        return this;
+    }
+
+    public SparkWindow frameBoundary(FrameDefinition definition) {
+
+        // special cases for some specifics functions because there
+        // is a difference  between Spark and our derby specification
+        // Spark will complain if you provide a frame for those functions
+
+        switch (functionType) {
+            case LAG_FUNCTION:
+            case ROW_NUMBER_FUNCTION:
+            case LEAD_FUNCTION:
+            return this;
+
+        }
+
+        // other cases
+        switch (definition.getFrameMode()) {
+            case ROWS:
+                spec = this.spec.rowsBetween(
+                        definition.getFrameStart().getValue(),
+                        definition.getFrameEnd().getValue());
+                break;
+
+            case RANGE:
+                spec = this.spec.rangeBetween(
+                        definition.getFrameStart().getValue(),
+                        definition.getFrameEnd().getValue());
+                break;
+
+        }
+        return this;
+    }
+
+    /**
+     * Define the input column. Winow function will be
+     * executed on those columns.
+     * @param inputColumnIds
+     * @return
+     */
+    public SparkWindow inputs(int[] inputColumnIds) {
+        this.inputColumnIds = inputColumnIds;
+        return this;
+    }
+
+    /**
+     * This is how you define which function you want to run
+     * @param functionType
+     * @return
+     */
+    public SparkWindow function(FunctionType functionType) {
+        this.functionType = functionType;
+        return this;
+    }
+
+    /**
+     * We need to defnie the result Column type because there is a difference
+     * between what Spark return and what our logic said.
+     * So some of the functions require some conversions like avg
+     * @param resultDataType
+     * @return
+     */
+    public  SparkWindow resultDataType(DataType resultDataType){
+        this.resultDataType = resultDataType;
+        return  this;
+    }
+
+    /**
+     * This is used to define some specific args
+     * @param specificArgs
+     * @return
+     */
+
+    public SparkWindow specificArgs(FormatableHashtable specificArgs){
+        this.specificArgs = specificArgs;
+        return this;
+    }
+
+    /**
+     * The reference to the column that hold the result
+     * @param resultColumn
+     * @return
+     */
+    public SparkWindow resultColumn(int resultColumn) {
+        this.resultColumn = resultColumn;
+        return this;
+    }
+
+    /**
+     *  The final method used to generate the Spark column definition.
+     *  Based on all the previous info provided
+     * @return
+     */
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public Column toColumn() {
+        Column column = null;
+        switch (functionType) {
+            case MAX_FUNCTION:
+                column = max(col(String.valueOf(inputColumnIds[0] - 1)))
+                        .over(spec)
+                        .as(String.valueOf(resultColumn - 1));
+                break;
+
+            case MIN_FUNCTION:
+                column = min(col(String.valueOf(inputColumnIds[0] - 1)))
+                        .over(spec)
+                        .as(String.valueOf(resultColumn - 1));
+                break;
+
+            case SUM_FUNCTION:
+                column = sum(col(String.valueOf(inputColumnIds[0] - 1)))
+                        .over(spec)
+                        .as(String.valueOf(resultColumn - 1));
+                break;
+
+
+            case LAST_VALUE_FUNCTION:
+                column = last(col(String.valueOf(inputColumnIds[0] - 1)),(Boolean) specificArgs.getOrDefault("IGNORE_NULLS",false))
+                        .over(spec)
+                        .as(String.valueOf(resultColumn - 1));
+                break;
+
+            case AVG_FUNCTION:
+                column = avg(col(String.valueOf(inputColumnIds[0] - 1)))
+                        .over(spec)
+                        .as(String.valueOf(resultColumn - 1))
+                        .cast(resultDataType);
+                break;
+
+            case COUNT_FUNCTION:
+                column = count(col(String.valueOf(inputColumnIds[0] - 1)))
+                        .over(spec)
+                        .as(String.valueOf(resultColumn - 1));
+                break;
+            case COUNT_STAR_FUNCTION:
+                column = count("*")
+                        .over(spec)
+                        .as(String.valueOf(resultColumn - 1));
+                break;
+
+            case DENSE_RANK_FUNCTION:
+                column = dense_rank()
+                        .over(spec)
+                        .as(String.valueOf(resultColumn - 1))
+                        .cast(resultDataType);
+                break;
+
+            case RANK_FUNCTION:
+                column = rank()
+                        .over(spec)
+                        .as(String.valueOf(resultColumn - 1))
+                        .cast(resultDataType);
+                break;
+
+            case FIRST_VALUE_FUNCTION:
+                column = first(col(String.valueOf(inputColumnIds[0] - 1)),(Boolean) specificArgs.getOrDefault("IGNORE_NULLS",false))
+                        .over(spec)
+                        .as(String.valueOf(resultColumn - 1));
+                break;
+
+            case LAG_FUNCTION:
+                column = lag(col(String.valueOf(inputColumnIds[0] - 1)),1)
+                        .over(spec)
+                        .as(String.valueOf(resultColumn - 1));
+                break;
+
+            case LEAD_FUNCTION:
+                column = lead(col(String.valueOf(inputColumnIds[0] - 1)),1)
+                        .over(spec)
+                        .as(String.valueOf(resultColumn - 1));
+                break;
+
+            case ROW_NUMBER_FUNCTION:
+                column = row_number()
+                        .over(spec)
+                        .as(String.valueOf(resultColumn - 1))
+                        .cast(resultDataType);
+                break;
+        }
+        return column;
+    }
+
+
+
+
+
+}

--- a/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/DataFrameIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/DataFrameIT.java
@@ -29,7 +29,7 @@ import com.splicemachine.db.impl.sql.GenericColumnDescriptor;
 import com.splicemachine.db.impl.sql.execute.IteratorNoPutResultSet;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
 
-import com.splicemachine.derby.stream.spark.RDDUtils;
+import com.splicemachine.derby.stream.spark.SparkUtils;
 import com.splicemachine.derby.test.framework.*;
 
 import org.apache.log4j.Logger;
@@ -259,7 +259,7 @@ public class DataFrameIT extends SpliceUnitTest {
         PreparedStatement pstmt = conn.prepareStatement("select * from " + table.toUpperCase());
         ResultSet res = pstmt.executeQuery();
         // Convert result set to Dataframe
-        Dataset<Row> resultSetDF = RDDUtils.resultSetToDF(res);
+        Dataset<Row> resultSetDF = SparkUtils.resultSetToDF(res);
         resultSets[0] = res;
 
         // Construct Stored Procedure Result

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
@@ -134,6 +134,7 @@ public class SpliceDatabase extends BasicDatabase{
         afterOptVisitors.add(BatchOnceVisitor.class);
         afterOptVisitors.add(LimitOffsetVisitor.class);
         afterOptVisitors.add(PlanPrinter.class);
+        afterOptVisitors.add(WindowFunctionVisitor.class);
 
         List<Class<? extends ISpliceVisitor>> afterBindVisitors=new ArrayList<>(1);
         afterBindVisitors.add(RepeatedPredicateVisitor.class);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/WindowOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/WindowOperation.java
@@ -121,23 +121,16 @@ public class WindowOperation extends SpliceBaseOperation {
         templateRow = windowContext.getSourceIndexRow();
     }
 
+
     @Override
     public DataSet<LocatedRow> getDataSet(DataSetProcessor dsp) throws StandardException {
         OperationContext<WindowOperation> operationContext = dsp.createOperationContext(this);
+        operationContext.pushScopeForOp(OperationContext.Scope.WINDOW);
         DataSet dataSet = source.getDataSet(dsp);
-        
-        operationContext.pushScopeForOp(OperationContext.Scope.SORT_KEYER);
-        KeyerFunction f = new KeyerFunction(operationContext, windowContext.getPartitionColumns());
-        PairDataSet pair = dataSet.keyBy(f);
         operationContext.popScope();
-        
-        operationContext.pushScopeForOp(OperationContext.Scope.GROUP_AGGREGATE_KEYER);
-        pair = pair.groupByKey("Group Values For Each Key");
-        operationContext.popScope();
-        
-        operationContext.pushScopeForOp(OperationContext.Scope.EXECUTE);
+
         try {
-            return pair.flatmap(new MergeWindowFunction(operationContext, windowContext.getWindowFunctions()), true);
+            return  dataSet.windows(windowContext,operationContext,true, OperationContext.Scope.EXECUTE.displayName());
         } finally {
             operationContext.popScope();
         }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/WindowAggregator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/WindowAggregator.java
@@ -16,8 +16,11 @@
 package com.splicemachine.derby.impl.sql.execute.operations.window;
 
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.services.io.FormatableHashtable;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
+import com.splicemachine.db.iapi.store.access.ColumnOrdering;
 import com.splicemachine.derby.impl.sql.execute.operations.window.function.SpliceGenericWindowFunction;
+import static com.splicemachine.db.iapi.sql.compile.AggregateDefinition.*;
 
 /**
  * @author Jeff Cunningham
@@ -46,5 +49,17 @@ public interface WindowAggregator {
 
     String getName();
 
+    FunctionType getType();
+
     SpliceGenericWindowFunction getCachedAggregator();
+
+    int[] getInputColumnIds();
+
+    String getFunctionName();
+
+    ColumnOrdering[] getOrderings();
+
+    ColumnOrdering[] getPartitions();
+
+    FormatableHashtable getFunctionSpecificArgs();
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
@@ -16,6 +16,7 @@
 package com.splicemachine.derby.stream.control;
 
 
+import com.splicemachine.derby.impl.sql.execute.operations.window.WindowContext;
 import org.apache.commons.collections.IteratorUtils;
 import org.spark_project.guava.base.Function;
 import org.spark_project.guava.collect.*;
@@ -354,6 +355,20 @@ public class ControlDataSet<V> implements DataSet<V> {
 
     @Override
     public DataSet<V> join(OperationContext operationContext, DataSet<V> rightDataSet, JoinType joinType, boolean isBroadcast) {
+        throw new UnsupportedOperationException("Not Implemented in Control Side");
+    }
+
+    /**
+     * Window Function. Take a WindowContext that define the partition, the order, and the frame boundary.
+     * Currently only run on top of Spark.
+     * @param windowContext
+     * @param context
+     * @param pushScope
+     * @param scopeDetail
+     * @return
+     */
+    @Override
+    public DataSet<V> windows(WindowContext windowContext, OperationContext context, boolean pushScope, String scopeDetail) {
         throw new UnsupportedOperationException("Not Implemented in Control Side");
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
@@ -17,6 +17,7 @@ package com.splicemachine.derby.stream.iapi;
 
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.LocatedRow;
+import com.splicemachine.derby.impl.sql.execute.operations.window.WindowContext;
 import com.splicemachine.derby.stream.function.*;
 import com.splicemachine.derby.stream.output.ExportDataSetWriterBuilder;
 import java.io.Serializable;
@@ -242,4 +243,15 @@ public interface DataSet<V> extends Iterable<V>, Serializable {
 
     DataSet<V> join(OperationContext operationContext, DataSet<V> rightDataSet,JoinType joinType, boolean isBroadcast);
 
+    /**
+     *  Window Function abstraction. Take a window context that defines the the partition, the sorting , the frame boundary
+     *  and the differents functions
+     * @param windowContext
+     * @param context
+     * @param pushScope
+     * @param scopeDetail
+     * @return
+     */
+
+    DataSet<V> windows(WindowContext windowContext, OperationContext context, boolean pushScope, String scopeDetail);
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/OperationContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/OperationContext.java
@@ -58,6 +58,7 @@ public interface OperationContext<Op extends SpliceOperation> extends Externaliz
         REDUCE("Reduce"),
         READ("Read Values"),
         SORT("Sort Records"),
+        WINDOW("Window Function"),
         READ_SORTED("Read Sorted Values"),
         ROLLUP("Rollup"),
         EXECUTE("Execute"),


### PR DESCRIPTION
Added a window method support in com.splicemachine.derby.stream.iapi.DataSet
and pushed down the execution implementation in both engines.

Ignored tests with a decimal precision difference between current implementation and Spark.
This is going to be fixed afterward.