### PR TITLE
 fix DB-5653

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
@@ -138,6 +138,14 @@ public class SpliceSpark {
         conf.set("executor.source.splice-machine.class", "com.splicemachine.derby.stream.spark.SpliceMachineSource");
         conf.set("driver.source.splice-machine.class", "com.splicemachine.derby.stream.spark.SpliceMachineSource");
 
+        // pull out Kerberos and set Yarn properties
+        if(HConfiguration.unwrapDelegate().get("hbase.regionserver.kerberos.principal") != null){
+            conf.set("spark.yarn.principal", HConfiguration.unwrapDelegate().get("hbase.regionserver.kerberos.principal"));
+        }
+
+        if(HConfiguration.unwrapDelegate().get("hbase.regionserver.keytab.file") != null){
+            conf.set("spark.yarn.keytab", HConfiguration.unwrapDelegate().get("hbase.regionserver.keytab.file"));
+        }
         // set all spark props that start with "splice.".  overrides are set below.
         for (Object sysPropertyKey : System.getProperties().keySet()) {
             String spsPropertyName = (String) sysPropertyKey;


### PR DESCRIPTION
Pulling up hbase.regionserver.kerberos.principal and hbase.regionserver.keytab.file from HBase configuration
and set spark.yarn.keytab and spark.yarn.principal for Spark

I have tested manually the settings and it works.