### PR TITLE
DB-5662: make sure BackupEndpointObserver is up to date for all platf…

### DIFF
--- a/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -206,11 +206,13 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
 
     private void waitForBackupToComplete() throws IOException{
         int i = 0;
+        long maxWaitTime = 60*1000;
         while (regionIsBeingBackup()) {
             try {
                 if (LOG.isDebugEnabled())
                     SpliceLogUtils.debug(LOG, "wait for backup to complete");
-                Thread.sleep(100 * (long) Math.pow(2, i));
+                long waitTime = Math.min(100 * (long) Math.pow(2, i), maxWaitTime);
+                Thread.sleep(waitTime);
                 i++;
             }
             catch (InterruptedException e) {

--- a/hbase_sql/hbase1.0.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.0.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -17,8 +17,17 @@ package com.splicemachine.hbase;
 
 import com.google.protobuf.Service;
 import com.splicemachine.access.HConfiguration;
+import com.splicemachine.backup.BackupRestoreConstants;
+import com.splicemachine.backup.BackupUtils;
 import com.splicemachine.coprocessor.SpliceMessage;
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.pipeline.Exceptions;
+import com.splicemachine.si.constants.SIConstants;
 import com.splicemachine.utils.SpliceLogUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Coprocessor;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.coprocessor.CoprocessorService;
@@ -26,6 +35,7 @@ import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.hadoop.hbase.zookeeper.RecoverableZooKeeper;
 import org.apache.log4j.Logger;
 import org.apache.zookeeper.CreateMode;
@@ -33,7 +43,6 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 
 import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.util.List;
 
 /**
@@ -48,10 +57,15 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private String tableName;
     private String regionName;
     private String path;
+    private Path backupDir;
+    private Configuration conf;
+    private FileSystem fs;
+    Path rootDir;
+    private volatile boolean preparing;
 
     @Override
     public void start(CoprocessorEnvironment e) throws IOException {
-        region =((RegionCoprocessorEnvironment) e).getRegion();
+        region = ((RegionCoprocessorEnvironment) e).getRegion();
         String[] name = region.getTableDesc().getNameAsString().split(":");
         if (name.length == 2) {
             namespace = name[0];
@@ -63,6 +77,11 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         regionName = region.getRegionInfo().getEncodedName();
 
         path = HConfiguration.getConfiguration().getBackupPath() + "/" + tableName + "/" + regionName;
+        conf = HConfiguration.unwrapDelegate();
+        rootDir = FSUtils.getRootDir(conf);
+        fs = FSUtils.getCurrentFileSystem(conf);
+        backupDir = new Path(rootDir, BackupRestoreConstants.BACKUP_DIR + "/data/splice/" + tableName + "/" + regionName);
+        preparing = false;
     }
 
     @Override
@@ -78,7 +97,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             com.google.protobuf.RpcCallback<SpliceMessage.PrepareBackupResponse> done) {
 
         try {
+            preparing = true;
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder = SpliceMessage.PrepareBackupResponse.newBuilder();
+            boolean canceled = false;
             if (isSplitting) {
                 if (LOG.isDebugEnabled()) {
                     SpliceLogUtils.debug(LOG, "%s:%s is being split before trying to prepare for backup", tableName, regionName);
@@ -88,30 +109,38 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             } else {
                 // A region might have been in backup
                 if (!regionIsBeingBackup()) {
-                    HBasePlatformUtils.flush(region);
-                    // Create a ZNode to indicate that the region is being copied
-                    ZkUtils.recursiveSafeCreate(path, HConfiguration.BACKUP_IN_PROGRESS, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-                }
-                // check again if the region is being split. If so, return an error
-                if (isSplitting) {
-                    if (LOG.isDebugEnabled()) {
-                        SpliceLogUtils.debug(LOG, "%s:%s is being split when trying to prepare for backup", tableName, regionName);
+                    canceled = backupCanceled();
+                    if (!canceled) {
+                        HBasePlatformUtils.flush(region);
+                        // Create a ZNode to indicate that the region is being copied
+                        ZkUtils.recursiveSafeCreate(path, HConfiguration.BACKUP_IN_PROGRESS, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
                     }
+                }
+                if (!canceled) {
+                    // check again if the region is being split. If so, return an error
+                    if (isSplitting) {
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s is being split when trying to prepare for backup", tableName, regionName);
+                        }
+                        responseBuilder.setReadyForBackup(false);
+                        //delete the ZNode
+                        ZkUtils.recursiveDelete(path);
+                    } else {
+                        //wait for all compaction and flush to complete
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
+                        }
+                        region.waitForFlushesAndCompactions();
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
+                        }
+                        responseBuilder.setReadyForBackup(true);
+                    }
+                }
+                else
                     responseBuilder.setReadyForBackup(false);
-                    //delete the ZNode
-                    ZkUtils.recursiveDelete(path);
-                } else {
-                    //wait for all compaction and flush to complete
-                    if (LOG.isDebugEnabled()) {
-                        SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
-                    }
-                    region.waitForFlushesAndCompactions();
-                    if (LOG.isDebugEnabled()) {
-                        SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
-                    }
-                    responseBuilder.setReadyForBackup(true);
-                }
             }
+            preparing = false;
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
@@ -163,50 +192,142 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
-        //TODO: register HFiles for incremental backup
+        // Register HFiles for incremental backup
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        try {
+            if (namespace.compareTo("splice") != 0)
+                return;
+            captureIncrementalChanges(resultFile.getPath().getName());
+        }
+        catch (Exception ex) {
+            throw new IOException(ex);
+        }
     }
 
     private void waitForBackupToComplete() throws IOException{
         int i = 0;
-        try {
-            while(regionIsBeingBackup()){
-                if(LOG.isDebugEnabled())
-                    SpliceLogUtils.debug(LOG,"wait for backup to complete");
-                Thread.sleep(100*(long)Math.pow(2,i));
+        long maxWaitTime = 60*1000;
+        while (regionIsBeingBackup()) {
+            try {
+                if (LOG.isDebugEnabled())
+                    SpliceLogUtils.debug(LOG, "wait for backup to complete");
+                long waitTime = Math.min(100 * (long) Math.pow(2, i), maxWaitTime);
+                Thread.sleep(waitTime);
                 i++;
             }
-        }catch(InterruptedException e){
-            throw new InterruptedIOException();
+            catch (InterruptedException e) {
+                throw new IOException(e);
+            }
         }
     }
 
-    private boolean regionIsBeingBackup() throws IOException, InterruptedException{
-        boolean isBackup;
-        RecoverableZooKeeper zooKeeper=ZkUtils.getRecoverableZooKeeper();
-        try{
-            if(zooKeeper.exists(path,false)==null){
-                if(LOG.isDebugEnabled())
-                    SpliceLogUtils.debug(LOG,"Table %s region %s is not in backup",tableName,regionName);
-                isBackup=false;
-            }else{
-                byte[] status=ZkUtils.getData(path);
-                if(Bytes.compareTo(status,HConfiguration.BACKUP_IN_PROGRESS)==0){
-                    if(LOG.isDebugEnabled())
-                        SpliceLogUtils.debug(LOG,"Table %s region %s is in backup",tableName,regionName);
-                    isBackup=true;
-                }else if(Bytes.compareTo(status,HConfiguration.BACKUP_DONE)==0){
-                    if(LOG.isDebugEnabled())
-                        SpliceLogUtils.debug(LOG,"Table %s region %s is done with backup",tableName,regionName);
-                    isBackup=false;
-                }else{
-                    throw new RuntimeException("Unexpected data in node:"+path);
+    private boolean regionIsBeingBackup() {
+        boolean isBackup = false;
+        try {
+            RecoverableZooKeeper zooKeeper = ZkUtils.getRecoverableZooKeeper();
+            if (zooKeeper.exists(path, false) == null) {
+                if (LOG.isDebugEnabled())
+                    SpliceLogUtils.debug(LOG, "Table %s region %s is not in backup", tableName, regionName);
+                isBackup = false;
+            }
+            else {
+                byte[] status = ZkUtils.getData(path);
+                if (Bytes.compareTo(status, HConfiguration.BACKUP_IN_PROGRESS) == 0) {
+                    if (LOG.isDebugEnabled())
+                        SpliceLogUtils.debug(LOG, "Table %s region %s is in backup", tableName, regionName);
+                    isBackup = true;
+                }
+                else if (Bytes.compareTo(status, HConfiguration.BACKUP_DONE) == 0) {
+                    if (LOG.isDebugEnabled())
+                        SpliceLogUtils.debug(LOG, "Table %s region %s is done with backup", tableName, regionName);
+                    isBackup = false;
+                }
+                else {
+                    throw new RuntimeException("Unexpected data in node:" + path);
                 }
             }
-        }catch(KeeperException ke){
-            throw new IOException(ke);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
 
         return isBackup;
     }
 
+    private boolean backupCanceled() throws KeeperException, InterruptedException {
+        RecoverableZooKeeper zooKeeper = ZkUtils.getRecoverableZooKeeper();
+        String path = HConfiguration.getConfiguration().getBackupPath();
+        return zooKeeper.exists(path, false) == null;
+    }
+
+    /**
+     * An HFile is eligible for incremental backup if
+     * 1) There is an ongoing full backup, flush is not triggered by preparing and backup for this region is done.
+     * 2) There is no ongoing backup, AND there is a previous full/incremental backup
+     * 3) There is an ongoing incremental backup
+     * @param fileName
+     * @throws StandardException
+     */
+    private void captureIncrementalChanges(String fileName) throws StandardException {
+        boolean shouldRegister = false;
+        try {
+            RecoverableZooKeeper zooKeeper = ZkUtils.getRecoverableZooKeeper();
+            String spliceBackupPath = HConfiguration.getConfiguration().getBackupPath();
+            if (zooKeeper.exists(spliceBackupPath, false) != null) {
+                byte[] backupType = ZkUtils.getData(spliceBackupPath);
+                if (Bytes.compareTo(backupType, BackupRestoreConstants.BACKUP_TYPE_FULL_BYTES) == 0) {
+                    if (!preparing && zooKeeper.exists(path, false) != null) {
+                        byte[] status = ZkUtils.getData(path);
+                        if (Bytes.compareTo(status, HConfiguration.BACKUP_DONE) == 0) {
+                            if (LOG.isDebugEnabled()) {
+                                SpliceLogUtils.debug(LOG, "Table %s is being backup", tableName);
+                            }
+                            shouldRegister = true;
+                        }
+                    }
+                }
+                else {
+                    shouldRegister = true;
+                }
+
+            }
+            else if (BackupUtils.existsDatabaseBackup(fs, rootDir)) {
+                shouldRegister = true;
+            }
+            if (shouldRegister) {
+                registerHFile(fileName);
+            }
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            throw Exceptions.parseException(e);
+        }
+    }
+
+    /**
+     * Register this HFile for incremental backup by creating an empty file
+     * backup/data/splice/tableName/regionName/V/fileName
+     * @param fileName
+     * @throws StandardException
+     */
+    private void registerHFile(String fileName) throws StandardException {
+
+        FSDataOutputStream out = null;
+        try {
+            if (!fs.exists(new Path(backupDir, BackupRestoreConstants.REGION_FILE_NAME))) {
+                HRegionFileSystem.createRegionOnFileSystem(conf, fs, backupDir.getParent(), region.getRegionInfo());
+            }
+            out = fs.create(new Path(backupDir.toString() + "/" + SIConstants.DEFAULT_FAMILY_NAME + "/" + fileName));
+        }
+        catch (Exception e) {
+            throw Exceptions.parseException(e);
+        }
+        finally {
+            try {
+                out.close();
+            }
+            catch (Exception e) {
+                throw Exceptions.parseException(e);
+            }
+        }
+    }
 }

--- a/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -17,8 +17,17 @@ package com.splicemachine.hbase;
 
 import com.google.protobuf.Service;
 import com.splicemachine.access.HConfiguration;
+import com.splicemachine.backup.BackupRestoreConstants;
+import com.splicemachine.backup.BackupUtils;
 import com.splicemachine.coprocessor.SpliceMessage;
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.pipeline.Exceptions;
+import com.splicemachine.si.constants.SIConstants;
 import com.splicemachine.utils.SpliceLogUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Coprocessor;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.coprocessor.CoprocessorService;
@@ -26,9 +35,11 @@ import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.hadoop.hbase.zookeeper.RecoverableZooKeeper;
 import org.apache.log4j.Logger;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 
 import java.io.IOException;
@@ -46,6 +57,11 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private String tableName;
     private String regionName;
     private String path;
+    private Path backupDir;
+    private Configuration conf;
+    private FileSystem fs;
+    Path rootDir;
+    private volatile boolean preparing;
 
     @Override
     public void start(CoprocessorEnvironment e) throws IOException {
@@ -61,6 +77,11 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         regionName = region.getRegionInfo().getEncodedName();
 
         path = HConfiguration.getConfiguration().getBackupPath() + "/" + tableName + "/" + regionName;
+        conf = HConfiguration.unwrapDelegate();
+        rootDir = FSUtils.getRootDir(conf);
+        fs = FSUtils.getCurrentFileSystem(conf);
+        backupDir = new Path(rootDir, BackupRestoreConstants.BACKUP_DIR + "/data/splice/" + tableName + "/" + regionName);
+        preparing = false;
     }
 
     @Override
@@ -76,7 +97,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             com.google.protobuf.RpcCallback<SpliceMessage.PrepareBackupResponse> done) {
 
         try {
+            preparing = true;
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder = SpliceMessage.PrepareBackupResponse.newBuilder();
+            boolean canceled = false;
             if (isSplitting) {
                 if (LOG.isDebugEnabled()) {
                     SpliceLogUtils.debug(LOG, "%s:%s is being split before trying to prepare for backup", tableName, regionName);
@@ -86,30 +109,38 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             } else {
                 // A region might have been in backup
                 if (!regionIsBeingBackup()) {
-                    HBasePlatformUtils.flush(region);
-                    // Create a ZNode to indicate that the region is being copied
-                    ZkUtils.recursiveSafeCreate(path, HConfiguration.BACKUP_IN_PROGRESS, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-                }
-                // check again if the region is being split. If so, return an error
-                if (isSplitting) {
-                    if (LOG.isDebugEnabled()) {
-                        SpliceLogUtils.debug(LOG, "%s:%s is being split when trying to prepare for backup", tableName, regionName);
+                    canceled = backupCanceled();
+                    if (!canceled) {
+                        HBasePlatformUtils.flush(region);
+                        // Create a ZNode to indicate that the region is being copied
+                        ZkUtils.recursiveSafeCreate(path, HConfiguration.BACKUP_IN_PROGRESS, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
                     }
+                }
+                if (!canceled) {
+                    // check again if the region is being split. If so, return an error
+                    if (isSplitting) {
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s is being split when trying to prepare for backup", tableName, regionName);
+                        }
+                        responseBuilder.setReadyForBackup(false);
+                        //delete the ZNode
+                        ZkUtils.recursiveDelete(path);
+                    } else {
+                        //wait for all compaction and flush to complete
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
+                        }
+                        region.waitForFlushesAndCompactions();
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
+                        }
+                        responseBuilder.setReadyForBackup(true);
+                    }
+                }
+                else
                     responseBuilder.setReadyForBackup(false);
-                    //delete the ZNode
-                    ZkUtils.recursiveDelete(path);
-                } else {
-                    //wait for all compaction and flush to complete
-                    if (LOG.isDebugEnabled()) {
-                        SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
-                    }
-                    region.waitForFlushesAndCompactions();
-                    if (LOG.isDebugEnabled()) {
-                        SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
-                    }
-                    responseBuilder.setReadyForBackup(true);
-                }
             }
+            preparing = false;
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
@@ -161,16 +192,27 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
-        //TODO: register HFiles for incremental backup
+        // Register HFiles for incremental backup
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        try {
+            if (namespace.compareTo("splice") != 0)
+                return;
+            captureIncrementalChanges(resultFile.getPath().getName());
+        }
+        catch (Exception ex) {
+            throw new IOException(ex);
+        }
     }
 
     private void waitForBackupToComplete() throws IOException{
         int i = 0;
+        long maxWaitTime = 60*1000;
         while (regionIsBeingBackup()) {
             try {
                 if (LOG.isDebugEnabled())
                     SpliceLogUtils.debug(LOG, "wait for backup to complete");
-                Thread.sleep(100 * (long) Math.pow(2, i));
+                long waitTime = Math.min(100 * (long) Math.pow(2, i), maxWaitTime);
+                Thread.sleep(waitTime);
                 i++;
             }
             catch (InterruptedException e) {
@@ -209,6 +251,84 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         }
 
         return isBackup;
+    }
+
+    private boolean backupCanceled() throws KeeperException, InterruptedException {
+        RecoverableZooKeeper zooKeeper = ZkUtils.getRecoverableZooKeeper();
+        String path = HConfiguration.getConfiguration().getBackupPath();
+        return zooKeeper.exists(path, false) == null;
+    }
+
+    /**
+     * An HFile is eligible for incremental backup if
+     * 1) There is an ongoing full backup, flush is not triggered by preparing and backup for this region is done.
+     * 2) There is no ongoing backup, AND there is a previous full/incremental backup
+     * 3) There is an ongoing incremental backup
+     * @param fileName
+     * @throws StandardException
+     */
+    private void captureIncrementalChanges(String fileName) throws StandardException {
+        boolean shouldRegister = false;
+        try {
+            RecoverableZooKeeper zooKeeper = ZkUtils.getRecoverableZooKeeper();
+            String spliceBackupPath = HConfiguration.getConfiguration().getBackupPath();
+            if (zooKeeper.exists(spliceBackupPath, false) != null) {
+                byte[] backupType = ZkUtils.getData(spliceBackupPath);
+                if (Bytes.compareTo(backupType, BackupRestoreConstants.BACKUP_TYPE_FULL_BYTES) == 0) {
+                    if (!preparing && zooKeeper.exists(path, false) != null) {
+                        byte[] status = ZkUtils.getData(path);
+                        if (Bytes.compareTo(status, HConfiguration.BACKUP_DONE) == 0) {
+                            if (LOG.isDebugEnabled()) {
+                                SpliceLogUtils.debug(LOG, "Table %s is being backup", tableName);
+                            }
+                            shouldRegister = true;
+                        }
+                    }
+                }
+                else {
+                    shouldRegister = true;
+                }
+
+            }
+            else if (BackupUtils.existsDatabaseBackup(fs, rootDir)) {
+                shouldRegister = true;
+            }
+            if (shouldRegister) {
+                registerHFile(fileName);
+            }
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            throw Exceptions.parseException(e);
+        }
+    }
+
+    /**
+     * Register this HFile for incremental backup by creating an empty file
+     * backup/data/splice/tableName/regionName/V/fileName
+     * @param fileName
+     * @throws StandardException
+     */
+    private void registerHFile(String fileName) throws StandardException {
+
+        FSDataOutputStream out = null;
+        try {
+            if (!fs.exists(new Path(backupDir, BackupRestoreConstants.REGION_FILE_NAME))) {
+                HRegionFileSystem.createRegionOnFileSystem(conf, fs, backupDir.getParent(), region.getRegionInfo());
+            }
+            out = fs.create(new Path(backupDir.toString() + "/" + SIConstants.DEFAULT_FAMILY_NAME + "/" + fileName));
+        }
+        catch (Exception e) {
+            throw Exceptions.parseException(e);
+        }
+        finally {
+            try {
+                out.close();
+            }
+            catch (Exception e) {
+                throw Exceptions.parseException(e);
+            }
+        }
     }
 
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {

--- a/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -17,8 +17,17 @@ package com.splicemachine.hbase;
 
 import com.google.protobuf.Service;
 import com.splicemachine.access.HConfiguration;
+import com.splicemachine.backup.BackupRestoreConstants;
+import com.splicemachine.backup.BackupUtils;
 import com.splicemachine.coprocessor.SpliceMessage;
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.pipeline.Exceptions;
+import com.splicemachine.si.constants.SIConstants;
 import com.splicemachine.utils.SpliceLogUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Coprocessor;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.coprocessor.CoprocessorService;
@@ -26,9 +35,11 @@ import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.hadoop.hbase.zookeeper.RecoverableZooKeeper;
 import org.apache.log4j.Logger;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 
 import java.io.IOException;
@@ -46,6 +57,11 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private String tableName;
     private String regionName;
     private String path;
+    private Path backupDir;
+    private Configuration conf;
+    private FileSystem fs;
+    Path rootDir;
+    private volatile boolean preparing;
 
     @Override
     public void start(CoprocessorEnvironment e) throws IOException {
@@ -61,6 +77,11 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         regionName = region.getRegionInfo().getEncodedName();
 
         path = HConfiguration.getConfiguration().getBackupPath() + "/" + tableName + "/" + regionName;
+        conf = HConfiguration.unwrapDelegate();
+        rootDir = FSUtils.getRootDir(conf);
+        fs = FSUtils.getCurrentFileSystem(conf);
+        backupDir = new Path(rootDir, BackupRestoreConstants.BACKUP_DIR + "/data/splice/" + tableName + "/" + regionName);
+        preparing = false;
     }
 
     @Override
@@ -76,7 +97,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             com.google.protobuf.RpcCallback<SpliceMessage.PrepareBackupResponse> done) {
 
         try {
+            preparing = true;
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder = SpliceMessage.PrepareBackupResponse.newBuilder();
+            boolean canceled = false;
             if (isSplitting) {
                 if (LOG.isDebugEnabled()) {
                     SpliceLogUtils.debug(LOG, "%s:%s is being split before trying to prepare for backup", tableName, regionName);
@@ -86,33 +109,41 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             } else {
                 // A region might have been in backup
                 if (!regionIsBeingBackup()) {
-                    HBasePlatformUtils.flush(region);
-                    // Create a ZNode to indicate that the region is being copied
-                    ZkUtils.recursiveSafeCreate(path, HConfiguration.BACKUP_IN_PROGRESS, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-                }
-                // check again if the region is being split. If so, return an error
-                if (isSplitting) {
-                    if (LOG.isDebugEnabled()) {
-                        SpliceLogUtils.debug(LOG, "%s:%s is being split when trying to prepare for backup", tableName, regionName);
+                    canceled = backupCanceled();
+                    if (!canceled) {
+                        HBasePlatformUtils.flush(region);
+                        // Create a ZNode to indicate that the region is being copied
+                        ZkUtils.recursiveSafeCreate(path, HConfiguration.BACKUP_IN_PROGRESS, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
                     }
+                }
+                if (!canceled) {
+                    // check again if the region is being split. If so, return an error
+                    if (isSplitting) {
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s is being split when trying to prepare for backup", tableName, regionName);
+                        }
+                        responseBuilder.setReadyForBackup(false);
+                        //delete the ZNode
+                        ZkUtils.recursiveDelete(path);
+                    } else {
+                        //wait for all compaction and flush to complete
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
+                        }
+                        region.waitForFlushesAndCompactions();
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
+                        }
+                        responseBuilder.setReadyForBackup(true);
+                    }
+                }
+                else
                     responseBuilder.setReadyForBackup(false);
-                    //delete the ZNode
-                    ZkUtils.recursiveDelete(path);
-                } else {
-                    //wait for all compaction and flush to complete
-                    if (LOG.isDebugEnabled()) {
-                        SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
-                    }
-                    region.waitForFlushesAndCompactions();
-                    if (LOG.isDebugEnabled()) {
-                        SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
-                    }
-                    responseBuilder.setReadyForBackup(true);
-                }
             }
+            preparing = false;
             done.run(responseBuilder.build());
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            controller.setFailed(e.getMessage());
         }
     }
 
@@ -161,16 +192,27 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
-        //TODO: register HFiles for incremental backup
+        // Register HFiles for incremental backup
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        try {
+            if (namespace.compareTo("splice") != 0)
+                return;
+            captureIncrementalChanges(resultFile.getPath().getName());
+        }
+        catch (Exception ex) {
+            throw new IOException(ex);
+        }
     }
 
     private void waitForBackupToComplete() throws IOException{
         int i = 0;
+        long maxWaitTime = 60*1000;
         while (regionIsBeingBackup()) {
             try {
                 if (LOG.isDebugEnabled())
                     SpliceLogUtils.debug(LOG, "wait for backup to complete");
-                Thread.sleep(100 * (long) Math.pow(2, i));
+                long waitTime = Math.min(100 * (long) Math.pow(2, i), maxWaitTime);
+                Thread.sleep(waitTime);
                 i++;
             }
             catch (InterruptedException e) {
@@ -209,6 +251,84 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         }
 
         return isBackup;
+    }
+
+    private boolean backupCanceled() throws KeeperException, InterruptedException {
+        RecoverableZooKeeper zooKeeper = ZkUtils.getRecoverableZooKeeper();
+        String path = HConfiguration.getConfiguration().getBackupPath();
+        return zooKeeper.exists(path, false) == null;
+    }
+
+    /**
+     * An HFile is eligible for incremental backup if
+     * 1) There is an ongoing full backup, flush is not triggered by preparing and backup for this region is done.
+     * 2) There is no ongoing backup, AND there is a previous full/incremental backup
+     * 3) There is an ongoing incremental backup
+     * @param fileName
+     * @throws StandardException
+     */
+    private void captureIncrementalChanges(String fileName) throws StandardException {
+        boolean shouldRegister = false;
+        try {
+            RecoverableZooKeeper zooKeeper = ZkUtils.getRecoverableZooKeeper();
+            String spliceBackupPath = HConfiguration.getConfiguration().getBackupPath();
+            if (zooKeeper.exists(spliceBackupPath, false) != null) {
+                byte[] backupType = ZkUtils.getData(spliceBackupPath);
+                if (Bytes.compareTo(backupType, BackupRestoreConstants.BACKUP_TYPE_FULL_BYTES) == 0) {
+                    if (!preparing && zooKeeper.exists(path, false) != null) {
+                        byte[] status = ZkUtils.getData(path);
+                        if (Bytes.compareTo(status, HConfiguration.BACKUP_DONE) == 0) {
+                            if (LOG.isDebugEnabled()) {
+                                SpliceLogUtils.debug(LOG, "Table %s is being backup", tableName);
+                            }
+                            shouldRegister = true;
+                        }
+                    }
+                }
+                else {
+                    shouldRegister = true;
+                }
+
+            }
+            else if (BackupUtils.existsDatabaseBackup(fs, rootDir)) {
+                shouldRegister = true;
+            }
+            if (shouldRegister) {
+                registerHFile(fileName);
+            }
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            throw Exceptions.parseException(e);
+        }
+    }
+
+    /**
+     * Register this HFile for incremental backup by creating an empty file
+     * backup/data/splice/tableName/regionName/V/fileName
+     * @param fileName
+     * @throws StandardException
+     */
+    private void registerHFile(String fileName) throws StandardException {
+
+        FSDataOutputStream out = null;
+        try {
+            if (!fs.exists(new Path(backupDir, BackupRestoreConstants.REGION_FILE_NAME))) {
+                HRegionFileSystem.createRegionOnFileSystem(conf, fs, backupDir.getParent(), region.getRegionInfo());
+            }
+            out = fs.create(new Path(backupDir.toString() + "/" + SIConstants.DEFAULT_FAMILY_NAME + "/" + fileName));
+        }
+        catch (Exception e) {
+            throw Exceptions.parseException(e);
+        }
+        finally {
+            try {
+                out.close();
+            }
+            catch (Exception e) {
+                throw Exceptions.parseException(e);
+            }
+        }
     }
 
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {

--- a/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -17,8 +17,17 @@ package com.splicemachine.hbase;
 
 import com.google.protobuf.Service;
 import com.splicemachine.access.HConfiguration;
+import com.splicemachine.backup.BackupRestoreConstants;
+import com.splicemachine.backup.BackupUtils;
 import com.splicemachine.coprocessor.SpliceMessage;
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.pipeline.Exceptions;
+import com.splicemachine.si.constants.SIConstants;
 import com.splicemachine.utils.SpliceLogUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Coprocessor;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.coprocessor.CoprocessorService;
@@ -26,9 +35,11 @@ import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.hadoop.hbase.zookeeper.RecoverableZooKeeper;
 import org.apache.log4j.Logger;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 
 import java.io.IOException;
@@ -46,6 +57,11 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private String tableName;
     private String regionName;
     private String path;
+    private Path backupDir;
+    private Configuration conf;
+    private FileSystem fs;
+    Path rootDir;
+    private volatile boolean preparing;
 
     @Override
     public void start(CoprocessorEnvironment e) throws IOException {
@@ -61,6 +77,11 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         regionName = region.getRegionInfo().getEncodedName();
 
         path = HConfiguration.getConfiguration().getBackupPath() + "/" + tableName + "/" + regionName;
+        conf = HConfiguration.unwrapDelegate();
+        rootDir = FSUtils.getRootDir(conf);
+        fs = FSUtils.getCurrentFileSystem(conf);
+        backupDir = new Path(rootDir, BackupRestoreConstants.BACKUP_DIR + "/data/splice/" + tableName + "/" + regionName);
+        preparing = false;
     }
 
     @Override
@@ -76,7 +97,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             com.google.protobuf.RpcCallback<SpliceMessage.PrepareBackupResponse> done) {
 
         try {
+            preparing = true;
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder = SpliceMessage.PrepareBackupResponse.newBuilder();
+            boolean canceled = false;
             if (isSplitting) {
                 if (LOG.isDebugEnabled()) {
                     SpliceLogUtils.debug(LOG, "%s:%s is being split before trying to prepare for backup", tableName, regionName);
@@ -86,33 +109,41 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             } else {
                 // A region might have been in backup
                 if (!regionIsBeingBackup()) {
-                    HBasePlatformUtils.flush(region);
-                    // Create a ZNode to indicate that the region is being copied
-                    ZkUtils.recursiveSafeCreate(path, HConfiguration.BACKUP_IN_PROGRESS, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-                }
-                // check again if the region is being split. If so, return an error
-                if (isSplitting) {
-                    if (LOG.isDebugEnabled()) {
-                        SpliceLogUtils.debug(LOG, "%s:%s is being split when trying to prepare for backup", tableName, regionName);
+                    canceled = backupCanceled();
+                    if (!canceled) {
+                        HBasePlatformUtils.flush(region);
+                        // Create a ZNode to indicate that the region is being copied
+                        ZkUtils.recursiveSafeCreate(path, HConfiguration.BACKUP_IN_PROGRESS, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
                     }
+                }
+                if (!canceled) {
+                    // check again if the region is being split. If so, return an error
+                    if (isSplitting) {
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s is being split when trying to prepare for backup", tableName, regionName);
+                        }
+                        responseBuilder.setReadyForBackup(false);
+                        //delete the ZNode
+                        ZkUtils.recursiveDelete(path);
+                    } else {
+                        //wait for all compaction and flush to complete
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
+                        }
+                        region.waitForFlushesAndCompactions();
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
+                        }
+                        responseBuilder.setReadyForBackup(true);
+                    }
+                }
+                else
                     responseBuilder.setReadyForBackup(false);
-                    //delete the ZNode
-                    ZkUtils.recursiveDelete(path);
-                } else {
-                    //wait for all compaction and flush to complete
-                    if (LOG.isDebugEnabled()) {
-                        SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
-                    }
-                    region.waitForFlushesAndCompactions();
-                    if (LOG.isDebugEnabled()) {
-                        SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
-                    }
-                    responseBuilder.setReadyForBackup(true);
-                }
             }
+            preparing = false;
             done.run(responseBuilder.build());
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            controller.setFailed(e.getMessage());
         }
     }
 
@@ -161,16 +192,27 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
-        //TODO: register HFiles for incremental backup
+        // Register HFiles for incremental backup
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        try {
+            if (namespace.compareTo("splice") != 0)
+                return;
+            captureIncrementalChanges(resultFile.getPath().getName());
+        }
+        catch (Exception ex) {
+            throw new IOException(ex);
+        }
     }
 
     private void waitForBackupToComplete() throws IOException{
         int i = 0;
+        long maxWaitTime = 60*1000;
         while (regionIsBeingBackup()) {
             try {
                 if (LOG.isDebugEnabled())
                     SpliceLogUtils.debug(LOG, "wait for backup to complete");
-                Thread.sleep(100 * (long) Math.pow(2, i));
+                long waitTime = Math.min(100 * (long) Math.pow(2, i), maxWaitTime);
+                Thread.sleep(waitTime);
                 i++;
             }
             catch (InterruptedException e) {
@@ -209,6 +251,84 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         }
 
         return isBackup;
+    }
+
+    private boolean backupCanceled() throws KeeperException, InterruptedException {
+        RecoverableZooKeeper zooKeeper = ZkUtils.getRecoverableZooKeeper();
+        String path = HConfiguration.getConfiguration().getBackupPath();
+        return zooKeeper.exists(path, false) == null;
+    }
+
+    /**
+     * An HFile is eligible for incremental backup if
+     * 1) There is an ongoing full backup, flush is not triggered by preparing and backup for this region is done.
+     * 2) There is no ongoing backup, AND there is a previous full/incremental backup
+     * 3) There is an ongoing incremental backup
+     * @param fileName
+     * @throws StandardException
+     */
+    private void captureIncrementalChanges(String fileName) throws StandardException {
+        boolean shouldRegister = false;
+        try {
+            RecoverableZooKeeper zooKeeper = ZkUtils.getRecoverableZooKeeper();
+            String spliceBackupPath = HConfiguration.getConfiguration().getBackupPath();
+            if (zooKeeper.exists(spliceBackupPath, false) != null) {
+                byte[] backupType = ZkUtils.getData(spliceBackupPath);
+                if (Bytes.compareTo(backupType, BackupRestoreConstants.BACKUP_TYPE_FULL_BYTES) == 0) {
+                    if (!preparing && zooKeeper.exists(path, false) != null) {
+                        byte[] status = ZkUtils.getData(path);
+                        if (Bytes.compareTo(status, HConfiguration.BACKUP_DONE) == 0) {
+                            if (LOG.isDebugEnabled()) {
+                                SpliceLogUtils.debug(LOG, "Table %s is being backup", tableName);
+                            }
+                            shouldRegister = true;
+                        }
+                    }
+                }
+                else {
+                    shouldRegister = true;
+                }
+
+            }
+            else if (BackupUtils.existsDatabaseBackup(fs, rootDir)) {
+                shouldRegister = true;
+            }
+            if (shouldRegister) {
+                registerHFile(fileName);
+            }
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            throw Exceptions.parseException(e);
+        }
+    }
+
+    /**
+     * Register this HFile for incremental backup by creating an empty file
+     * backup/data/splice/tableName/regionName/V/fileName
+     * @param fileName
+     * @throws StandardException
+     */
+    private void registerHFile(String fileName) throws StandardException {
+
+        FSDataOutputStream out = null;
+        try {
+            if (!fs.exists(new Path(backupDir, BackupRestoreConstants.REGION_FILE_NAME))) {
+                HRegionFileSystem.createRegionOnFileSystem(conf, fs, backupDir.getParent(), region.getRegionInfo());
+            }
+            out = fs.create(new Path(backupDir.toString() + "/" + SIConstants.DEFAULT_FAMILY_NAME + "/" + fileName));
+        }
+        catch (Exception e) {
+            throw Exceptions.parseException(e);
+        }
+        finally {
+            try {
+                out.close();
+            }
+            catch (Exception e) {
+                throw Exceptions.parseException(e);
+            }
+        }
     }
 
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {

--- a/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -17,8 +17,17 @@ package com.splicemachine.hbase;
 
 import com.google.protobuf.Service;
 import com.splicemachine.access.HConfiguration;
+import com.splicemachine.backup.BackupRestoreConstants;
+import com.splicemachine.backup.BackupUtils;
 import com.splicemachine.coprocessor.SpliceMessage;
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.pipeline.Exceptions;
+import com.splicemachine.si.constants.SIConstants;
 import com.splicemachine.utils.SpliceLogUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Coprocessor;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.coprocessor.CoprocessorService;
@@ -26,9 +35,11 @@ import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.hadoop.hbase.zookeeper.RecoverableZooKeeper;
 import org.apache.log4j.Logger;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 
 import java.io.IOException;
@@ -46,10 +57,15 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private String tableName;
     private String regionName;
     private String path;
+    private Path backupDir;
+    private Configuration conf;
+    private FileSystem fs;
+    Path rootDir;
+    private volatile boolean preparing;
 
     @Override
     public void start(CoprocessorEnvironment e) throws IOException {
-        region = (HRegion) ((RegionCoprocessorEnvironment) e).getRegion();
+        region = (HRegion)((RegionCoprocessorEnvironment) e).getRegion();
         String[] name = region.getTableDesc().getNameAsString().split(":");
         if (name.length == 2) {
             namespace = name[0];
@@ -61,6 +77,11 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         regionName = region.getRegionInfo().getEncodedName();
 
         path = HConfiguration.getConfiguration().getBackupPath() + "/" + tableName + "/" + regionName;
+        conf = HConfiguration.unwrapDelegate();
+        rootDir = FSUtils.getRootDir(conf);
+        fs = FSUtils.getCurrentFileSystem(conf);
+        backupDir = new Path(rootDir, BackupRestoreConstants.BACKUP_DIR + "/data/splice/" + tableName + "/" + regionName);
+        preparing = false;
     }
 
     @Override
@@ -76,7 +97,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             com.google.protobuf.RpcCallback<SpliceMessage.PrepareBackupResponse> done) {
 
         try {
+            preparing = true;
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder = SpliceMessage.PrepareBackupResponse.newBuilder();
+            boolean canceled = false;
             if (isSplitting) {
                 if (LOG.isDebugEnabled()) {
                     SpliceLogUtils.debug(LOG, "%s:%s is being split before trying to prepare for backup", tableName, regionName);
@@ -86,30 +109,38 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             } else {
                 // A region might have been in backup
                 if (!regionIsBeingBackup()) {
-                    HBasePlatformUtils.flush(region);
-                    // Create a ZNode to indicate that the region is being copied
-                    ZkUtils.recursiveSafeCreate(path, HConfiguration.BACKUP_IN_PROGRESS, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-                }
-                // check again if the region is being split. If so, return an error
-                if (isSplitting) {
-                    if (LOG.isDebugEnabled()) {
-                        SpliceLogUtils.debug(LOG, "%s:%s is being split when trying to prepare for backup", tableName, regionName);
+                    canceled = backupCanceled();
+                    if (!canceled) {
+                        HBasePlatformUtils.flush(region);
+                        // Create a ZNode to indicate that the region is being copied
+                        ZkUtils.recursiveSafeCreate(path, HConfiguration.BACKUP_IN_PROGRESS, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
                     }
+                }
+                if (!canceled) {
+                    // check again if the region is being split. If so, return an error
+                    if (isSplitting) {
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s is being split when trying to prepare for backup", tableName, regionName);
+                        }
+                        responseBuilder.setReadyForBackup(false);
+                        //delete the ZNode
+                        ZkUtils.recursiveDelete(path);
+                    } else {
+                        //wait for all compaction and flush to complete
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
+                        }
+                        region.waitForFlushesAndCompactions();
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
+                        }
+                        responseBuilder.setReadyForBackup(true);
+                    }
+                }
+                else
                     responseBuilder.setReadyForBackup(false);
-                    //delete the ZNode
-                    ZkUtils.recursiveDelete(path);
-                } else {
-                    //wait for all compaction and flush to complete
-                    if (LOG.isDebugEnabled()) {
-                        SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
-                    }
-                    region.waitForFlushesAndCompactions();
-                    if (LOG.isDebugEnabled()) {
-                        SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
-                    }
-                    responseBuilder.setReadyForBackup(true);
-                }
             }
+            preparing = false;
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
@@ -161,16 +192,27 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
-        //TODO: register HFiles for incremental backup
+        // Register HFiles for incremental backup
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        try {
+            if (namespace.compareTo("splice") != 0)
+                return;
+            captureIncrementalChanges(resultFile.getPath().getName());
+        }
+        catch (Exception ex) {
+            throw new IOException(ex);
+        }
     }
 
     private void waitForBackupToComplete() throws IOException{
         int i = 0;
+        long maxWaitTime = 60*1000;
         while (regionIsBeingBackup()) {
             try {
                 if (LOG.isDebugEnabled())
                     SpliceLogUtils.debug(LOG, "wait for backup to complete");
-                Thread.sleep(100 * (long) Math.pow(2, i));
+                long waitTime = Math.min(100 * (long) Math.pow(2, i), maxWaitTime);
+                Thread.sleep(waitTime);
                 i++;
             }
             catch (InterruptedException e) {
@@ -211,7 +253,84 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         return isBackup;
     }
 
-    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
+    private boolean backupCanceled() throws KeeperException, InterruptedException {
+        RecoverableZooKeeper zooKeeper = ZkUtils.getRecoverableZooKeeper();
+        String path = HConfiguration.getConfiguration().getBackupPath();
+        return zooKeeper.exists(path, false) == null;
+    }
 
+    /**
+     * An HFile is eligible for incremental backup if
+     * 1) There is an ongoing full backup, flush is not triggered by preparing and backup for this region is done.
+     * 2) There is no ongoing backup, AND there is a previous full/incremental backup
+     * 3) There is an ongoing incremental backup
+     * @param fileName
+     * @throws StandardException
+     */
+    private void captureIncrementalChanges(String fileName) throws StandardException {
+        boolean shouldRegister = false;
+        try {
+            RecoverableZooKeeper zooKeeper = ZkUtils.getRecoverableZooKeeper();
+            String spliceBackupPath = HConfiguration.getConfiguration().getBackupPath();
+            if (zooKeeper.exists(spliceBackupPath, false) != null) {
+                byte[] backupType = ZkUtils.getData(spliceBackupPath);
+                if (Bytes.compareTo(backupType, BackupRestoreConstants.BACKUP_TYPE_FULL_BYTES) == 0) {
+                    if (!preparing && zooKeeper.exists(path, false) != null) {
+                        byte[] status = ZkUtils.getData(path);
+                        if (Bytes.compareTo(status, HConfiguration.BACKUP_DONE) == 0) {
+                            if (LOG.isDebugEnabled()) {
+                                SpliceLogUtils.debug(LOG, "Table %s is being backup", tableName);
+                            }
+                            shouldRegister = true;
+                        }
+                    }
+                }
+                else {
+                    shouldRegister = true;
+                }
+
+            }
+            else if (BackupUtils.existsDatabaseBackup(fs, rootDir)) {
+                shouldRegister = true;
+            }
+            if (shouldRegister) {
+                registerHFile(fileName);
+            }
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            throw Exceptions.parseException(e);
+        }
+    }
+
+    /**
+     * Register this HFile for incremental backup by creating an empty file
+     * backup/data/splice/tableName/regionName/V/fileName
+     * @param fileName
+     * @throws StandardException
+     */
+    private void registerHFile(String fileName) throws StandardException {
+
+        FSDataOutputStream out = null;
+        try {
+            if (!fs.exists(new Path(backupDir, BackupRestoreConstants.REGION_FILE_NAME))) {
+                HRegionFileSystem.createRegionOnFileSystem(conf, fs, backupDir.getParent(), region.getRegionInfo());
+            }
+            out = fs.create(new Path(backupDir.toString() + "/" + SIConstants.DEFAULT_FAMILY_NAME + "/" + fileName));
+        }
+        catch (Exception e) {
+            throw Exceptions.parseException(e);
+        }
+        finally {
+            try {
+                out.close();
+            }
+            catch (Exception e) {
+                throw Exceptions.parseException(e);
+            }
+        }
+    }
+
+    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
     }
 }

--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -447,6 +447,26 @@
                             <runOrder>alphabetical</runOrder>
                         </configuration>
                     </execution>
+		    <!-- = = = = = = = = = = = = = = = = = = = = = = = = = = = Integration tests: BACKUP -->
+                    <execution>
+                        <id>integration-tests-backup</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <groups>com.splicemachine.test.BackupTest</groups>
+                            <argLine>-Xmx3g</argLine>
+                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                            <includes>
+                                <include>**/*RestoreIT.java</include>
+                            </includes>
+                            <excludes>
+                                <!-- Skip all unit tests -->
+                                <exclude>**/*Test.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>


### PR DESCRIPTION
Code changes address 3 issues:
1) make sure BackupEndpointObserver are consistent across all platforms we support
2) run backup/restore ITs
3) flush/split/compaction should not be blocked by backup for more than 60 seconds