### PR TITLE
SPLICE-966 Fixing With Clause omissions

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -12285,9 +12285,11 @@ void withClause(Vector parameterList) throws StandardException :
     {
     	tableName = qualifiedName(Limits.MAX_IDENTIFIER_LENGTH)
     		beginToken = <AS>
+    		[<LEFT_PAREN>]
     		queryExpression = queryExpression(null, NO_SET_OP, topNOut)
     		[ orderCols = orderByClause(queryExpression) ]
             hasJDBClimitClause = offsetFetchFirstClause( offsetClauses )
+            [<RIGHT_PAREN>]
     	{
     		checkOptionType = ViewDescriptor.NO_CHECK_OPTION;
     		endToken = getToken(0);
@@ -12335,9 +12337,12 @@ viewDefinition(Token beginToken) throws StandardException :
 {
 	<VIEW> tableName = qualifiedName(Limits.MAX_IDENTIFIER_LENGTH) 
 		[ <LEFT_PAREN> resultColumns = viewColumnList() <RIGHT_PAREN> ]
-		<AS> queryExpression = queryExpression(null, NO_SET_OP, topNOut)
+		<AS>
+		    		[<LEFT_PAREN>]
+		queryExpression = queryExpression(null, NO_SET_OP, topNOut)
 		[ orderCols = orderByClause(queryExpression) ]
         hasJDBClimitClause = offsetFetchFirstClause( offsetClauses )
+            		[<RIGHT_PAREN>]
 	{
 		checkOptionType = ViewDescriptor.NO_CHECK_OPTION;
 		endToken = getToken(0);

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WithStatementIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WithStatementIT.java
@@ -24,6 +24,7 @@ import org.junit.*;
 import java.sql.ResultSet;
 import static com.splicemachine.test_tools.Rows.row;
 import static com.splicemachine.test_tools.Rows.rows;
+import static org.junit.Assert.assertEquals;
 
 /**
  *
@@ -67,6 +68,11 @@ public class WithStatementIT extends SpliceUnitTest {
                     .withCreate("create table FOO3 (col1 int primary key, col2 int)")
                     .withInsert("insert into FOO3 values(?,?)")
                     .withRows(rows(row(1, 5), row(3, 7))).create();
+
+            new TableCreator(connection)
+                    .withCreate("create table t10 (i int)")
+                    .withInsert("insert into t10 values (?)")
+                    .withRows(rows(row(1),row(2),row(3),row(4),row(5))).create();
 
         }
 
@@ -155,5 +161,17 @@ public class WithStatementIT extends SpliceUnitTest {
         Assert.assertEquals("Wrong Sum" , 4, rs.getInt(3));
         Assert.assertFalse("with join algebra incorrect",rs.next());
     }
+
+    @Test
+//    @Ignore("SPLICE-966")
+    public void testWithContainingOrderBy() throws Exception {
+        ResultSet rs = methodWatcher.executeQuery("with abc as (select i, i+20 as i_2 from t10 where i<3 order by i) select * from abc");
+        String expectedResult = "I | I_2 |\n" +
+                "----------\n" +
+                " 1 | 21  |\n" +
+                " 2 | 22  |";
+        assertEquals(expectedResult, TestUtils.FormattedResult.ResultFactory.toString(rs));
+    }
+
 
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WithStatementIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WithStatementIT.java
@@ -173,5 +173,14 @@ public class WithStatementIT extends SpliceUnitTest {
         assertEquals(expectedResult, TestUtils.FormattedResult.ResultFactory.toString(rs));
     }
 
-
+    @Test
+    //    @Ignore("SPLICE-979")
+    public void testWithContainingTop() throws Exception {
+        ResultSet rs = methodWatcher.executeQuery("with abc as (select TOP i from t10 where i<3 order by i) select * from abc");
+        String expectedResult = "I |\n" +
+                "----\n" +
+                " 1 |";
+        assertEquals(expectedResult, TestUtils.FormattedResult.ResultFactory.toString(rs));
+    }
+    
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WithStatementIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WithStatementIT.java
@@ -182,5 +182,15 @@ public class WithStatementIT extends SpliceUnitTest {
                 " 1 |";
         assertEquals(expectedResult, TestUtils.FormattedResult.ResultFactory.toString(rs));
     }
-    
+
+    @Test
+    //    @Ignore("SPLICE-980")
+    public void testWithContainingLimit() throws Exception {
+        ResultSet rs = methodWatcher.executeQuery("with abc as (select i from t10 where i<4 order by i OFFSET 2 rows fetch first row only ) select * from abc");
+        String expectedResult = "I |\n" +
+                "----\n" +
+                " 3 |";
+        assertEquals(expectedResult, TestUtils.FormattedResult.ResultFactory.toString(rs));
+    }
+
 }


### PR DESCRIPTION
Handles the "(" and ")" properly so with clauses can allow order bys...