### PR TITLE
SPLICE-1072: propogate table referece map from subquery

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromSubquery.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromSubquery.java
@@ -504,6 +504,9 @@ public class FromSubquery extends FromTable
 		/* Set up the PRN's referencedTableMap */
 		newJBS = new JBitSet(numTables);
 		newJBS.set(tableNumber);
+		if (referencedTableMap != null) {
+			newJBS.or(referencedTableMap);
+		}
 		newPRN.setReferencedTableMap(newJBS);
 		((FromTable) newPRN).setTableNumber(tableNumber);
 


### PR DESCRIPTION
During subquery fattening, reference table map of the subquery was not propagated upwards. This information is needed for hash join with a function applied to join column. Missing this information will cause the result column of join  out of order.