### PR TITLE
SPLICE-1101: set cardinality to 0 when there is no statistics

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/FakePartitionStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/FakePartitionStatisticsImpl.java
@@ -172,7 +172,7 @@ public class FakePartitionStatisticsImpl implements PartitionStatistics {
      */
     @Override
     public long cardinality(int positionNumber) {
-        return rowCount();
+        return 0;
     }
 
     /**

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/IndexIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/IndexIT.java
@@ -475,7 +475,6 @@ public class IndexIT extends SpliceUnitTest{
     }
 
     @Test(timeout=1000*60*5)  // Time out after 3 min
-    @Ignore
     public void testJoinCustomerOrdersOrderLineWithIndexNotInColumnOrder() throws Exception{
         SpliceIndexWatcher.createIndex(conn,SCHEMA_NAME,CustomerTable.TABLE_NAME,CustomerTable.INDEX_NAME,CustomerTable.INDEX_ORDER_DEF,false);
         SpliceIndexWatcher.createIndex(conn,SCHEMA_NAME,OrderTable.TABLE_NAME,OrderTable.INDEX_NAME,OrderTable.INDEX_ORDER_DEF,false);


### PR DESCRIPTION
Default cardinality to row count will result in a very low selectivity for nested loop join predicate. Thus nestedloop join will be more likely picked than other join strategies. Reset cardinality to 0, the selectivity of join predicate will be 0.1. This was the behavior before John's code change to statistics.