### PR TITLE
DB-5671 & DB-5672

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/RepeatedPredicateVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/RepeatedPredicateVisitor.java
@@ -150,8 +150,10 @@ public class RepeatedPredicateVisitor extends AbstractSpliceVisitor {
     public Visitable defaultVisit(Visitable node) throws StandardException {
 
         Visitable updatedNode = node;
-
-        if(node instanceof ValueNode){
+        // DB-5672: Disable repeated predicate elimination because it does not work in general. Much
+        // more work needs to be done to make sure the predicates are equivalent before and after transformation.
+        //
+        /*if(node instanceof ValueNode){
 
             foundWhereClause = true;
 
@@ -170,10 +172,10 @@ public class RepeatedPredicateVisitor extends AbstractSpliceVisitor {
                             ((ValueNode) node).getContextManager());
                     newNode = newAndNode;
                 }
-            }
+
 
             updatedNode = newNode;
-        }
+        }*/
 
         return updatedNode;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CastNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CastNode.java
@@ -1137,6 +1137,11 @@ public class CastNode extends ValueNode
 		else
 			castOperand.setHashableJoinColumnReference(cr);
 	}
+
+	@Override
+	public int getTableNumber() {
+		return castOperand.getTableNumber();
+	}
 }
 
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromSubquery.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromSubquery.java
@@ -504,9 +504,11 @@ public class FromSubquery extends FromTable
 		/* Set up the PRN's referencedTableMap */
 		newJBS = new JBitSet(numTables);
 		newJBS.set(tableNumber);
-		if (referencedTableMap != null) {
-			newJBS.or(referencedTableMap);
+		if (referencedTableMap == null) {
+			referencedTableMap = subquery.referencedTableMap;
 		}
+		newJBS.or(referencedTableMap);
+
 		newPRN.setReferencedTableMap(newJBS);
 		((FromTable) newPRN).setTableNumber(tableNumber);
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
@@ -1916,6 +1916,9 @@ public class ResultColumn extends ValueNode
 			// Else recurse down the VCN.
 			return vcn.getSourceColumn().getTableNumber();
 		}
+		else if (expression instanceof TernaryOperatorNode) {
+			return ((TernaryOperatorNode) expression).receiver.getTableNumber();
+		}
 
 		// We can get here if expression has neither a column
 		// reference nor a FromBaseTable beneath it--for example,

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperationIT.java
@@ -907,6 +907,15 @@ public class TableScanOperationIT{
         }
     }
 
+    @Test
+    public void testDuplicatePredicates () throws Exception {
+        try(Statement s=conn.createStatement()){
+            try(ResultSet rs=s.executeQuery(format("select * from %s where sd=1 and (1!=0 or sa='j') and (1!=0 and sa='i')",spliceTableWatcher))){
+                assertTrue("Incorrect number of rows returned!",rs.next());
+            }
+        }
+    }
+
     private void assertCountEquals(Connection connection,long expectedCount,String query) throws SQLException{
         long count=0l;
         try(Statement s=connection.createStatement()){


### PR DESCRIPTION
Fixes two customer bugs:
DB-5671: correct the result column order for hash join whose join column is applied by a function. We used to rely on table number and table reference map to determine if a column is from left or right child result set, but these information can be missing. It's more reliable to lookup source result set of a result column from left/right subtree to determine whether the column is from left/right child result set.

DB-5672: an optimization to extract out duplicate predicates from where clause does not work in general. The query that can be optimized is rarely seen, but it can cause problem if there are duplicate predicates. Disable it for now.  