### PR TITLE
SPLICE-938 : Splice Machine 3.0 on a cluster with Spark 2.0.0

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -89,6 +89,8 @@
                                 kryo-serializers,
                                 lucene-core,
                                 memory,
+                                netty,
+                                netty-all,
                                 opencsv,
                                 protobuf-java,
                                 sketches-core,

--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -494,6 +494,8 @@
                     <artifactSet>
                         <includes>
                             <include>io.netty:netty-all</include>
+                            <include>io.netty:netty</include>
+                            <include>org.jboss.netty:netty</include>
                             <!-- <include>com.typesafe.akka:akka-remote_${scala.binary.version}</include> -->
                         </includes>
                     </artifactSet>
@@ -513,6 +515,13 @@
                     <shadedPattern>splice.io.netty</shadedPattern>
                     <includes>
                         <include>io.netty.**</include>
+                    </includes>
+                </relocation>
+                <relocation>
+                    <pattern>org.jboss.netty</pattern>
+                    <shadedPattern>splice.org.jboss.netty</shadedPattern>
+                    <includes>
+                        <include>org.jboss.netty.**</include>
                     </includes>
                 </relocation>
                 <!-- <relocation>

--- a/pom.xml
+++ b/pom.xml
@@ -315,8 +315,18 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
+                <version>4.0.42.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.6.6.Final</version>
+                <version>3.10.6.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.netty</groupId>
+                <artifactId>netty</artifactId>
+                <version>3.2.10.Final</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>


### PR DESCRIPTION
Point 0: this is not (yet) to merge, just want to ask you all to take a look at it.

Fellas, heres a branch with some pom changes to get MapR 5.x.x to start up. SELECT works in master at least to HBase. Still don't have Spark starting up and a "CALL SYSCS_UTIL.SYSCS_GET_VERSION_INFO();" peters out as well.

I bumped some Netty dep versions to their latest 3.x and 4.x "final" releases, shaded and included them in the assembly.

Updating the JIRA issue shortly.