### PR TITLE
SPLICE-1145 Adding logging required for parquet reading on a cluster.

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -106,6 +106,7 @@
                                 db-tools-ij,
                                 db-tools-testing,
                                 pipeline_api,
+                                jul-to-slf4j,
                                 splice_access_api,
                                 splice_encoding,
                                 splice_machine,


### PR DESCRIPTION
Adding for assembly so Parquet can run on parcels.  We thought this was provided by Hadoop and we were wrong...