### PR TITLE
SPLICE-1146 Making sure we are only using shaded kryo

### DIFF
--- a/splice_machine/pom.xml
+++ b/splice_machine/pom.xml
@@ -79,6 +79,10 @@
                     <groupId>com.google.protobuf</groupId>
                     <artifactId>protobuf-java</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.esotericsoftware</groupId>
+                    <artifactId>kryo</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Attempting to remove this issue from HDP logs...

```
============= begin nested exception, level (1) ===========
java.lang.IncompatibleClassChangeError: Found interface org.objectweb.asm.MethodVisitor, but class was expected
	at com.esotericsoftware.reflectasm.ConstructorAccess.insertConstructor(ConstructorAccess.java:124)
	at com.esotericsoftware.reflectasm.ConstructorAccess.get(ConstructorAccess.java:95)
	at com.esotericsoftware.kryo.Kryo$DefaultInstantiatorStrategy.newInstantiatorOf(Kryo.java:1233)
	at com.esotericsoftware.kryo.Kryo.newInstantiator(Kryo.java:1078)
	at com.esotericsoftware.kryo.Kryo.newInstance(Kryo.java:1087)
	at com.esotericsoftware.kryo.serializers.CollectionSerializer.create(CollectionSerializer.java:107)
	at com.esotericsoftware.kryo.serializers.CollectionSerializer.read(CollectionSerializer.java:111)
	at com.esotericsoftware.kryo.serializers.CollectionSerializer.read(CollectionSerializer.java:40)
	at com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:790)
	at com.splicemachine.derby.hbase.PipelineKryoRegistry$1.read(PipelineKryoRegistry.java:47)
	at com.splicemachine.derby.hbase.PipelineKryoRegistry$1.read(PipelineKryoRegistry.java:39)
	at com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:686)
	at com.splicemachine.pipeline.utils.SimplePipelineCompressor.decompress(SimplePipelineCompressor.java:80)
	at com.splicemachine.pipeline.client.BulkWriteChannelInvoker.invoke(BulkWriteChannelInvoker.java:96)
	at com.splicemachine.pipeline.client.BulkWritesRPCInvoker.write(BulkWritesRPCInvoker.java:68)
	at com.splicemachine.pipeline.client.BulkWriteAction.executeSingle(BulkWriteAction.java:258)
	at com.splicemachine.pipeline.client.BulkWriteAction.execute(BulkWriteAction.java:224)
	at com.splicemachine.pipeline.client.BulkWriteAction.call(BulkWriteAction.java:133)
	at com.splicemachine.pipeline.client.BulkWriteAction.call(BulkWriteAction.java:49)
	at com.splicemachine.pipeline.threadpool.MonitoredThreadPool$WatchingCallable.call(MonitoredThreadPool.java:115)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
============= end nested exception, level (1) ===========
```