### PR TITLE
Added Spark type to ResultColumnDescriptor and now resultSetToSF uses…

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ResultColumnDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ResultColumnDescriptor.java
@@ -26,6 +26,7 @@
 package com.splicemachine.db.iapi.sql;
 
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+import org.apache.spark.sql.types.StructField;
 
 /**
  * A ResultColumnDescriptor describes a result column in a ResultSet.
@@ -42,6 +43,15 @@ public interface ResultColumnDescriptor
 	 * @return	A DataTypeDescriptor describing the type of the column.
 	 */
 	DataTypeDescriptor	getType();
+
+	/**
+	 * Returns a Spark Type for the column. This StructField
+	 * will not represent an actual value, it will only represent the type
+	 * that all values in the column will have.
+	 *
+	 * @return	A StructField describing the type of the column.
+	 */
+	StructField getStructField();
 
 	/**
 	 * Returns the name of the Column.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericColumnDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericColumnDescriptor.java
@@ -26,6 +26,7 @@
 package com.splicemachine.db.impl.sql;
 
 import com.splicemachine.db.catalog.types.RoutineAliasInfo;
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.ResultColumnDescriptor;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 
@@ -33,10 +34,13 @@ import com.splicemachine.db.iapi.services.sanity.SanityManager;
 
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 import com.splicemachine.db.iapi.services.io.Formatable;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
 
 import java.io.ObjectOutput;
 import java.io.ObjectInput;
 import java.io.IOException;
+import java.sql.Types;
 
 /**
  * This is a stripped down implementation of a column
@@ -113,6 +117,21 @@ public final class GenericColumnDescriptor
 	public DataTypeDescriptor	getType()
 	{
 		return type;
+	}
+
+	/**
+	 * Returns a Spark Type for the column. This StructField
+	 * will not represent an actual value, it will only represent the Spark type
+	 * that all values in the column will have.
+	 *
+	 * @return	A StructField describing the type of the column.
+	 */
+	public StructField getStructField() {
+		try {
+			return getType().getNull().getStructField(getName());
+		} catch (StandardException e) {
+			return null;
+		}
 	}
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
@@ -25,6 +25,7 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
+import java.sql.Types;
 import java.util.Collections;
 import java.util.List;
 
@@ -47,6 +48,8 @@ import com.splicemachine.db.iapi.types.DataValueFactory;
 import com.splicemachine.db.iapi.types.StringDataValue;
 import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.util.StringUtil;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
 
 /**
  * A ResultColumn represents a result column in a SELECT, INSERT, or UPDATE
@@ -1990,6 +1993,21 @@ public class ResultColumn extends ValueNode
 
     public void setColumnDescriptor(ColumnDescriptor columnDescriptor) {
         this.columnDescriptor = columnDescriptor;
+    }
+
+    /**
+     * Returns a Spark Type for the column. This StructField
+     * will not represent an actual value, it will only represent the Spark type
+     * that all values in the column will have.
+     *
+     * @return	A StructField describing the type of the column.
+     */
+    public StructField getStructField() {
+        try {
+            return getType().getNull().getStructField(getName());
+        } catch (StandardException e) {
+            return null;
+        }
     }
 }
 


### PR DESCRIPTION
… new Tungsten Row interface on ExecRow

... Modified to use Uses getNull() on a DTD to get DVD which has a StructField