### PR TITLE
SPLICE-1129: make import transaction additive

### DIFF
--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/ActiveWriteTxn.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/ActiveWriteTxn.java
@@ -85,6 +85,9 @@ public class ActiveWriteTxn extends AbstractTxnView{
         return additive;
     }
 
+    public void setAdditive(boolean additive) {
+        this.additive = additive;
+    }
     @Override
     public void readExternal(ObjectInput input) throws IOException, ClassNotFoundException{
         super.readExternal(input);

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/WritableTxn.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/WritableTxn.java
@@ -93,6 +93,10 @@ public class WritableTxn extends AbstractTxn{
         return isAdditive;
     }
 
+    public void setAdditive(boolean additive) {
+        this.isAdditive = additive;
+    }
+
     @Override
     public long getGlobalCommitTimestamp(){
         if(globalCommitTimestamp<0) return parentTxn.getGlobalCommitTimestamp();


### PR DESCRIPTION
Import transaction should be additive, so that write-write conflicts between sibling transaction can be handled as primary key/unique constraints violations.
I intended to add ITs similar to Daniel's except some more assertions. Since Daniel will check in IT, I will modify after his checkin.