### PR TITLE
SPLICE-1129: make import transaction additive

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/stream/output/SpliceOutputCommitter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/output/SpliceOutputCommitter.java
@@ -83,7 +83,7 @@ public class SpliceOutputCommitter extends OutputCommitter {
             SpliceLogUtils.debug(LOG,"setupTask");
         // Create child additive transaction so we don't read rows inserted by ourselves in this operation
         TxnView txn = SIDriver.driver().lifecycleManager().beginChildTransaction(parentTxn, parentTxn.getIsolationLevel(), true, destinationTable);
-        ActiveWriteTxn childTxn = new ActiveWriteTxn(txn.getTxnId(), txn.getTxnId(), parentTxn, parentTxn.isAdditive(), parentTxn.getIsolationLevel());
+        ActiveWriteTxn childTxn = new ActiveWriteTxn(txn.getTxnId(), txn.getTxnId(), parentTxn, true, parentTxn.getIsolationLevel());
         taskAttemptMap.put(taskContext.getTaskAttemptID(), childTxn);
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG,"beginTxn=%s and destinationTable=%s",childTxn,destinationTable);

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/PartitionWriteHandler.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/PartitionWriteHandler.java
@@ -185,11 +185,10 @@ public class PartitionWriteHandler implements WriteHandler {
                 //see if it's due to constraints, otherwise just pass it through
                 if (constraintChecker != null && constraintChecker.matches(stat)) {
                     ctx.result(mutation, constraintChecker.asWriteResult(stat));
-                    break;
                 }else{
-                    failed++;
                     ctx.failed(mutation, WriteResult.failed(stat.errorMessage()));
                 }
+                failed++;
             }
         }
 

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Row_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Row_IT.java
@@ -220,6 +220,8 @@ public class Trigger_Row_IT {
     }
 
     @Test
+    @Ignore
+    //SPLICE-1168
     public void afterUpdate_sinkingTriggerAction() throws Exception {
         try(Statement s = conn.createStatement()){
             s.executeUpdate("insert into RECORD values('aaa')");


### PR DESCRIPTION
Import transaction should be additive, so that write-write conflicts between sibling transaction can be handled as primary key/unique constraints violations.

Report all constraint violations (per Daniel's comments)

I intended to add ITs similar to Daniel's except some more assertions. Since Daniel will check in IT, I will modify after his checkin.
 