### PR TITLE
SPLICE-1186 Remove ZK nodes on standalone startup

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/test/SpliceTestPlatform.java
+++ b/hbase_sql/src/test/java/com/splicemachine/test/SpliceTestPlatform.java
@@ -15,8 +15,14 @@
 
 package com.splicemachine.test;
 
+import com.splicemachine.hbase.ZkUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.MiniHBaseCluster;
+import org.apache.hadoop.hbase.zookeeper.RecoverableZooKeeper;
+import org.apache.hadoop.hbase.zookeeper.ZKUtil;
+import org.apache.zookeeper.KeeperException;
+
+import java.io.IOException;
 
 /**
  * Start MiniHBaseCluster for use by ITs.
@@ -45,6 +51,18 @@ public class SpliceTestPlatform {
                     regionServerInfoPort,
                     derbyPort,
                     failTasksRandomly);
+
+            // clean-up zookeeper
+            try {
+                ZkUtils.delete("/hbase/master");
+            } catch (KeeperException.NoNodeException ex) {
+                // ignore
+            }
+            try {
+                ZkUtils.recursiveDelete("/hbase/rs");
+            } catch (KeeperException.NoNodeException | IOException ex) {
+                // ignore
+            }
 
             MiniHBaseCluster miniHBaseCluster = new MiniHBaseCluster(config, 1, 1);
 


### PR DESCRIPTION
Fix 'master not started after 30 seconds' errors when restarting standalone quickly.