### PR TITLE
SPLICE-1019: fix the nullability of the not-null columns with rollup …

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
@@ -346,6 +346,30 @@ public class SelectNode extends ResultSetNode{
     }
 
     /**
+     * Find colName in the result columns and return underlying columnReference.
+     *
+     * @param    colName        Name of the column
+     * @return ColumnReference    ColumnReference to the column, if found
+     */
+    private ResultColumn getColumnInResult(String colName) throws StandardException{
+        if (resultColumns != null) {
+            // Loop through the result columns looking for a match
+            int rclSize = resultColumns.size();
+            for (int index = 0; index < rclSize; index++) {
+                ResultColumn rc = resultColumns.elementAt(index);
+                if (!(rc.getExpression() instanceof ColumnReference))
+                    return null;
+
+                ColumnReference crNode = (ColumnReference) rc.getExpression();
+
+                if (crNode.columnName.equals(colName))
+                    return rc;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Return the whereClause for this SelectNode.
      *
      * @return ValueNode    The whereClause for this SelectNode.
@@ -653,6 +677,17 @@ public class SelectNode extends ResultSetNode{
 		 */
         fromList.bindResultColumns(fromListParam);
         super.bindResultColumns(fromListParam);
+
+        // Find the group-by-rollup columns in the resultset and mark it nullable
+        if (groupByList != null && groupByList.isRollup()) {
+            for (int i = 0; i < groupByList.size(); i++) {
+                String col = groupByList.getGroupByColumn(i).getColumnExpression().getColumnName();
+                ResultColumn rc = getColumnInResult(col);
+                if (rc != null)
+                    rc.setNullability(true);
+            }
+        }
+
 		/* Only 1012 elements allowed in select list */
         if(resultColumns.size()>Limits.DB2_MAX_ELEMENTS_IN_SELECT_LIST){
             throw StandardException.newException(SQLState.LANG_TOO_MANY_ELEMENTS);

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiGroupGroupedAggregateOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiGroupGroupedAggregateOperationIT.java
@@ -521,7 +521,8 @@ public class MultiGroupGroupedAggregateOperationIT extends SpliceUnitTest {
     }
 
     @Test
-    public void testRollupWithNotNull_1() throws Exception {
+    public void testRollupWithNotNull() throws Exception {
+    	// simple rollup with not-null column
     	String sqlText = String.format("SELECT deptno, sum(salary) from %s group by rollup(deptno) order by 1, 2", EMP_2_REF);
 
 		ResultSet rs = methodWatcher.executeQuery(sqlText);
@@ -540,7 +541,8 @@ public class MultiGroupGroupedAggregateOperationIT extends SpliceUnitTest {
 	}
 
 	@Test
-	public void testRollupWithNotNull_2() throws Exception {
+	public void testRollupWithNotNullMultiCols() throws Exception {
+		// rollup with multiple not-null cols
 		String sqlText = String.format("SELECT deptno, empno, sum(salary) from %s group by rollup(deptno, empno) order by 1, 2", EMP_2_REF);
 
 		ResultSet rs = methodWatcher.executeQuery(sqlText);
@@ -574,7 +576,8 @@ public class MultiGroupGroupedAggregateOperationIT extends SpliceUnitTest {
 	}
 
 	@Test
-	public void testRollupWithNotNull_3() throws Exception {
+	public void testRollupWithNotNullAndSubq() throws Exception {
+		// subquery with rollup and not-null columns
 		String sqlText = String.format(" " +
 				"SELECT * from (" +
 						"SELECT deptno, sum(salary) "+
@@ -597,7 +600,8 @@ public class MultiGroupGroupedAggregateOperationIT extends SpliceUnitTest {
 	}
 
 	@Test
-	public void testRollupWithNotNull_4() throws Exception {
+	public void testRollupWithNotNullNestedSubq() throws Exception {
+		// nested subquery with rollup on not-null columns
 		String sqlText = String.format(" " +
 			"SELECT * from (" +
 			  "SELECT * from (" +
@@ -621,7 +625,8 @@ public class MultiGroupGroupedAggregateOperationIT extends SpliceUnitTest {
 	}
 
 	@Test
-	public void testRollupWithNotNull_5() throws Exception {
+	public void testRollupWithNotNullNestedSubqRollup() throws Exception {
+		// nested subquery with nested rollup on not-null columns
 		String sqlText = String.format(
 				"SELECT deptno, count(s_sum) from (" +
 					"SELECT deptno, empno, sum(salary) as s_sum " +
@@ -646,8 +651,8 @@ public class MultiGroupGroupedAggregateOperationIT extends SpliceUnitTest {
 	}
 
 	@Test
-	public void testRollupWithNotNull_6() throws Exception {
-	    // rollup with aggr distinct
+	public void testRollupWithNotNullDistinct() throws Exception {
+	    // rollup with not-null columns and aggr distinct
 		String sqlText = String.format(
 				"SELECT deptno, count(distinct s_sum) from (" +
 				  "SELECT deptno, count(distinct salary) as s_sum " +


### PR DESCRIPTION
Rollup columns are nullable by nature, but if the schema is defined with not-null columns and rollup used with the sub-queries, the nullability of those columns were not getting set causing the issue in the DRDA layer later. This fix adds the check and sets the nullability of such columns during the binding process where all the result columns should be set.