### PR TITLE
SPLICE-1216 Block Coding Configurability

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
+++ b/hbase_sql/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
@@ -19,6 +19,9 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.spark_project.guava.collect.Lists.transform;
 import java.util.List;
+
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
 import org.spark_project.guava.base.Function;
 import org.spark_project.guava.base.Joiner;
 import org.spark_project.guava.collect.ImmutableList;
@@ -175,6 +178,7 @@ class SpliceTestPlatformConfig {
         //
         // HFile
         //
+        config.set(HConfiguration.DATA_BLOCK_ENCODING,DataBlockEncoding.FAST_DIFF.name());
         config.setInt("hfile.index.block.max.size", 16 * 1024); // 16KiB
         config.setFloat("hfile.block.cache.size", 0.25f); // set block cache to 25% of heap
         config.setFloat("io.hfile.bloom.error.rate", (float) 0.005);

--- a/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
+++ b/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.*;
 import org.apache.hadoop.hbase.io.compress.Compression;
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
 import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.log4j.Logger;
@@ -173,6 +174,7 @@ public class HBaseConnectionFactory{
         columnDescriptor.setMaxVersions(5);
         Compression.Algorithm compress=Compression.getCompressionAlgorithmByName(config.getCompressionAlgorithm());
         columnDescriptor.setCompressionType(compress);
+        columnDescriptor.setDataBlockEncoding(DataBlockEncoding.valueOf(config.getDataBlockEncoding()));
         columnDescriptor.setInMemory(HConfiguration.DEFAULT_IN_MEMORY);
         columnDescriptor.setBlockCacheEnabled(HConfiguration.DEFAULT_BLOCKCACHE);
         columnDescriptor.setBloomFilterType(BloomType.valueOf(HConfiguration.DEFAULT_BLOOMFILTER.toUpperCase()));
@@ -194,6 +196,7 @@ public class HBaseConnectionFactory{
         HColumnDescriptor snapshot=new HColumnDescriptor(DEFAULT_FAMILY_BYTES);
         snapshot.setMaxVersions(Integer.MAX_VALUE);
         Compression.Algorithm compress=Compression.getCompressionAlgorithmByName(config.getCompressionAlgorithm());
+        snapshot.setDataBlockEncoding(DataBlockEncoding.valueOf(config.getDataBlockEncoding()));
         snapshot.setCompressionType(compress);
         snapshot.setInMemory(HConfiguration.DEFAULT_IN_MEMORY);
         snapshot.setBlockCacheEnabled(HConfiguration.DEFAULT_BLOCKCACHE);

--- a/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
+++ b/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.io.compress.Compression;
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
 import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.log4j.Logger;
@@ -176,6 +177,7 @@ public class HBaseConnectionFactory{
         columnDescriptor.setMaxVersions(5);
         Compression.Algorithm compress=Compression.getCompressionAlgorithmByName(config.getCompressionAlgorithm());
         columnDescriptor.setCompressionType(compress);
+        columnDescriptor.setDataBlockEncoding(DataBlockEncoding.valueOf(config.getDataBlockEncoding()));
         columnDescriptor.setInMemory(HConfiguration.DEFAULT_IN_MEMORY);
         columnDescriptor.setBlockCacheEnabled(HConfiguration.DEFAULT_BLOCKCACHE);
         columnDescriptor.setBloomFilterType(BloomType.valueOf(HConfiguration.DEFAULT_BLOOMFILTER.toUpperCase()));
@@ -197,6 +199,7 @@ public class HBaseConnectionFactory{
         HColumnDescriptor snapshot=new HColumnDescriptor(DEFAULT_FAMILY_BYTES);
         snapshot.setMaxVersions(Integer.MAX_VALUE);
         Compression.Algorithm compress=Compression.getCompressionAlgorithmByName(config.getCompressionAlgorithm());
+        snapshot.setDataBlockEncoding(DataBlockEncoding.valueOf(config.getDataBlockEncoding()));
         snapshot.setCompressionType(compress);
         snapshot.setInMemory(HConfiguration.DEFAULT_IN_MEMORY);
         snapshot.setBlockCacheEnabled(HConfiguration.DEFAULT_BLOCKCACHE);

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.io.compress.Compression;
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
 import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.log4j.Logger;
@@ -176,6 +177,7 @@ public class HBaseConnectionFactory{
         columnDescriptor.setMaxVersions(5);
         Compression.Algorithm compress=Compression.getCompressionAlgorithmByName(config.getCompressionAlgorithm());
         columnDescriptor.setCompressionType(compress);
+        columnDescriptor.setDataBlockEncoding(DataBlockEncoding.valueOf(config.getDataBlockEncoding()));
         columnDescriptor.setInMemory(HConfiguration.DEFAULT_IN_MEMORY);
         columnDescriptor.setBlockCacheEnabled(HConfiguration.DEFAULT_BLOCKCACHE);
         columnDescriptor.setBloomFilterType(BloomType.valueOf(HConfiguration.DEFAULT_BLOOMFILTER.toUpperCase()));
@@ -198,6 +200,7 @@ public class HBaseConnectionFactory{
         snapshot.setMaxVersions(Integer.MAX_VALUE);
         Compression.Algorithm compress=Compression.getCompressionAlgorithmByName(config.getCompressionAlgorithm());
         snapshot.setCompressionType(compress);
+        snapshot.setDataBlockEncoding(DataBlockEncoding.valueOf(config.getDataBlockEncoding()));
         snapshot.setInMemory(HConfiguration.DEFAULT_IN_MEMORY);
         snapshot.setBlockCacheEnabled(HConfiguration.DEFAULT_BLOCKCACHE);
         snapshot.setBloomFilterType(BloomType.ROW);

--- a/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
+++ b/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.io.compress.Compression;
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
 import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.log4j.Logger;
@@ -176,6 +177,7 @@ public class HBaseConnectionFactory{
         columnDescriptor.setMaxVersions(5);
         Compression.Algorithm compress=Compression.getCompressionAlgorithmByName(config.getCompressionAlgorithm());
         columnDescriptor.setCompressionType(compress);
+        columnDescriptor.setDataBlockEncoding(DataBlockEncoding.valueOf(config.getDataBlockEncoding()));
         columnDescriptor.setInMemory(HConfiguration.DEFAULT_IN_MEMORY);
         columnDescriptor.setBlockCacheEnabled(HConfiguration.DEFAULT_BLOCKCACHE);
         columnDescriptor.setBloomFilterType(BloomType.valueOf(HConfiguration.DEFAULT_BLOOMFILTER.toUpperCase()));
@@ -199,6 +201,7 @@ public class HBaseConnectionFactory{
         Compression.Algorithm compress=Compression.getCompressionAlgorithmByName(config.getCompressionAlgorithm());
         snapshot.setCompressionType(compress);
         snapshot.setInMemory(HConfiguration.DEFAULT_IN_MEMORY);
+        snapshot.setDataBlockEncoding(DataBlockEncoding.valueOf(config.getDataBlockEncoding()));
         snapshot.setBlockCacheEnabled(HConfiguration.DEFAULT_BLOCKCACHE);
         snapshot.setBloomFilterType(BloomType.ROW);
         snapshot.setTimeToLive(HConfiguration.DEFAULT_TTL);

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.io.compress.Compression;
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
 import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.log4j.Logger;
@@ -175,6 +176,7 @@ public class HBaseConnectionFactory{
         columnDescriptor.setMaxVersions(5);
         Compression.Algorithm compress=Compression.getCompressionAlgorithmByName(config.getCompressionAlgorithm());
         columnDescriptor.setCompressionType(compress);
+        columnDescriptor.setDataBlockEncoding(DataBlockEncoding.valueOf(config.getDataBlockEncoding()));
         columnDescriptor.setInMemory(HConfiguration.DEFAULT_IN_MEMORY);
         columnDescriptor.setBlockCacheEnabled(HConfiguration.DEFAULT_BLOCKCACHE);
         columnDescriptor.setBloomFilterType(BloomType.valueOf(HConfiguration.DEFAULT_BLOOMFILTER.toUpperCase()));
@@ -196,6 +198,7 @@ public class HBaseConnectionFactory{
         HColumnDescriptor snapshot=new HColumnDescriptor(DEFAULT_FAMILY_BYTES);
         snapshot.setMaxVersions(Integer.MAX_VALUE);
         Compression.Algorithm compress=Compression.getCompressionAlgorithmByName(config.getCompressionAlgorithm());
+        snapshot.setDataBlockEncoding(DataBlockEncoding.valueOf(config.getDataBlockEncoding()));
         snapshot.setCompressionType(compress);
         snapshot.setInMemory(HConfiguration.DEFAULT_IN_MEMORY);
         snapshot.setBlockCacheEnabled(HConfiguration.DEFAULT_BLOCKCACHE);

--- a/hbase_storage/src/main/java/com/splicemachine/access/HConfiguration.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/HConfiguration.java
@@ -19,7 +19,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.log4j.Logger;
-
 import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.access.configuration.ConfigurationBuilder;
 import com.splicemachine.access.configuration.ConfigurationSource;
@@ -47,7 +46,9 @@ import com.splicemachine.constants.SpliceConfiguration;
 public class HConfiguration extends HBaseConfiguration {
     private static final Logger LOG = Logger.getLogger("splice.config");
 
-    private static final String DEFAULT_COMPRESSION = "none";
+    private static final String DEFAULT_COMPRESSION = HColumnDescriptor.DEFAULT_COMPRESSION;
+    private static final String DEFAULT_BLOCK_ENCODING = HColumnDescriptor.DEFAULT_DATA_BLOCK_ENCODING;
+
 
     // Splice Default Table Definitions
     public static final Boolean DEFAULT_IN_MEMORY = HColumnDescriptor.DEFAULT_IN_MEMORY;
@@ -106,10 +107,9 @@ public class HConfiguration extends HBaseConfiguration {
         builder.regionServerHandlerCount = configurationSource.getInt(REGION_SERVER_HANDLER_COUNT, HConstants.DEFAULT_REGION_SERVER_HANDLER_COUNT);
         // TODO: JC - this looks strange (transactionLockStripes = REGION_SERVER_HANDLER_COUNT) but is as I found it, typo?
         builder.transactionLockStripes = configurationSource.getInt(REGION_SERVER_HANDLER_COUNT, HConstants.DEFAULT_REGION_SERVER_HANDLER_COUNT);
-
         builder.regionMaxFileSize = configurationSource.getLong(REGION_MAX_FILE_SIZE, HConstants.DEFAULT_MAX_FILE_SIZE);
-
         builder.compressionAlgorithm = configurationSource.getString(COMPRESSION_ALGORITHM, DEFAULT_COMPRESSION);
+        builder.dataBlockEncoding = configurationSource.getString(DATA_BLOCK_ENCODING,DEFAULT_BLOCK_ENCODING);
     }
 
     private SConfiguration init() {

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
@@ -90,6 +90,8 @@ public interface SConfiguration {
 
     String getCompressionAlgorithm();
 
+    String getDataBlockEncoding();
+
     String getNamespace();
 
     String getSpliceRootPath();

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
@@ -83,6 +83,7 @@ public class ConfigurationBuilder {
     public long regionLoadUpdateInterval;
     public String backupPath;
     public String compressionAlgorithm;
+    public String dataBlockEncoding;
     public String namespace;
     public String spliceRootPath;
     public String hbaseSecurityAuthorization;

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/HBaseConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/HBaseConfiguration.java
@@ -161,6 +161,14 @@ public class HBaseConfiguration implements ConfigurationDefault {
      */
     public static final String COMPRESSION_ALGORITHM = "splice.compression";
 
+    /**
+     *
+     * The data block encoding that Splice Machine will use for hbase.  Please see
+     * https://hbase.apache.org/book.html#compression for a more thorough discussion.
+     *
+     */
+    public static final String DATA_BLOCK_ENCODING = "splice.datablockencoding";
+
 
     @Override
     public void setDefaults(ConfigurationBuilder builder, ConfigurationSource configurationSource) {

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
@@ -70,6 +70,7 @@ public final class SConfigurationImpl implements SConfiguration {
     private final  long regionLoadUpdateInterval;
     private final  String backupPath;
     private final  String compressionAlgorithm;
+    private final String dataBlockEncoding;
     private final  String namespace;
     private final  String spliceRootPath;
     private final  String hbaseSecurityAuthorization;
@@ -260,6 +261,10 @@ public final class SConfigurationImpl implements SConfiguration {
     @Override
     public String getCompressionAlgorithm() {
         return compressionAlgorithm;
+    }
+    @Override
+    public String getDataBlockEncoding() {
+        return dataBlockEncoding;
     }
     @Override
     public String getNamespace() {
@@ -627,6 +632,7 @@ public final class SConfigurationImpl implements SConfiguration {
         backupPath = builder.backupPath;
         backupParallelism = builder.backupParallelism;
         compressionAlgorithm = builder.compressionAlgorithm;
+        dataBlockEncoding = builder.dataBlockEncoding;
         namespace = builder.namespace;
         spliceRootPath = builder.spliceRootPath;
         hbaseSecurityAuthorization = builder.hbaseSecurityAuthorization;


### PR DESCRIPTION
Adding the ability to perform HBase block encoding via configuration.  Once we get results, good possibility FAST_DIFF becomes are default.