### PR TITLE
SPLICE-1267

### DIFF
--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -602,7 +602,7 @@ public interface Property {
 	 * Undocumented.
 	 */
 	String	LANG_TD_CACHE_SIZE = "derby.language.tableDescriptorCacheSize";
-	int		LANG_TD_CACHE_SIZE_DEFAULT = 64;
+	int		LANG_TD_CACHE_SIZE_DEFAULT = 128;
 
     /**
      * The size of the permissions cache used by the data dictionary.
@@ -611,7 +611,7 @@ public interface Property {
 	 * Undocumented.
 	 */
 	String	LANG_PERMISSIONS_CACHE_SIZE = "derby.language.permissionsCacheSize";
-	int		LANG_PERMISSIONS_CACHE_SIZE_DEFAULT = 64;
+	int		LANG_PERMISSIONS_CACHE_SIZE_DEFAULT = 128;
 	/**
 	 * The size of the stored prepared statment descriptor cache 
 	 * used by the data dictionary.  Database.  Static.


### PR DESCRIPTION
Increasing Default Table Cache Descriptor Size to make sure we have a bit of overhead over dictionary tables.