### PR TITLE
SPLICE-1268 Modifying Default Test Config

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
+++ b/hbase_sql/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
@@ -138,6 +138,9 @@ class SpliceTestPlatformConfig {
         // Threads, timeouts
         //
         config.setLong("hbase.rpc.timeout", MINUTES.toMillis(2));
+        config.setInt("hbase.client.max.perserver.tasks",50);
+        config.setInt("hbase.client.ipc.pool.size",10);
+
         config.setLong("hbase.client.scanner.timeout.period", MINUTES.toMillis(2)); // hbase.regionserver.lease.period is deprecated
         config.setLong("hbase.client.operation.timeout", MINUTES.toMillis(2));
         config.setLong("hbase.regionserver.handler.count", 200);


### PR DESCRIPTION
Increasing the ipc pool size under the covers in hbase for tests and the per region tasks.