### PR TITLE
SPLICE-1270 Fixing Dictionary Index Lookup Logic

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/ConglomerateController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/ConglomerateController.java
@@ -25,12 +25,15 @@
 
 package com.splicemachine.db.iapi.store.access;
 
+import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 
 import com.splicemachine.db.iapi.types.RowLocation;
 
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
+
+import java.util.List;
 
 
 /**
@@ -184,7 +187,36 @@ public interface ConglomerateController extends ConglomPropertyQueryable
     FormatableBitSet                 validColumns) 
 		throws StandardException;
 
-    /**
+	/**
+	 * Fetch the (partial) rows at the given location.
+	 * <p>
+	 *
+	 * @param locations             The "RowLocations" which describes the exact row
+	 *                        to fetch from the table.
+	 * @param destRows         The rows to read the data into.
+	 * @param validColumns    A description of which columns to return from
+	 *                        row on the page into "destRow."  destRow
+	 *                        and validColumns work together to
+	 *                        describe the row to be returned by the fetch -
+	 *                        see RowUtil for description of how these three
+	 *                        parameters work together to describe a fetched
+	 *                        "row".
+	 *
+	 * @return Returns true if fetch was successful, false if the record
+	 *         pointed at no longer represents a valid record.
+	 *
+	 * @exception  StandardException  Standard exception policy.
+	 *
+	 * @see RowUtil
+	 **/
+	boolean batchFetch(
+			List<RowLocation> locations,
+			List<ExecRow>   destRows,
+			FormatableBitSet                 validColumns)
+			throws StandardException;
+
+
+	/**
      * Fetch the (partial) row at the given location.
      * <p>
      *
@@ -218,39 +250,74 @@ public interface ConglomerateController extends ConglomPropertyQueryable
     boolean     waitForLock) 
 		throws StandardException;
 
-    /**
+	/**
+	 * Fetch the (partial) row at the given location.
+	 * <p>
+	 *
+	 * @param locations             The "RowLocation" which describes the exact row
+	 *                        to fetch from the table.
+	 * @param destRows         The row to read the data into.
+	 * @param validColumns    A description of which columns to return from
+	 *                        row on the page into "destRow."  destRow
+	 *                        and validColumns work together to
+	 *                        describe the row to be returned by the fetch -
+	 *                        see RowUtil for description of how these three
+	 *                        parameters work together to describe a fetched
+	 *                        "row".
+	 * @param waitForLock     If false, then the call will throw a lock timeout
+	 *                        exception immediately, if the lock can not be
+	 *                        granted without waiting.  If true call will
+	 *                        act exactly as fetch() interface with no
+	 *                        waitForLock parameter.
+	 *
+	 * @return Returns true if fetch was successful, false if the record
+	 *         pointed at no longer represents a valid record.
+	 *
+	 * @exception  StandardException  Standard exception policy.
+	 *
+	 * @see RowUtil
+	 **/
+	boolean batchFetch(
+			List<RowLocation> locations,
+			List<ExecRow>   destRows,
+			FormatableBitSet     validColumns,
+			boolean     waitForLock)
+			throws StandardException;
+
+
+	/**
      * Fetch the (partial) row at the given location.
      * <p>
      * RESOLVE - interface NOT SUPPORTED YET!!!!!
      *
-	 * @param loc             The "RowLocation" which describes the exact row
+     * @param loc             The "RowLocation" which describes the exact row
      *                        to fetch from the table.
-	 * @param destRow         The row to read the data into.
-	 * @param validColumns    A description of which columns to return from
+     * @param destRow         The row to read the data into.
+     * @param validColumns    A description of which columns to return from
      *                        row on the page into "destRow."  destRow,
      *                        and validColumns work together to
-     *                        describe the row to be returned by the fetch - 
-     *                        see RowUtil for description of how these three 
-     *                        parameters work together to describe a fetched 
+     *                        describe the row to be returned by the fetch -
+     *                        see RowUtil for description of how these three
+     *                        parameters work together to describe a fetched
      *                        "row".
-	 * @param qualifier       An array of qualifiers which, 
-     *                        applied to each key, restrict the rows returned 
-     *                        by the scan.  Rows for which any one of the 
-     *                        qualifiers returns false are not returned by 
-     *                        the scan. If null, all rows are returned.  
-     *                        Qualifiers can only reference columns which are 
-     *                        included in the scanColumnList.  The column id 
-     *                        that a qualifier returns in the column id the 
+     * @param qualifier       An array of qualifiers which,
+     *                        applied to each key, restrict the rows returned
+     *                        by the scan.  Rows for which any one of the
+     *                        qualifiers returns false are not returned by
+     *                        the scan. If null, all rows are returned.
+     *                        Qualifiers can only reference columns which are
+     *                        included in the scanColumnList.  The column id
+     *                        that a qualifier returns in the column id the
      *                        table, not the column id in the partial row being
-     *                        returned.  See openScan() for description of how 
+     *                        returned.  See openScan() for description of how
      *                        qualifiers are applied.
      *
-	 * @return Returns true if fetch was successful, false if the record 
+     * @return Returns true if fetch was successful, false if the record
      *         pointed at no longer represents a valid record.
      *
-	 * @exception  StandardException  Standard exception policy.
+     * @exception  StandardException  Standard exception policy.
      *
-	 * @see RowUtil
+     * @see RowUtil
      **/
     /*
     boolean fetch(

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
@@ -132,6 +132,7 @@ public class DataDictionaryCache {
         if (LOG.isDebugEnabled())
             LOG.debug("nameTdCacheAdd " + tableKey + " : " + td);
         nameTdCache.put(tableKey,td);
+        oidTdCache.put(td.getUUID(),td);
     }
 
     public TableDescriptor nameTdCacheRemove(TableKey tableKey) throws StandardException {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceController.java
@@ -16,6 +16,8 @@
 package com.splicemachine.derby.impl.store.access.base;
 
 import com.carrotsearch.hppc.BitSet;
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
 import com.splicemachine.access.api.PartitionFactory;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
@@ -41,7 +43,12 @@ import com.splicemachine.si.api.data.TxnOperationFactory;
 import com.splicemachine.si.constants.SIConstants;
 import com.splicemachine.storage.*;
 import org.apache.log4j.Logger;
+import org.apache.parquet.Closeables;
+
+import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Properties;
 
 public abstract class SpliceController implements ConglomerateController{
@@ -53,6 +60,17 @@ public abstract class SpliceController implements ConglomerateController{
     private String tableVersion;
     private Partition table;
     protected TxnOperationFactory opFactory;
+    private static Function ROWLOCATION_TO_BYTES = new Function<RowLocation, byte[]>() {
+        @Override
+        public byte[] apply(@Nullable RowLocation rowLocation) {
+            try {
+                return rowLocation.getBytes();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    };
+
 
     public SpliceController(){
     }
@@ -167,6 +185,51 @@ public abstract class SpliceController implements ConglomerateController{
             throw Exceptions.parseException(e);
         }
     }
+    @Override
+    public boolean batchFetch(List<RowLocation> locations, List<ExecRow> destRows, FormatableBitSet validColumns) throws StandardException{
+        return batchFetch(locations,destRows,validColumns,false);
+    }
+    @Override
+    public boolean batchFetch(List<RowLocation> locations, List<ExecRow> destRows,FormatableBitSet validColumns,boolean waitForLock) throws StandardException{
+        if (locations.size() == 0)
+            return false;
+        Partition htable = getTable();
+        KeyHashDecoder rowDecoder = null;
+        try{
+            DataGet baseGet=opFactory.newDataGet(trans.getTxnInformation(),locations.get(0).getBytes(),null);
+            baseGet.returnAllVersions();
+            DataGet get = createGet(baseGet,destRows.get(0).getRowArray(),validColumns);//loc,destRow,validColumns,trans.getTxnInformation());
+            Iterator<DataResult> results = htable.batchGet(get, Lists.transform(locations, ROWLOCATION_TO_BYTES));
+            assert results != null:"Results Returned are Null";
+            int i = 0;
+            DescriptorSerializer[] serializers = null;
+            int[] cols=FormatableBitSetUtils.toIntArray(validColumns);
+            while (results.hasNext()) {
+                DataResult result = results.next();
+                DataValueDescriptor[] destRow = destRows.get(i).getRowArray();
+                if (serializers ==null) {
+                    serializers = VersionedSerializers.forVersion(tableVersion, true).getSerializers(destRow);
+                    rowDecoder=new EntryDataDecoder(cols,null,serializers);
+                }
+                ExecRow row=new ValueRow(destRow.length);
+                row.setRowArray(destRow);
+                row.resetRowArray();
+                DataCell keyValue=result.userData();
+                rowDecoder.set(keyValue.valueArray(),keyValue.valueOffset(),keyValue.valueLength());
+                rowDecoder.decode(row);
+                i++;
+            }
+            return true;
+        }catch(Exception e){
+            e.printStackTrace();
+            throw Exceptions.parseException(e);
+        } finally {
+            if (rowDecoder !=null)
+                Closeables.closeAndSwallowIOExceptions(rowDecoder);
+        }
+
+    }
+
 
     @Override
     public String toString(){

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceController.java
@@ -221,7 +221,6 @@ public abstract class SpliceController implements ConglomerateController{
             }
             return true;
         }catch(Exception e){
-            e.printStackTrace();
             throw Exceptions.parseException(e);
         } finally {
             if (rowDecoder !=null)

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/hbase/HBaseRowLocation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/hbase/HBaseRowLocation.java
@@ -131,7 +131,7 @@ public class HBaseRowLocation extends DataType implements RowLocation {
      */
     @Override
     public HBaseRowLocation cloneValue(boolean forceMaterialization) {
-        return new HBaseRowLocation(this);
+        return forceMaterialization?deepClone(this):new HBaseRowLocation(this);
     }
 
     @Override


### PR DESCRIPTION
Inside the dictionary (not query stack), we currently do our index lookups from an index scan serially .  This will perform a single batch multi-get to reduce RPC calls.