### PR TITLE
SPLICE-1180 Fixing Time, Small int, and Clob data types

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/StatsBoundaryDataValueDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/StatsBoundaryDataValueDescriptor.java
@@ -505,4 +505,9 @@ public class StatsBoundaryDataValueDescriptor implements DataValueDescriptor {
     public int getTypeFormatId() {
         return dvd.getTypeFormatId();
     }
+
+    @Override
+    public Object getSparkObject() throws StandardException {
+        return dvd.getSparkObject();
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataType.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataType.java
@@ -1335,4 +1335,9 @@ public abstract class DataType extends NullValueData
 	public int getRowWidth() {
 		return 8;
 	}
+
+	@Override
+	public Object getSparkObject() throws StandardException {
+		return getObject();
+	}
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueDescriptor.java
@@ -1088,4 +1088,11 @@ public interface DataValueDescriptor extends Storable, Orderable, Comparator<Dat
 
 	int getRowWidth();
 
+	/**
+	 * Retrieve the Spark Object (required in places where spark has type issues (time for example).
+	 *
+	 * @return
+     */
+	Object getSparkObject() throws StandardException;
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLSmallint.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLSmallint.java
@@ -853,6 +853,10 @@ public final class SQLSmallint
 		return DataTypes.createStructField(columnName, DataTypes.ShortType, true);
 	}
 
+	@Override
+	public Object getSparkObject() throws StandardException {
+		return getShort();
+	}
 
 	public void updateThetaSketch(UpdateSketch updateSketch) {
 		updateSketch.update(value);

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTime.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTime.java
@@ -1180,7 +1180,7 @@ public final class SQLTime extends DataType
 			setToNull();
 		else {
 			isNull = false;
-			encodedTime = computeEncodedTime(row.getDate(ordinal));
+			encodedTime = computeEncodedTime(row.getTimestamp(ordinal));
 			encodedTimeFraction = 0;
 		}
 	}
@@ -1235,7 +1235,7 @@ public final class SQLTime extends DataType
 
 	@Override
 	public StructField getStructField(String columnName) {
-		return DataTypes.createStructField(columnName, DataTypes.DateType, true);
+		return DataTypes.createStructField(columnName, DataTypes.TimestampType, true);
 	}
 
 
@@ -1243,5 +1243,9 @@ public final class SQLTime extends DataType
 		updateSketch.update(new int[]{encodedTime,encodedTimeFraction});
 	}
 
+	@Override
+	public Object getSparkObject() throws StandardException {
+		return getTimestamp(null);
+	}
 }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
@@ -416,7 +416,7 @@ public class ValueRow implements ExecRow, Externalizable {
 	@Override
 	public Object get(int i) {
 		try {
-			return column[i].getObject();
+			return column[i].getSparkObject();
 		} catch (StandardException se) {
 			throw new RuntimeException(se);
 		}

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -404,6 +404,51 @@ public class ExternalTableIT extends SpliceUnitTest{
         Assert.assertEquals("",TestUtils.FormattedResult.ResultFactory.toString(rs));
     }
 
+    @Test
+    // SPLICE-1180
+    public void testReadTimeFromFile() throws Exception {
+        File directory = new File(String.valueOf(getExternalResourceDirectory()+"timestamp_parquet"));
+        if (!directory.exists())
+            directory.mkdir();
+        methodWatcher.executeUpdate(String.format("create external table timestamp_parquet (a time)" +
+                " STORED AS PARQUET LOCATION '%s'", getExternalResourceDirectory()+"timestamp_parquet"));
+        methodWatcher.executeUpdate("insert into timestamp_parquet values ('22:22:22')");
+        ResultSet rs = methodWatcher.executeQuery("select * from timestamp_parquet");
+        Assert.assertEquals("A    |\n" +
+                "----------\n" +
+                "22:22:22 |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+    }
+
+    @Test
+    // SPLICE-1180
+    public void testReadClobFromFile() throws Exception {
+        File directory = new File(String.valueOf(getExternalResourceDirectory()+"clob_parquet"));
+        if (!directory.exists())
+            directory.mkdir();
+        methodWatcher.executeUpdate(String.format("create external table clob_parquet (largecol clob(65535))" +
+                " STORED AS PARQUET LOCATION '%s'", getExternalResourceDirectory()+"clob_parquet"));
+        methodWatcher.executeUpdate("insert into clob_parquet values ('asdfasfd234234')");
+        ResultSet rs = methodWatcher.executeQuery("select * from clob_parquet");
+        Assert.assertEquals("LARGECOL    |\n" +
+                "----------------\n" +
+                "asdfasfd234234 |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+    }
+
+    @Test
+    // SPLICE-1180
+    public void testReadSmallIntFromFile() throws Exception {
+        File directory = new File(String.valueOf(getExternalResourceDirectory()+"short_parquet"));
+        if (!directory.exists())
+            directory.mkdir();
+        methodWatcher.executeUpdate(String.format("create external table short_parquet (col1 smallint)" +
+                " STORED AS PARQUET LOCATION '%s'", getExternalResourceDirectory()+"short_parquet"));
+        methodWatcher.executeUpdate("insert into short_parquet values (12)");
+        ResultSet rs = methodWatcher.executeQuery("select * from short_parquet");
+        Assert.assertEquals("COL1 |\n" +
+                "------\n" +
+                " 12  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+    }
+
 
     @Test
     public void testCannotAlterExternalTable() throws Exception {

--- a/splice_machine/src/test/java/com/splicemachine/homeless/TestUtils.java
+++ b/splice_machine/src/test/java/com/splicemachine/homeless/TestUtils.java
@@ -21,6 +21,7 @@ import java.io.PrintStream;
 import java.sql.*;
 import java.util.*;
 
+import com.splicemachine.db.iapi.types.SQLClob;
 import org.spark_project.guava.collect.Lists;
 import com.splicemachine.utils.Pair;
 import org.apache.commons.dbutils.BasicRowProcessor;
@@ -447,7 +448,12 @@ public class TestUtils {
                             columns.add(metaData.getColumnName(i).trim());
                         }
                         Object value = rs.getObject(i);
-                        row.add((value != null ? value.toString().trim() : "NULL"));
+                        if (value != null && value instanceof Clob) {
+                            Clob clob = (Clob) value;
+                             row.add( clob.getSubString(1,(int)clob.length()));
+                        } else {
+                            row.add((value != null && value.toString() != null ? value.toString().trim() : "NULL"));
+                        }
                     }
                     rows.add(row);
                     gotColumnNames = true;


### PR DESCRIPTION
Fixes places where the DataValueDescriptor#getObject() does not allign to Spark types.