### PR TITLE
SPLICE-1177: Correct failed rows for import

### DIFF
--- a/hbase_storage/src/main/java/com/splicemachine/storage/HLock.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HLock.java
@@ -28,18 +28,6 @@ import java.util.concurrent.locks.Lock;
  *         Date: 12/15/15
  */
 public class HLock implements Lock{
-    protected static boolean HAS_READ_LOCK_IMPL = false;
-
-    static {
-        try {
-            Class rowLockContextClass = Class.forName("org.apache.hadoop.hbase.regionserver.HRegion$RowLockContext");
-            rowLockContextClass.getDeclaredMethod("newReadLock", new Class[]{});
-            HAS_READ_LOCK_IMPL = true;
-        } catch (Exception e) {
-
-        }
-    }
-
 
     private final byte[] key;
 
@@ -73,7 +61,7 @@ public class HLock implements Lock{
     @Override
     public boolean tryLock(){
         try{
-            delegate = region.getRowLock(key,HAS_READ_LOCK_IMPL?true:false); // Null Lock Delegate means not run...
+            delegate = region.getRowLock(key); // Null Lock Delegate means not run...
             return delegate!=null;
         }catch(IOException e){
             return false;

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsImportIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsImportIT.java
@@ -337,9 +337,8 @@ public class HdfsImportIT extends SpliceUnitTest {
             try (ResultSet rs = ps.executeQuery()) {
                 assertTrue(rs.next());
 
-                // TODO SPLICE-1177 check for exact number of failed rows
-//                int failed = rs.getInt(2);
-//                assertEquals("Failed rows don't match", 4, failed);
+                int failed = rs.getInt(2);
+                assertEquals("Failed rows don't match", 4, failed);
 
                 boolean exists = existsBadFile(BADDIR, "multiFilePKViolation.bad");
                 List<String> badFiles = getAllBadFiles(BADDIR, "multiFilePKViolation.bad");
@@ -348,8 +347,7 @@ public class HdfsImportIT extends SpliceUnitTest {
                 for(String badFile : badFiles) {
                     badLines.addAll(Files.readAllLines((new File(BADDIR, badFile)).toPath(), Charset.defaultCharset()));
                 }
-                // TODO SPLICE-1177 expect exactly 4 lines
-                assertTrue("Expected some lines in bad files "+badFiles, badLines.size() > 0);
+                assertEquals("Expected some lines in bad files "+badFiles, 4, badLines.size());
             }
         }
         try(ResultSet rs = methodWatcher.executeQuery("select count(*) from "+multiPK)){


### PR DESCRIPTION
Fix two issues that caused import to report wrong failed rows
1) Take a write row lock(instead of read lock) before writing. A read lock may fail to detect duplicate rows
2) For ControlDatasetWriter, report failed rows after flushing write buffer.