### PR TITLE
DB-5678: get right version of hadoop-client-core

### DIFF
--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -120,6 +120,10 @@
                     <groupId>org.scala-lang</groupId>
                     <artifactId>scala-reflect</artifactId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>hadoop-client</artifactId>
+                    <groupId>org.apache.hadoop</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -719,7 +723,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <excludedGroups>com.splicemachine.test.SerialTest, ${excluded.categories}</excludedGroups>
+                            <excludedGroups>com.splicemachine.test.SerialTest, com.splicemachine.test.RestoreTest, ${excluded.categories}</excludedGroups>
                             <parallel>classes</parallel>
                             <threadCount>1</threadCount>
                             <!-- -sf- single-threaded for now -->
@@ -747,7 +751,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <groups>com.splicemachine.test.BackupTest</groups>
+                            <groups>com.splicemachine.test.RestoreTest</groups>
                             <argLine>-Xmx3g</argLine>
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <includes>

--- a/splice_machine/src/test/java/com/splicemachine/test/RestoreTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/test/RestoreTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2012 - 2016 Splice Machine, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.splicemachine.test;
+
+/**
+ * Created by jyuan on 4/21/15.
+ */
+public class RestoreTest {
+}


### PR DESCRIPTION
Fix hadoop-client dependencies for cdh5.8.0. Run RestoreIT at the end of ITs.

Please also review pull request at spliceengine-ee.