### PR TITLE
SPLICE-1290 Adding Batch Write Operations to Dictionary

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/ConglomerateController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/ConglomerateController.java
@@ -347,7 +347,30 @@ public interface ConglomerateController extends ConglomPropertyQueryable
 	int insert(DataValueDescriptor[]    row) 
 		throws StandardException;
 
-    /**
+
+	/**
+	 insert rows into the conglomerate.
+
+	 @param row the row to insert into the conglomerate.  the stored
+	 representations of the row's columns are copied into a new row
+	 somewhere in the conglomerate.
+
+	 @return returns 0 if insert succeeded.  returns
+	 conglomeratecontroller.rowisduplicate if conglomerate supports uniqueness
+	 checks and has been created to disallow duplicates, and the row inserted
+	 had key columns which were duplicate of a row already in the table.  other
+	 insert failures will raise standardexception's.
+
+	 @exception standardexception standard exception policy.
+	 @see rowutil
+	 **/
+	int batchInsert(List<ExecRow>    rows)
+			throws StandardException;
+
+
+
+
+	/**
      * insert row and fetch it's row location in one operation.
      * <p>
      * Insert a row into the conglomerate, and store its location in 
@@ -370,6 +393,32 @@ public interface ConglomerateController extends ConglomPropertyQueryable
     DataValueDescriptor[]   row, 
     RowLocation             destRowLocation)
 		throws StandardException;
+
+	/**
+	 * insert rows and fetch there row location in one batchPut operation.
+	 * <p>
+	 * Insert a row into the conglomerate, and store its location in
+	 * the provided destination row location.  The row location must be of the
+	 * correct type for this conglomerate (a new row location of the correct
+	 * type can be obtained from newRowLocationTemplate()).
+	 *
+	 * @param row           The row to insert into the conglomerate.  The
+	 *                      stored representations of the row's columns are
+	 *                      copied into a new row somewhere in the conglomerate.
+	 *
+	 * @param rowLocations The rowlocation to read the inserted row location
+	 *                      into.
+	 *
+	 * @exception  StandardException  Standard exception policy.
+	 *
+	 * @see RowUtil
+	 **/
+
+	void batchInsertAndFetchLocation(
+			ExecRow[]			rows,
+			RowLocation[]       rowLocations
+	) throws StandardException;
+
 
     /**
 	Return whether this is a keyed conglomerate.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/TabInfoImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/TabInfoImpl.java
@@ -48,6 +48,9 @@ import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 
 import com.splicemachine.db.iapi.types.RowLocation;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -507,48 +510,36 @@ public class TabInfoImpl
         heapLocation = heapController.newRowLocationTemplate();
         rowLocationOut[0]=heapLocation;
 
-        // loop through rows on this list, inserting them into system table
-        for (int rowNumber = 0; rowNumber < rowList.length; rowNumber++)
-        {
-            ExecRow row = rowList[rowNumber];
-            // insert the base row and get its new location
-            heapController.insertAndFetchLocation(row.getRowArray(), heapLocation);
+        RowLocation[] rowLocations = new RowLocation[rowList.length];
+        for ( int i = 0; i< rowLocations.length;i++) {
+            rowLocations[i] = heapController.newRowLocationTemplate();
+        }
 
-            for ( int ictr = 0; ictr < indexCount; ictr++ )
-            {
-                if (indexControllers[ ictr ] == null)
-                {
+        heapController.batchInsertAndFetchLocation(rowList,rowLocations);
+            for ( int ictr = 0; ictr < indexCount; ictr++ ) {
+                if (indexControllers[ ictr ] == null) {
                     continue;
                 }
-
-                // Get an index row based on the base row
-                indexableRow = getIndexRowFromHeapRow( getIndexRowGenerator(ictr),
-                        heapLocation,
-                        row );
-
-                insertRetCode =
-                        indexControllers[ ictr ].insert(indexableRow.getRowArray());
-
-                if ( insertRetCode == ConglomerateController.ROWISDUPLICATE )
-                {
-                    retCode = rowNumber;
+                List<ExecRow> indexRows = new ArrayList(rowList.length);
+                for (int i =0; i< rowList.length; i++) {
+                    // Get an index row based on the base row
+                    indexRows.add(getIndexRowFromHeapRow(getIndexRowGenerator(ictr),
+                            rowLocations[i],
+                            rowList[i]).getClone());
+                }
+                insertRetCode = indexControllers[ ictr ].batchInsert(indexRows);
+                if ( insertRetCode == ConglomerateController.ROWISDUPLICATE ) {
+                    retCode = 1;
                 }
             }
-
-        }	// end loop through rows on list
-
         // Close the open conglomerates
-        for ( int ictr = 0; ictr < indexCount; ictr++ )
-        {
-            if (indexControllers[ ictr ] == null)
-            {
+        for ( int ictr = 0; ictr < indexCount; ictr++ ) {
+            if (indexControllers[ ictr ] == null) {
                 continue;
             }
-
             indexControllers[ ictr ].close();
         }
         heapController.close();
-
         return	retCode;
     }
 

--- a/mem_sql/src/main/resources/log4j.properties
+++ b/mem_sql/src/main/resources/log4j.properties
@@ -18,9 +18,9 @@ log4j.appender.Console1.layout=org.apache.log4j.PatternLayout
 log4j.appender.Console1.layout.ConversionPattern=%d{HH:mm:ss,SSS} (%t) %-5p [%c] - %m%n
 
 log4j.rootLogger=INFO, Console1
-
-log4j.logger.com.splicemachine.derby.impl.store.access=INFO, Console1
-#log4j.logger.com.splicemachine.derby.impl.SpliceService=INFO, Console1
-log4j.logger.com.splicemachine.derby.utils=INFO, Console1
-log4j.logger.com.splicemachine.si.impl=INFO, Console1
-log4j.logger.com.splicemachine.db.impl.sql.catalog.DataDictionaryCache=INFO, Console1
+#log4j.logger.com.splicemachine.derby.utils=INFO
+#log4j.logger.com.splicemachine.si.impl=INFO
+#log4j.logger.com.splicemachine.db.impl.sql.catalog.DataDictionaryCache=INFO
+#log4j.logger.com.splicemachine.derby.ddl.DDLWatchRefresher=TRACE
+#log4j.logger.com.splicemachine.derby.impl.store.access.hbase=TRACE
+#log4j.logger.com.splicemachine.db.impl.sql.compile.Level2OptimizerTrace=INFO

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatchRefresher.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatchRefresher.java
@@ -172,6 +172,7 @@ public class DDLWatchRefresher{
 
     private void processPreCommitChange(DDLChange ddlChange,
                                         Collection<DDLWatcher.DDLListener> ddlListeners) throws StandardException {
+        LOG.error("processPreCommitChanges -> " + ddlChange);
         currChangeCount.incrementAndGet();
         tentativeDDLS.put(ddlChange.getChangeId(),ddlChange);
         for(DDLWatcher.DDLListener listener:ddlListeners){
@@ -191,6 +192,7 @@ public class DDLWatchRefresher{
             if(!children.contains(entry)){
                 LOG.debug("Removing change with id " + entry);
                 changeTimeouts.remove(entry);
+                LOG.error("clearFinishedChanges -> " + entry);
                 currentDDLChanges.remove(entry);
                 currChangeCount.decrementAndGet();
                 DDLChange ddlChange = tentativeDDLS.remove(entry);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
@@ -431,6 +431,7 @@ public class CreateTableConstantOperation extends DDLConstantOperation {
          */
         long txnId = ((SpliceTransactionManager)tc).getRawTransaction().getActiveStateTxn().getTxnId();
         DDLMessage.DDLChange change =DDLMessage.DDLChange.newBuilder().setDdlChangeType(DDLMessage.DDLChangeType.CREATE_TABLE).setTxnId(txnId).build();
+
         tc.prepareDataDictionaryChange(DDLDriver.driver().ddlController().notifyMetadataChange(change));
 
         // is this a external file ?

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceController.java
@@ -221,6 +221,7 @@ public abstract class SpliceController implements ConglomerateController{
             }
             return true;
         }catch(Exception e){
+            e.printStackTrace();
             throw Exceptions.parseException(e);
         } finally {
             if (rowDecoder !=null)


### PR DESCRIPTION
Optimization for the dictionary to batch writes to main tables and indexes.

We behave a bit sluggishly when we are over a network partition due to all the RPC requests.