### PR TITLE
Splice 976 v1

### DIFF
--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAConnThread.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAConnThread.java
@@ -247,6 +247,13 @@ class DRDAConnThread extends Thread {
     	String prdDTA = reader.convertBytes(prd);
     	if(prdDTA.compareTo(SPLICE_ODBC_NAME) == 0) 
     		session.enableCompress(true);
+
+		if (!appRequester.srvclsnm.equals("QDERBY/JVM")) {
+			// make sure this request is coming from the splice driver
+			if (!prdDTA.contains("Splice")) {
+				invalidClient(appRequester.prdid);
+            }
+		}
     }
 
 	// constructor

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAProtocolException.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAProtocolException.java
@@ -273,6 +273,10 @@ class DRDAProtocolException extends Exception
 				+ messageid +
 				"; RDBNAM = "+ rdbnam;
 		}
+		else if (cpArg == CodePoint.PRDID) {
+			this.svrcod = exceptionInfo.svrcod;
+			msg = "Execution failed because of invalid client connection attempt, please use Slice Machine Driver.";
+		}
 		else
 		{
 			this.svrcod = exceptionInfo.svrcod;

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/DRDAConstants.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/DRDAConstants.java
@@ -44,7 +44,7 @@ public	interface	DRDAConstants
 	// list of legal DRDA Product Identifiers.
 	//
 	public	static	final	String	DERBY_DRDA_SERVER_ID = "CSS";
-	public	static	final	String	DERBY_DRDA_CLIENT_ID = "DNC";
+	public	static	final	String	DERBY_DRDA_CLIENT_ID = "SNC";
 
     // Maximum size of a DDM block
     public static final int DATA_STREAM_STRUCTURE_MAX_LENGTH = 32767;

--- a/splice_machine/pom.xml
+++ b/splice_machine/pom.xml
@@ -131,6 +131,12 @@
             <type>jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derbyclient</artifactId>
+            <version>10.9.1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/splice_machine/src/test/java/com/splicemachine/derby/client/TestUnknownClient.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/client/TestUnknownClient.java
@@ -1,0 +1,21 @@
+package com.splicemachine.derby.client;
+
+import org.junit.Test;
+
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.SQLNonTransientConnectionException;
+import java.util.Properties;
+
+/**
+ * Created by jleach on 12/13/16.
+ */
+public class TestUnknownClient {
+
+    @Test (expected = SQLNonTransientConnectionException.class)
+    public void testDerbyDriverFails() throws Exception {
+        Driver derbyDriver = DriverManager.getDriver("jdbc:derby://localhost:1527/splicedb;create=true;user=hmm;password=splice;create=admin");
+        derbyDriver.connect("jdbc:derby://localhost:1527/splicedb;create=true;user=splice;password=admin",new Properties());
+    }
+
+}

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceNetConnection.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceNetConnection.java
@@ -42,7 +42,7 @@ public class SpliceNetConnection {
         return String.format(DB_URL_LOCAL, DEFAULT_USER, DEFAULT_USER_PASSWORD);
     }
 
-    private static Connection getConnectionAs(String providedURL, String userName, String password) throws SQLException {
+    public static Connection getConnectionAs(String providedURL, String userName, String password) throws SQLException {
         String url = String.format(providedURL, userName, password);
         return DriverManager.getConnection(url, new Properties());
     }


### PR DESCRIPTION
Added a check for odbc driver so that only splice odbc driver is allowed to proceed. Tested with our odbc and jdbc app, and odbc app with Easysoft derby odbc driver which would now fail to connect.
**Note: the only new change is in DRDAConnThread