### PR TITLE
SPLICE-1209: pick up a remote cost per Kb

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ScanCostFunction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ScanCostFunction.java
@@ -251,7 +251,8 @@ public class ScanCostFunction{
         double closeLatency = scc.getCloseLatency();
         double localLatency = scc.getLocalLatency();
         double remoteLatency = scc.getRemoteLatency();
-        double remoteCost = openLatency + closeLatency + totalRowCount*totalSelectivity*remoteLatency*(1+colSizeFactor/100d);
+        double remoteCost = openLatency + closeLatency + totalRowCount*totalSelectivity*remoteLatency*(1+colSizeFactor/1024d); // Per Kb
+
         assert openLatency >= 0 : "openLatency cannot be negative -> " + openLatency;
         assert closeLatency >= 0 : "closeLatency cannot be negative -> " + closeLatency;
         assert localLatency >= 0 : "localLatency cannot be negative -> " + localLatency;


### PR DESCRIPTION
Use per Kb in calculation instead of 100. 

FYI, I am also running tpcds explain workload plans to see if we are regressing anywhere far too much to ensure the sanity. There are bunch of small changes in planner related bugs that John has pointed out the changes.