### PR TITLE
SPLICE-1208: fix mergeSortJoin overestimate by 3x

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
@@ -260,13 +260,13 @@ public class SelectivityUtil {
      * @param outerCost
      * @return
      */
-    public static double mergeSortJoinStrategyLocalCost(CostEstimate innerCost, CostEstimate outerCost, double replicationFactor) {
-        double outerShuffleCost = outerCost.localCostPerPartition()+replicationFactor*outerCost.getRemoteCost()/outerCost.partitionCount()
-                +outerCost.getOpenCost()+outerCost.getCloseCost();;
-        double innerShuffleCost = innerCost.localCostPerPartition()+replicationFactor*innerCost.getRemoteCost()/innerCost.partitionCount()
-                +innerCost.getOpenCost()+innerCost.getCloseCost();;
-        double outerReadCost = outerCost.localCost()/16;
-        double innerReadCost = innerCost.localCost()/16;
+    public static double mergeSortJoinStrategyLocalCost(CostEstimate innerCost, CostEstimate outerCost) {
+        double outerShuffleCost = outerCost.localCostPerPartition()+outerCost.getRemoteCost()/outerCost.partitionCount()
+                +outerCost.getOpenCost()+outerCost.getCloseCost();
+        double innerShuffleCost = innerCost.localCostPerPartition()+innerCost.getRemoteCost()/innerCost.partitionCount()
+                +innerCost.getOpenCost()+innerCost.getCloseCost();
+        double outerReadCost = outerCost.localCost()/outerCost.partitionCount();
+        double innerReadCost = innerCost.localCost()/outerCost.partitionCount();
 
         return outerShuffleCost+innerShuffleCost+outerReadCost+innerReadCost;
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/HalfMergeSortJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/HalfMergeSortJoinStrategy.java
@@ -110,7 +110,7 @@ public class HalfMergeSortJoinStrategy extends HashableJoinStrategy {
         double joinSelectivity = SelectivityUtil.estimateJoinSelectivity(innerTable, cd, predList, (long) innerCost.rowCount(), (long) outerCost.rowCount(), outerCost);
         double totalOutputRows = SelectivityUtil.getTotalRows(joinSelectivity, outerCost.rowCount(), innerCost.rowCount());
         // Half sort merge join cost is 90% the cost of doing a merge sort join
-        double joinCost = 0.9D * SelectivityUtil.mergeSortJoinStrategyLocalCost(innerCost, outerCost, 3);
+        double joinCost = 0.9D * SelectivityUtil.mergeSortJoinStrategyLocalCost(innerCost, outerCost);
         innerCost.setLocalCost(joinCost);
         innerCost.setLocalCostPerPartition(joinCost);
         innerCost.setRemoteCost(SelectivityUtil.getTotalRemoteCost(innerCost, outerCost, totalOutputRows));

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
@@ -88,7 +88,7 @@ public class MergeSortJoinStrategy extends HashableJoinStrategy {
         double joinSelectivity = SelectivityUtil.estimateJoinSelectivity(innerTable, cd, predList, (long) innerCost.rowCount(), (long) outerCost.rowCount(), outerCost);
         double totalOutputRows = SelectivityUtil.getTotalRows(joinSelectivity, outerCost.rowCount(), innerCost.rowCount());
         innerCost.setNumPartitions(outerCost.partitionCount());
-        double joinCost = SelectivityUtil.mergeSortJoinStrategyLocalCost(innerCost, outerCost, 3);
+        double joinCost = SelectivityUtil.mergeSortJoinStrategyLocalCost(innerCost, outerCost);
         innerCost.setLocalCost(joinCost);
         innerCost.setLocalCostPerPartition(joinCost);
         innerCost.setRemoteCost(SelectivityUtil.getTotalRemoteCost(innerCost,outerCost,totalOutputRows));


### PR DESCRIPTION
It seems since 1.5 release we were multiplying the mergeSortJoin cost by3x since it was being replicated three times. It does not make sense now to do so since that is not the case, so adjusting the cost by removing that factor.
Tested the plans with the tpcds workload query plan for sanity.