### PR TITLE
SPLICE-1207: remove the static partitions count and rowOrdering(null)…

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
@@ -93,10 +93,9 @@ public class MergeSortJoinStrategy extends HashableJoinStrategy {
         innerCost.setLocalCostPerPartition(joinCost);
         innerCost.setRemoteCost(SelectivityUtil.getTotalRemoteCost(innerCost,outerCost,totalOutputRows));
         innerCost.setRowOrdering(outerCost.getRowOrdering());
+        innerCost.setNumPartitions(outerCost.partitionCount());
         innerCost.setRowCount(totalOutputRows);
         innerCost.setEstimatedHeapSize((long)SelectivityUtil.getTotalHeapSize(innerCost,outerCost,totalOutputRows));
-        innerCost.setRowOrdering(null);
-        innerCost.setNumPartitions(16);
     }
 
     @Override


### PR DESCRIPTION
remove the static partition count from legacy temp hbase temp table approach, keep the row ordering in consistent with all other joinStrategies use.