### PR TITLE
SPLICE-1210: remove dup of setRemoteCost

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
@@ -263,7 +263,6 @@ public class NestedLoopJoinStrategy extends BaseJoinStrategy{
         innerCost.setNumPartitions(outerCost.partitionCount());
         innerCost.setRowCount(totalRowCount);
         innerCost.setRemoteCost(SelectivityUtil.getTotalRemoteCost(innerCost, outerCost, totalRowCount));
-        innerCost.setRemoteCost(SelectivityUtil.getTotalRemoteCost(innerCost, outerCost, totalRowCount));
         double joinCost = SelectivityUtil.nestedLoopJoinStrategyLocalCost(innerCost, outerCost);
         innerCost.setLocalCost(joinCost);
         innerCost.setLocalCostPerPartition(joinCost);


### PR DESCRIPTION
By extra dup line, it was increasing the NLJ cost higher.