### PR TITLE
DB-5744: remove check for collecting schema level stats for external …

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -689,4 +689,68 @@ public class ExternalTableIT extends SpliceUnitTest{
         }
     }
 
+    @Test
+    public void testCollectStats() throws Exception {
+        methodWatcher.executeUpdate(String.format("create external table t1_orc (col1 int, col2 char(24))" +
+                " STORED AS ORC LOCATION '%s'", getExternalResourceDirectory()+"t1_orc_test"));
+        int insertCount = methodWatcher.executeUpdate(String.format("insert into t1_orc values (1,'XXXX')," +
+                "(2,'YYYY')," +
+                "(3,'ZZZZ')"));
+        Assert.assertEquals("insertCount is wrong",3,insertCount);
+        ResultSet rs = methodWatcher.executeQuery("select * from t1_orc");
+        Assert.assertEquals("COL1 |COL2 |\n" +
+                "------------\n" +
+                "  1  |XXXX |\n" +
+                "  2  |YYYY |\n" +
+                "  3  |ZZZZ |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+        // collect table level stats
+        PreparedStatement ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.COLLECT_TABLE_STATISTICS(?,?,?) ");
+        ps.setString(1, "EXTERNALTABLEIT");
+        ps.setString(2, "T1_ORC");
+        ps.setBoolean(3, true);
+        rs = ps.executeQuery();
+        rs.next();
+        Assert.assertEquals("Error with COLLECT_TABLE_STATISTICS for external table","EXTERNALTABLEIT",  rs.getString(1));
+        rs.close();
+
+        ResultSet rs2 = methodWatcher.executeQuery("select total_row_count from sys.systablestatistics where schemaname = 'EXTERNALTABLEIT' ");
+        String expected = "TOTAL_ROW_COUNT |\n" +
+                "------------------\n" +
+                "        3        |";
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs2));
+        rs2.close();
+
+        // drop stats using table
+        spliceClassWatcher.executeUpdate("CALL  SYSCS_UTIL.DROP_TABLE_STATISTICS ('EXTERNALTABLEIT', 'T1_ORC')");
+
+        // make sure it is clean
+        rs2 = methodWatcher.executeQuery("select total_row_count from sys.systablestatistics where schemaname = 'EXTERNALTABLEIT' ");
+        Assert.assertEquals("", TestUtils.FormattedResult.ResultFactory.toString(rs2));
+        rs2.close();
+
+        // Now, collect schema level stats
+        ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.COLLECT_SCHEMA_STATISTICS(?,?) ");
+        ps.setString(1, "EXTERNALTABLEIT");
+        ps.setBoolean(2, false);
+        rs = ps.executeQuery();
+        rs.next();
+        Assert.assertEquals("Error with COLLECT_SCHEMA_STATISTICS for external table","EXTERNALTABLEIT",  rs.getString(1));
+        rs.close();
+
+        // check the stats again
+        rs2 = methodWatcher.executeQuery("select total_row_count from sys.systablestatistics where schemaname = 'EXTERNALTABLEIT' ");
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs2));
+        rs2.close();
+
+        // drop stats using schema
+        spliceClassWatcher.executeUpdate("CALL  SYSCS_UTIL.DROP_SCHEMA_STATISTICS ('EXTERNALTABLEIT')");
+
+        // make sure it is clean
+        rs2 = methodWatcher.executeQuery("select total_row_count from sys.systablestatistics where schemaname = 'EXTERNALTABLEIT' ");
+        Assert.assertEquals("", TestUtils.FormattedResult.ResultFactory.toString(rs2));
+        rs2.close();
+    }
+
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
@@ -192,8 +192,6 @@ public class StatisticsAdmin extends BaseAdminProcedures {
             HashMap<Long,Pair<String,String>> display = new HashMap<>();
             List<Future<StatsResult>> futures = new ArrayList(tds.size());
             for (TableDescriptor td : tds) {
-                if (td.getStoredAs() != null)
-                    continue; // Cannot run stats currently on external tables.
                 display.put(td.getHeapConglomerateId(),Pair.newPair(schema,td.getName()));
                 futures.add(collectTableStatistics(td, txn, conn));
             }


### PR DESCRIPTION
Removing the check that was not enabling stats collection from schema level for external table, added more tests.