### PR TITLE
Splice 1325

### DIFF
--- a/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
@@ -101,6 +101,8 @@ public interface SConfiguration {
     // OperationConfiguration
     int getSequenceBlockSize();
 
+    int getThreadPoolMaxSize();
+
     // PipelineConfiguration
     int getCoreWriterThreads();
 

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
@@ -40,6 +40,7 @@ public class ConfigurationBuilder {
 
     // OperationConfiguration
     public int sequenceBlockSize;
+    public int threadPoolMaxSize;
 
     // DDLConfiguration
     public long ddlDrainingInitialWait;

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/OperationConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/OperationConfiguration.java
@@ -48,8 +48,13 @@ public class OperationConfiguration implements ConfigurationDefault {
     public static final String SEQUENCE_BLOCK_SIZE = "splice.sequence.allocationBlockSize";
     private static final int DEFAULT_SEQUENCE_BLOCK_SIZE = 1000;
 
+    /* The maximum number of threads to be created in the general thread pool */
+    public static final String THREAD_POOL_MAX_SIZE = "splice.threadPool.maxSize";
+    private static final int DEFAULT_THREAD_POOL_MAX_SIZE = 256;
+
     @Override
     public void setDefaults(ConfigurationBuilder builder, ConfigurationSource configurationSource) {
         builder.sequenceBlockSize = configurationSource.getInt(SEQUENCE_BLOCK_SIZE, DEFAULT_SEQUENCE_BLOCK_SIZE);
+        builder.threadPoolMaxSize = configurationSource.getInt(THREAD_POOL_MAX_SIZE, DEFAULT_THREAD_POOL_MAX_SIZE);
     }
 }

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
@@ -78,6 +78,7 @@ public final class SConfigurationImpl implements SConfiguration {
 
     // OperationConfiguration
     private final  int sequenceBlockSize;
+    private final  int threadPoolMaxSize;
 
     // PipelineConfiguration
     private final  int coreWriterThreads;

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
@@ -287,6 +287,11 @@ public final class SConfigurationImpl implements SConfiguration {
         return sequenceBlockSize;
     }
 
+    @Override
+    public int getThreadPoolMaxSize() {
+         return threadPoolMaxSize;
+    }
+
     // PipelineConfiguration
     @Override
     public int getCoreWriterThreads() {
@@ -601,6 +606,7 @@ public final class SConfigurationImpl implements SConfiguration {
         transactionKeepAliveInterval = builder.transactionKeepAliveInterval;
         transactionTimeout = builder.transactionTimeout;
         sequenceBlockSize = builder.sequenceBlockSize;
+        threadPoolMaxSize = builder.threadPoolMaxSize;
         ddlDrainingInitialWait = builder.ddlDrainingInitialWait;
         ddlDrainingMaximumWait = builder.ddlDrainingMaximumWait;
         ddlRefreshInterval = builder.ddlRefreshInterval;

--- a/splice_machine/src/main/java/com/splicemachine/EngineDriver.java
+++ b/splice_machine/src/main/java/com/splicemachine/EngineDriver.java
@@ -59,6 +59,11 @@ public class EngineDriver{
         INSTANCE=new EngineDriver(environment);
     }
 
+    public static void shutdownDriver() {
+        driver().threadPool.shutdown();
+        INSTANCE = null;
+    }
+
     public static EngineDriver driver(){
         return INSTANCE;
     }

--- a/splice_machine/src/main/java/com/splicemachine/EngineDriver.java
+++ b/splice_machine/src/main/java/com/splicemachine/EngineDriver.java
@@ -91,9 +91,10 @@ public class EngineDriver{
 
         /* Create a general purpose thread pool */
         final AtomicLong count = new AtomicLong(0);
-        this.threadPool = new ThreadPoolExecutor(0, 64, /* TODO: use config.get??? */
+        this.threadPool = new ThreadPoolExecutor(0, config.getThreadPoolMaxSize(),
                 60L, TimeUnit.SECONDS, new SynchronousQueue<>(),
-                (runnable) -> new Thread(runnable, "SpliceThreadPool-" + count.getAndIncrement()));
+                (runnable) -> new Thread(runnable, "SpliceThreadPool-" + count.getAndIncrement()),
+                new ThreadPoolExecutor.CallerRunsPolicy());
     }
 
     public DatabaseAdministrator dbAdministrator(){
@@ -148,5 +149,7 @@ public class EngineDriver{
         return olapClient;
     }
 
-    public ExecutorService getExecutorService() { return threadPool; }
+    public ExecutorService getExecutorService() {
+        return threadPool;
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/EngineDriver.java
+++ b/splice_machine/src/main/java/com/splicemachine/EngineDriver.java
@@ -60,7 +60,7 @@ public class EngineDriver{
     }
 
     public static void shutdownDriver() {
-        driver().threadPool.shutdown();
+        driver().threadPool.shutdownNow();
         INSTANCE = null;
     }
 
@@ -97,8 +97,13 @@ public class EngineDriver{
         /* Create a general purpose thread pool */
         final AtomicLong count = new AtomicLong(0);
         this.threadPool = new ThreadPoolExecutor(0, config.getThreadPoolMaxSize(),
-                60L, TimeUnit.SECONDS, new SynchronousQueue<>(),
-                (runnable) -> new Thread(runnable, "SpliceThreadPool-" + count.getAndIncrement()),
+                60L, TimeUnit.SECONDS,
+                new SynchronousQueue<>(),
+                (runnable) -> {
+                    Thread t = new Thread(runnable, "SpliceThreadPool-" + count.getAndIncrement());
+                    t.setDaemon(true);
+                    return t;
+                },
                 new ThreadPoolExecutor.CallerRunsPolicy());
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/EngineLifecycleService.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/EngineLifecycleService.java
@@ -148,6 +148,8 @@ public class EngineLifecycleService implements DatabaseLifecycleService{
             LOG.error("Unexpected error during shutdown",e);
         }
 
+        EngineDriver.shutdownDriver();
+
         try{
             SIDriver driver = SIDriver.driver();
             if(driver!=null)

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJoinFunction.java
@@ -60,7 +60,6 @@ public abstract class NLJoinFunction <Op extends SpliceOperation, From, To> exte
     protected boolean isOneRowInnerJoin;
 
     protected ExecutorCompletionService<Pair<OperationContext, Iterator<LocatedRow>>> completionService;
-    protected ExecutorService executorService;
 
     public NLJoinFunction () {}
 
@@ -75,8 +74,7 @@ public abstract class NLJoinFunction <Op extends SpliceOperation, From, To> exte
         batchSize = configuration.getNestedLoopJoinBatchSize();
         nLeftRows = 0;
         leftSideIterator = from;
-        executorService = Executors.newFixedThreadPool(batchSize);
-        completionService = new ExecutorCompletionService<>(executorService);
+        completionService = new ExecutorCompletionService<>(EngineDriver.driver().getExecutorService());
 
         initOperationContexts();
         loadBatch();
@@ -154,9 +152,6 @@ public abstract class NLJoinFunction <Op extends SpliceOperation, From, To> exte
                     leftRowLocation = currentOperationContext.getOperation().getLeftOperation().getCurrentRowLocation();
                     operationContext.getOperation().getLeftOperation().setCurrentLocatedRow(getLeftLocatedRow());
                 }
-            }
-            if (!rightSideNLJIterator.hasNext()) {
-                executorService.shutdownNow();
             }
 
             return rightSideNLJIterator.hasNext();


### PR DESCRIPTION
A global thread pool is created. The default maximum number of threads in the pool is 256.
The pool is used in NLJoinFunction to avoid new thread pool creation on every invocation.