### PR TITLE
Fix SPLICE-1333 : 

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/InsertOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/InsertOperation.java
@@ -310,7 +310,7 @@ public class InsertOperation extends DMLWriteOperation implements HasIncrement{
                 dsp.setSchedulerPool("import");
             if (storedAs!=null) {
 
-                if(!SIDriver.driver().fileSystem().getPath(location).toFile().canWrite()){
+                if(!SIDriver.driver().fileSystem().getInfo(location).isWritable()){
                     throw  ErrorState.CANNOT_WRITE_AT_LOCATION.newException(location);
                 }
 
@@ -340,6 +340,8 @@ public class InsertOperation extends DMLWriteOperation implements HasIncrement{
                     .txn(txn)
                     .build();
             return writer.write();
+        }catch (Exception e) {
+            throw StandardException.plainWrapException(e);
         }finally{
             operationContext.popScope();
         }

--- a/splice_machine/src/main/java/com/splicemachine/procedures/external/CreateExternalTableJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/procedures/external/CreateExternalTableJob.java
@@ -48,23 +48,12 @@ public class CreateExternalTableJob implements Callable<Void> {
         dsp.setJobGroup(request.getJobGroup(), "");
 
         // look at the file, if it doesn't exist create it.
-        if(!SIDriver.driver().fileSystem().getPath(request.getLocation()).toFile().exists()){
+        if(!SIDriver.driver().fileSystem().getInfo(request.getLocation()).exists()){
+            Path pathToParent = SIDriver.driver().fileSystem().getPath(request.getLocation()).getParent();
 
-            //throws a error if the parent doesn't have the permission.
-            Path parent = SIDriver.driver().fileSystem().getPath(request.getLocation()).getParent();
-            if(parent == null) {
-                if (!SIDriver.driver().fileSystem().getPath(".").toFile().canWrite()) {
-                    throw ErrorState.CANNOT_WRITE_AT_LOCATION.newException(request.getLocation());
-                }
+            if(!SIDriver.driver().fileSystem().getInfo(pathToParent.toString()).isWritable()){
+                throw  ErrorState.CANNOT_WRITE_AT_LOCATION.newException(request.getLocation());
             }
-            else {
-                if(!parent.toFile().canWrite()){
-                    throw  ErrorState.CANNOT_WRITE_AT_LOCATION.newException(request.getLocation());
-                }
-            }
-
-
-
             dsp.createEmptyExternalFile(execRow, IntArrays.count(execRowTypeFormatIds.length), request.getPartitionBy(),  request.getStoredAs(), request.getLocation(),request.getCompression());
         }
 


### PR DESCRIPTION
Creating External Table - ERROR EXT22: Cannot write at the location

Replaced this
 SIDriver.driver().fileSystem().getPath(request.getLocation()).toFile().exists())
 by this
 SIDriver.driver().fileSystem().getInfo(request.getLocation()).isWritable()

There is no additional tests as the ones written before cover the use cases but this patch change the code to make sure it use the hadoop api instead of java library....