### PR TITLE
SPLICE-1349: serialize and initialize BatchOnceOperation correctly

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/batchonce/BatchOnceOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/batchonce/BatchOnceOperation.java
@@ -157,8 +157,8 @@ public class BatchOnceOperation extends SpliceBaseOperation {
         this.source = (SpliceOperation) in.readObject();
         this.subquerySource = (SpliceOperation) in.readObject();
         this.updateResultSetFieldName = in.readUTF();
-        this.sourceCorrelatedColumnPositions = ArrayUtil.readIntArray(in);
-        this.subqueryCorrelatedColumnPositions = ArrayUtil.readIntArray(in);
+        this.sourceCorrelatedColumnItem = in.readInt();
+        this.subqueryCorrelatedColumnItem = in.readInt();
     }
 
     @Override
@@ -167,8 +167,8 @@ public class BatchOnceOperation extends SpliceBaseOperation {
         out.writeObject(this.source);
         out.writeObject(this.subquerySource);
         out.writeUTF(this.updateResultSetFieldName);
-        ArrayUtil.writeIntArray(out, this.sourceCorrelatedColumnPositions);
-        ArrayUtil.writeIntArray(out, this.subqueryCorrelatedColumnPositions);
+        out.writeInt(this.sourceCorrelatedColumnItem);
+        out.writeInt(this.subqueryCorrelatedColumnItem);
     }
 
     public SpliceOperation getSubquerySource() {

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/BatchOnceOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/BatchOnceOperationIT.java
@@ -121,6 +121,31 @@ public class BatchOnceOperationIT {
                 "21 |NULL |", TestUtils.FormattedResult.ResultFactory.toString(rs));
     }
 
+    @Test
+    public void updateOnSpark() throws Exception {
+         String sql = "update A --SPLICE-PROPERTIES useSpark=true \n" +
+                 " \tset A.name = (select B.name from B where A.id = B.id) where A.name IS NULL";
+
+        doUpdate(true, 6, sql);
+
+        ResultSet rs = methodWatcher.executeQuery("select A.id,A.name from A");
+
+        assertEquals("" +
+                "ID |NAME |\n" +
+                "----------\n" +
+                "10 | 10_ |\n" +
+                "11 | 11_ |\n" +
+                "12 | 12_ |\n" +
+                "13 |NULL |\n" +
+                "14 |NULL |\n" +
+                "15 |NULL |\n" +
+                "16 | 16_ |\n" +
+                "17 | 17_ |\n" +
+                "18 | 18_ |\n" +
+                "19 |NULL |\n" +
+                "20 |NULL |\n" +
+                "21 |NULL |", TestUtils.FormattedResult.ResultFactory.toString(rs));
+    }
     /* Same test as above but position of column refs in subquery where clause is reversed. */
     @Test
     public void updateReverseSubqueryColumnReferences() throws Exception {


### PR DESCRIPTION
serialize column positions for correlated subquery, so that BatchOnceOperation can initialize correctly.