### PR TITLE
SPLICE-1323: Fix NPE for in-list caluse on spark side

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeDerbyScanInformation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeDerbyScanInformation.java
@@ -114,7 +114,7 @@ public class MultiProbeDerbyScanInformation extends DerbyScanInformation{
 			Qualifier[] ands  = qualifiers[0];
 			if(ands!=null){
 					Qualifier first = ands[0];
-					if(first!=null){
+					if(first!=null && probeValue != null){
 							first.clearOrderableCache();
 							first.getOrderable().setValue(probeValue);
 					}


### PR DESCRIPTION
Need to fence the populateQualifier with more null checks on the probeValue. Tested with various tests manually on multiple size tables/indexes with IN clause combination.