### PR TITLE
Splice-1329 Memory leak in SpliceObserverInstructions

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/stream/QueryJob.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/QueryJob.java
@@ -17,7 +17,6 @@ package com.splicemachine.stream;
 
 import com.splicemachine.EngineDriver;
 import com.splicemachine.db.iapi.sql.Activation;
-import com.splicemachine.db.impl.jdbc.EmbedConnection;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.iapi.sql.olap.OlapStatus;
 import com.splicemachine.derby.impl.sql.execute.operations.LocatedRow;

--- a/hbase_sql/src/main/java/com/splicemachine/stream/QueryJob.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/QueryJob.java
@@ -87,9 +87,6 @@ public class QueryJob implements Callable<Void>{
 
             status.markCompleted(new QueryResult(numPartitions));
         } finally {
-            EmbedConnection internalConnection=(EmbedConnection)EngineDriver.driver().getInternalConnection();
-            internalConnection.getContextManager().popContext();
-            ah.getActivation().getLanguageConnectionContext().popMe();
             ah.close();
         }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
@@ -175,8 +175,6 @@ public class SpliceDatabase extends BasicDatabase{
         cm.setLocaleFinder(this);
         pushDbContext(cm);
         LanguageConnectionContext lctx=lcf.newLanguageConnectionContext(cm,tc,lf,this,user,drdaID,dbname,type);
-        cm.setActiveThread();
-        ContextService.getFactory().setCurrentContextManager(cm);
 
         pushClassFactoryContext(cm,lcf.getClassFactory());
         ExecutionFactory ef=lcf.getExecutionFactory();

--- a/splice_machine/src/main/java/com/splicemachine/derby/jdbc/SpliceTransactionResourceImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/jdbc/SpliceTransactionResourceImpl.java
@@ -74,11 +74,14 @@ public final class SpliceTransactionResourceImpl implements AutoCloseable{
     }
 
     public boolean marshallTransaction(TxnView txn) throws StandardException, SQLException{
-        if(LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG,"marshallTransaction with transactionID %s",txn);
+        if (LOG.isDebugEnabled()) {
+            SpliceLogUtils.debug(LOG, "marshallTransaction with transactionID %s", txn);
+        }
 
         oldCm=csf.getCurrentContextManager();
         cm=csf.newContextManager();
+        csf.setCurrentContextManager(cm);
+
         lcc=database.generateLanguageConnectionContext(txn, cm, username, drdaID, dbname, CompilerContext.DataSetProcessorType.DEFAULT_CONTROL);
 
         return true;

--- a/splice_machine/src/main/java/com/splicemachine/derby/serialization/SpliceObserverInstructions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/serialization/SpliceObserverInstructions.java
@@ -256,7 +256,6 @@ public class SpliceObserverInstructions implements Externalizable{
                 EmbedConnection internalConnection=(EmbedConnection)EngineDriver.driver().getInternalConnection();
                 Context connectionContext = new EmbedConnectionContext(activation.getLanguageConnectionContext().getContextManager(),
                         (EmbedConnection)internalConnection);
-                internalConnection.getContextManager().pushContext(statementContext);
 
                 return activation;
             }catch(Exception e){

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
@@ -201,7 +201,7 @@ public class ActivationHolder implements Externalizable {
             prepared =  impl.marshallTransaction(txnView);
             activation = soi.getActivation(this, impl.getLcc());
 
-            Context statementContext = ContextService.getContext(ContextId.LANG_STATEMENT);
+            Context statementContext = activation.getLanguageConnectionContext().getStatementContext();
             EmbedConnection internalConnection = (EmbedConnection)EngineDriver.driver().getInternalConnection();
             internalConnection.getContextManager().pushContext(statementContext);
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
@@ -157,11 +157,10 @@ public class ActivationHolder implements Externalizable {
                 so.init(context);
             }
         } catch (Exception e) {
-            throw new RuntimeException(e);
-        } finally {
             if (prepared) {
                 impl.close();
             }
+            throw new RuntimeException(e);
         }
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
@@ -15,6 +15,11 @@
 
 package com.splicemachine.derby.stream;
 
+import com.splicemachine.EngineDriver;
+import com.splicemachine.db.iapi.reference.ContextId;
+import com.splicemachine.db.iapi.services.context.Context;
+import com.splicemachine.db.iapi.services.context.ContextService;
+import com.splicemachine.db.impl.jdbc.EmbedConnection;
 import org.apache.log4j.Logger;
 import org.spark_project.guava.collect.Maps;
 import com.splicemachine.db.iapi.error.StandardException;
@@ -157,10 +162,11 @@ public class ActivationHolder implements Externalizable {
                 so.init(context);
             }
         } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
             if (prepared) {
                 impl.close();
             }
-            throw new RuntimeException(e);
         }
     }
 
@@ -195,6 +201,10 @@ public class ActivationHolder implements Externalizable {
             prepared =  impl.marshallTransaction(txnView);
             activation = soi.getActivation(this, impl.getLcc());
 
+            Context statementContext = ContextService.getContext(ContextId.LANG_STATEMENT);
+            EmbedConnection internalConnection = (EmbedConnection)EngineDriver.driver().getInternalConnection();
+            internalConnection.getContextManager().pushContext(statementContext);
+
             if (reinit) {
                 SpliceOperationContext context = SpliceOperationContext.newContext(activation);
                 for (SpliceOperation so : operationsList) {
@@ -211,5 +221,8 @@ public class ActivationHolder implements Externalizable {
             impl.close();
             prepared = false;
         }
+
+        EmbedConnection internalConnection=(EmbedConnection)EngineDriver.driver().getInternalConnection();
+        internalConnection.getContextManager().popContext();
     }
 }


### PR DESCRIPTION
The proposed fix moves pushContext(statementContext) from SpliceObserverInstructions.ActivationContext.populateActivation() and the matching popContext() from QueryJob.call() to ActivationHolder so that they are either invoked or not invoked together.
The assumption is that ActivationHolder.reinitialize() must be matched by ActivationHolder.close() unlike ActivationHolder.init(), which closes underlying SpliceTransactionResourceImpl, and thus pops all contexts and context managers, itself.