### PR TITLE
DB-5743: fix table number to allow predicate push down

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnReference.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnReference.java
@@ -985,7 +985,13 @@ public class ColumnReference extends ValueNode {
 					// column, so fall back on column name, which is unique
 					// then.
 					ftRC = rcl.getResultColumn(columnName);
+                    tableNumber = ft.getTableNumber();
 				}
+				else {
+				    // DB-5743: set tableNumber to where source result column is from
+					tableNumber = ftRC.getTableNumber()!= -1 ? ftRC.getTableNumber() : ft.getTableNumber();
+				}
+
 
 				if (SanityManager.DEBUG) {
 					SanityManager.ASSERT(
@@ -994,8 +1000,6 @@ public class ColumnReference extends ValueNode {
 									"' in the " + "RCL for '" + ft.getTableName() +
 									"'.");
 				}
-
-				tableNumber = ft.getTableNumber();
 
 				if (SanityManager.DEBUG) {
 					SanityManager.ASSERT(tableNumber != -1,

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
@@ -16,10 +16,8 @@
 package com.splicemachine.derby.impl.sql.execute.operations;
 
 import com.splicemachine.derby.test.framework.*;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import com.splicemachine.test_tools.TableCreator;
+import org.junit.*;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -28,6 +26,8 @@ import java.math.BigDecimal;
 import java.sql.*;
 import java.util.Properties;
 
+import static com.splicemachine.test_tools.Rows.row;
+import static com.splicemachine.test_tools.Rows.rows;
 import static java.lang.String.format;
 
 /**
@@ -36,7 +36,7 @@ import static java.lang.String.format;
 public class ExplainPlanIT extends SpliceUnitTest  {
 
     public static final String CLASS_NAME = ExplainPlanIT.class.getSimpleName().toUpperCase();
-    protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher();
+    protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);
     public static final String TABLE_NAME = "A";
     protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
 
@@ -73,7 +73,24 @@ public class ExplainPlanIT extends SpliceUnitTest  {
 
             });
     @Rule
-    public SpliceWatcher methodWatcher = new SpliceWatcher();
+    public SpliceWatcher methodWatcher = new SpliceWatcher(CLASS_NAME);
+
+    @BeforeClass
+    public static void createTables() throws Exception {
+        Connection conn = spliceClassWatcher.getOrCreateConnection();
+
+        new TableCreator(conn)
+                .withCreate("create table t1 (c1 int, c2 int)")
+                .create();
+
+        new TableCreator(conn)
+                .withCreate("create table t2 (c1 int, c2 int)")
+                .create();
+
+        new TableCreator(conn)
+                .withCreate("create table t3 (c1 int, c2 int)")
+                .create();
+    }
 
     @Test
     public void testExplainSelect() throws Exception {
@@ -153,5 +170,26 @@ public class ExplainPlanIT extends SpliceUnitTest  {
         Assert.assertTrue(rs.next());
         Assert.assertTrue("expect explain plan contains useSpark=false", rs.getString(1).contains("engine=Spark"));
 
+    }
+
+    //DB-5743
+    @Test
+    public void testPredicatePushDownAfterOJ2IJ() throws Exception {
+
+        String query =
+                "explain select count(*) from t1 a\n" +
+                "left join t2 b on a.c1=b.c1\n" +
+                "left join t2 c on b.c2=c.c2\n" +
+                "where a.c2 not in (1, 2, 3) and c.c1 > 0";
+        
+        // Make sure predicate on a.c2 is pushed down to the base table scan
+        String predicate = "preds=[(A.C2[0:2] <> 1),(A.C2[0:2] <> 2),(A.C2[0:2] <> 3)]";
+        ResultSet rs  = methodWatcher.executeQuery(query);
+        while(rs.next()) {
+            String s = rs.getString(1);
+            if (s.contains(predicate)) {
+                Assert.assertTrue(s, s.contains("TableScan"));
+            }
+        }
     }
 }


### PR DESCRIPTION
Correct table number of a predicate's column reference, so that predicate can be pushed down from JoinNode to base table.