### PR TITLE
SPLICE-8: make CTAS work with case sensitive names

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SpliceCreateTableOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SpliceCreateTableOperation.java
@@ -162,7 +162,7 @@ public class SpliceCreateTableOperation extends CreateTableConstantOperation {
 			try ( // try with resources
 				  Connection conn = cc.getNestedConnection(true);
 				  PreparedStatement ps =
-						  conn.prepareStatement("insert into "+schemaName+"."+tableName+" "+withDataQueryString)
+						  conn.prepareStatement("insert into \""+schemaName+"\".\""+tableName+"\" "+withDataQueryString)
 			)  {
 				int rows = ps.executeUpdate();
 				activation.addRowsSeen(rows);

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableWithDataIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableWithDataIT.java
@@ -140,6 +140,29 @@ public class CreateTableWithDataIT{
     }
 
     @Test
+    public void testCTASQuotedName() throws Exception {
+        try(PreparedStatement ps=methodWatcher.prepareStatement(String.format("create table %s.\"t3\" as select * from %s with data",spliceSchemaWatcher.schemaName,baseTable))){
+            int numRows=ps.executeUpdate();
+            Assert.assertEquals("It does not claim to have updated rows!",10,numRows);
+
+        }
+
+        try(Statement s = conn.createStatement()){
+            try(ResultSet rs=s.executeQuery("select * from "+spliceSchemaWatcher.schemaName+".\"t3\"")){
+                int count=0;
+                while(rs.next()){
+                    int first=rs.getInt(1);
+                    int second=rs.getInt(2);
+                    Assert.assertEquals("Incorrect row: ("+first+","+second+")",first*2,second);
+                    count++;
+                }
+                Assert.assertEquals("Incorrect row count",10,count);
+            }
+        }
+    }
+
+
+    @Test
     public void testCreateTableWithData2() throws Exception{
         try(PreparedStatement ps=conn.prepareStatement(String.format("create table %s.t4 as select t1.a, t2.c from %s t1, %s t2 where t1.b = t2.b with data",spliceSchemaWatcher.schemaName,baseTable,rightTable))){
             int numRows=ps.executeUpdate();


### PR DESCRIPTION
Quote table names for CTAS to respect table/schema name case sensitivity. 