### PR TITLE
SPLICE-1361 : Kerberos keytab not picked up by Spark on Splice Machin…

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
@@ -149,6 +149,15 @@ public class SpliceSpark {
             conf.set("spark.yarn.keytab", HConfiguration.unwrapDelegate().get("hbase.regionserver.keytab.file"));
         }
 
+        // fallback on hbase.master.keytab.file property if we don't yet have a keytab
+        if(conf.get("spark.yarn.principal", "") != ""){
+            if(conf.get("spark.yarn.keytab", "") == ""){
+                if(HConfiguration.unwrapDelegate().get("hbase.master.keytab.file") != null){
+                    conf.set("spark.yarn.keytab", HConfiguration.unwrapDelegate().get("hbase.master.keytab.file"));
+                }
+                // likely need an else that does a conf.remove("spark.yarn.principal"); if we don't have a keytab, and vice versa
+            }
+        }
 
         // set all spark props that start with "splice.".  overrides are set below.
         for (Object sysPropertyKey : System.getProperties().keySet()) {


### PR DESCRIPTION
…e 2.5/2.6

fall back on hbase.master.keytab.file for spark.yarn.keytab if we don't set it from hbase.regionserver.keytab.file. Need both spark.yarn.keytab and spark.yarn.principal for Kerberized Spark on YARN.

Successfully tested on Kerberized CDH 5.8.0 and Splice Machine master branch.