### PR TITLE
SPLICE-1169 : Fix External Table with Csv - Text FIles

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkScanSetBuilder.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkScanSetBuilder.java
@@ -79,7 +79,7 @@ public class SparkScanSetBuilder<V> extends TableScannerBuilder<V> {
             ExecRow execRow = operation==null?template:op.getExecRowDefinition();
             Qualifier[][] qualifiers = operation == null?null:operation.getScanInformation().getScanQualifiers();
             if (storedAs.equals("T"))
-                return dsp.readTextFile(op,location,escaped,delimited,baseColumnMap,operationContext,execRow).flatMap(new TableScanQualifierFunction(operationContext,null));
+                return dsp.readTextFile(op,location,escaped,delimited,baseColumnMap,operationContext,qualifiers,null,execRow).flatMap(new TableScanQualifierFunction(operationContext,null));
             if (storedAs.equals("P"))
                 return dsp.readParquetFile(baseColumnMap,location,operationContext,qualifiers,null,operation.getExecRowDefinition()).flatMap(new TableScanQualifierFunction(operationContext,null));
             if (storedAs.equals("O"))

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -298,6 +298,35 @@ public class ExternalTableIT extends SpliceUnitTest{
 
 
     @Test
+    public void testWriteReadFromSimpleCsvExternalTable() throws Exception {
+        String tablePath = getExternalResourceDirectory()+"dt_txt";
+        methodWatcher.executeUpdate(String.format("create external table dt_txt(a date) stored as textfile location '%s'",tablePath));
+        int insertCount = methodWatcher.executeUpdate(String.format("insert into dt_txt values (current_date)"));
+        Assert.assertEquals("insertCount is wrong",1,insertCount);
+        ResultSet rs = methodWatcher.executeQuery("select a from dt_txt");
+        Assert.assertEquals("A     |\n" +
+                "------------\n" +
+                "2017-01-25 |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+
+
+    }
+
+
+    @Test
+    public void testReadSmallIntFromCsv() throws Exception {
+
+        String tablePath = getExternalResourceDirectory()+"small_int_txt";
+        methodWatcher.executeUpdate(String.format("create external table small_int_txt(a smallint) stored as textfile location '%s'",tablePath));
+        int insertCount = methodWatcher.executeUpdate(String.format("insert into small_int_txt values (12)"));
+        Assert.assertEquals("insertCount is wrong",1,insertCount);
+        ResultSet rs = methodWatcher.executeQuery("select a from small_int_txt");
+        Assert.assertEquals("A |\n" +
+                "----\n" +
+                "12 |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+    }
+
+
+    @Test
     public void testWriteReadWithPartitionedByFloatTable() throws Exception {
         String tablePath = getExternalResourceDirectory()+"simple_parquet_with_partition";
         methodWatcher.executeUpdate(String.format("create external table simple_parquet_with_partition (col1 int, col2 varchar(24), col3 float(10) )" +

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
@@ -326,9 +326,10 @@ public class ControlDataSetProcessor implements DataSetProcessor{
     }
 
     @Override
-    public <V> DataSet<LocatedRow> readTextFile(SpliceOperation op, String location, String characterDelimiter, String columnDelimiter, int[] baseColumnMap, OperationContext context, ExecRow execRow) throws StandardException{
+    public <V> DataSet<LocatedRow> readTextFile(SpliceOperation op, String location, String characterDelimiter, String columnDelimiter, int[] baseColumnMap,
+                                                OperationContext context, Qualifier[][] qualifiers, DataValueDescriptor probeValue, ExecRow execRow) throws StandardException{
         DistributedDataSetProcessor proc = EngineDriver.driver().processorFactory().distributedProcessor();
-        return new ControlDataSet(proc.readTextFile(op,location,characterDelimiter,columnDelimiter,baseColumnMap,context,execRow).toLocalIterator());
+        return new ControlDataSet(proc.readTextFile(op,location,characterDelimiter,columnDelimiter,baseColumnMap, context, qualifiers, probeValue, execRow).toLocalIterator());
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
@@ -225,7 +225,7 @@ public interface DataSetProcessor {
      * @throws StandardException
      */
     public <V> DataSet<LocatedRow> readTextFile(SpliceOperation op, String location, String characterDelimiter, String columnDelimiter, int[] baseColumnMap,
-                                                OperationContext context,  ExecRow execRow) throws StandardException;
+                                                OperationContext context, Qualifier[][] qualifiers, DataValueDescriptor probeValue,  ExecRow execRow) throws StandardException;
 
     /**
      *

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ForwardingDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ForwardingDataSetProcessor.java
@@ -159,8 +159,8 @@ public abstract class ForwardingDataSetProcessor implements DataSetProcessor{
     }
 
     @Override
-    public <V> DataSet<LocatedRow> readTextFile(SpliceOperation op, String location, String characterDelimiter, String columnDelimiter, int[] baseColumnMap, OperationContext context,ExecRow execRow) throws StandardException {
-        return delegate.readTextFile(op, location, characterDelimiter, columnDelimiter, baseColumnMap, context,execRow);
+    public <V> DataSet<LocatedRow> readTextFile(SpliceOperation op, String location, String characterDelimiter, String columnDelimiter, int[] baseColumnMap, OperationContext context, Qualifier[][] qualifiers, DataValueDescriptor probeValue,ExecRow execRow) throws StandardException {
+        return delegate.readTextFile(op, location, characterDelimiter, columnDelimiter, baseColumnMap, context,  qualifiers, probeValue, execRow);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/stats/StatsCollectionJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/stats/StatsCollectionJob.java
@@ -58,7 +58,7 @@ public class StatsCollectionJob implements Callable<Void> {
                 ScanSetBuilder builder = request.scanSetBuilder;
                 String storedAs = request.scanSetBuilder.getStoredAs();
                     if (storedAs.equals("T"))
-                        statsDataSet = dsp.readTextFile(null,builder.getLocation(),builder.getDelimited(),null,builder.getColumnPositionMap(),null,builder.getTemplate());
+                        statsDataSet = dsp.readTextFile(null,builder.getLocation(),builder.getDelimited(),null,builder.getColumnPositionMap(),null,null,null, builder.getTemplate());
                     else if (storedAs.equals("P"))
                         statsDataSet = dsp.readParquetFile(builder.getColumnPositionMap(),builder.getLocation(),null,null,null,builder.getTemplate());
                     else if (storedAs.equals("O"))


### PR DESCRIPTION

- re-implemented readTextFile in SparkDataSetProcessor to be consistent with the others methods of the class. 
I have a jira to clean that class and have that merged with SpliceFileVTI

- Added to test to make sure data and small datatype work with csv 
