### PR TITLE
SPLICE-1361 : Kerberos keytab not picked up by Spark on Splice Machin…

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
@@ -124,13 +124,24 @@ public class SpliceSpark {
         }
         conf.set("executor.source.splice-machine.class", "com.splicemachine.derby.stream.spark.SpliceMachineSource");
         conf.set("driver.source.splice-machine.class", "com.splicemachine.derby.stream.spark.SpliceMachineSource");
+
         // pull out Kerberos and set Yarn properties
-        if(HConfiguration.unwrapDelegate().get("hbase.regionserver.kerberos.principal") != null){
-             conf.set("spark.yarn.keytab", HConfiguration.unwrapDelegate().get("hbase.regionserver.kerberos.principal"));
+        if((HConfiguration.unwrapDelegate().get("hbase.master.kerberos.principal") != null) ||
+           (HConfiguration.unwrapDelegate().get("hbase.regionserver.kerberos.principal") != null)){
+            if(HConfiguration.unwrapDelegate().get("hbase.master.kerberos.principal") != null){
+                conf.set("spark.yarn.principal", HConfiguration.unwrapDelegate().get("hbase.master.kerberos.principal"));
+            } else if(HConfiguration.unwrapDelegate().get("hbase.regionserver.kerberos.principal") != null){
+                conf.set("spark.yarn.principal", HConfiguration.unwrapDelegate().get("hbase.regionserver.kerberos.principal"));
+            }
         }
 
-        if(HConfiguration.unwrapDelegate().get("hbase.regionserver.keytab.file") != null){
-            conf.set("spark.yarn.principal", HConfiguration.unwrapDelegate().get("hbase.regionserver.keytab.file"));
+        if((HConfiguration.unwrapDelegate().get("hbase.master.keytab.file") != null) ||
+           (HConfiguration.unwrapDelegate().get("hbase.regionserver.keytab.file") != null)){
+            if(HConfiguration.unwrapDelegate().get("hbase.master.keytab.file") != null){
+                conf.set("spark.yarn.keytab", HConfiguration.unwrapDelegate().get("hbase.master.keytab.file"));
+            } else if(HConfiguration.unwrapDelegate().get("hbase.regionserver.keytab.file") != null){
+                conf.set("spark.yarn.keytab", HConfiguration.unwrapDelegate().get("hbase.regionserver.keytab.file"));
+            }
         }
 
         // set all spark props that start with "splice.".  overrides are set below.


### PR DESCRIPTION
…e 2.5/2.6

Second attempt. Use HBase Master principal/keytab settings and fall back to RegionServer.