### PR TITLE
SPLICE-737: getTableNumber should return -1 if it cannot be determined

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
@@ -1920,6 +1920,9 @@ public class ResultColumn extends ValueNode
 		else if (expression instanceof TernaryOperatorNode) {
 			return ((TernaryOperatorNode) expression).receiver.getTableNumber();
 		}
+		else if (expression == null) {
+			return -1;
+		}
 
 		// We can get here if expression has neither a column
 		// reference nor a FromBaseTable beneath it--for example,

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/OuterJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/OuterJoinIT.java
@@ -68,6 +68,9 @@ public class OuterJoinIT extends SpliceUnitTest {
     private static SpliceTableWatcher t4 = new SpliceTableWatcher(TABLE_NAME_12, CLASS_NAME, "(id int, parentId int)");
     private static SpliceTableWatcher bvarchar = new SpliceTableWatcher("bvc", CLASS_NAME, "(a varchar(3))");
     private static SpliceTableWatcher bchar = new SpliceTableWatcher("bc", CLASS_NAME, "(b char(3))");
+    private static SpliceTableWatcher tab_a = new SpliceTableWatcher("tab_a", CLASS_NAME, "(id int)");
+    private static SpliceTableWatcher tab_b = new SpliceTableWatcher("tab_b", CLASS_NAME, "(id int)");
+    private static SpliceTableWatcher tab_c = new SpliceTableWatcher("tab_c", CLASS_NAME, "(id int)");
 
     @ClassRule
     public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
@@ -86,6 +89,9 @@ public class OuterJoinIT extends SpliceUnitTest {
             .around(t4)
             .around(bchar)
             .around(bvarchar)
+            .around(tab_a)
+            .around(tab_b)
+            .around(tab_c)
             .around(new SpliceDataWatcher() {
                 @Override
                 protected void starting(Description description) {
@@ -158,6 +164,28 @@ public class OuterJoinIT extends SpliceUnitTest {
                         s.executeUpdate("insert into "+ bvarchar+" values 'MCI','STL','STL'");
                     }catch(SQLException se){
                         throw new RuntimeException(se);
+                    }
+                }
+            })
+            .around(new SpliceDataWatcher(){
+                @Override
+                protected void starting(Description description) {
+                    try {
+                        Statement statement = spliceClassWatcher.getStatement();
+                        statement.execute(String.format("insert into %s values  (1)", tab_a));
+                        statement.execute(String.format("insert into %s values  (2)", tab_a));
+                        statement.execute(String.format("insert into %s values  (3)", tab_a));
+
+                        statement.execute(String.format("insert into %s values  (1)", tab_b));
+                        statement.execute(String.format("insert into %s values  (3)", tab_b));
+                        statement.execute(String.format("insert into %s values  (4)", tab_b));
+
+                        statement.execute(String.format("insert into %s values  (3)", tab_c));
+                        statement.execute(String.format("insert into %s values  (6)", tab_c));
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    } finally {
+                        spliceClassWatcher.closeAll();
                     }
                 }
             })
@@ -420,6 +448,17 @@ public class OuterJoinIT extends SpliceUnitTest {
     	} finally {
     		methodWatcher.executeUpdate("drop table "+CLASS_NAME+".foo");
     	}
+    }
+
+    @Test
+    public void testRightOuterWithRightOuter() throws Exception{
+        ResultSet rs = methodWatcher.executeQuery("select * from "+ tab_a + " right join " +  tab_b +
+                " using(id) right join "+ tab_c +" using(id)");
+        int count = 0;
+        while (rs.next()) {
+            count++;
+        }
+        Assert.assertEquals("Returned the wrong number of rows", 2,count);
     }
 
     @Test


### PR DESCRIPTION
for the chained outer join queries, this was causing NPE, getTableNumber() should return -1 if it cannot determine the tablenumber.