### PR TITLE
SPLICE-1365 :ORDER BY: Nulls first does not work for pinned table

### DIFF
--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WindowFunctionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WindowFunctionIT.java
@@ -3313,15 +3313,14 @@ public class WindowFunctionIT extends SpliceUnitTest {
         rs.close();
     }
 
-    //TODO : next version of Spark will support it
-    @Test @Ignore
+    @Test
     public void testNullsMultiFunctionSameOverClause() throws Exception {
         String sqlText =
             String.format("SELECT empnum, dept, salary, " +
-//                              "DENSE_RANK() OVER (PARTITION BY dept ORDER BY salary desc, empnum) AS DenseRank " +
-//                              "RANK() OVER (PARTITION BY dept ORDER BY salary desc, empnum) AS Rank, " +
-                              "ROW_NUMBER() OVER (PARTITION BY dept ORDER BY salary desc, empnum) AS RowNumber " +
-                              "FROM %s  --SPLICE-PROPERTIES useSpark = %s \n ORDER BY dept, salary, EMPNUM",
+                            "DENSE_RANK() OVER (PARTITION BY dept ORDER BY salary desc, empnum) AS DenseRank, " +
+                            "RANK() OVER (PARTITION BY dept ORDER BY salary desc, empnum) AS Rank, " +
+                            "ROW_NUMBER() OVER (PARTITION BY dept ORDER BY salary desc, empnum) AS RowNumber " +
+                            "FROM %s --SPLICE-PROPERTIES useSpark = %s \n ORDER BY EMPNUM",
                           this.getTableReference(EMPTAB_NULLS), useSpark);
 
         ResultSet rs = methodWatcher.executeQuery(sqlText);


### PR DESCRIPTION
Fixed correct ordering for null first or last

Backport to 2.5