### PR TITLE
DB-5792: avoid bad file naming collision

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/BadRecordsRecorder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/BadRecordsRecorder.java
@@ -168,7 +168,8 @@ public class BadRecordsRecorder implements Externalizable, Closeable {
         if (fileOut == null) {
             try {
                 DistributedFileSystem dfs = SIDriver.driver().fileSystem();
-                String filePath = badRecordMasterPath.toString() + "_" + this.hashCode();
+                String postfix = java.util.UUID.randomUUID().toString().replaceAll("-","");
+                String filePath = badRecordMasterPath.toString() + "_" + postfix;
                 fileOut = dfs.newOutputStream(filePath, StandardOpenOption.CREATE);
             } catch (Exception e) {
                 close();


### PR DESCRIPTION
port to master