### PR TITLE
SPLICE-1370 ; INSERT, UPDATE, DELETE error message for pin tables

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DeleteNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DeleteNode.java
@@ -58,6 +58,7 @@ import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.store.access.StaticCompiledOpenConglomInfo;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 
+import com.splicemachine.db.iapi.util.StringUtil;
 import com.splicemachine.db.vti.DeferModification;
 
 import com.splicemachine.db.catalog.UUID;
@@ -91,6 +92,7 @@ import com.splicemachine.db.iapi.services.compiler.LocalField;
 
 public class DeleteNode extends DMLModStatementNode
 {
+	public static String PIN = "pin";
 	/* Column name for the RowLocation column in the ResultSet */
 	// Splice fork: changed this to public, like it is in UpdateNode.
 	public static final String COLUMNNAME = "###RowLocationToDelete";
@@ -1057,6 +1059,11 @@ public class DeleteNode extends DMLModStatementNode
 	@Override
 	void verifyTargetTable() throws StandardException {
 		super.verifyTargetTable();
+		Boolean pin = Boolean.parseBoolean(StringUtil.SQLToUpperCase(targetTable.getProperties().getProperty(PIN)));
+
+		if(pin){
+			throw StandardException.newException(SQLState.DELETE_PIN_VIOLATION);
+		}
 		if (targetTableDescriptor.getTableType() == TableDescriptor.EXTERNAL_TYPE)
 			throw StandardException.newException(SQLState.EXTERNAL_TABLES_ARE_NOT_UPDATEABLE, targetTableName);
 	}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InsertNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InsertNode.java
@@ -92,6 +92,7 @@ public final class InsertNode extends DMLModStatementNode {
     public static final String STATUS_DIRECTORY = "statusDirectory";
     public static final String BAD_RECORDS_ALLOWED = "badRecordsAllowed";
     public static final String INSERT = "INSERT";
+    public static final String PIN = "pin";
 
 
 	public		ResultColumnList	targetColumnList;
@@ -716,6 +717,11 @@ public final class InsertNode extends DMLModStatementNode {
 		String insertModeString = targetProperties.getProperty(INSERT_MODE);
         String statusDirectoryString = targetProperties.getProperty(STATUS_DIRECTORY);
         String failBadRecordCountString = targetProperties.getProperty(BAD_RECORDS_ALLOWED);
+        Boolean pin = Boolean.parseBoolean(StringUtil.SQLToUpperCase(targetProperties.getProperty(PIN)));
+
+        if(pin){
+			throw StandardException.newException(SQLState.INSERT_PIN_VIOLATION);
+		}
 
 		if (insertModeString != null) {
             String upperValue = StringUtil.SQLToUpperCase(insertModeString);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UpdateNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UpdateNode.java
@@ -39,6 +39,7 @@ import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.sql.conn.Authorizer;
 import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
+import com.splicemachine.db.iapi.util.StringUtil;
 import com.splicemachine.db.impl.sql.execute.FKInfo;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.error.StandardException;
@@ -79,6 +80,7 @@ import java.util.Vector;
 
 public final class UpdateNode extends DMLModStatementNode
 {
+	public static String PIN = "pin";
 	//Note: These are public so they will be visible to
 	//the RepUpdateNode.
 	public int[]				changedColumnIds;
@@ -1535,6 +1537,11 @@ public final class UpdateNode extends DMLModStatementNode
 
 	@Override
 	void verifyTargetTable() throws StandardException {
+		Boolean pin = Boolean.parseBoolean(StringUtil.SQLToUpperCase(targetTable.getProperties().getProperty(PIN)));
+
+		if(pin){
+			throw StandardException.newException(SQLState.UPDATE_PIN_VIOLATION);
+		}
 		super.verifyTargetTable();
 		if (targetTableDescriptor.getTableType() == TableDescriptor.EXTERNAL_TYPE)
 			throw StandardException.newException(SQLState.EXTERNAL_TABLES_ARE_NOT_UPDATEABLE, targetTableName);

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -1978,6 +1978,9 @@ public interface SQLState {
 	String FILESYSTEM_URI_EXCEPTION				    				= "EXT25";
 	String FILESYSTEM_IO_EXCEPTION				    				= "EXT26";
 	String NO_ARRAY_IN_PRIMARY_KEY				    				= "EXT27";
+    String INSERT_PIN_VIOLATION				    					= "EXT29";
+    String UPDATE_PIN_VIOLATION				    					= "EXT30";
+    String DELETE_PIN_VIOLATION				    					= "EXT31";
 
 
 }

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -8977,8 +8977,6 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
 
 
 
-
-
            <msg>
                <name>EXT21</name>
                <text>'{0} is not defined in the table definition'</text>
@@ -9019,6 +9017,22 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
                <name>EXT27</name>
                <text>Column '{0}' defined as an Array cannot be part of a primary key</text>
                <arg>column</arg>
+           </msg>
+
+
+           <msg>
+               <name>EXT29</name>
+               <text>INSERT in a PIN TABLE is not allowed</text>
+           </msg>
+
+           <msg>
+               <name>EXT30</name>
+               <text>UPDATE a PIN TABLE is not allowed</text>
+           </msg>
+
+           <msg>
+               <name>EXT31</name>
+               <text>DELETE in a PIN TABLE is not allowed</text>
            </msg>
 
 

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/PinTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/PinTableIT.java
@@ -43,6 +43,7 @@ public class PinTableIT extends SpliceUnitTest{
     private static final SpliceTableWatcher spliceTableWatcher2 = new SpliceTableWatcher("PinTable2",SCHEMA_NAME,"(col1 int)");
     private static final SpliceTableWatcher spliceTableWatcher3 = new SpliceTableWatcher("PinTable3",SCHEMA_NAME,"(col1 int)");
     private static final SpliceTableWatcher spliceTableWatcher4 = new SpliceTableWatcher("PinTable4",SCHEMA_NAME,"(col1 int)");
+    private static final SpliceTableWatcher spliceTableWatcher5 = new SpliceTableWatcher("PinTable5",SCHEMA_NAME,"(col1 int)");
 
     @Rule
     public SpliceWatcher methodWatcher = new SpliceWatcher(SCHEMA_NAME);
@@ -53,7 +54,8 @@ public class PinTableIT extends SpliceUnitTest{
             .around(spliceTableWatcher)
             .around(spliceTableWatcher2)
             .around(spliceTableWatcher3)
-            .around(spliceTableWatcher4);
+            .around(spliceTableWatcher4)
+            .around(spliceTableWatcher5);
     @Test
     public void testPinTableDoesNotExist() throws Exception {
         try {
@@ -106,5 +108,39 @@ public class PinTableIT extends SpliceUnitTest{
                 "------------\n" +
                 "   false   |", TestUtils.FormattedResult.ResultFactory.toString(rs));
     }
+
+
+    @Test
+    public void testPinTableInsertViolation() throws Exception {
+        try {
+            methodWatcher.executeUpdate("insert into PinTable5  --splice-properties pin=true \n values (1)");
+            Assert.fail("INSERT is not allowed in pin table but it didn't failed");
+        } catch (SQLException e) {
+            Assert.assertEquals("Wrong Exception","EXT25",e.getSQLState());
+        }
+    }
+
+    @Test
+    public void testPinTableUpdateViolation() throws Exception {
+        try {
+            methodWatcher.executeUpdate("UPDATE PinTable5 --splice-properties pin=true \n SET col1=20");
+            Assert.fail("UPDATE is not allowed in pin table but it didn't failed");
+        } catch (SQLException e) {
+            Assert.assertEquals("Wrong Exception","EXT26",e.getSQLState());
+        }
+    }
+
+    @Test
+    public void testPinTableDeleteViolation() throws Exception {
+        try {
+            methodWatcher.executeUpdate("DELETE FROM PinTable5 --splice-properties pin=true \n");
+            Assert.fail("UPDATE is not allowed in pin table but it didn't failed");
+        } catch (SQLException e) {
+            Assert.assertEquals("Wrong Exception","EXT27",e.getSQLState());
+        }
+    }
+
+
+
 
 }


### PR DESCRIPTION
Fixed the issues :
INSERT INTO the pinned view reports success and inserts into the original table (but not the pinned view). This should not be allowed.
DELETE FROM the pinned view reports '0 rows inserted/updated/deleted', but does not display an error message, which is misleading
UPDATE on a pinned view generates a network protocol error and bombs Splice