### PR TITLE
SPLICE-1122 -backport

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDescriptorGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDescriptorGenerator.java
@@ -119,13 +119,14 @@ public class DataDescriptorGenerator
 		String 				lines,
 		String 				storedAs,
 		String 				location,
-		String 				compression
+		String 				compression,
+		boolean 			isPined
 
     )
 	{
 		return new TableDescriptor
 			(dataDictionary, tableName, schema, tableType, lockGranularity,columnSequence,
-					delimited,escaped,lines,storedAs,location, compression);
+					delimited,escaped,lines,storedAs,location, compression, isPined);
 	}
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableDescriptor.java
@@ -160,6 +160,7 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
     private String storedAs;
     private String location;
     private String compression;
+    private boolean isPined;
 
 
     /**
@@ -232,7 +233,7 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
                            int tableType,
                            boolean onCommitDeleteRows,
                            boolean onRollbackDeleteRows, int numberOfColumns){
-        this(dataDictionary,tableName,schema,tableType,'\0',numberOfColumns,null,null,null,null,null,null);
+        this(dataDictionary,tableName,schema,tableType,'\0',numberOfColumns,null,null,null,null,null,null,false);
         this.onCommitDeleteRows=onCommitDeleteRows;
         this.onRollbackDeleteRows=onRollbackDeleteRows;
     }
@@ -258,7 +259,8 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
                            String lines,
                            String storedAs,
                            String location,
-                           String compression
+                           String compression,
+                           boolean isPined
     ){
         super(dataDictionary);
 
@@ -277,6 +279,7 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
         this.storedAs = storedAs;
         this.location = location;
         this.compression = compression;
+        this.isPined = isPined;
 
     }
 
@@ -361,6 +364,23 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
      */
     public String getDelimited() {
         return delimited;
+    }
+
+    /**
+     * Will tell if the current table is currently pined in the memory
+     * @return
+     */
+
+    public boolean isPined() {
+        return isPined;
+    }
+
+    /**
+     * Will mark the table pined
+     * @param pined
+     */
+    public void setPined(boolean pined) {
+        isPined = pined;
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -1349,7 +1349,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
         if(SchemaDescriptor.STD_SYSTEM_DIAG_SCHEMA_NAME.equals(
                 sd.getSchemaName())){
             TableDescriptor td=new TableDescriptor(this,tableName,sd,TableDescriptor.VTI_TYPE,TableDescriptor.DEFAULT_LOCK_GRANULARITY,-1,
-                    null,null,null,null,null,null);
+                    null,null,null,null,null,null, false);
 
             // ensure a vti class exists
             if(getVTIClass(td,false)!=null)
@@ -6747,7 +6747,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
 
         columnCount=columnList.length;
         td=ddg.newTableDescriptor(name,sd,TableDescriptor.SYSTEM_TABLE_TYPE,TableDescriptor.ROW_LOCK_GRANULARITY,-1,
-                null,null,null,null,null,null);
+                null,null,null,null,null,null, false);
         td.setUUID(crf.getCanonicalTableUUID());
         addDescriptor(td,sd,SYSTABLES_CATALOG_NUM,false,tc);
         toid=td.getUUID();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTABLESRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTABLESRowFactory.java
@@ -77,6 +77,7 @@ public class SYSTABLESRowFactory extends CatalogRowFactory
 	protected static final int		SYSTABLES_STORED_AS = 11;
 	protected static final int		SYSTABLES_LOCATION = 12;
 	protected static final int		SYSTABLES_COMPRESSION = 13;
+	protected static final int		SYSTABLES_IS_PINED = 14;
 	/* End External Tables Columns	*/
 	protected static final int		SYSTABLES_INDEX1_ID = 0;
 	protected static final int		SYSTABLES_INDEX1_TABLENAME = 1;
@@ -154,6 +155,7 @@ public class SYSTABLESRowFactory extends CatalogRowFactory
 		String 					storedAs = null;
 		String 					location = null;
 		String 					compression = null;
+		boolean 				isPined = false;
 
 		if (td != null)
 		{
@@ -228,6 +230,7 @@ public class SYSTABLESRowFactory extends CatalogRowFactory
 			storedAs = descriptor.getStoredAs();
 			location = descriptor.getLocation();
 			compression = descriptor.getCompression();
+			isPined = descriptor.isPined();
 		}
 
 		/* Insert info into systables */
@@ -265,6 +268,7 @@ public class SYSTABLESRowFactory extends CatalogRowFactory
 		row.setColumn(SYSTABLES_STORED_AS,new SQLVarchar(storedAs));
 		row.setColumn(SYSTABLES_LOCATION,new SQLVarchar(location));
 		row.setColumn(SYSTABLES_COMPRESSION,new SQLVarchar(compression));
+		row.setColumn(SYSTABLES_IS_PINED,new SQLBoolean(isPined));
 
 		return row;
 	}
@@ -393,6 +397,7 @@ public class SYSTABLESRowFactory extends CatalogRowFactory
 		String storedAs;
 		String location;
 		String compression;
+		boolean isPined;
 
 
 		/* 1st column is TABLEID (UUID - char(36)) */
@@ -467,6 +472,7 @@ public class SYSTABLESRowFactory extends CatalogRowFactory
 		DataValueDescriptor storedDVD = row.getColumn(SYSTABLES_STORED_AS);
 		DataValueDescriptor locationDVD = row.getColumn(SYSTABLES_LOCATION);
 		DataValueDescriptor compressionDVD = row.getColumn(SYSTABLES_COMPRESSION);
+		DataValueDescriptor isPinedDVD = row.getColumn(SYSTABLES_IS_PINED);
 
 
 
@@ -478,7 +484,8 @@ public class SYSTABLESRowFactory extends CatalogRowFactory
 				linesDVD!=null?linesDVD.getString():null,
 				storedDVD!=null?storedDVD.getString():null,
 				locationDVD!=null?locationDVD.getString():null,
-				compressionDVD!=null?compressionDVD.getString():null
+				compressionDVD!=null?compressionDVD.getString():null,
+				isPinedDVD.getBoolean()
 				);
 		tabDesc.setUUID(tableUUID);
 
@@ -530,7 +537,8 @@ public class SYSTABLESRowFactory extends CatalogRowFactory
 			SystemColumnImpl.getColumn("LINES", Types.VARCHAR, true),
 			SystemColumnImpl.getColumn("STORED", Types.VARCHAR, true),
 			SystemColumnImpl.getColumn("LOCATION", Types.VARCHAR, true),
-			SystemColumnImpl.getColumn("COMPRESSION", Types.VARCHAR, true)
+			SystemColumnImpl.getColumn("COMPRESSION", Types.VARCHAR, true),
+			SystemColumnImpl.getColumn("IS_PINNED", Types.BOOLEAN, false)
         };
 	}
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateViewNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateViewNode.java
@@ -459,7 +459,7 @@ public class CreateViewNode extends DDLStatementNode
 		 * (Pass in row locking, even though meaningless for views.)
 		 */
 		DataDescriptorGenerator ddg = dd.getDataDescriptorGenerator();
-		TableDescriptor td = ddg.newTableDescriptor(getRelativeName(),sd,TableDescriptor.WITH_TYPE,TableDescriptor.ROW_LOCK_GRANULARITY,-1,null,null,null,null,null, null);
+		TableDescriptor td = ddg.newTableDescriptor(getRelativeName(),sd,TableDescriptor.WITH_TYPE,TableDescriptor.ROW_LOCK_GRANULARITY,-1,null,null,null,null,null, null,false);
 		UUID toid = td.getUUID();
 
 		// No Need to add since this will be dynamic!!!

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NewInvocationNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NewInvocationNode.java
@@ -157,7 +157,7 @@ public class NewInvocationNode extends MethodCallNode
 					getSchemaDescriptor(vtiName.getSchemaName()),
 					TableDescriptor.VTI_TYPE,
 					TableDescriptor.DEFAULT_LOCK_GRANULARITY,-1,
-					null,null,null,null,null,null);
+					null,null,null,null,null,null, false);
 		}
 
 		/* Use the table descriptor to figure out what the corresponding

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
@@ -767,4 +767,12 @@ public class SparkDataSet<V> implements DataSet<V> {
     }
 
 
+    @Override @SuppressWarnings({ "unchecked", "rawtypes" })
+    public void dropPin(long conglomId) {
+
+        SpliceSpark.getSession().catalog().uncacheTable("SPLICE_"+conglomId);
+    }
+
+
+
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -572,7 +572,7 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
 
         DataDescriptorGenerator ddg=getDataDescriptorGenerator();
         TableDescriptor view=ddg.newTableDescriptor("SYSTABLESTATISTICS",
-                sysSchema,TableDescriptor.VIEW_TYPE,TableDescriptor.ROW_LOCK_GRANULARITY,-1,null,null,null,null,null,null);
+                sysSchema,TableDescriptor.VIEW_TYPE,TableDescriptor.ROW_LOCK_GRANULARITY,-1,null,null,null,null,null,null,false);
         addDescriptor(view,sysSchema,DataDictionary.SYSTABLES_CATALOG_NUM,false,tc);
         UUID viewId=view.getUUID();
         ColumnDescriptor[] tableViewCds=SYSTABLESTATISTICSRowFactory.getViewColumns(view,viewId);
@@ -593,7 +593,7 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
 
         DataDescriptorGenerator ddg=getDataDescriptorGenerator();
         TableDescriptor view=ddg.newTableDescriptor("SYSCOLUMNSTATISTICS",
-                sysSchema,TableDescriptor.VIEW_TYPE,TableDescriptor.ROW_LOCK_GRANULARITY,-1,null,null,null,null,null,null);
+                sysSchema,TableDescriptor.VIEW_TYPE,TableDescriptor.ROW_LOCK_GRANULARITY,-1,null,null,null,null,null,null,false);
         addDescriptor(view,sysSchema,DataDictionary.SYSTABLES_CATALOG_NUM,false,tc);
         UUID viewId=view.getUUID();
         ColumnDescriptor[] tableViewCds=SYSCOLUMNSTATISTICSRowFactory.getViewColumns(view,viewId);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateAliasConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateAliasConstantOperation.java
@@ -300,7 +300,7 @@ public class CreateAliasConstantOperation extends DDLConstantOperation {
 			DataDescriptorGenerator ddg = dd.getDataDescriptorGenerator();
 			td = ddg.newTableDescriptor(aliasName, sd, TableDescriptor.SYNONYM_TYPE,
 						TableDescriptor.DEFAULT_LOCK_GRANULARITY,-1,
-					null,null,null,null,null,null);
+					null,null,null,null,null,null, false);
 			dd.addDescriptor(td, sd, DataDictionary.SYSTABLES_CATALOG_NUM, false, tc);
             break;
 		

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreatePinConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreatePinConstantOperation.java
@@ -20,9 +20,12 @@ import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
+import com.splicemachine.db.iapi.sql.depend.DependencyManager;
 import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ConstantAction;
 import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.db.impl.services.uuid.BasicUUID;
+import com.splicemachine.ddl.DDLMessage;
 import com.splicemachine.derby.ddl.DDLUtils;
 import com.splicemachine.derby.impl.sql.execute.operations.LocatedRow;
 import com.splicemachine.derby.impl.sql.execute.operations.ScanOperation;
@@ -33,6 +36,8 @@ import com.splicemachine.derby.stream.iapi.DistributedDataSetProcessor;
 import com.splicemachine.derby.stream.iapi.ScanSetBuilder;
 import com.splicemachine.derby.stream.iapi.ScopeNamed;
 import com.splicemachine.derby.stream.utils.StreamUtils;
+import com.splicemachine.pipeline.ErrorState;
+import com.splicemachine.protobuf.ProtoUtil;
 import com.splicemachine.si.api.txn.TxnView;
 import com.splicemachine.utils.IntArrays;
 import com.splicemachine.utils.SpliceLogUtils;
@@ -101,6 +106,7 @@ public class CreatePinConstantOperation implements ConstantAction, ScopeNamed {
 
         LanguageConnectionContext lcc = activation.getLanguageConnectionContext();
         DataDictionary dd = lcc.getDataDictionary();
+        DependencyManager dm = dd.getDependencyManager();
         TransactionController userTransaction = lcc.getTransactionExecute();
         SchemaDescriptor sd = dd.getSchemaDescriptor(schemaName, userTransaction, true);
         TableDescriptor td = dd.getTableDescriptor(tableName, sd, userTransaction);
@@ -110,6 +116,54 @@ public class CreatePinConstantOperation implements ConstantAction, ScopeNamed {
 
         DistributedDataSetProcessor dsp = EngineDriver.driver().processorFactory().distributedProcessor();
         TxnView parentTxn = ((SpliceTransactionManager)userTransaction).getActiveStateTxn();
+        /*
+        ** Inform the data dictionary that we are about to write to it.
+        ** There are several calls to data dictionary "get" methods here
+        ** that might be done in "read" mode in the data dictionary, but
+        ** it seemed safer to do this whole operation in "write" mode.
+        **
+        ** We tell the data dictionary we're done writing at the end of
+        ** the transaction.
+        */
+        dd.startWriting(lcc);
+        // Drop the table and then recreate it with the pin marked.
+        try {
+            dd.dropTableDescriptor(td,sd,userTransaction);
+        } catch (StandardException e) {
+            if (ErrorState.WRITE_WRITE_CONFLICT.getSqlState().equals(e.getSQLState())) {
+                throw ErrorState.DDL_ACTIVE_TRANSACTIONS.newException("Add Pin ()",
+                        e.getMessage());
+            }
+            throw e;
+        }
+
+        // Change the table name of the table descriptor
+        td.setColumnSequence(td.getColumnSequence()+1);
+
+        //Mark the table pined
+        td.setPined(true);
+        		    /* Prepare all dependents to invalidate.  (This is their chance
+		     * to say that they can't be invalidated.  For example, an open
+		     * cursor referencing a table/view that the user is attempting to
+		     * alter.) If no one objects, then invalidate any dependent objects.
+		     */
+        dm.invalidateFor(td, DependencyManager.ALTER_TABLE, lcc);
+
+        TransactionController tc = lcc.getTransactionExecute();
+
+        DDLMessage.DDLChange ddlChange = ProtoUtil.createAlterTable(((SpliceTransactionManager) tc).getActiveStateTxn().getTxnId(),
+                (BasicUUID) td.getUUID());
+        // Run Remotely
+        tc.prepareDataDictionaryChange(DDLUtils.notifyMetadataChange(ddlChange));
+
+
+        // Save the TableDescriptor off in the Activation
+        activation.setDDLTableDescriptor(td);
+
+
+        dd.addDescriptor(td,sd,DataDictionary.SYSTABLES_CATALOG_NUM,false,userTransaction);
+
+
         SpliceConglomerate conglomerate = (SpliceConglomerate) ((SpliceTransactionManager) activation.getTransactionController()).findConglomerate(td.getHeapConglomerateId());
         int[] baseColumnMap = IntArrays.count(conglomerate.getFormat_ids().length);
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
@@ -277,7 +277,8 @@ public class CreateTableConstantOperation extends DDLConstantOperation {
                     lines,
                     storedAs,
                     location,
-                    compression
+                    compression,
+                    false
                     );
         } else {
             td = ddg.newTableDescriptor(tableName, sd, tableType, onCommitDeleteRows, onRollbackDeleteRows,columnInfo.length);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateViewConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateViewConstantOperation.java
@@ -154,7 +154,7 @@ public class CreateViewConstantOperation extends DDLConstantOperation {
 		 * (Pass in row locking, even though meaningless for views.)
 		 */
 		DataDescriptorGenerator ddg = dd.getDataDescriptorGenerator();
-		td = ddg.newTableDescriptor(tableName,sd,tableType,TableDescriptor.ROW_LOCK_GRANULARITY,-1,null,null,null,null,null,null);
+		td = ddg.newTableDescriptor(tableName,sd,tableType,TableDescriptor.ROW_LOCK_GRANULARITY,-1,null,null,null,null,null,null,false);
 
 		dd.addDescriptor(td, sd, DataDictionary.SYSTABLES_CATALOG_NUM, false, tc);
 		toid = td.getUUID();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropAliasConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropAliasConstantOperation.java
@@ -120,7 +120,7 @@ public class DropAliasConstantOperation extends DDLConstantOperation {
             DataDescriptorGenerator ddg = dd.getDataDescriptorGenerator();
             TableDescriptor td = ddg.newTableDescriptor(aliasName, sd,
                     TableDescriptor.SYNONYM_TYPE, TableDescriptor.DEFAULT_LOCK_GRANULARITY,-1,
-                    null,null,null,null,null,null);
+                    null,null,null,null,null,null, false);
             dd.dropTableDescriptor(td, sd, tc);
         }
         else

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropTableConstantOperation.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.derby.impl.sql.execute.actions;
 
+import com.splicemachine.EngineDriver;
 import com.splicemachine.db.impl.services.uuid.BasicUUID;
 import com.splicemachine.db.impl.sql.catalog.DataDictionaryCache;
 import com.splicemachine.db.impl.sql.catalog.TableKey;
@@ -31,6 +32,7 @@ import com.splicemachine.db.iapi.sql.depend.DependencyManager;
 import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.protobuf.ProtoUtil;
+import com.splicemachine.si.api.txn.TxnView;
 
 
 /**
@@ -153,8 +155,8 @@ public class DropTableConstantOperation extends DDLSingleTableConstantOperation 
             }
 
             /* Invalidate dependencies remotely. */
-
-            DDLChange ddlChange = ProtoUtil.createDropTable(((SpliceTransactionManager) tc).getActiveStateTxn().getTxnId(), (BasicUUID) this.tableId);
+            TxnView activeTransaction = ((SpliceTransactionManager) tc).getActiveStateTxn();
+            DDLChange ddlChange = ProtoUtil.createDropTable(activeTransaction.getTxnId(), (BasicUUID) this.tableId);
             // Run locally first to capture any errors.
             dm.invalidateFor(td, DependencyManager.DROP_TABLE, lcc);
             // Run Remotely
@@ -174,6 +176,12 @@ public class DropTableConstantOperation extends DDLSingleTableConstantOperation 
 
             /* Drop the store element at last, to prevent dangling reference for open cursor, beetle 4393. */
             tc.dropConglomerate(heapId);
+
+            /* is the table pinned ? , if yes we need to drop it */
+            if(td.isPined()){
+                EngineDriver.driver().processorFactory().distributedProcessor().dropPinnedTable(td.getHeapConglomerateId());
+            }
+
         } catch (Exception e) {
             // If dropping table fails, it could happen that the table object in cache has been modified.
             // Invalidate the table in cache.

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
@@ -475,6 +475,15 @@ public class ControlDataSet<V> implements DataSet<V> {
     }
 
     /**
+     * Not Supported
+     * @param conglomId
+     */
+    @Override
+    public void dropPin(long conglomId) {
+        throw new UnsupportedOperationException("Un Pin Not Supported in Control Mode");
+    }
+
+    /**
      *
      * Non Lazy Callable
      *

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
@@ -305,4 +305,13 @@ public interface DataSet<V> extends Iterable<V>, Serializable {
      */
     public void pin(ExecRow template, long conglomId);
 
+
+    /**
+     *
+     * Drop Pin the conglomerate from memory.
+     *
+     * @param conglomId
+     */
+    public void dropPin(long conglomId);
+
 }


### PR DESCRIPTION
We need to do the following...

When a table is pinned in memory, the dictionary should be modified to say the table is in memory.  We should then remove the pin when we delete the table from the dictionary.