### PR TITLE
SPLICE-1285 - backport to 2.5 already approved

### DIFF
--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -1975,7 +1975,7 @@ public interface SQLState {
     String CANNOT_WRITE_AT_LOCATION				    				= "EXT22";
     String INCONSISTENT_NUMBER_OF_ATTRIBUTE				    		= "EXT23";
     String INCONSISTENT_DATATYPE_ATTRIBUTES				    		= "EXT24";
-
+    String TABLE_NOT_PINNED				    						= "EXT28";
 
 }
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -9000,6 +9000,12 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
                <arg>externalAttributeCount</arg>
            </msg>
 
+           <msg>
+               <name>EXT28</name>
+               <text> Table '{0}' is not pinned</text>
+               <arg>location</arg>
+           </msg>
+
        </family>
     </section>
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
@@ -758,21 +758,11 @@ public class SparkDataSet<V> implements DataSet<V> {
     }
 
     @Override @SuppressWarnings({ "unchecked", "rawtypes" })
-    public void pin(ExecRow template, long conglomId) {
+    public void pin(ExecRow template, long conglomId) throws StandardException {
         Dataset<Row> pinDF = SpliceSpark.getSession().createDataFrame(
                 rdd.map(new LocatedRowToRowFunction()),
                 template.schema());
         pinDF.createOrReplaceTempView("SPLICE_"+conglomId);
         SpliceSpark.getSession().catalog().cacheTable("SPLICE_"+conglomId);
     }
-
-
-    @Override @SuppressWarnings({ "unchecked", "rawtypes" })
-    public void dropPin(long conglomId) {
-
-        SpliceSpark.getSession().catalog().uncacheTable("SPLICE_"+conglomId);
-    }
-
-
-
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropPinConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropPinConstantOperation.java
@@ -80,6 +80,9 @@ public class DropPinConstantOperation extends DDLSingleTableConstantOperation {
         if (td == null) {
             throw StandardException.newException(SQLState.LANG_TABLE_NOT_FOUND_DURING_EXECUTION, fullTableName);
         }
+        if(!td.isPined()){
+            throw StandardException.newException(SQLState.TABLE_NOT_PINNED, fullTableName);
+        }
         long heapId = td.getHeapConglomerateId();
         DistributedDataSetProcessor dsp = EngineDriver.driver().processorFactory().distributedProcessor();
         dsp.dropPinnedTable(heapId);

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
@@ -474,14 +474,6 @@ public class ControlDataSet<V> implements DataSet<V> {
         throw new UnsupportedOperationException("Pin Not Supported in Control Mode");
     }
 
-    /**
-     * Not Supported
-     * @param conglomId
-     */
-    @Override
-    public void dropPin(long conglomId) {
-        throw new UnsupportedOperationException("Un Pin Not Supported in Control Mode");
-    }
 
     /**
      *

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.derby.stream.iapi;
 
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.LocatedRow;
@@ -303,15 +304,7 @@ public interface DataSet<V> extends Iterable<V>, Serializable {
      * @param template
      * @param conglomId
      */
-    public void pin(ExecRow template, long conglomId);
+    public void pin(ExecRow template, long conglomId) throws StandardException;
 
-
-    /**
-     *
-     * Drop Pin the conglomerate from memory.
-     *
-     * @param conglomId
-     */
-    public void dropPin(long conglomId);
 
 }


### PR DESCRIPTION
Partially fixed the issue when the table wasn't pined to begin with. This will help to understand the underlying issue that causes the problem by removing one case bug.