### PR TITLE
SPLICE-1379 The number of threads in the HBase priority executor is low

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
+++ b/hbase_sql/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
@@ -142,7 +142,8 @@ class SpliceTestPlatformConfig {
 
         config.setLong("hbase.client.scanner.timeout.period", MINUTES.toMillis(2)); // hbase.regionserver.lease.period is deprecated
         config.setLong("hbase.client.operation.timeout", MINUTES.toMillis(2));
-        config.setLong("hbase.regionserver.handler.count", 200);
+        config.setLong("hbase.regionserver.handler.count", 100);
+        config.setLong("hbase.regionserver.metahandler.count", 100);
         config.setLong("hbase.regionserver.msginterval", 1000);
         config.setLong("hbase.master.event.waiting.time", 20);
         config.setLong("hbase.master.lease.thread.wakefrequency", SECONDS.toMillis(3));


### PR DESCRIPTION
Porting forward from 2.5