### PR TITLE
SPLICE-1211: open and close latency calculated twice for NLJ

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
@@ -297,7 +297,7 @@ public class SelectivityUtil {
      *
      * Nested Loop Join Local Cost Computation
      *
-     * Total Cost = (Left Side Cost)/Left Side Partition Count) + (Left Side Row Count/Left Side Partition Count)*(Right Side Cost + Right Side Transfer Cost + Open Cost + Close Cost)
+     * Total Cost = (Left Side Cost)/Left Side Partition Count) + (Left Side Row Count/Left Side Partition Count)*(Right Side Cost + Right Side Transfer Cost)
      *
      * @param innerCost
      * @param outerCost
@@ -305,6 +305,6 @@ public class SelectivityUtil {
      */
 
     public static double nestedLoopJoinStrategyLocalCost(CostEstimate innerCost, CostEstimate outerCost) {
-        return outerCost.localCostPerPartition() + (outerCost.rowCount()/outerCost.partitionCount())*(innerCost.localCost()+innerCost.getRemoteCost()+innerCost.getOpenCost()+innerCost.getCloseCost());
+        return outerCost.localCostPerPartition() + (outerCost.rowCount()/outerCost.partitionCount())*(innerCost.localCost()+innerCost.getRemoteCost());
     }
 }


### PR DESCRIPTION
just taking out open/close latency cost which is already factored in transfer cost.