### PR TITLE
DB-5638: do not backup temporary tables(backport to 2.0)

### DIFF
--- a/hbase_storage/src/main/java/com/splicemachine/access/hbase/H10PartitionAdmin.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/hbase/H10PartitionAdmin.java
@@ -166,4 +166,10 @@ public class H10PartitionAdmin implements PartitionAdmin{
     public void move(String partition, String server) throws IOException {
         admin.move(partition.getBytes(), server!=null && server.length()>0?server.getBytes():null);
     }
+
+    @Override
+    public TableDescriptor getTableDescriptor(String table) throws IOException{
+        HTableDescriptor hTableDescriptor = admin.getTableDescriptor(TableName.valueOf(table));
+        return new HBaseTableDescriptor(hTableDescriptor);
+    }
 }

--- a/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MEnginePartitionAdmin.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MEnginePartitionAdmin.java
@@ -85,4 +85,9 @@ public class MEnginePartitionAdmin implements PartitionAdmin{
     public void move(String partition, String server) throws IOException {
         admin.move(partition, server);
     }
+
+    @Override
+    public TableDescriptor getTableDescriptor(String table) throws IOException{
+        return admin.getTableDescriptor(table);
+    }
 }

--- a/mem_storage/src/main/java/com/splicemachine/storage/MPartitionFactory.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MPartitionFactory.java
@@ -153,5 +153,10 @@ public class MPartitionFactory implements PartitionFactory<Object>{
         public void move(String partition, String server) throws IOException {
             throw new UnsupportedOperationException("Cannot move partitions in an in-memory storage engine!");
         }
+
+        @Override
+        public TableDescriptor getTableDescriptor(String table) throws IOException{
+            throw new UnsupportedOperationException("Cannot get table descriptors in an in-memory storage engine!");
+        }
     }
 }

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/PartitionAdmin.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/PartitionAdmin.java
@@ -47,4 +47,6 @@ public interface PartitionAdmin extends AutoCloseable{
     TableDescriptor[] getTableDescriptors(List<String> tables) throws IOException;
 
     void move(String partition,String server) throws IOException;
+
+    TableDescriptor getTableDescriptor(String table) throws IOException;
 }


### PR DESCRIPTION
backport a fix to branch-2.0. It should be done a while ago, but I only found out today.