### PR TITLE
SPLICE-1387 backport branch 2.5

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -249,13 +249,42 @@ public class ExternalTableIT extends SpliceUnitTest{
         PreparedStatement ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.SYSCS_REFRESH_EXTERNAL_TABLE(?,?) ");
         ps.setString(1, "EXTERNALTABLEIT");
         ps.setString(2, "EXTERNAL_TABLE_REFRESH");
-        ResultSet rs = ps.executeQuery();
-        rs.next();
-
-        Assert.assertEquals("Error with refresh external table","EXTERNALTABLEIT.EXTERNAL_TABLE_REFRESH schema table refreshed",  rs.getString(1));
+        ps.execute();
 
 
     }
+
+    @Test
+    public void refreshRequireExternalTableNotFound() throws  Exception{
+
+        try {
+            PreparedStatement ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.SYSCS_REFRESH_EXTERNAL_TABLE(?,?) ");
+            ps.setString(1, "EXTERNALTABLEIT");
+            ps.setString(2, "NOT_EXIST");
+            ResultSet rs = ps.executeQuery();
+            Assert.fail("Exception not thrown");
+        } catch (SQLException e) {
+            Assert.assertEquals("Wrong Exception","42X05",e.getSQLState());
+        }
+
+    }
+
+    //SPLICE-1387
+    @Test
+    public void refreshRequireExternalTableWrongParameters() throws  Exception{
+
+        try {
+            PreparedStatement ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.SYSCS_REFRESH_EXTERNAL_TABLE('arg1','arg2','arg3') ");
+
+            ResultSet rs = ps.executeQuery();
+            Assert.fail("Exception not thrown");
+        } catch (SQLException e) {
+            Assert.assertEquals("Wrong Exception","42Y03",e.getSQLState());
+        }
+
+    }
+
+
 
     @Test
     public void testWriteReadNullValues() throws Exception {
@@ -699,8 +728,6 @@ public class ExternalTableIT extends SpliceUnitTest{
         return getHBaseDirectory()+"/target/external/";
 
     }
-
-
 
 
     @Test

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -115,7 +115,7 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
 
                 if (key.equals(sysUUID)) {
                     Procedure refreshExternalTable = Procedure.newBuilder().name("SYSCS_REFRESH_EXTERNAL_TABLE")
-                            .numOutputParams(0).numResultSets(1).ownerClass(ExternalTableSystemProcedures.class.getCanonicalName())
+                            .numOutputParams(0).numResultSets(0).ownerClass(ExternalTableSystemProcedures.class.getCanonicalName())
                             .varchar("schema", 32672)
                             .varchar("table", 32672)
                             .build();


### PR DESCRIPTION
Corrected multiples issues:
1) remove 3th arg : CALL SYSCS_UTIL.SYSCS_REFRESH_EXTERNAL_TABLE('APP', 'myTable', rs);
2) check for table not found.