### PR TITLE
SPLICE-1424 Removing Unneeded Visitor from FromTable

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
@@ -592,18 +592,17 @@ public abstract class FromTable extends ResultSetNode implements Optimizable{
         return false;
     }
 
+    /**
+     *
+     * Always meterializable
+     *
+     * @return
+     * @throws StandardException
+     */
     @Override
-    public boolean isMaterializable() throws StandardException{
-		/* Derived tables are materializable
-		 * iff they are not correlated with an outer query block.
-		 */
 
+    public boolean isMaterializable() throws StandardException{
         return true;
-        /* This no longer holds true with our predicate pulling...
-        HasCorrelatedCRsVisitor visitor=new HasCorrelatedCRsVisitor();
-        accept(visitor);
-        return !(visitor.hasCorrelatedCRs());
-        */
     }
 
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
@@ -598,9 +598,12 @@ public abstract class FromTable extends ResultSetNode implements Optimizable{
 		 * iff they are not correlated with an outer query block.
 		 */
 
+        return true;
+        /* This no longer holds true with our predicate pulling...
         HasCorrelatedCRsVisitor visitor=new HasCorrelatedCRsVisitor();
         accept(visitor);
         return !(visitor.hasCorrelatedCRs());
+        */
     }
 
     @Override


### PR DESCRIPTION
This visitor does a lot of work especially on queries with many joins at the FromTable.  Not needed anymore.