### PR TITLE
SPLICE-1411: resolve over clause expr with alias from inner query 

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowResultSetNode.java
@@ -495,6 +495,35 @@ public class WindowResultSetNode extends SingleChildResultSetNode {
                         // Cache the ref
                         pulledUp.put(expKey, new ColumnRefPosition(bottomRC, childRCL.size()));
                     }
+                } else {
+                    // Check again if we find match, if not then add it in cache ref if we have the equivalent match
+                    if (pulledUp.get(expKey) == null) {
+                        ResultColumn srcRC = findOrPullUpRC(expRC,
+                                ((SingleChildResultSetNode) childResult).getChildResult(),
+                                rCtoCRfactory);
+                        if (srcRC != null) {
+                            // We found the RC referenced by this column from the over clause. Create RC->CR pairs
+                            // in our two RCLs (our projection -- this RCL -- and the PR we created as a staging
+                            // below us. Then cache the PR's RC so that we can reference repeated columns to the
+                            // same RC.
+                            String baseName = exp.getColumnName();
+
+                            // create RC->CR->srcRC for bottom PR
+                            ResultColumn bottomRC = createRC_CR_Pair(srcRC, baseName, getNodeFactory(),
+                                    getContextManager(), this.getLevel(), this.getLevel());
+                            childRCL.addElement(bottomRC);
+                            bottomRC.setVirtualColumnId(childRCL.size());
+
+                            // create RC->CR->bottomRC for window PR
+                            ResultColumn winRC = createRC_CR_Pair(bottomRC, baseName, getNodeFactory(),
+                                    getContextManager(), this.getLevel(), this.getLevel());
+                            winRCL.addElement(winRC);
+                            winRC.setVirtualColumnId(winRCL.size());
+
+                            // Cache the ref
+                            pulledUp.put(expKey, new ColumnRefPosition(bottomRC, childRCL.size()));
+                        }
+                    }
                 }
             } else {
                 if (LOG.isDebugEnabled()) {

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WindowFunctionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WindowFunctionIT.java
@@ -3756,4 +3756,31 @@ public class WindowFunctionIT extends SpliceUnitTest {
         rs.close();
     }
 
+    @Test
+    public void testWindowFnWithSubqAlias() throws Exception {
+        String sqlText =
+                String.format(
+                        "select distinct " +
+                        "sum(d1.c6) over (partition by d1.c7) as aggr_sum " +
+                        ",d1.c7 " +
+                        "from (select mgr as c7, sal c6 from %s  --SPLICE-PROPERTIES useSpark = %s \n" +
+                        ") as d1 order by 1",
+                        this.getTableReference(EMP),useSpark);
+
+        ResultSet rs = methodWatcher.executeQuery(sqlText);
+        String expected =
+                "AGGR_SUM | C7  |\n"+
+                        "----------------\n" +
+                        " 800.00  |7902 |\n" +
+                        " 1100.00 |7788 |\n" +
+                        " 1300.00 |7782 |\n" +
+                        " 5000.00 |NULL |\n" +
+                        " 6000.00 |7566 |\n" +
+                        " 6550.00 |7698 |\n" +
+                        " 8275.00 |7839 |";
+
+        assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    }
+
 }


### PR DESCRIPTION
When inner query has aliases and used in the window function, over clause could not resolve that expression well from the cache map causing NPE. We check again if the match is present when the equivalent alias is present for it.