### PR TITLE
SPLICE-1258 : Move logic  outside of Spark Job

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/procedures/external/CreateExternalTableJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/procedures/external/CreateExternalTableJob.java
@@ -62,15 +62,8 @@ public class CreateExternalTableJob implements Callable<Void> {
         DistributedDataSetProcessor dsp = EngineDriver.driver().processorFactory().distributedProcessor();
         dsp.setSchedulerPool("admin");
         dsp.setJobGroup(request.getJobGroup(), "");
+        dsp.createEmptyExternalFile(execRow, IntArrays.count(execRowTypeFormatIds.length), request.getPartitionBy(),  request.getStoredAs(), request.getLocation(),request.getCompression());
 
-        // look at the file, if it doesn't exist create it.
-        DistributedFileSystem dfs = SIDriver.driver().getSIEnvironment().fileSystem(request.getLocation());
-        if(!dfs.getInfo(request.getLocation()).exists()){
-            String location =  request.getLocation();
-            String pathToParent = location.substring(0, location.lastIndexOf("/"));
-            ImportUtils.validateWritable(pathToParent.toString(),false);
-            dsp.createEmptyExternalFile(execRow, IntArrays.count(execRowTypeFormatIds.length), request.getPartitionBy(),  request.getStoredAs(), request.getLocation(),request.getCompression());
-        }
 
         jobStatus.markCompleted(new SuccessfulOlapResult());
         return null;


### PR DESCRIPTION
- Moved the logic of checking if a file exist outside of the job to avoid all the exception wrapping 