### PR TITLE
DB-5469 Fix filesystem code (master)

### DIFF
--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/HBasePipelineEnvironment.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/HBasePipelineEnvironment.java
@@ -180,11 +180,6 @@ public class HBasePipelineEnvironment implements PipelineEnvironment{
         return pipelineFactory;
     }
 
-    @Override
-    public DistributedFileSystem fileSystem(){
-        return delegate.fileSystem();
-    }
-
     /**
      *
      * Retrieve the appropriate filesystem based on the scheme.  If not scheme provided,

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/HBaseSIEnvironment.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/HBaseSIEnvironment.java
@@ -222,11 +222,6 @@ public class HBaseSIEnvironment implements SIEnvironment{
     }
 
     @Override
-    public DistributedFileSystem fileSystem(){
-        return fileSystem;
-    }
-
-    @Override
     public DistributedFileSystem fileSystem(String path) throws IOException, URISyntaxException  {
         return new HNIOFileSystem(FileSystem.get(new URI(path), (Configuration) config.getConfigSource().unwrapDelegate()), exceptionFactory());
     }

--- a/mem_pipeline/src/main/java/com/splicemachine/pipeline/MPipelineEnv.java
+++ b/mem_pipeline/src/main/java/com/splicemachine/pipeline/MPipelineEnv.java
@@ -182,11 +182,6 @@ public class MPipelineEnv  implements PipelineEnvironment{
     }
 
     @Override
-    public DistributedFileSystem fileSystem(){
-        return siEnv.fileSystem();
-    }
-
-    @Override
     public SnowflakeFactory snowflakeFactory() {
         return siEnv.snowflakeFactory();
     }

--- a/mem_storage/src/main/java/com/splicemachine/si/MemSIEnvironment.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/MemSIEnvironment.java
@@ -160,11 +160,6 @@ public class MemSIEnvironment implements SIEnvironment{
     }
 
     @Override
-    public DistributedFileSystem fileSystem(){
-        return fileSystem;
-    }
-
-    @Override
     public DistributedFileSystem fileSystem(String path) throws IOException, URISyntaxException {
         return fileSystem;
     }

--- a/mem_storage/src/main/java/com/splicemachine/storage/MemFileSystem.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MemFileSystem.java
@@ -29,9 +29,12 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.file.*;
 import java.nio.file.attribute.*;
 import java.nio.file.spi.FileSystemProvider;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.regex.Pattern;
 
 /**
  * @author Scott Fines
@@ -46,22 +49,6 @@ public class MemFileSystem extends DistributedFileSystem{
     }
 
     @Override
-    public void delete(Path path,boolean recursive) throws IOException{
-        //TODO -sf- deal with recursive deletes
-        localDelegate.delete(path);
-    }
-
-    @Override
-    public void delete(Path path) throws IOException{
-        localDelegate.delete(path);
-    }
-
-    @Override
-    public boolean deleteIfExists(Path path) throws IOException{
-        return localDelegate.deleteIfExists(path);
-    }
-
-    @Override
     public void delete(String dir,boolean recursive) throws IOException{
         localDelegate.delete(getPath(dir));
     }
@@ -72,15 +59,33 @@ public class MemFileSystem extends DistributedFileSystem{
     }
 
     public String[] getExistingFiles(String dir, String filePattern) throws IOException {
-        return new String[]{};
-    };
+        Pattern pattern = Pattern.compile(filePattern);
+        try (DirectoryStream<Path> stream =
+                     localDelegate.newDirectoryStream(
+                             getPath(dir),
+                             entry -> pattern.matcher(entry.getFileName().toString()).matches())) {
+            List<String> files = new ArrayList<>();
+            for (Path i : stream) {
+                files.add(i.toAbsolutePath().toString());
+            }
+            return files.toArray(new String[files.size()]);
+        }
+    }
 
     @Override
+    public String getFileName(String fullPath) {
+        return getPath(fullPath).getFileName().toString();
+    }
+
+    @Override
+    public boolean exists(String fullPath) throws IOException {
+        return Files.exists(getPath(fullPath));
+    }
+
     public Path getPath(String directory,String fileName){
         return Paths.get(directory,fileName);
     }
 
-    @Override
     public Path getPath(String fullPath){
         return Paths.get(fullPath);
     }
@@ -89,42 +94,6 @@ public class MemFileSystem extends DistributedFileSystem{
     public FileInfo getInfo(String filePath){
         Path p = getPath(filePath);
         return new PathInfo(p);
-    }
-
-    /*delegate methods*/
-    @Override
-    public String getScheme(){
-        return localDelegate.getScheme();
-    }
-
-    @Override
-    public FileSystem newFileSystem(URI uri,Map<String, ?> env) throws IOException{
-        return localDelegate.newFileSystem(uri,env);
-    }
-
-    @Override
-    public FileSystem getFileSystem(URI uri){
-        return localDelegate.getFileSystem(uri);
-    }
-
-    @Override
-    public Path getPath(URI uri){
-        return localDelegate.getPath(uri);
-    }
-
-    @Override
-    public FileSystem newFileSystem(Path path,Map<String, ?> env) throws IOException{
-        return localDelegate.newFileSystem(path,env);
-    }
-
-    @Override
-    public InputStream newInputStream(Path path,OpenOption... options) throws IOException{
-        return localDelegate.newInputStream(path,options);
-    }
-
-    @Override
-    public OutputStream newOutputStream(Path path,OpenOption... options) throws IOException{
-        return localDelegate.newOutputStream(path,options);
     }
 
     @Override
@@ -138,26 +107,10 @@ public class MemFileSystem extends DistributedFileSystem{
     }
 
     @Override
-    public FileChannel newFileChannel(Path path,Set<? extends OpenOption> options,FileAttribute<?>... attrs) throws IOException{
-        return localDelegate.newFileChannel(path,options,attrs);
+    public InputStream newInputStream(String fullPath, OpenOption... options) throws IOException {
+        return localDelegate.newInputStream(Paths.get(fullPath),options);
     }
 
-    @Override
-    public AsynchronousFileChannel newAsynchronousFileChannel(Path path,Set<? extends OpenOption> options,ExecutorService executor,FileAttribute<?>... attrs) throws IOException{
-        return localDelegate.newAsynchronousFileChannel(path,options,executor,attrs);
-    }
-
-    @Override
-    public SeekableByteChannel newByteChannel(Path path,Set<? extends OpenOption> options,FileAttribute<?>... attrs) throws IOException{
-        return localDelegate.newByteChannel(path,options,attrs);
-    }
-
-    @Override
-    public DirectoryStream<Path> newDirectoryStream(Path dir,DirectoryStream.Filter<? super Path> filter) throws IOException{
-        return localDelegate.newDirectoryStream(dir,filter);
-    }
-
-    @Override
     public boolean createDirectory(Path dir,boolean errorIfExists) throws IOException{
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "createDirectory(): path = %s", dir);
@@ -174,21 +127,6 @@ public class MemFileSystem extends DistributedFileSystem{
     }
 
     @Override
-    public void createDirectory(Path dir,FileAttribute<?>... attrs) throws IOException{
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "createDirectory(): path = %s", dir);
-        try{
-            localDelegate.createDirectory(dir,attrs);
-        }catch(FileAlreadyExistsException fafe){
-            //determine if the path is already a directory, or if it is a file. If it's a file, then
-            //throw a NotADirectoryException. Otherwise, we are good
-            if(!Files.isDirectory(dir)){
-                throw fafe;
-            }
-        }
-    }
-
-    @Override
     public boolean createDirectory(String fullPath,boolean errorIfExists) throws IOException {
         Path path = getPath(fullPath);
         if (LOG.isDebugEnabled())
@@ -198,78 +136,12 @@ public class MemFileSystem extends DistributedFileSystem{
     }
 
     @Override
-    public void touchFile(Path path) throws IOException{
-        Files.createFile(path);
-    }
-
-    @Override
     public void touchFile(String dir, String fileName) throws IOException{
         Files.createFile(Paths.get(dir, fileName));
     }
 
-    @Override
-    public void createSymbolicLink(Path link,Path target,FileAttribute<?>... attrs) throws IOException{
-        localDelegate.createSymbolicLink(link,target,attrs);
-    }
-
-    @Override
-    public void createLink(Path link,Path existing) throws IOException{
-        localDelegate.createLink(link,existing);
-    }
-
-    @Override
-    public Path readSymbolicLink(Path link) throws IOException{
-        return localDelegate.readSymbolicLink(link);
-    }
-
-    @Override
     public void copy(Path source,Path target,CopyOption... options) throws IOException{
         localDelegate.copy(source,target,options);
-    }
-
-    @Override
-    public void move(Path source,Path target,CopyOption... options) throws IOException{
-        localDelegate.move(source,target,options);
-    }
-
-    @Override
-    public boolean isSameFile(Path path,Path path2) throws IOException{
-        return localDelegate.isSameFile(path,path2);
-    }
-
-    @Override
-    public boolean isHidden(Path path) throws IOException{
-        return localDelegate.isHidden(path);
-    }
-
-    @Override
-    public FileStore getFileStore(Path path) throws IOException{
-        return localDelegate.getFileStore(path);
-    }
-
-    @Override
-    public void checkAccess(Path path,AccessMode... modes) throws IOException{
-        localDelegate.checkAccess(path,modes);
-    }
-
-    @Override
-    public <V extends FileAttributeView> V getFileAttributeView(Path path,Class<V> type,LinkOption... options){
-        return localDelegate.getFileAttributeView(path,type,options);
-    }
-
-    @Override
-    public <A extends BasicFileAttributes> A readAttributes(Path path,Class<A> type,LinkOption... options) throws IOException{
-        return localDelegate.readAttributes(path,type,options);
-    }
-
-    @Override
-    public Map<String, Object> readAttributes(Path path,String attributes,LinkOption... options) throws IOException{
-        return localDelegate.readAttributes(path,attributes,options);
-    }
-
-    @Override
-    public void setAttribute(Path path,String attribute,Object value,LinkOption... options) throws IOException{
-        localDelegate.setAttribute(path,attribute,value,options);
     }
 
     @Override

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/DistributedFileSystem.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/DistributedFileSystem.java
@@ -15,6 +15,7 @@
 package com.splicemachine.access.api;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
@@ -24,9 +25,7 @@ import java.nio.file.spi.FileSystemProvider;
  * @author Scott Fines
  *         Date: 1/11/16
  */
-public abstract class DistributedFileSystem extends FileSystemProvider{
-
-    public abstract void delete(Path path,boolean recursive) throws IOException;
+public abstract class DistributedFileSystem {
 
     public abstract void delete(String directory,boolean recursive) throws IOException;
 
@@ -43,9 +42,9 @@ public abstract class DistributedFileSystem extends FileSystemProvider{
      */
     public abstract String[] getExistingFiles(String dir, String filePattern) throws IOException;
 
-    public abstract Path getPath(String directory,String fileName);
+    public abstract String getFileName(String fullPath);
 
-    public abstract Path getPath(String fullPath);
+    public abstract boolean exists(String fullPath) throws IOException;
 
     public abstract FileInfo getInfo(String filePath) throws IOException;
 
@@ -53,27 +52,9 @@ public abstract class DistributedFileSystem extends FileSystemProvider{
 
     public abstract OutputStream newOutputStream(String fullPath, OpenOption... options) throws IOException;
 
-    /**
-     * Creates the specified directory.
-     *
-     * @param path the directory
-     * @param errorIfExists if {@code true}, then throw an error if the directory already exists;
-     *                      if {@code false}, no error is thrown
-     * @return whether the creation was successful
-     * @throws IOException
-     */
-    public abstract boolean createDirectory(Path path,boolean errorIfExists) throws IOException;
+    public abstract InputStream newInputStream(String fullPath, OpenOption... options) throws IOException;
 
     public abstract boolean createDirectory(String fullPath,boolean errorIfExists) throws IOException;
-
-    /**
-     * Create a new, empty file at the specified location.
-     *
-     * @param path the location to create the empty file at.
-     * @throws java.nio.file.FileAlreadyExistsException if the file already exists
-     * @throws IOException if something generically goes wrong.
-     */
-    public abstract void touchFile(Path path) throws IOException;
 
     public abstract void touchFile(String dir, String fileName) throws IOException;
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
@@ -451,7 +451,7 @@ public class CreateTableConstantOperation extends DDLConstantOperation {
         try {
             if(storedAs != null){
                 // test constraint only if the external file exits
-                if(SIDriver.driver().fileSystem().getPath(location).toFile().exists()) {
+                if(SIDriver.driver().getFileSystem(location).exists(location)) {
                     GetSchemaExternalResult result = EngineDriver.driver().getOlapClient().execute(new DistributedGetSchemaExternalJob(location, jobGroup, storedAs));
                     StructType externalSchema = result.getSchema();
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportFile.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportFile.java
@@ -54,7 +54,7 @@ public class ExportFile {
     
     public OutputStream getOutputStream() throws IOException {
         // Filename
-        Path fullyQualifiedExportFilePath = buildOutputFilePath();
+        String fullyQualifiedExportFilePath = buildOutputFilePath();
 
         // OutputStream
         OutputStream rawOutputStream =fileSystem.newOutputStream(fullyQualifiedExportFilePath,
@@ -134,8 +134,8 @@ public class ExportFile {
         }
     }
 
-    protected Path buildOutputFilePath() {
-        return fileSystem.getPath(exportParams.getDirectory(),buildFilenameFromTaskId(taskId));
+    protected String buildOutputFilePath() {
+        return exportParams.getDirectory() + "/" + buildFilenameFromTaskId(taskId);
     }
 
     protected String buildFilenameFromTaskId(byte[] taskId) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/BadRecordsRecorder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/BadRecordsRecorder.java
@@ -206,10 +206,9 @@ public class BadRecordsRecorder implements Externalizable, Closeable {
                                                  String extension) throws StandardException {
         try {
             DistributedFileSystem fileSystem = SIDriver.driver().getSIEnvironment().fileSystem(vtiFilePath);
-            Path inputFilePath = fileSystem.getPath(vtiFilePath);
+            String inputFileName = fileSystem.getFileName(vtiFilePath);
             if (LOG.isTraceEnabled())
-                SpliceLogUtils.trace(LOG, "BadRecordsRecorder: badDirectory=%s, filePath=%s", badDirectory, inputFilePath);
-            assert inputFilePath != null;
+                SpliceLogUtils.trace(LOG, "BadRecordsRecorder: badDirectory=%s, filePath=%s", badDirectory, vtiFilePath);
 
             if (badDirectory == null || badDirectory.isEmpty() || badDirectory.toUpperCase().equals("NULL")) {
                 badDirectory = vtiFilePath.substring(0, vtiFilePath.lastIndexOf("/"));
@@ -220,10 +219,9 @@ public class BadRecordsRecorder implements Externalizable, Closeable {
             fileSystem = SIDriver.driver().getSIEnvironment().fileSystem(badDirectory);
             int i = 0;
             while (true) {
-                String fileName = badDirectory + "/" + inputFilePath.getFileName();
+                String fileName = badDirectory + "/" + inputFileName;
                 fileName = fileName + (i == 0 ? extension : "_" + i + extension);
-                Path fileSystemPathForWrites = fileSystem.getPath(fileName);
-                if (!Files.exists(fileSystemPathForWrites)) {
+                if (!fileSystem.exists(fileName)) {
                     return fileName;
                 }
                 i++;

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
@@ -288,7 +288,7 @@ public class ControlDataSet<V> implements DataSet<V> {
     public void saveAsTextFile(String path) {
         OutputStream fileOut = null;
         try {
-            DistributedFileSystem dfs = SIDriver.driver().fileSystem();
+            DistributedFileSystem dfs = SIDriver.driver().getFileSystem(path);
             fileOut = dfs.newOutputStream(path, StandardOpenOption.CREATE);
             while (iterator.hasNext()) {
                 fileOut.write(Bytes.toBytes(iterator.next().toString()));

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
@@ -18,6 +18,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
+import java.net.URISyntaxException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.OpenOption;
@@ -183,6 +184,8 @@ public class ControlDataSetProcessor implements DataSetProcessor{
             return singleRowPairDataSet(s,is);
         }catch(IOException e){
             throw new RuntimeException(e);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -197,6 +200,8 @@ public class ControlDataSetProcessor implements DataSetProcessor{
             InputStream is=getFileStream(s);
             return new ControlDataSet<>(new TextFileIterator(is));
         }catch(IOException e) {
+            throw new RuntimeException(e);
+        } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
     }
@@ -278,36 +283,32 @@ public class ControlDataSetProcessor implements DataSetProcessor{
 
     /* ****************************************************************************************************************/
     /*private helper methods*/
-    private InputStream newInputStream(DistributedFileSystem dfs,@Nonnull Path p,OpenOption... options) throws IOException{
+    private InputStream newInputStream(DistributedFileSystem dfs,@Nonnull String p,OpenOption... options) throws IOException{
+        assert p!=null;
         InputStream value = dfs.newInputStream(p,options);
-        String s=p.getFileName().toString();
-        assert s!=null;
-        if(s.endsWith("gz")){
+        if(p.endsWith("gz")){
             //need to open up a decompressing inputStream
             value = new GZIPInputStream(value);
         }
         return value;
     }
 
-    private InputStream getFileStream(String s) throws IOException{
-        DistributedFileSystem dfs=SIDriver.driver().fileSystem();
+    private InputStream getFileStream(String s) throws IOException, URISyntaxException {
+        DistributedFileSystem dfs=SIDriver.driver().getSIEnvironment().fileSystem(s);
         InputStream value;
         if(dfs.getInfo(s).isDirectory()){
             //we need to open a Stream against each file in the directory
             InputStream inputStream = null;
-            boolean sequenced = false;
-            try(DirectoryStream<Path> stream =Files.newDirectoryStream(dfs.getPath(s))){
-                for(Path p:stream){
-                    if(inputStream==null){
-                        inputStream = newInputStream(dfs,p,StandardOpenOption.READ);
-                    }else {
-                        inputStream = new SequenceInputStream(inputStream,newInputStream(dfs,p,StandardOpenOption.READ));
-                    }
+            for (String file : dfs.getExistingFiles(s, "*")) {
+                if(inputStream==null){
+                    inputStream = newInputStream(dfs,file,StandardOpenOption.READ);
+                }else {
+                    inputStream = new SequenceInputStream(inputStream,newInputStream(dfs,file,StandardOpenOption.READ));
                 }
             }
             value = inputStream;
         }else{
-            value = newInputStream(dfs,dfs.getPath(s),StandardOpenOption.READ);
+            value = newInputStream(dfs,s,StandardOpenOption.READ);
         }
         return value;
     }

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIDriver.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIDriver.java
@@ -88,7 +88,6 @@ public class SIDriver {
     private final DataFilterFactory filterFactory;
     private final Clock clock;
     private final AsyncReadResolver readResolver;
-    private final DistributedFileSystem fileSystem;
     private final OperationFactory baseOpFactory;
     private final PartitionInfoCache partitionInfoCache;
     private final SnowflakeFactory snowflakeFactory;
@@ -122,7 +121,6 @@ public class SIDriver {
         this.lifecycleManager =clientTxnLifecycleManager;
         readController = new SITransactionReadController(txnSupplier);
         readResolver = initializedReadResolver(config,env.keyedReadResolver());
-        this.fileSystem = env.fileSystem();
         this.baseOpFactory = env.baseOperationFactory();
         this.env = env;
     }
@@ -219,10 +217,6 @@ public class SIDriver {
 
     public Clock getClock(){
         return clock;
-    }
-
-    public DistributedFileSystem fileSystem(){
-        return fileSystem;
     }
 
     public DistributedFileSystem getFileSystem(String path) throws URISyntaxException, IOException {

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIEnvironment.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIEnvironment.java
@@ -67,8 +67,6 @@ public interface SIEnvironment{
 
     KeyedReadResolver keyedReadResolver();
 
-    DistributedFileSystem fileSystem();
-
     /**
      *
      * Retrieve the appropriate filesystem based on the path and configuration.


### PR DESCRIPTION
We were mixing APIs at different places, sometimes using the local filesystem and sometimes the correct filesystem.

I also removed a bunch of dangerous APIs such as SIDriver.driver().fileSystem() and made DistributedFilesystem not extend FileSystemProvider.

Tested this on a MapR cluster, the original test case passes, both running on control or Spark. I tested other filesystems (webhdfs) and exports. I didn't test backups/restores.

This fixes SPLICE-21 also which is the same issue.