### PR TITLE
SPLICE-1433 Fix drop pinned table case (2.5)

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
@@ -52,6 +52,18 @@ public class SpliceSpark {
 
     // Sets both ctx and session
     public static synchronized SparkSession getSession() {
+        String threadName = Thread.currentThread().getName();
+        if (!threadName.startsWith("olap-worker-")) {
+             // Not running on the Olap Server... raise exception. Use getSessionUnsafe() if you know what you are doing.
+            throw new RuntimeException("Trying to get a SparkSession from outside the OlapServer");
+        }
+        return getSessionUnsafe();
+    }
+
+    /** This method is unsafe, it should only be used on tests are as a convenience when trying to
+     * get a local Spark Context, it should never be used when implementing Splice operations or functions
+     */
+    public static synchronized SparkSession getSessionUnsafe() {
         if (!initialized) {
             session = initializeSparkSession();
             ctx =  new JavaSparkContext(session.sparkContext());
@@ -64,10 +76,16 @@ public class SpliceSpark {
         return session;
     }
 
-
-
     public static synchronized JavaSparkContext getContext() {
         SparkSession s = getSession();
+        return ctx;
+    }
+
+    /** This method is unsafe, it should only be used on tests are as a convenience when trying to
+     * get a local Spark Context, it should never be used when implementing Splice operations or functions
+     */
+    public static synchronized JavaSparkContext getContextUnsafe() {
+        SparkSession s = getSessionUnsafe();
         return ctx;
     }
 

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/PinTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/PinTableIT.java
@@ -44,6 +44,8 @@ public class PinTableIT extends SpliceUnitTest{
     private static final SpliceTableWatcher spliceTableWatcher3 = new SpliceTableWatcher("PinTable3",SCHEMA_NAME,"(col1 int)");
     private static final SpliceTableWatcher spliceTableWatcher4 = new SpliceTableWatcher("PinTable4",SCHEMA_NAME,"(col1 int)");
     private static final SpliceTableWatcher spliceTableWatcher5 = new SpliceTableWatcher("PinTable5",SCHEMA_NAME,"(col1 int)");
+    private static final SpliceTableWatcher spliceTableWatcher6 = new SpliceTableWatcher("PinTable6",SCHEMA_NAME,"(col1 int)");
+    private static final SpliceTableWatcher spliceTableWatcher7 = new SpliceTableWatcher("PinTable7",SCHEMA_NAME,"(col1 int)");
 
     @Rule
     public SpliceWatcher methodWatcher = new SpliceWatcher(SCHEMA_NAME);
@@ -55,7 +57,9 @@ public class PinTableIT extends SpliceUnitTest{
             .around(spliceTableWatcher2)
             .around(spliceTableWatcher3)
             .around(spliceTableWatcher4)
-            .around(spliceTableWatcher5);
+            .around(spliceTableWatcher5)
+            .around(spliceTableWatcher6)
+            .around(spliceTableWatcher7);
     @Test
     public void testPinTableDoesNotExist() throws Exception {
         try {
@@ -152,5 +156,30 @@ public class PinTableIT extends SpliceUnitTest{
         } catch (SQLException e) {
             Assert.assertEquals("Wrong Exception","EXT30",e.getSQLState());
         }
+    }
+
+    @Test
+    public void testDropPinnedTable() throws Exception {
+        methodWatcher.executeUpdate("insert into PinTable6 values (1)");
+        methodWatcher.executeUpdate("pin table PinTable6");
+        ResultSet rs = methodWatcher.executeQuery("select * from PinTable6 --splice-properties pin=true");
+        Assert.assertEquals("COL1 |\n" +
+                "------\n" +
+                "  1  |", TestUtils.FormattedResult.ResultFactory.toString(rs));
+
+        methodWatcher.executeUpdate("drop table PinTable6");
+    }
+
+    @Test
+    public void testDropUnpinnedTable() throws Exception {
+        methodWatcher.executeUpdate("insert into PinTable7 values (1)");
+        methodWatcher.executeUpdate("pin table PinTable7");
+        ResultSet rs = methodWatcher.executeQuery("select * from PinTable7 --splice-properties pin=true");
+        Assert.assertEquals("COL1 |\n" +
+                "------\n" +
+                "  1  |", TestUtils.FormattedResult.ResultFactory.toString(rs));
+
+        methodWatcher.executeUpdate("unpin table PinTable7");
+        methodWatcher.executeUpdate("drop table PinTable7");
     }
 }

--- a/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/SMOutputFormatTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/SMOutputFormatTest.java
@@ -40,7 +40,7 @@ public class SMOutputFormatTest extends BaseStreamTest {
 
     @Test
     public void readExceptionsCauseAbort() throws StandardException, IOException {
-        SparkPairDataSet<ExecRow, ExecRow> dataset = new SparkPairDataSet<>(SpliceSpark.getContext().parallelizePairs(tenRows).mapToPair(new FailFunction()));
+        SparkPairDataSet<ExecRow, ExecRow> dataset = new SparkPairDataSet<>(SpliceSpark.getContextUnsafe().parallelizePairs(tenRows).mapToPair(new FailFunction()));
         JavaPairRDD<ExecRow, Either<Exception, ExecRow>> rdd = dataset.wrapExceptions();
 
         final Configuration conf=new Configuration(HConfiguration.unwrapDelegate());
@@ -62,7 +62,7 @@ public class SMOutputFormatTest extends BaseStreamTest {
 
     @Test
     public void writeExceptionsCauseAbort() throws StandardException, IOException {
-        SparkPairDataSet<RowLocation, ExecRow> dataset = new SparkPairDataSet<>(SpliceSpark.getContext().parallelizePairs(tenRows).mapToPair(new ToRowLocationFunction()));
+        SparkPairDataSet<RowLocation, ExecRow> dataset = new SparkPairDataSet<>(SpliceSpark.getContextUnsafe().parallelizePairs(tenRows).mapToPair(new ToRowLocationFunction()));
         JavaPairRDD<RowLocation, Either<Exception, ExecRow>> rdd = dataset.wrapExceptions();
 
         final Configuration conf=new Configuration(HConfiguration.unwrapDelegate());
@@ -84,7 +84,7 @@ public class SMOutputFormatTest extends BaseStreamTest {
 
     @Test
     public void abortNotCalled() throws StandardException, IOException {
-        SparkPairDataSet<RowLocation, ExecRow> dataset = new SparkPairDataSet<>(SpliceSpark.getContext().parallelizePairs(tenRows).mapToPair(new ToRowLocationFunction()));
+        SparkPairDataSet<RowLocation, ExecRow> dataset = new SparkPairDataSet<>(SpliceSpark.getContextUnsafe().parallelizePairs(tenRows).mapToPair(new ToRowLocationFunction()));
         JavaPairRDD<RowLocation, Either<Exception, ExecRow>> rdd = dataset.wrapExceptions();
 
         final Configuration conf=new Configuration(HConfiguration.unwrapDelegate());

--- a/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/SparkDataSetTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/SparkDataSetTest.java
@@ -51,7 +51,7 @@ public class SparkDataSetTest extends AbstractDataSetTest{
 
     @Override
     protected DataSet<ExecRow> getTenRowsTwoDuplicateRecordsDataSet() {
-        return new SparkDataSet<>(SpliceSpark.getContext().parallelize(tenRowsTwoDuplicateRecords));
+        return new SparkDataSet<>(SpliceSpark.getContextUnsafe().parallelize(tenRowsTwoDuplicateRecords));
     }
 // Supported join types include: 'inner', 'outer', 'full', 'fullouter', 'leftouter', 'left', 'rightouter', 'right', 'leftsemi', 'leftanti'
     @Test
@@ -75,12 +75,12 @@ public class SparkDataSetTest extends AbstractDataSetTest{
                 .select(new Column("0"),new Column("1"))
                 .filter(col("0").gt(1).or(col("0").lt(4))).explain(true);
 */
-        SpliceSpark.getSession().createDataFrame(foo,schema).write().format("orc").mode(SaveMode.Append)
+        SpliceSpark.getSessionUnsafe().createDataFrame(foo,schema).write().format("orc").mode(SaveMode.Append)
                 .orc("/Users/jleach/Documents/workspace/spliceengine/hbase_sql/target/external/orc_it");
 
         Column filter = (new Column("col1")).gt(1l).and(new Column("col1").lt(1l));
 
-        SpliceSpark.getSession().read().schema(schema)
+        SpliceSpark.getSessionUnsafe().read().schema(schema)
                 .orc("/Users/jleach/Documents/workspace/spliceengine/hbase_sql/target/external/orc_it")
                 .filter(filter).show();
 //                .select(new Column("0"),new Column("1")).show();

--- a/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/SparkPairDataSetTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/SparkPairDataSetTest.java
@@ -28,11 +28,11 @@ public class SparkPairDataSetTest extends AbstractPairDataSetTest{
 
     @Override
     protected PairDataSet<ExecRow, ExecRow> getTenRows() {
-        return new SparkPairDataSet<>(SpliceSpark.getContext().parallelizePairs(tenRows));
+        return new SparkPairDataSet<>(SpliceSpark.getContextUnsafe().parallelizePairs(tenRows));
     }
 
     @Override
     protected PairDataSet<ExecRow, ExecRow> getEvenRows() {
-        return new SparkPairDataSet<>(SpliceSpark.getContext().parallelizePairs(evenRows));
+        return new SparkPairDataSet<>(SpliceSpark.getContextUnsafe().parallelizePairs(evenRows));
     }
 }

--- a/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/DataFrameIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/DataFrameIT.java
@@ -38,6 +38,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.Assert;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -62,6 +63,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Created by mzweben on 8/25/16.
  */
+@Ignore("SPLICE-1444")
 public class DataFrameIT extends SpliceUnitTest {
 
     private static Logger LOG = Logger.getLogger(DataFrameIT.class);

--- a/hbase_sql/src/test/java/com/splicemachine/stream/StreamableRDDTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/stream/StreamableRDDTest.java
@@ -55,7 +55,7 @@ public class StreamableRDDTest extends BaseStreamTest implements Serializable {
         StreamListener<ExecRow> sl = new StreamListener<>();
         HostAndPort hostAndPort = server.getHostAndPort();
         server.register(sl);
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(tenRows, 10);
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(tenRows, 10);
         StreamableRDD srdd = new StreamableRDD(rdd.values(), sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort());
         srdd.submit();
         Iterator<ExecRow> it = sl.getIterator();
@@ -79,7 +79,7 @@ public class StreamableRDDTest extends BaseStreamTest implements Serializable {
         List<Tuple2<ExecRow,ExecRow>> shuffledRows = new ArrayList<>(tenRows);
         Collections.shuffle(shuffledRows);
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(shuffledRows, 10);
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(shuffledRows, 10);
         JavaRDD<ExecRow> sorted = rdd.values().sortBy(new Function<ExecRow, Integer>() {
             @Override
             public Integer call(ExecRow execRow) throws Exception {
@@ -114,7 +114,7 @@ public class StreamableRDDTest extends BaseStreamTest implements Serializable {
             manyRows.add(new Tuple2<ExecRow, ExecRow>(getExecRow(i, 1), getExecRow(i, 2)));
         }
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(manyRows, 6);
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(manyRows, 6);
         final StreamableRDD srdd = new StreamableRDD(rdd.values(), sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort());
         new Thread() {
             @Override
@@ -149,7 +149,7 @@ public class StreamableRDDTest extends BaseStreamTest implements Serializable {
             manyRows.add(new Tuple2<ExecRow, ExecRow>(getExecRow(i, 1), getExecRow(i, 2)));
         }
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(manyRows, 12);
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(manyRows, 12);
         final StreamableRDD srdd = new StreamableRDD(rdd.values(), sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort());
         new Thread() {
             @Override
@@ -184,7 +184,7 @@ public class StreamableRDDTest extends BaseStreamTest implements Serializable {
             manyRows.add(new Tuple2<ExecRow, ExecRow>(getExecRow(i, 1), getExecRow(i, 2)));
         }
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(manyRows, 13);
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(manyRows, 13);
         final StreamableRDD srdd = new StreamableRDD(rdd.values(), sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort());
         new Thread() {
             @Override
@@ -222,7 +222,7 @@ public class StreamableRDDTest extends BaseStreamTest implements Serializable {
             manyRows.add(new Tuple2<ExecRow, ExecRow>(getExecRow(i, 1), getExecRow(i, 2)));
         }
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(manyRows, 1);
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(manyRows, 1);
         final StreamableRDD srdd = new StreamableRDD(rdd.values(), sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort());
         new Thread() {
             @Override
@@ -263,7 +263,7 @@ public class StreamableRDDTest extends BaseStreamTest implements Serializable {
             manyRows.add(new Tuple2<ExecRow, ExecRow>(getExecRow(i, 1), getExecRow(i, 2)));
         }
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(manyRows, 1);
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(manyRows, 1);
         final StreamableRDD srdd = new StreamableRDD(rdd.values(), null, sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort(), batches, batchSize);
         new Thread() {
             @Override
@@ -300,7 +300,7 @@ public class StreamableRDDTest extends BaseStreamTest implements Serializable {
             manyRows.add(new Tuple2<ExecRow, ExecRow>(getExecRow(i, 1), getExecRow(i, 2)));
         }
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(manyRows, 13);
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(manyRows, 13);
         final StreamableRDD srdd = new StreamableRDD(rdd.values(), sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort());
         new Thread() {
             @Override
@@ -337,7 +337,7 @@ public class StreamableRDDTest extends BaseStreamTest implements Serializable {
             manyRows.add(new Tuple2<ExecRow, ExecRow>(getExecRow(i, 1), getExecRow(i, 2)));
         }
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(manyRows, 13);
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(manyRows, 13);
         final StreamableRDD srdd = new StreamableRDD(rdd.values(), sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort());
         new Thread() {
             @Override
@@ -373,7 +373,7 @@ public class StreamableRDDTest extends BaseStreamTest implements Serializable {
             manyRows.add(new Tuple2<ExecRow, ExecRow>(getExecRow(i, 1), getExecRow(i, 2)));
         }
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(manyRows, 13);
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(manyRows, 13);
         final StreamableRDD srdd = new StreamableRDD(rdd.values(), sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort());
         new Thread() {
             @Override
@@ -414,7 +414,7 @@ public class StreamableRDDTest extends BaseStreamTest implements Serializable {
             manyRows.add(new Tuple2<ExecRow, ExecRow>(getExecRow(i, 1), getExecRow(i, 2)));
         }
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(manyRows, 12);
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(manyRows, 12);
         final StreamableRDD srdd1 = new StreamableRDD(rdd.values(), sl1.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort());
         final StreamableRDD srdd2 = new StreamableRDD(rdd.values().map(new Function<ExecRow,ExecRow>() {
             @Override

--- a/hbase_sql/src/test/java/com/splicemachine/stream/StreamableRDDTest_Failures.java
+++ b/hbase_sql/src/test/java/com/splicemachine/stream/StreamableRDDTest_Failures.java
@@ -66,7 +66,7 @@ public class StreamableRDDTest_Failures extends BaseStreamTest implements Serial
         StreamListener<ExecRow> sl = new StreamListener<>();
         HostAndPort hostAndPort = server.getHostAndPort();
         server.register(sl);
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(tenRows, 2).mapToPair(new FailsFunction(3));
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(tenRows, 2).mapToPair(new FailsFunction(3));
         StreamableRDD srdd = new StreamableRDD(rdd.values(), sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort());
         srdd.submit();
         Iterator<ExecRow> it = sl.getIterator();
@@ -86,7 +86,7 @@ public class StreamableRDDTest_Failures extends BaseStreamTest implements Serial
         StreamListener<ExecRow> sl = new StreamListener<>();
         HostAndPort hostAndPort = server.getHostAndPort();
         server.register(sl);
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(tenRows, 20).mapToPair(new FailsFunction(4));
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(tenRows, 20).mapToPair(new FailsFunction(4));
         StreamableRDD srdd = new StreamableRDD(rdd.values(), sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort());
         srdd.submit();
         Iterator<ExecRow> it = sl.getIterator();
@@ -115,7 +115,7 @@ public class StreamableRDDTest_Failures extends BaseStreamTest implements Serial
             manyRows.add(new Tuple2<ExecRow, ExecRow>(getExecRow(i, 1), getExecRow(i, 2)));
         }
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(manyRows, 2).sortByKey().mapToPair(new FailsFunction(5000));
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(manyRows, 2).sortByKey().mapToPair(new FailsFunction(5000));
         final StreamableRDD srdd = new StreamableRDD(rdd.values(), null, sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort(), batches, batchSize);
         new Thread() {
             @Override
@@ -152,7 +152,7 @@ public class StreamableRDDTest_Failures extends BaseStreamTest implements Serial
             manyRows.add(new Tuple2<ExecRow, ExecRow>(getExecRow(i, 1), getExecRow(i, 2)));
         }
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(manyRows, 12).sortByKey().mapToPair(new FailsFunction(10000));
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(manyRows, 12).sortByKey().mapToPair(new FailsFunction(10000));
         final StreamableRDD srdd = new StreamableRDD(rdd.values(), null, sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort(), batches, batchSize);
         new Thread() {
             @Override
@@ -186,7 +186,7 @@ public class StreamableRDDTest_Failures extends BaseStreamTest implements Serial
             manyRows.add(new Tuple2<ExecRow, ExecRow>(getExecRow(i, 1), getExecRow(i, 2)));
         }
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(manyRows, 13).mapToPair(new FailsFunction(29500));;
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(manyRows, 13).mapToPair(new FailsFunction(29500));;
         final StreamableRDD srdd = new StreamableRDD(rdd.values(), sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort());
         new Thread() {
             @Override
@@ -222,7 +222,7 @@ public class StreamableRDDTest_Failures extends BaseStreamTest implements Serial
             manyRows.add(new Tuple2<ExecRow, ExecRow>(getExecRow(i, 1), getExecRow(i, 2)));
         }
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(manyRows, 13).mapToPair(new FailsFunction(200));;
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(manyRows, 13).mapToPair(new FailsFunction(200));;
         final StreamableRDD srdd = new StreamableRDD(rdd.values(), sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort());
         new Thread() {
             @Override
@@ -259,7 +259,7 @@ public class StreamableRDDTest_Failures extends BaseStreamTest implements Serial
             manyRows.add(new Tuple2<ExecRow, ExecRow>(getExecRow(i, 1), getExecRow(i, 2)));
         }
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(manyRows, 13).mapToPair(new FailsFunction(14000));;
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(manyRows, 13).mapToPair(new FailsFunction(14000));;
         final StreamableRDD srdd = new StreamableRDD(rdd.values(), sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort());
         new Thread() {
             @Override
@@ -295,7 +295,7 @@ public class StreamableRDDTest_Failures extends BaseStreamTest implements Serial
             manyRows.add(new Tuple2<ExecRow, ExecRow>(getExecRow(i, 1), getExecRow(i, 2)));
         }
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(manyRows, 13).mapToPair(new FailsFunction(40301));;
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(manyRows, 13).mapToPair(new FailsFunction(40301));;
         final StreamableRDD srdd = new StreamableRDD(rdd.values(), sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort());
         new Thread() {
             @Override
@@ -336,7 +336,7 @@ public class StreamableRDDTest_Failures extends BaseStreamTest implements Serial
             manyRows.add(new Tuple2<ExecRow, ExecRow>(getExecRow(i, 1), getExecRow(i, 2)));
         }
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(manyRows, 2).sortByKey().mapToPair(new FailsTwiceFunction(10000, 100));
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(manyRows, 2).sortByKey().mapToPair(new FailsTwiceFunction(10000, 100));
         final StreamableRDD srdd = new StreamableRDD(rdd.values(), null, sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort(), batches, batchSize);
         new Thread() {
             @Override
@@ -373,7 +373,7 @@ public class StreamableRDDTest_Failures extends BaseStreamTest implements Serial
             manyRows.add(new Tuple2<ExecRow, ExecRow>(getExecRow(i, 1), getExecRow(i, 2)));
         }
 
-        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContext().parallelizePairs(manyRows, 2).sortByKey().mapToPair(new FailsTwiceFunction(10000, 2000));
+        JavaPairRDD<ExecRow, ExecRow> rdd = SpliceSpark.getContextUnsafe().parallelizePairs(manyRows, 2).sortByKey().mapToPair(new FailsTwiceFunction(10000, 2000));
         final StreamableRDD srdd = new StreamableRDD(rdd.values(), null, sl.getUuid(), hostAndPort.getHostText(), hostAndPort.getPort(), batches, batchSize);
         new Thread() {
             @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropTableConstantOperation.java
@@ -20,6 +20,7 @@ import com.splicemachine.db.impl.sql.catalog.DataDictionaryCache;
 import com.splicemachine.db.impl.sql.catalog.TableKey;
 import com.splicemachine.ddl.DDLMessage.*;
 import com.splicemachine.derby.ddl.DDLUtils;
+import com.splicemachine.derby.impl.sql.execute.pin.RemoteDropPinJob;
 import com.splicemachine.derby.impl.store.access.SpliceTransactionManager;
 import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
@@ -179,7 +180,11 @@ public class DropTableConstantOperation extends DDLSingleTableConstantOperation 
 
             /* is the table pinned ? , if yes we need to drop it */
             if(td.isPinned()){
-                EngineDriver.driver().processorFactory().distributedProcessor().dropPinnedTable(td.getHeapConglomerateId());
+                try {
+                    EngineDriver.driver().getOlapClient().execute(new RemoteDropPinJob(heapId));
+                } catch (Exception e) {
+                    throw StandardException.plainWrapException(e);
+                }
             }
 
         } catch (Exception e) {


### PR DESCRIPTION
Protect unsafe API SpliceSpark.getSession/Context against misuse, add
explicit Unsafe versions for testing and handful of legitimate cases

(backport to 2.5)