### PR TITLE
SPLICE-1464: dump csv schema for external table

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -931,4 +931,34 @@ public class ExternalTableIT extends SpliceUnitTest{
         rs2.close();
     }
 
+    @Test
+    public void testUsingExsitingCsvFile() throws Exception {
+
+        // Create an external table stored as text
+        methodWatcher.executeUpdate(String.format("CREATE EXTERNAL TABLE EXT_TEXT (id INT, c_text varchar(30)) \n" +
+                "ROW FORMAT DELIMITED \n" +
+                "FIELDS TERMINATED BY ','\n" +
+                "STORED AS TEXTFILE\n" +
+                "location '%s'", getExternalResourceDirectory() + "testUsingExsitingCsvFile"));
+
+        // insert into the table
+        methodWatcher.execute("insert into EXT_TEXT values (1, 'text1'), (2, 'text2'), (3, 'text3'), (4, 'text4')");
+        ResultSet rs = methodWatcher.executeQuery("select * from ext_text order by 1");
+        String before = TestUtils.FormattedResult.ResultFactory.toString(rs);
+
+        // drop and recreate another external table using previous data
+        methodWatcher.execute("drop table ext_text");
+
+        methodWatcher.executeUpdate(String.format("CREATE EXTERNAL TABLE EXT_TEXT2 (id INT, c_text varchar(30)) \n" +
+                "ROW FORMAT DELIMITED \n" +
+                "FIELDS TERMINATED BY ','\n" +
+                "STORED AS TEXTFILE\n" +
+                "location '%s'", getExternalResourceDirectory() + "testUsingExsitingCsvFile"));
+
+        rs = methodWatcher.executeQuery("select * from ext_text2 order by 1");
+        String after = TestUtils.FormattedResult.ResultFactory.toString(rs);
+
+        Assert.assertEquals(after, before, after);
+
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
@@ -357,7 +357,7 @@ public class ControlDataSetProcessor implements DataSetProcessor{
     }
 
     @Override
-    public StructType getExternalFileSchema(String storedAs, String location) {
+    public StructType getExternalFileSchema(String storedAs, String location) throws IOException {
         DistributedDataSetProcessor proc = EngineDriver.driver().processorFactory().distributedProcessor();
         return proc.getExternalFileSchema(storedAs,location);
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
@@ -24,6 +24,7 @@ import com.splicemachine.derby.impl.sql.execute.operations.LocatedRow;
 import com.splicemachine.derby.stream.function.Partitioner;
 import org.apache.spark.sql.types.StructType;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
 
@@ -162,7 +163,7 @@ public interface DataSetProcessor {
      * @param location
      * @return
      */
-    public StructType getExternalFileSchema(String storedAs, String location);
+    public StructType getExternalFileSchema(String storedAs, String location) throws IOException;
     /**
      * This is used when someone modify the external table outside of Splice.
      * One need to refresh the schema table if the underlying file have been modify outside Splice because


### PR DESCRIPTION
Schema information is not available for csv files of an external table. This patch dumps schema into to external table directory for validation when an external table is created using exiting csv files.