### PR TITLE
SPLICE-1478 Fixing Statement Limits

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/serialization/SpliceObserverInstructions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/serialization/SpliceObserverInstructions.java
@@ -212,7 +212,7 @@ public class SpliceObserverInstructions implements Externalizable{
         public void writeExternal(ObjectOutput out) throws IOException{
             out.writeBoolean(statementAtomic);
             out.writeBoolean(statementReadOnly);
-            out.writeUTF(stmtText);
+            out.writeObject(stmtText);
             out.writeBoolean(stmtRollBackParentContext);
             out.writeLong(stmtTimeout);
             out.writeBoolean(pvs!=null);
@@ -227,7 +227,7 @@ public class SpliceObserverInstructions implements Externalizable{
         public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException{
             this.statementAtomic=in.readBoolean();
             this.statementReadOnly=in.readBoolean();
-            this.stmtText=in.readUTF();
+            this.stmtText=(String)in.readObject();
             this.stmtRollBackParentContext=in.readBoolean();
             this.stmtTimeout=in.readLong();
             if(in.readBoolean()){
@@ -271,6 +271,9 @@ public class SpliceObserverInstructions implements Externalizable{
             return null;
         }
 
+        public String getStatementTxt() {
+            return stmtText;
+        }
     }
 
     public SchemaDescriptor getDefaultSchemaDescriptor(){

--- a/splice_machine/src/test/java/com/splicemachine/derby/serialization/ActivationSerializerTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/serialization/ActivationSerializerTest.java
@@ -19,6 +19,7 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.splicemachine.SpliceKryoRegistry;
+import com.splicemachine.db.iapi.sql.ParameterValueSet;
 import com.splicemachine.si.testenv.ArchitectureIndependent;
 import com.splicemachine.utils.kryo.KryoObjectInput;
 import com.splicemachine.utils.kryo.KryoObjectOutput;
@@ -27,9 +28,16 @@ import com.splicemachine.db.iapi.types.SQLChar;
 import com.splicemachine.db.iapi.types.SQLInteger;
 import com.splicemachine.db.iapi.types.SQLVarchar;
 import com.splicemachine.utils.kryo.KryoPool;
+import org.apache.commons.io.IOExceptionWithCause;
+import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 /**
  * @author Scott Fines
@@ -100,5 +108,37 @@ public class ActivationSerializerTest {
         ActivationSerializer.DataValueStorage dvs = (ActivationSerializer.DataValueStorage)koi.readObject();
 
         Assert.assertEquals("Incorrect ser/de", dvd.getString(), ((DataValueDescriptor) dvs.getValue(null)).getString());
+    }
+
+    @Test
+    public void canSerdeStatementTextLargerThanUTF8Limit() throws Exception {
+        ObjectOutputStream oos = null;
+        ObjectInputStream ois = null;
+        try {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 65535 + 1; i++) {
+                sb.append('A');
+            }
+            SpliceObserverInstructions.ActivationContext context =
+                    new SpliceObserverInstructions.ActivationContext(null,
+                            true, true,
+                            sb.toString(), false, 100,
+                            "foo".getBytes());
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            oos = new ObjectOutputStream(baos);
+            context.writeExternal(oos);
+            oos.flush();
+            ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+            ois = new ObjectInputStream(bais);
+            SpliceObserverInstructions.ActivationContext context2 = new SpliceObserverInstructions.ActivationContext();
+            context2.readExternal(ois);
+            Assert.assertEquals("Serde Incorrect",context.getStatementTxt(),context2.getStatementTxt());
+        } finally {
+            if (oos!=null)
+                oos.close();
+            if (ois !=null)
+                ois.close();
+            }
+
     }
 }


### PR DESCRIPTION
Allows for arbitrary statement length vs. putting a UTF serde limit on it.