### PR TITLE
SPLICE-1423: clean up import error messages for bad file

### DIFF
--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -8682,7 +8682,7 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
 						</msg>
 						<msg>
 							<name>SE009</name>
-							<text>Too many bad records in import, please check bad records file {0}</text>
+							<text>Too many bad records in import, please check bad records in directory {0}</text>
                             <arg>file</arg>
                         </msg>
 						<msg>

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/InsertDataSetWriter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/InsertDataSetWriter.java
@@ -96,7 +96,7 @@ public class InsertDataSetWriter<K,V> implements DataSetWriter{
                 long numBadRecords = opContext.getBadRecords();
                 valueRow.setColumn(2,new SQLLongint(numBadRecords));
                 if (numBadRecords > 0) {
-                    String fileName = opContext.getBadRecordFileName();
+                    String fileName = opContext.getStatusDirectory();
                     valueRow.setColumn(3,new SQLVarchar(fileName));
                     if (insertOperation.isAboveFailThreshold(numBadRecords)) {
                         throw ErrorState.LANG_IMPORT_TOO_MANY_BAD_RECORDS.newException(fileName);

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkOperationContext.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkOperationContext.java
@@ -421,9 +421,9 @@ public class SparkOperationContext<Op extends SpliceOperation> implements Operat
     }
 
     @Override
-    public String getBadRecordFileName() {
+    public String getStatusDirectory() {
         // can only be called after we're back on the client side since we need to reference accumulator value
-        return (getBadRecordsRecorder() != null ? getBadRecordsRecorder().getBadRecordFileName() : "");
+        return (getBadRecordsRecorder() != null ? getBadRecordsRecorder().getStatusDirectory() : "");
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/load/HdfsImport.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/load/HdfsImport.java
@@ -370,7 +370,8 @@ public class HdfsImport {
                 ! insertColumnListString.toLowerCase().equals("null")) {
                 insertColumnList = normalizeIdentifierList(insertColumnListString);
             }
-
+            // Remove trailing back slash
+            badRecordDirectory = badRecordDirectory.replaceAll("/$", "");
             ColumnInfo columnInfo = new ColumnInfo(conn, schemaName, tableName, insertColumnList);
             String insertSql = "INSERT INTO " + entityName + "(" + columnInfo.getInsertColumnNames() + ") " +
                 "--splice-properties useSpark=true , insertMode=" + (isUpsert ? "UPSERT" : "INSERT") + ", statusDirectory=" +

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/BadRecordsRecorder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/BadRecordsRecorder.java
@@ -53,6 +53,7 @@ public class BadRecordsRecorder implements Externalizable, Closeable {
     private long badRecordTolerance;
     private long numberOfBadRecords = 0L;
     private String badRecordMasterPath;
+    private String statusDirectory;
     private transient OutputStream fileOut;
     private String filePath;
     private int fileCounter = 0; // When we close the stream we increment the counter so there's no collision
@@ -70,6 +71,7 @@ public class BadRecordsRecorder implements Externalizable, Closeable {
      *                           bad records.
      */
     public BadRecordsRecorder(String statusDirectory, String inputFilePath, long badRecordTolerance) {
+        this.statusDirectory = statusDirectory;
         this.badRecordTolerance = badRecordTolerance;
         try {
             this.badRecordMasterPath = generateWritableFilePath(statusDirectory, inputFilePath, BAD_EXTENSION);
@@ -240,6 +242,7 @@ public class BadRecordsRecorder implements Externalizable, Closeable {
         out.writeLong(badRecordTolerance);
         out.writeLong(numberOfBadRecords);
         out.writeUTF(badRecordMasterPath);
+        out.writeUTF(statusDirectory);
     }
 
     @Override
@@ -247,10 +250,15 @@ public class BadRecordsRecorder implements Externalizable, Closeable {
         badRecordTolerance = in.readLong();
         numberOfBadRecords = in.readLong();
         badRecordMasterPath = in.readUTF();
+        statusDirectory = in.readUTF();
     }
 
     @Override
     public String toString(){
         return Long.toString(numberOfBadRecords);
+    }
+
+    public String getStatusDirectory() {
+        return statusDirectory;
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetWriter.java
@@ -97,7 +97,7 @@ public class ControlDataSetWriter<K> implements DataSetWriter{
                 badRecords = (brr != null ? brr.getNumberOfBadRecords() : 0);
                 operationContext.getActivation().getLanguageConnectionContext().setFailedRecords(badRecords);
                 if(badRecords > 0){
-                    String fileName = operationContext.getBadRecordFileName();
+                    String fileName = operationContext.getStatusDirectory();
                     operationContext.getActivation().getLanguageConnectionContext().setBadFile(fileName);
                     if (insertOperation.isAboveFailThreshold(badRecords)) {
                         throw ErrorState.LANG_IMPORT_TOO_MANY_BAD_RECORDS.newException(fileName);
@@ -108,7 +108,7 @@ public class ControlDataSetWriter<K> implements DataSetWriter{
             if (badRecords > 0) {
                 valueRow = new ValueRow(3);
                 valueRow.setColumn(2, new SQLLongint(badRecords));
-                valueRow.setColumn(3, new SQLVarchar(operationContext.getBadRecordFileName()));
+                valueRow.setColumn(3, new SQLVarchar(operationContext.getStatusDirectory()));
             }
             else {
                 valueRow = new ValueRow(1);

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlOperationContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlOperationContext.java
@@ -320,8 +320,8 @@ public class ControlOperationContext<Op extends SpliceOperation> implements Oper
     }
 
     @Override
-    public String getBadRecordFileName() {
-        return (badRecordsRecorder != null ? badRecordsRecorder.getBadRecordFileName() : "");
+    public String getStatusDirectory() {
+        return (badRecordsRecorder != null ? badRecordsRecorder.getStatusDirectory() : "");
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/OperationContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/OperationContext.java
@@ -46,7 +46,7 @@ public interface OperationContext<Op extends SpliceOperation> extends Externaliz
     void setPermissive(String statusDirectory, String importFileName, long badRecordThreshold);
     boolean isFailed();
     long getBadRecords();
-    String getBadRecordFileName();
+    String getStatusDirectory();
 
     enum Scope{
         READ_TEXT_FILE("Read File"),


### PR DESCRIPTION
Change the message for import bad file from some like:

ERROR SE009: Too many bad records in import, please check bad records file /data/import_test_data/bad/nulls4.csv.bad

to

ERROR SE009: Too many bad records in import, please check bad records in directory /data/import_test_data/bad