### PR TITLE
SPLICE-1098: prevent nonnull selectivity from being 0

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/stats/StoreCostControllerImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/stats/StoreCostControllerImpl.java
@@ -219,8 +219,18 @@ public class StoreCostControllerImpl implements StoreCostController {
 
     @Override
     public double nullSelectivity(int columnNumber) {
-        return  tableStatistics.rowCount() ==0?0.0d:((double) (tableStatistics.rowCount() - tableStatistics.notNullCount(columnNumber-1)))
-                / ((double)tableStatistics.rowCount());
+        long rowCount = tableStatistics.rowCount();
+        long nonNullCount = tableStatistics.notNullCount(columnNumber-1);
+        // If a column has null values for all rows, set its null selectivity to be slightly less than 1 to prevent
+        // nonnull selectivity from being 0.
+        if (rowCount == 0)
+            return 0.0d;
+        else if (nonNullCount == 0)
+            return (double)(rowCount - 1) / (double)rowCount;
+        else
+            return (double)(rowCount - nonNullCount) / (double)rowCount;
+
+
     }
 
     @Override

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SelectivityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SelectivityIT.java
@@ -136,6 +136,14 @@ public class SelectivityIT extends SpliceUnitTest {
                         row(4, "4", "1990-01-01 23:03:20", false),
                         row(5, "5", "1995-01-01 23:03:20", false))).create();
 
+        new TableCreator(conn)
+                .withCreate("create table ts_allnulls(i int, j int)")
+                .withInsert("insert into ts_allnulls values (?, ?)")
+                .withRows(rows(
+                        row(null, null),
+                        row(null, null),
+                        row(null, null))).create();
+
         conn.createStatement().executeQuery(format(
                 "call SYSCS_UTIL.COLLECT_SCHEMA_STATISTICS('%s',false)",
                 schemaName));
@@ -399,6 +407,11 @@ public class SelectivityIT extends SpliceUnitTest {
         rowContainsQuery(2, "explain select distinct trim(cast(c1 as char(5))) as j from ts_nulls", "outputRows=5,", methodWatcher);
     }
 
+    @Test
+    public void testAllNullSelectivity() throws Exception {
+        rowContainsQuery(3, "explain select * from ts_allnulls t1, ts_allnulls t2 where t1.i = t2.i", "outputRows=1", methodWatcher);
+    }
+    
     @Test
     @Ignore
     public void testSelectColumnStatistics() throws Exception {


### PR DESCRIPTION
backport to 2.5