### PR TITLE
SPLICE-77: order by column in subquery not projected should not be resolved

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromSubquery.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromSubquery.java
@@ -358,10 +358,14 @@ public class FromSubquery extends FromTable
 		{
 		    resultColumn = resultColumns.getAtMostOneResultColumn(columnReference, correlationName, false);
 		}
-		    
+
 
 		if (resultColumn != null)
 		{
+		    if (resultColumn.pulledupOrderingColumn()) {
+		        // do not return match if the ordering column is not only in ordering list
+                return null;
+			}
 			columnReference.setTableNumber(tableNumber);
             columnReference.setColumnNumber(resultColumn.getColumnPosition());
 		}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderByColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderByColumn.java
@@ -418,6 +418,7 @@ public class OrderByColumn extends OrderedColumn {
 										    cr.getColumnName(),
 										    cr,
 										    getContextManager());
+				resultCol.markAsPulledupOrderingColumn();
 				targetCols.addResultColumn(resultCol);
                 addedColumnOffset = targetCols.getOrderBySelect();
 				targetCols.incOrderBySelect();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
@@ -103,7 +103,7 @@ public class ResultColumn extends ValueNode
 	boolean			updatableByCursor;
 	private boolean defaultColumn;
 	private boolean wasDefault;
-	private DataTypeDescriptor castToType;
+	private boolean isPulledupOrderingColumn;
 
 	//Following 2 fields have been added for DERBY-4631.
 	//rightOuterJoinUsingClause will be set to true for following 2 cases
@@ -1478,6 +1478,10 @@ public class ResultColumn extends ValueNode
 		isGroupingColumn = true;
 	}
 
+	public void markAsPulledupOrderingColumn() { isPulledupOrderingColumn = true; }
+
+	public boolean pulledupOrderingColumn() { return isPulledupOrderingColumn; }
+
 	/**
 	 * Look for and reject ?/-?/+? parameter under this ResultColumn.  This is
 	 * called for SELECT statements.
@@ -1636,6 +1640,9 @@ public class ResultColumn extends ValueNode
 
 		if (isGenerated()) {
 			newResultColumn.markGenerated();
+		}
+		if (pulledupOrderingColumn()) {
+			newResultColumn.markAsPulledupOrderingColumn();
 		}
 
 		return newResultColumn;

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Table_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Table_IT.java
@@ -23,6 +23,7 @@ import org.junit.*;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Collections;
@@ -369,6 +370,37 @@ public class Subquery_Table_IT {
                 "--------\n" +
                 "20 |30 |\n" +
                 "20 |40 |");
+    }
+
+    @Test
+    public void orderByInSubQuery() throws Exception {
+        try {
+            methodWatcher.executeQuery("select * from (select a, b from s order by d ) as vt order by d ");
+            Assert.fail("Error not thrown");
+        } catch (SQLException e) {
+            Assert.assertEquals("42X04", e.getSQLState());
+        }
+
+        try {
+            methodWatcher.executeQuery("select * from (select a, b, c from s order by c, d ) as vt order by d ");
+            Assert.fail("Error not thrown");
+        } catch (SQLException e) {
+            Assert.assertEquals("42X04", e.getSQLState());
+        }
+
+        ResultSet rs = methodWatcher.executeQuery("select * from (select a, b, d from s order by d ) as vt order by d ");
+        assertUnorderedResult(rs, "" +
+                "A | B | D |\n" +
+                "------------\n" +
+                " 0 | 1 | 3 |\n" +
+                "10 |11 |13 |");
+
+        ResultSet rs1 = methodWatcher.executeQuery("select a, b, d from (select * from s order by d ) as vt order by d ");
+        assertUnorderedResult(rs1, "" +
+                "A | B | D |\n" +
+                "------------\n" +
+                " 0 | 1 | 3 |\n" +
+                "10 |11 |13 |");
     }
 
     private static void assertUnorderedResult(ResultSet rs, String expectedResult) throws Exception {


### PR DESCRIPTION
Order by column in subquery being not projected in the subquery select list could get resolved during bind time for the outer query, which however is not in scope for the outer query and so it should be errored out. Compared the semantics with mysql which supports order by in the subquery, which does the similar error-out.
(Ran full cdh profile regression suite)
