### PR TITLE
SPLICE-1497 Add flag for inserts to skip conflict detection 

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
@@ -125,6 +125,7 @@ public interface ResultSetFactory {
 								 String insertMode,
 								 String statusDirectory,
 								 int failBadRecordCount,
+								 boolean skipConflictDetection,
                                  double optimizerEstimatedRowCount,
                                  double optimizerEstimatedCost,
                                  String tableVersion,

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InsertNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InsertNode.java
@@ -93,6 +93,7 @@ public final class InsertNode extends DMLModStatementNode {
     public static final String STATUS_DIRECTORY = "statusDirectory";
 	public static final String BAD_RECORDS_ALLOWED = "badRecordsAllowed";
 	public static final String USE_SPARK = "useSpark";
+	public static final String SKIP_CONFLICT_DETECTION = "skipConflictDetection";
     public static final String INSERT = "INSERT";
     public static final String PIN = "pin";
 
@@ -107,7 +108,8 @@ public final class InsertNode extends DMLModStatementNode {
     private     ValueNode           fetchFirst;
     private     boolean           hasJDBClimitClause; // true if using JDBC limit/offset escape syntax
     private     String              statusDirectory;
-    private     int              badRecordsAllowed = 0;
+	private     int              badRecordsAllowed = 0;
+	private     boolean              skipConflictDetection = false;
 	private CompilerContext.DataSetProcessorType dataSetProcessorType = CompilerContext.DataSetProcessorType.DEFAULT_CONTROL;
 
 
@@ -724,7 +726,7 @@ public final class InsertNode extends DMLModStatementNode {
         if(pin){
 			throw StandardException.newException(SQLState.INSERT_PIN_VIOLATION);
 		}
-
+		String skipConflictDetectionString = targetProperties.getProperty(SKIP_CONFLICT_DETECTION);
 
 		if (insertModeString != null) {
 			String upperValue = StringUtil.SQLToUpperCase(insertModeString);
@@ -743,6 +745,9 @@ public final class InsertNode extends DMLModStatementNode {
 		if (statusDirectoryString != null) {
 			// validated for writing in ImportUtils.generateFileSystemPathForWrite()
 			statusDirectory = statusDirectoryString;
+		}
+		if (skipConflictDetectionString != null) {
+			skipConflictDetection = Boolean.parseBoolean(StringUtil.SQLToUpperCase(skipConflictDetectionString));
 		}
 
 		if (useSparkString != null) {
@@ -985,7 +990,8 @@ public final class InsertNode extends DMLModStatementNode {
                 mb.pushNull("java.lang.String");
             else
                 mb.push(statusDirectory);
-            mb.push(badRecordsAllowed);
+			mb.push(badRecordsAllowed);
+			mb.push(skipConflictDetection);
             mb.push((double) this.resultSet.getFinalCostEstimate().getEstimatedRowCount());
             mb.push(this.resultSet.getFinalCostEstimate().getEstimatedCost());
             mb.push(targetTableDescriptor.getVersion());
@@ -997,7 +1003,7 @@ public final class InsertNode extends DMLModStatementNode {
 			BaseJoinStrategy.pushNullableString(mb,targetTableDescriptor.getLocation());
 			BaseJoinStrategy.pushNullableString(mb,targetTableDescriptor.getCompression());
 			mb.push(partitionReferenceItem);
-			mb.callMethod(VMOpcode.INVOKEINTERFACE, (String) null, "getInsertResultSet", ClassName.ResultSet, 17);
+			mb.callMethod(VMOpcode.INVOKEINTERFACE, (String) null, "getInsertResultSet", ClassName.ResultSet, 18);
 		}
 		else
 		{

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/SIObserver.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/SIObserver.java
@@ -227,7 +227,7 @@ public class SIObserver extends BaseRegionObserver{
                 boolean processed=false;
                 while (!processed) {
                     @SuppressWarnings("unchecked") Iterable<MutationStatus> status =
-                            region.bulkWrite(txn, fam, column.getKey(), operationStatusFactory.getNoOpConstraintChecker(), Collections.singleton(column.getValue()));
+                            region.bulkWrite(txn, fam, column.getKey(), operationStatusFactory.getNoOpConstraintChecker(), Collections.singleton(column.getValue()), false);
                     Iterator<MutationStatus> itr = status.iterator();
                     if (!itr.hasNext())
                         throw new IllegalStateException();

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/PartitionWritePipeline.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/PartitionWritePipeline.java
@@ -99,7 +99,7 @@ public class PartitionWritePipeline{
 
         WriteContext context;
         try{
-            context=ctxFactory.create(writeBufferFactory,txn,txnRegion,toWrite.getSize(),toWrite.skipIndexWrite(),rce);
+            context=ctxFactory.create(writeBufferFactory,txn,txnRegion,toWrite.getSize(),toWrite.skipIndexWrite(),toWrite.skipConflictDetection(),rce);
         }catch(InterruptedException e){
             return INTERRUPTED;
         }catch(IndexNotSetUpException e){

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/PartitionBuffer.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/PartitionBuffer.java
@@ -34,12 +34,14 @@ public class PartitionBuffer{
     private Partition partition;
     private PreFlushHook preFlushHook;
     private boolean skipIndexWrites;
+    private boolean skipConflictDetection;
 
-    public PartitionBuffer(Partition partition,PreFlushHook preFlushHook,boolean skipIndexWrites) {
+    public PartitionBuffer(Partition partition,PreFlushHook preFlushHook,boolean skipIndexWrites,boolean skipConflictDetection) {
         this.partition=partition;
         this.buffer = new ArrayList<>();
         this.preFlushHook = preFlushHook;
         this.skipIndexWrites = skipIndexWrites;
+        this.skipConflictDetection = skipConflictDetection;
     }
 
     public void add(KVPair element) throws Exception {
@@ -72,7 +74,7 @@ public class PartitionBuffer{
     }
 
     public BulkWrite getBulkWrite() throws Exception {
-        return new BulkWrite(heapSize, preFlushHook.transform(buffer), partition.getName(), skipIndexWrites);
+        return new BulkWrite(heapSize, preFlushHook.transform(buffer), partition.getName(), skipIndexWrites, skipConflictDetection);
     }
 
     /**

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/PipingCallBuffer.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/PipingCallBuffer.java
@@ -233,7 +233,7 @@ public class PipingCallBuffer implements RecordingCallBuffer<KVPair>, Rebuildabl
 //                }
 
             	// Create a new PartitionBuffer, add it to the map, and add it to the ServerCallBuffer.
-                PartitionBuffer newBuffer = new PartitionBuffer(region, preFlushHook, skipIndexWrites);
+                PartitionBuffer newBuffer = new PartitionBuffer(region, preFlushHook, skipIndexWrites, writeConfiguration.skipConflictDetection());
                 startKeyToRegionCBMap.put(startKey, Pair.newPair(newBuffer,server));
                 regionServerCB.add(Pair.newPair(startKey, newBuffer));
             } else {

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/client/PipelineEncoding.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/client/PipelineEncoding.java
@@ -41,7 +41,7 @@ public class PipelineEncoding {
          * for 1...# of BulkWrites:
          *  encodedStringName
          * for 1...# of BulkWrites:
-         *  skipWriteIndex
+         *  flags
          * for 1...# of BulkWrites:
          *  KVPairs
          *
@@ -65,7 +65,7 @@ public class PipelineEncoding {
         }
 
         for(BulkWrite bw:bws){
-            buffer.encode(bw.getSkipIndexWrite());
+            buffer.encode(bw.getFlags());
         }
 
         for(BulkWrite bw:bws){
@@ -91,12 +91,12 @@ public class PipelineEncoding {
         for(int i=0;i<bwSize;i++) {
             stringNames.add(decoder.decodeString());
         }
-        byte[] skipIndexWrites = new byte[bwSize];
+        byte[] flags = new byte[bwSize];
         for (int i=0; i<bwSize; i++) {
-            skipIndexWrites[i] = decoder.decodeByte();
+            flags[i] = decoder.decodeByte();
         }
 
-        return new BulkWrites(new BulkWriteCol(skipIndexWrites,data,decoder.currentOffset(),stringNames),txn);
+        return new BulkWrites(new BulkWriteCol(flags,data,decoder.currentOffset(),stringNames),txn);
     }
 
 
@@ -105,7 +105,7 @@ public class PipelineEncoding {
     private static class BulkWriteCol extends AbstractCollection<BulkWrite>{
         private final int kvOffset;
         private final List<String> encodedStringNames;
-        private final byte[] skipIndexWrites;
+        private final byte[] flags;
         private final byte[] buffer;
         /*
          * we keep a cache of previously created BulkWrites, so that we can have
@@ -116,11 +116,11 @@ public class PipelineEncoding {
         private transient ExpandedDecoder decoder;
         private transient int lastIndex = 0;
 
-        public BulkWriteCol(byte[] skipIndexWrites, byte[] buffer,int kvOffset, List<String> encodedStringNames) {
+        public BulkWriteCol(byte[] flags, byte[] buffer,int kvOffset, List<String> encodedStringNames) {
             this.kvOffset = kvOffset;
             this.encodedStringNames = encodedStringNames;
             this.buffer = buffer;
-            this.skipIndexWrites = skipIndexWrites;
+            this.flags = flags;
         }
 
         @Override
@@ -162,7 +162,7 @@ public class PipelineEncoding {
             @Override
             public BulkWrite next() {
                 String esN = encodedStrings.next();
-                byte skipIndexWrite = skipIndexWrites[index++];
+                byte elementFlags = flags[index++];
                 int size = decoder.decodeInt();
                 Collection<KVPair> kvPairs = new ArrayList<>(size);
                 KVPair template = new KVPair();
@@ -176,7 +176,7 @@ public class PipelineEncoding {
                 }
 
 
-                BulkWrite bulkWrite = new BulkWrite(kvPairs, esN, skipIndexWrite);
+                BulkWrite bulkWrite = new BulkWrite(kvPairs, esN, elementFlags);
                 cache.add(bulkWrite);
                 lastIndex=index;
                 return bulkWrite;

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/config/BaseWriteConfiguration.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/config/BaseWriteConfiguration.java
@@ -201,4 +201,8 @@ public abstract class BaseWriteConfiguration implements WriteConfiguration {
         return exceptionFactory;
     }
 
+    @Override
+    public boolean skipConflictDetection() {
+        return false;
+    }
 }

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/config/ForwardingWriteConfiguration.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/config/ForwardingWriteConfiguration.java
@@ -48,6 +48,11 @@ public class ForwardingWriteConfiguration implements WriteConfiguration {
     }
 
     @Override
+    public boolean skipConflictDetection() {
+        return delegate.skipConflictDetection();
+    }
+
+    @Override
     public int getMaximumRetries() {
         return delegate.getMaximumRetries();
     }

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/config/WriteConfiguration.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/config/WriteConfiguration.java
@@ -52,4 +52,6 @@ public interface WriteConfiguration {
     RecordingContext getRecordingContext();
 
     void setRecordingContext(RecordingContext recordingContext);
+
+    boolean skipConflictDetection();
 }

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/context/PipelineWriteContext.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/context/PipelineWriteContext.java
@@ -55,6 +55,7 @@ public class PipelineWriteContext implements WriteContext, Comparable<PipelineWr
     private final ServerControl env;
     private final WriteNode head;
     private final PipelineExceptionFactory pef;
+    private final boolean skipConflictDetection;
 
     private WriteNode tail;
 
@@ -63,6 +64,7 @@ public class PipelineWriteContext implements WriteContext, Comparable<PipelineWr
                                  TxnView txn,
                                  TransactionalRegion rce,
                                  boolean skipIndexWrites,
+                                 boolean skipConflictDetection,
                                  ServerControl env,
                                 PipelineExceptionFactory pef) {
         this.indexSharedCallBuffer = indexSharedCallBuffer;
@@ -74,6 +76,7 @@ public class PipelineWriteContext implements WriteContext, Comparable<PipelineWr
         this.head = this.tail = new WriteNode(null, this);
         this.partitionFactory = partitionFactory;
         this.pef = pef;
+        this.skipConflictDetection = skipConflictDetection;
     }
 
     public void addLast(WriteHandler handler) {
@@ -225,6 +228,11 @@ public class PipelineWriteContext implements WriteContext, Comparable<PipelineWr
     @Override
     public boolean skipIndexWrites() {
         return this.skipIndexWrites;
+    }
+
+    @Override
+    public boolean skipConflictDetection() {
+        return this.skipConflictDetection;
     }
 
     @Override

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/context/WriteContext.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/context/WriteContext.java
@@ -109,6 +109,8 @@ public interface WriteContext {
 
     boolean skipIndexWrites();
 
+    boolean skipConflictDetection();
+
     TransactionalRegion txnRegion();
 
     PipelineExceptionFactory exceptionFactory();

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/context/WriteNode.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/context/WriteNode.java
@@ -150,6 +150,11 @@ public class WriteNode implements WriteContext {
     }
 
     @Override
+    public boolean skipConflictDetection() {
+        return pipelineWriteContext.skipConflictDetection();
+    }
+
+    @Override
     public TransactionalRegion txnRegion(){
         return pipelineWriteContext.txnRegion();
     }

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/LocalWriteContextFactory.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/LocalWriteContextFactory.java
@@ -112,7 +112,7 @@ class LocalWriteContextFactory<TableInfo> implements WriteContextFactory<Transac
         CachedPartitionFactory<TableInfo> pf = new CachedPartitionFactory<TableInfo>(basePartitionFactory){
             @Override protected String infoAsString(TableInfo tableName){ return tableInfoParseFunction.apply(tableName); }
         };
-        PipelineWriteContext context = new PipelineWriteContext(indexSharedCallBuffer,pf, txn, rce, false, env,pipelineExceptionFactory);
+        PipelineWriteContext context = new PipelineWriteContext(indexSharedCallBuffer,pf, txn, rce, false, false, env,pipelineExceptionFactory);
         BatchConstraintChecker checker = buildConstraintChecker(txn);
         context.addLast(new PartitionWriteHandler(rce, tableWriteLatch, checker));
         addWriteHandlerFactories(1000, context);
@@ -121,13 +121,13 @@ class LocalWriteContextFactory<TableInfo> implements WriteContextFactory<Transac
 
     @Override
     public WriteContext create(SharedCallBufferFactory indexSharedCallBuffer,
-                               TxnView txn, TransactionalRegion region, int expectedWrites, boolean skipIndexWrites,
+                               TxnView txn, TransactionalRegion region, int expectedWrites, boolean skipIndexWrites, boolean skipConflictDetection,
                                ServerControl env) throws IOException, InterruptedException {
         CachedPartitionFactory<TableInfo> pf = new CachedPartitionFactory<TableInfo>(basePartitionFactory){
             @Override protected String infoAsString(TableInfo tableName){ return tableInfoParseFunction.apply(tableName); }
         };
         PipelineWriteContext context = new PipelineWriteContext(indexSharedCallBuffer,
-                pf,txn, region, skipIndexWrites, env,pipelineExceptionFactory);
+                pf,txn, region, skipIndexWrites,skipConflictDetection, env,pipelineExceptionFactory);
         BatchConstraintChecker checker = buildConstraintChecker(txn);
         context.addLast(new PartitionWriteHandler(region, tableWriteLatch, checker));
         addWriteHandlerFactories(expectedWrites, context);
@@ -158,7 +158,7 @@ class LocalWriteContextFactory<TableInfo> implements WriteContextFactory<Transac
         CachedPartitionFactory<TableInfo> pf = new CachedPartitionFactory<TableInfo>(basePartitionFactory){
             @Override protected String infoAsString(TableInfo tableName){ return tableInfoParseFunction.apply(tableName); }
         };
-        PipelineWriteContext context = new PipelineWriteContext(indexSharedCallBuffer, pf,txn, region, false, env,pipelineExceptionFactory);
+        PipelineWriteContext context = new PipelineWriteContext(indexSharedCallBuffer, pf,txn, region, false, false, env,pipelineExceptionFactory);
         addWriteHandlerFactories(expectedWrites, context);
         return context;
     }

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/WriteContextFactory.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/WriteContextFactory.java
@@ -37,6 +37,7 @@ public interface WriteContextFactory<T> {
                         T key,
                         int expectedWrites,
                         boolean skipIndexWrites,
+                        boolean skipConflictDetection,
                         ServerControl env) throws IOException, InterruptedException;
 
     /**

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/PartitionWriteHandler.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/PartitionWriteHandler.java
@@ -163,7 +163,8 @@ public class PartitionWriteHandler implements WriteHandler {
                 SIConstants.DEFAULT_FAMILY_BYTES,
                 SIConstants.PACKED_COLUMN_BYTES,
                 constraintChecker,
-                toProcess
+                toProcess,
+                ctx.skipConflictDetection()
         );
 
         int i = 0;

--- a/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
+++ b/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
@@ -594,7 +594,7 @@ public class SpliceKryoRegistry implements KryoPool.KryoRegistry{
         instance.register(BulkWrite.class,new Serializer<BulkWrite>(){
             @Override
             public void write(Kryo kryo,Output output,BulkWrite object){
-                output.writeByte(object.getSkipIndexWrite());
+                output.writeByte(object.getFlags());
                 output.writeString(object.getEncodedStringName());
                 kryo.writeClassAndObject(output,object.getMutations());
             }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -46,6 +46,7 @@ import com.splicemachine.procedures.external.ExternalTableSystemProcedures;
 public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
 
     private static final String IMPORT_DATA_NAME = "SYSCS_IMPORT_DATA";
+    private static final String IMPORT_DATA_UNSAFE_NAME = "SYSCS_IMPORT_DATA_UNSAFE";
     public static final String RESTORE_DATABASE_NAME = "SYSCS_RESTORE_DATABASE";
     public static final String BACKUP_DATABASE_NAME = "SYSCS_BACKUP_DATABASE";
 
@@ -293,6 +294,24 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                             .varchar("charset",32672)
                             .build();
                     procedures.add(importWithBadRecords);
+
+                    Procedure importUnsafe = Procedure.newBuilder().name("IMPORT_DATA_UNSAFE")
+                            .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
+                            .catalog("schemaName")
+                            .catalog("tableName")
+                            .varchar("insertColumnList",32672)
+                            .varchar("fileName",32672)
+                            .varchar("columnDelimiter",5)
+                            .varchar("characterDelimiter", 5)
+                            .varchar("timestampFormat",32672)
+                            .varchar("dateFormat",32672)
+                            .varchar("timeFormat",32672)
+                            .bigint("maxBadRecords")
+                            .varchar("badRecordDirectory",32672)
+                            .varchar("oneLineRecords",5)
+                            .varchar("charset",32672)
+                            .build();
+                    procedures.add(importUnsafe);
 
                     Procedure upport = Procedure.newBuilder().name("UPSERT_DATA_FROM_FILE")
                             .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
@@ -1116,6 +1116,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                                              String insertMode,
                                              String statusDirectory,
                                              int failBadRecordCount,
+                                             boolean skipConflictDetection,
                                              double optimizerEstimatedRowCount,
                                              double optimizerEstimatedCost,
                                              String tableVersion,
@@ -1131,7 +1132,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
         try{
             ConvertedResultSet below = (ConvertedResultSet)source;
             SpliceOperation top = new InsertOperation(below.getOperation(), generationClauses, checkGM, insertMode,
-                    statusDirectory, failBadRecordCount,optimizerEstimatedRowCount,optimizerEstimatedCost, tableVersion,
+                    statusDirectory, failBadRecordCount, skipConflictDetection, optimizerEstimatedRowCount,optimizerEstimatedCost, tableVersion,
                     delimited,escaped,lines,storedAs,location, compression, partitionBy);
             source.getActivation().getLanguageConnectionContext().getAuthorizer().authorize(source.getActivation(), 1);
             top.markAsTopResultSet();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/InsertOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/InsertOperation.java
@@ -81,7 +81,7 @@ public class InsertOperation extends DMLWriteOperation implements HasIncrement{
     protected String compression;
     protected int partitionByRefItem;
     protected int[] partitionBy;
-
+    private boolean skipConflictDetection;
 
 
     @Override
@@ -100,6 +100,7 @@ public class InsertOperation extends DMLWriteOperation implements HasIncrement{
                            String insertMode,
                            String statusDirectory,
                            int failBadRecordCount,
+                           boolean skipConflictDetection,
                            double optimizerEstimatedRowCount,
                            double optimizerEstimatedCost,
                            String tableVersion,
@@ -113,6 +114,7 @@ public class InsertOperation extends DMLWriteOperation implements HasIncrement{
         super(source,generationClauses,checkGM,source.getActivation(),optimizerEstimatedRowCount,optimizerEstimatedCost,tableVersion);
         this.insertMode=InsertNode.InsertMode.valueOf(insertMode);
         this.statusDirectory=statusDirectory;
+        this.skipConflictDetection=skipConflictDetection;
         this.failBadRecordCount = (failBadRecordCount >= 0 ? failBadRecordCount : -1);
         this.delimited = delimited;
         this.escaped = escaped;
@@ -253,6 +255,7 @@ public class InsertOperation extends DMLWriteOperation implements HasIncrement{
         location = in.readBoolean()?in.readUTF():null;
         compression = in.readBoolean()?in.readUTF():null;
         this.partitionByRefItem = in.readInt();
+        skipConflictDetection=in.readBoolean();
     }
 
     @Override
@@ -287,6 +290,7 @@ public class InsertOperation extends DMLWriteOperation implements HasIncrement{
         if (compression!=null)
             out.writeUTF(compression);
         out.writeInt(partitionByRefItem);
+        out.writeBoolean(skipConflictDetection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -349,4 +353,7 @@ public class InsertOperation extends DMLWriteOperation implements HasIncrement{
     }
 
 
+    public boolean skipConflictDetection() {
+        return skipConflictDetection;
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/PermissiveInsertWriteConfiguration.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/PermissiveInsertWriteConfiguration.java
@@ -39,10 +39,12 @@ import java.util.concurrent.ExecutionException;
  */
 public class PermissiveInsertWriteConfiguration extends ForwardingWriteConfiguration {
     private static final Logger LOG = Logger.getLogger(PermissiveInsertWriteConfiguration.class);
+    protected boolean skipConflictDetection;
     protected OperationContext operationContext;
     protected ThreadLocal<PairDecoder> pairDecoder;
 
-    public PermissiveInsertWriteConfiguration(WriteConfiguration delegate, OperationContext operationContext, PairEncoder encoder, ExecRow execRowDefinition) {
+    public PermissiveInsertWriteConfiguration(WriteConfiguration delegate, OperationContext operationContext,
+                                              final PairEncoder encoder, final ExecRow execRowDefinition, boolean skipConflictDetection) {
         super(delegate);
         assert operationContext!=null && encoder != null:"Passed in null values to PermissiveInsert";
         this.operationContext = operationContext;
@@ -52,6 +54,7 @@ public class PermissiveInsertWriteConfiguration extends ForwardingWriteConfigura
                 return encoder.getDecoder(execRowDefinition.getClone());
             }
         };
+        this.skipConflictDetection = skipConflictDetection;
     }
 
     @Override
@@ -140,6 +143,11 @@ public class PermissiveInsertWriteConfiguration extends ForwardingWriteConfigura
         }
         sb.append(": " + row);
         return sb.toString();
+    }
+
+    @Override
+    public boolean skipConflictDetection() {
+        return skipConflictDetection;
     }
 }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/insert/InsertPipelineWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/insert/InsertPipelineWriter.java
@@ -94,7 +94,7 @@ public class InsertPipelineWriter extends AbstractPipelineWriter<ExecRow>{
             if(insertOperation!=null && operationContext.isPermissive())
                     writeConfiguration = new PermissiveInsertWriteConfiguration(writeConfiguration,
                             operationContext,
-                            encoder, execRowDefinition);
+                            encoder, execRowDefinition, insertOperation.skipConflictDetection());
 
             writeConfiguration.setRecordingContext(operationContext);
             this.table =SIDriver.driver().getTableFactory().getTable(Long.toString(heapConglom));

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsUnsafeImportIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsUnsafeImportIT.java
@@ -1,0 +1,540 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.impl.load;
+
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceTableWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.test_dao.TableDAO;
+import com.splicemachine.test_tools.TableCreator;
+import org.apache.commons.io.FileUtils;
+import org.hamcrest.Matcher;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
+import org.spark_project.guava.collect.Lists;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import static com.splicemachine.test_tools.Rows.row;
+import static com.splicemachine.test_tools.Rows.rows;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class HdfsUnsafeImportIT extends SpliceUnitTest {
+    protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher();
+    public static final String CLASS_NAME = HdfsUnsafeImportIT.class.getSimpleName().toUpperCase();
+    protected static String TABLE_1 = "A";
+    protected static String TABLE_2 = "B";
+    protected static String TABLE_6 = "F";
+    protected static String TABLE_11 = "K";
+    protected static String TABLE_18 = "R";
+    protected static String TABLE_20 = "T";
+    private static final String AUTO_INCREMENT_TABLE = "INCREMENT";
+
+
+    protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
+    protected static SpliceTableWatcher spliceTableWatcher1 = new SpliceTableWatcher(TABLE_1, spliceSchemaWatcher
+            .schemaName, "(name varchar(40), title varchar(40), age int)");
+    protected static SpliceTableWatcher spliceTableWatcher2 = new SpliceTableWatcher(TABLE_2, spliceSchemaWatcher
+            .schemaName, "(name varchar(40), title varchar(40), age int,PRIMARY KEY(name))");
+    protected static SpliceTableWatcher spliceTableWatcher20 = new SpliceTableWatcher(TABLE_20, spliceSchemaWatcher
+            .schemaName, "(i int, j int check (j<15))");
+    protected static SpliceTableWatcher spliceTableWatcher6 = new SpliceTableWatcher(TABLE_6, spliceSchemaWatcher
+            .schemaName, "(name varchar(40), title varchar(40), age int)");
+    protected static SpliceTableWatcher spliceTableWatcher11 = new SpliceTableWatcher(TABLE_11, spliceSchemaWatcher
+            .schemaName, "(i int default 10, j int)");
+    protected static SpliceTableWatcher spliceTableWatcher18 = new SpliceTableWatcher(TABLE_18, spliceSchemaWatcher
+            .schemaName, "(name varchar(40), title varchar(40), age int)");
+
+    private static SpliceTableWatcher  multiLine = new SpliceTableWatcher("mytable",spliceSchemaWatcher.schemaName,
+            "(a int, b char(10),c timestamp, d varchar(100),e bigint)");
+    private static SpliceTableWatcher  multiPK = new SpliceTableWatcher("withpk",spliceSchemaWatcher.schemaName,
+            "(a int primary key)");
+
+
+    protected static SpliceTableWatcher autoIncTableWatcher = new SpliceTableWatcher(AUTO_INCREMENT_TABLE,
+            spliceSchemaWatcher.schemaName,
+            "(i int generated always as " +
+                    "identity, j int)");
+
+    @ClassRule
+    public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
+            .around(spliceSchemaWatcher)
+            .around(spliceTableWatcher1)
+            .around(spliceTableWatcher2)
+            .around(spliceTableWatcher6)
+            .around(spliceTableWatcher11)
+            .around(spliceTableWatcher18)
+            .around(spliceTableWatcher20)
+            .around(multiLine)
+            .around(multiPK)
+            .around(autoIncTableWatcher);
+
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        createDataSet();
+        BADDIR = SpliceUnitTest.createBadLogDirectory(spliceSchemaWatcher.schemaName);
+        assertNotNull(BADDIR);
+    }
+
+    private static void createDataSet() throws Exception {
+        Connection conn = spliceClassWatcher.getOrCreateConnection();
+
+        //noinspection unchecked
+        new TableCreator(conn)
+                .withCreate(format("create table %s.num_dt1 (i smallint, j int, k bigint, primary key(j))",
+                        spliceSchemaWatcher.schemaName))
+                .withInsert(format("insert into %s.num_dt1 values(?,?,?)", spliceSchemaWatcher.schemaName))
+                .withRows(rows(
+                        row(4256, 42031, 87049),
+                        row(1140, 30751, 791),
+                        row(25, 81278, 975),
+                        row(-54, 62648, 3115),
+                        row(57, 21099, 1081),
+                        row(1430, 68915, null),
+                        row(49, 19765, null),
+                        row(-31, 10610, null),
+                        row(-47, 34483, 40801),
+                        row(7694, 20015, 52662),
+                        row(35, 14202, 80476),
+                        row(9393, 61174, 68211),
+                        row(7058, 75830, null),
+                        row(302, 5770, 53257),
+                        row(3567, 15812, null),
+                        row(-71, 92497, 85),
+                        row(6229, 65149, 1583),
+                        row(-36, 53846, 9128),
+                        row(57, 95839, null),
+                        row(3832, 90042, 433),
+                        row(4818, 1483, 71600),
+                        row(4493, 31875, 75291),
+                        row(58, 85771, 3383),
+                        row(9477, 77588, null),
+                        row(6150, 88770, null),
+                        row(8755, 44597, null),
+                        row(68, 51844, 29940),
+                        row(5926, 74926, 90887),
+                        row(6017, 45829, 146),
+                        row(8053, 45192, null)))
+                .withIndex(format("create index idx1 on %s.num_dt1(k)", spliceSchemaWatcher.schemaName))
+                .create();
+    }
+
+    private static File BADDIR;
+
+    @Test
+    public void testHdfsUnsafeImport() throws Exception {
+        testImport(spliceSchemaWatcher.schemaName, TABLE_1, getResourceDirectory() + "importTest.in", "NAME,TITLE," +
+                "AGE", 0);
+    }
+
+    @Test
+    public void testImportWithPrimaryKeys() throws Exception {
+        testImport(spliceSchemaWatcher.schemaName, TABLE_2, getResourceDirectory() + "importTest.in", "NAME,TITLE," +
+                "AGE", 0);
+    }
+
+    @Test
+    public void testImportMultiFilesPKViolations() throws Exception {
+        try(PreparedStatement ps = methodWatcher.prepareStatement(format("call SYSCS_UTIL.IMPORT_DATA_UNSAFE(" +
+                        "'%s'," +  // schema name
+                        "'%s'," +  // table name
+                        "null," +  // insert column list
+                        "'%s'," +  // file path
+                        "','," +   // column delimiter
+                        "null," +  // character delimiter
+                        "null," +  // timestamp format
+                        "null," +  // date format
+                        "null," +  // time format
+                        "-1," +    // max bad records
+                        "'%s'," +  // bad record dir
+                        "'true'," +  // has one line records
+                        "null)",   // char set
+                spliceSchemaWatcher.schemaName,multiPK.tableName, getResourceDirectory()+"/multiFilePKViolation",
+                BADDIR.getCanonicalPath()))){
+            try (ResultSet rs = ps.executeQuery()) {
+                assertTrue(rs.next());
+
+                int failed = rs.getInt(2);
+                // With import_unsafe we shouldn't catch PK violations
+                assertEquals("Failed rows don't match", 0, failed);
+
+                boolean exists = existsBadFile(BADDIR, "multiFilePKViolation.bad");
+                assertFalse("Bad file exists.",exists);
+            }
+        }
+        try(ResultSet rs = methodWatcher.executeQuery("select count(*) from "+multiPK)){
+            Assert.assertTrue("Did not return a row!",rs.next());
+            long c = rs.getLong(1);
+            Assert.assertEquals("Incorrect row count!",9,c);
+            assertFalse("Returned too many rows!",rs.next());
+        }
+    }
+
+    // more tests to write:
+    // test bad records at threshold and beyond threshold
+
+    private void testImport(String schemaName, String tableName, String location, String colList, long
+            badRecordsAllowed) throws Exception {
+        PreparedStatement ps = methodWatcher.prepareStatement(format("call SYSCS_UTIL.IMPORT_DATA_UNSAFE(" +
+                        "'%s'," +  // schema name
+                        "'%s'," +  // table name
+                        "'%s'," +  // insert column list
+                        "'%s'," +  // file path
+                        "','," +   // column delimiter
+                        "null," +  // character delimiter
+                        "null," +  // timestamp format
+                        "null," +  // date format
+                        "null," +  // time format
+                        "%d," +    // max bad records
+                        "'%s'," +  // bad record dir
+                        "null," +  // has one line records
+                        "null)",   // char set
+                schemaName,            tableName, colList,
+                location,              badRecordsAllowed,
+                BADDIR.getCanonicalPath()));
+
+
+        ps.execute();
+        ResultSet rs = methodWatcher.executeQuery(format("select * from %s.%s", schemaName, tableName));
+        List<String> results = Lists.newArrayList();
+        while (rs.next()) {
+            String name = rs.getString(1);
+            String title = rs.getString(2);
+            int age = rs.getInt(3);
+            Assert.assertTrue("age was null!", !rs.wasNull());
+            assertNotNull("Name is null!", name);
+            assertNotNull("Title is null!", title);
+            assertNotNull("Age is null!", age);
+            results.add(String.format("name:%s,title:%s,age:%d", name, title, age));
+        }
+        Assert.assertTrue("no rows imported!", results.size() > 0);
+    }
+
+    @ClassRule
+    public static TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void testConstaintsImportNullBadDir() throws Exception {
+        // DB-5017: When bad record dir is null or empty, the input file dir becomes the bad record dir
+        String inputFileName =  "constraintViolation.csv";
+        String inputFileOrigin = getResourceDirectory() +inputFileName;
+        // copy the given input file under a temp folder so that it will get cleaned up
+        // this used to go under the "target/test-classes" folder but doesn't work when we execute test from
+        // a different location.
+        File newImportFile = tempFolder.newFile(inputFileName);
+        FileUtils.copyFile(new File(inputFileOrigin), newImportFile);
+        assertTrue("Import file copy failed: "+newImportFile.getCanonicalPath(), newImportFile.exists());
+        String badFileName = newImportFile.getParent()+"/" +inputFileName+".bad";
+
+        PreparedStatement ps = methodWatcher.prepareStatement(format("call SYSCS_UTIL.IMPORT_DATA_UNSAFE(" +
+                        "'%s'," +  // schema name
+                        "'%s'," +  // table name
+                        "null," +  // insert column list
+                        "'%s'," +  // file path
+                        "','," +   // column delimiter
+                        "null," +  // character delimiter
+                        "null," +  // timestamp format
+                        "null," +  // date format
+                        "null," +  // time format
+                        "%d," +    // max bad records
+                        "null," +  // bad record dir
+                        "null," +  // has one line records
+                        "null)",   // char set
+                spliceSchemaWatcher.schemaName, TABLE_20,
+                newImportFile.getCanonicalPath(), 0));
+        try {
+            ps.execute();
+            fail("Too many bad records.");
+        } catch (SQLException e) {
+            assertEquals("Expected too many bad records, but got: "+e.getLocalizedMessage(), "SE009", e.getSQLState());
+        }
+        boolean exists = existsBadFile(new File(newImportFile.getParent()), inputFileName+".bad");
+        assertTrue("Bad file " +badFileName+" does not exist.", exists);
+    }
+
+    @Test
+    public void testHdfsImportGzipFile() throws Exception {
+        testImport(spliceSchemaWatcher.schemaName, TABLE_6, getResourceDirectory() + "importTest.in.gz", "NAME,TITLE," +
+                "AGE", 0);
+    }
+
+
+    @Test
+    public void testImportTabWithDefaultColumnValue() throws Exception {
+        PreparedStatement ps = methodWatcher.prepareStatement(format("call SYSCS_UTIL.IMPORT_DATA_UNSAFE(" +
+                        "'%s'," +  // schema name
+                        "'%s'," +  // table name
+                        "'J'," +   // insert column list
+                        "'%s'," +  // file path
+                        "null," +  // column delimiter
+                        "null," +  // character delimiter
+                        "null," +  // timestamp format
+                        "null," +  // date format
+                        "null," +  // time format
+                        "%d," +    // max bad records
+                        "'%s'," +  // bad record dir
+                        "null," +  // has one line records
+                        "null)",   // char set
+                spliceSchemaWatcher.schemaName,
+                TABLE_11,
+                getResourceDirectory() + "default_column.txt", 0,
+                BADDIR.getCanonicalPath()));
+        ps.execute();
+
+        ResultSet rs = methodWatcher.executeQuery(format("select * from %s.%s", spliceSchemaWatcher.schemaName,
+                TABLE_11));
+        while (rs.next()) {
+            Assert.assertEquals(10, rs.getInt(1));
+            Assert.assertEquals(1, rs.getInt(2));
+        }
+    }
+
+    @Test
+    public void testImportTableWithAutoIncrementColumn() throws Exception {
+        PreparedStatement ps = methodWatcher.prepareStatement(format("call SYSCS_UTIL.IMPORT_DATA_UNSAFE(" +
+                        "'%s'," +  // schema name
+                        "'%s'," +  // table name
+                        "'J'," +   // insert column list
+                        "'%s'," +  // file path
+                        "null," +   // column delimiter
+                        "null," +  // character delimiter
+                        "null," +  // timestamp format
+                        "null," +  // date format
+                        "null," +  // time format
+                        "%d," +    // max bad records
+                        "'%s'," +  // bad record dir
+                        "null," +  // has one line records
+                        "null)",   // char set
+                spliceSchemaWatcher.schemaName,
+                AUTO_INCREMENT_TABLE,
+                getResourceDirectory() + "default_column.txt", 0,
+                BADDIR.getCanonicalPath()));
+        ps.execute();
+
+        ResultSet rs = methodWatcher.executeQuery(format("select * from %s.%s", spliceSchemaWatcher.schemaName,
+                AUTO_INCREMENT_TABLE));
+        while (rs.next()) {
+            Assert.assertEquals(1, rs.getInt(1));
+            Assert.assertEquals(1, rs.getInt(2));
+        }
+    }
+
+    /**
+     * Tests an import scenario where a quoted column is missing the end quote and the EOF is
+     * reached before the maximum number of lines in a quoted column is exceeded.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testMissingEndQuoteForQuotedColumnEOF() throws Exception {
+        String badDirPath = BADDIR.getCanonicalPath();
+        String csvPath = getResourceDirectory() + "import/missing-end-quote/employees.csv";
+        try {
+            testMissingEndQuoteForQuotedColumn(spliceSchemaWatcher.schemaName, TABLE_18, csvPath, "NAME,TITLE,AGE",
+                    badDirPath, 0, 1, "false");
+            fail("Expected to many bad records.");
+        } catch (SQLException e) {
+            assertEquals("Expected too many bad records but got: "+e.getLocalizedMessage(), "SE009", e.getSQLState());
+            SpliceUnitTest.assertBadFileContainsError(new File(badDirPath), "employees.csv",
+                                                      null, "unexpected end of file while reading quoted column beginning on line 2 and ending on line 6");
+        }
+    }
+
+    /**
+     * Tests an import scenario where a quoted column is missing the end quote and the
+     * maximum number of lines in a quoted column is exceeded.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testMissingEndQuoteForQuotedColumnMax() throws Exception {
+        String badDirPath = BADDIR.getCanonicalPath();
+        String csvPath = getResourceDirectory() + "import/missing-end-quote/employeesMaxQuotedColumnLines.csv";
+        try {
+            testMissingEndQuoteForQuotedColumn(spliceSchemaWatcher.schemaName, TABLE_18, csvPath, "NAME,TITLE,AGE",
+                    badDirPath, 0, 199999, "false");
+            fail("Expected to many bad records.");
+        } catch (SQLException e) {
+            assertEquals("Expected too many bad records but got: "+e.getLocalizedMessage(), "SE009", e.getSQLState());
+            SpliceUnitTest.assertBadFileContainsError(new File(badDirPath), "employeesMaxQuotedColumnLines.csv",
+                                                      null, "Quoted column beginning on line 3 has exceed the maximum allowed lines");
+        }
+    }
+
+    /**
+     * Worker method for import tests related to CSV files that are missing the end quote for a quoted column.
+     *
+     * @param schemaName     table schema
+     * @param tableName      table name
+     * @param importFilePath full path to the import file
+     * @param colList        list of columns and their order
+     * @param badDir         where to place the error file
+     * @param failErrorCount how many errors do we allow before failing the whole import
+     * @param importCount    verification of number of rows imported
+     * @param oneLineRecords whether the import file has one record per line or records span lines
+     * @throws Exception
+     */
+    private void testMissingEndQuoteForQuotedColumn(
+            String schemaName, String tableName, String importFilePath, String colList, String badDir, int
+            failErrorCount, int importCount, String oneLineRecords)
+            throws Exception {
+        methodWatcher.executeUpdate("delete from " + schemaName + "." + tableName);
+        PreparedStatement ps = methodWatcher.prepareStatement(
+                format("call SYSCS_UTIL.IMPORT_DATA_UNSAFE('%s','%s','%s','%s',',',null,null,null,null,%d,'%s','%s',null)",
+                        schemaName, tableName, colList, importFilePath, failErrorCount, badDir, oneLineRecords));
+        ps.execute();
+        ResultSet rs = methodWatcher.executeQuery(format("select * from %s.%s", schemaName, tableName));
+        List<String> results = Lists.newArrayList();
+        while (rs.next()) {
+            String name = rs.getString(1);
+            String title = rs.getString(2);
+            int age = rs.getInt(3);
+            Assert.assertTrue("age was null!", !rs.wasNull());
+            assertNotNull("name is null!", name);
+            assertNotNull("title is null!", title);
+            results.add(String.format("name:%s,title:%s,age:%d", name, title, age));
+        }
+        Assert.assertEquals("Incorrect number of rows imported", importCount, results.size());
+    }
+
+    @Test
+    public void testCheckConstraintLoad() throws Exception {
+        // File has 3 lines 2 fo which are constraint violations.
+        // No error -- tolerating 2 errors so 1 row should be inserted
+        helpTestConstraints(2, 1, false);
+    }
+
+    @Test
+    public void testCheckConstraintLoad2() throws Exception {
+        // File has 3 lines 2 fo which are constraint violations.
+        // No error -- tolerating 3 errors so 1 row should be inserted
+        helpTestConstraints(3, 1, false);
+    }
+
+    @Test
+    public void testCheckConstraintLoadError() throws Exception {
+        // File has 3 lines 2 fo which are constraint violations.
+        // Expect error
+        helpTestConstraints(1, 0, true);
+    }
+
+    @Test
+    public void testCheckConstraintLoadPermissive() throws Exception {
+        // File has 3 lines 2 fo which are constraint violations.
+        // No error -- we are tolerating ALL errors so 1 row should be inserted
+        helpTestConstraints(-1, 1, false);
+    }
+
+    @Test
+    public void testCheckConstraintLoadPermissive2() throws Exception {
+        // File has 3 lines 2 fo which are constraint violations.
+        // No error -- we are tolerating ALL errors so 1 row should be inserted
+        // Notice ANYTHING < 0 is considered -1 (permissive)
+        helpTestConstraints(-20, 1, false);
+    }
+
+    public void helpTestConstraints(long maxBadRecords, int insertRowsExpected, boolean expectException) throws Exception {
+        String tableName = "CONSTRAINED_TABLE";
+        TableDAO td = new TableDAO(methodWatcher.getOrCreateConnection());
+        td.drop(spliceSchemaWatcher.schemaName, tableName);
+
+        methodWatcher.getOrCreateConnection().createStatement().executeUpdate(
+                format("create table %s ",spliceSchemaWatcher.schemaName+"."+tableName)+
+                        "(EMPNO CHAR(6) NOT NULL CONSTRAINT EMP_PK PRIMARY KEY, " +
+                        "SALARY DECIMAL(9,2) CONSTRAINT SAL_CK CHECK (SALARY >= 10000), " +
+                        "BONUS DECIMAL(9,2),TAX DECIMAL(9,2),CONSTRAINT BONUS_CK CHECK (BONUS > TAX))");
+
+        PreparedStatement ps = methodWatcher.prepareStatement(format("call SYSCS_UTIL.IMPORT_DATA_UNSAFE(" +
+                        "'%s'," +  // schema name
+                        "'%s'," +  // table name
+                        "'%s'," +  // insert column list
+                        "'%s'," +  // file path
+                        "','," +   // column delimiter
+                        "null," +  // character delimiter
+                        "null," +  // timestamp format
+                        "null," +  // date format
+                        "null," +  // time format
+                        "%d," +    // max bad records
+                        "'%s'," +  // bad record dir
+                        "null," +  // has one line records
+                        "null)",   // char set
+                spliceSchemaWatcher.schemaName, tableName,
+                "EMPNO,SALARY,BONUS,TAX",
+                getResourceDirectory() + "test_data/salary_check_constraint.csv",
+                maxBadRecords, BADDIR.getCanonicalPath()));
+
+        try {
+            ps.execute();
+        } catch (SQLException e) {
+            if (! expectException) {
+                throw e;
+            }
+        }
+        ResultSet rs = methodWatcher.executeQuery(format("select * from %s.%s", spliceSchemaWatcher.schemaName,
+                tableName));
+        List<String> results = Lists.newArrayList();
+        while (rs.next()) {
+            String name = rs.getString(1);
+            String title = rs.getString(2);
+            int age = rs.getInt(3);
+            Assert.assertTrue("age was null!", !rs.wasNull());
+            assertNotNull("Name is null!", name);
+            assertNotNull("Title is null!", title);
+            assertNotNull("Age is null!", age);
+            results.add(String.format("name:%s,title:%s,age:%d", name, title, age));
+        }
+        Assert.assertEquals(format("Expected %s row1 imported", insertRowsExpected), insertRowsExpected, results.size());
+
+        boolean exists = existsBadFile(BADDIR, "salary_check_constraint.csv.bad");
+        String badFile = getBadFile(BADDIR, "salary_check_constraint.csv.bad");
+        assertTrue("Bad file " +badFile+" does not exist.",exists);
+        List<String> badLines = Files.readAllLines((new File(BADDIR, badFile)).toPath(), Charset.defaultCharset());
+        assertEquals("Expected 2 lines in bad file "+badFile, 2, badLines.size());
+        assertContains(badLines, containsString("BONUS_CK"));
+        assertContains(badLines, containsString(spliceSchemaWatcher.schemaName+"."+tableName));
+        assertContains(badLines, containsString("SAL_CK"));
+    }
+
+    private static void assertContains(List<String> collection, Matcher<String> target) {
+        for (String source : collection) {
+            if (target.matches(source)) {
+                return;
+            }
+        }
+        fail("Expected to contain " + target.toString() + " in: " + collection);
+    }
+}

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/server/TransactionalRegion.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/server/TransactionalRegion.java
@@ -17,10 +17,8 @@ package com.splicemachine.si.api.server;
 import com.splicemachine.kvpair.KVPair;
 import com.splicemachine.si.api.filter.TxnFilter;
 import com.splicemachine.si.api.readresolve.ReadResolver;
-import com.splicemachine.si.api.txn.Txn;
 import com.splicemachine.si.api.txn.TxnSupplier;
 import com.splicemachine.si.api.txn.TxnView;
-import com.splicemachine.si.impl.DDLFilter;
 import com.splicemachine.storage.EntryPredicateFilter;
 import com.splicemachine.storage.MutationStatus;
 import com.splicemachine.storage.Partition;
@@ -67,10 +65,9 @@ public interface TransactionalRegion<InternalScanner> extends AutoCloseable{
     void updateWriteRequests(long writeRequests);
 
     Iterable<MutationStatus> bulkWrite(TxnView txn,
-                                byte[] family, byte[] qualifier,
-                                ConstraintChecker constraintChecker,
-                                Collection<KVPair> data) throws IOException;
-
+                                       byte[] family, byte[] qualifier,
+                                       ConstraintChecker constraintChecker,
+                                       Collection<KVPair> data, boolean skipConflictDetection) throws IOException;
 
     String getRegionName();
 

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/server/Transactor.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/server/Transactor.java
@@ -48,6 +48,6 @@ public interface Transactor{
                                     byte[] packedColumnBytes,
                                     Collection<KVPair> toProcess,
                                     TxnView txn,
-                                    ConstraintChecker constraintChecker) throws IOException;
+                                    ConstraintChecker constraintChecker, boolean skipConflictDetection) throws IOException;
 
 }

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/TxnRegion.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/TxnRegion.java
@@ -112,13 +112,13 @@ public class TxnRegion<InternalScanner> implements TransactionalRegion<InternalS
 
     @Override
     public Iterable<MutationStatus> bulkWrite(TxnView txn,
-                                       byte[] family,byte[] qualifier,
-                                       ConstraintChecker constraintChecker, //TODO -sf- can we encapsulate this as well?
-                                       Collection<KVPair> data) throws IOException{
+                                              byte[] family, byte[] qualifier,
+                                              ConstraintChecker constraintChecker, //TODO -sf- can we encapsulate this as well?
+                                              Collection<KVPair> data, boolean skipConflictDetection) throws IOException{
         /*
          * Designed for subclasses. Override this if you want to bypass transactional writes
          */
-        final MutationStatus[] status = transactor.processKvBatch(region, rollForward, family, qualifier, data,txn,constraintChecker);
+        final MutationStatus[] status = transactor.processKvBatch(region, rollForward, family, qualifier, data,txn,constraintChecker,skipConflictDetection);
         return new Iterable<MutationStatus>(){
             @Override public Iterator<MutationStatus> iterator(){ return Iterators.forArray(status); }
         };

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/server/SITransactor.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/server/SITransactor.java
@@ -142,7 +142,7 @@ public class SITransactor implements Transactor{
                                             long txnId,
                                             ConstraintChecker constraintChecker) throws IOException{
         TxnView txn=txnSupplier.getTransaction(txnId);
-        return processKvBatch(table,rollForward,defaultFamilyBytes,packedColumnBytes,toProcess,txn,constraintChecker);
+        return processKvBatch(table,rollForward,defaultFamilyBytes,packedColumnBytes,toProcess,txn,constraintChecker, false);
     }
 
     @Override
@@ -152,9 +152,9 @@ public class SITransactor implements Transactor{
                                            byte[] packedColumnBytes,
                                            Collection<KVPair> toProcess,
                                            TxnView txn,
-                                           ConstraintChecker constraintChecker) throws IOException{
+                                           ConstraintChecker constraintChecker, boolean skipConflictDetection) throws IOException{
         ensureTransactionAllowsWrites(txn);
-        return processInternal(table,rollForward,txn,defaultFamilyBytes,packedColumnBytes,toProcess,constraintChecker);
+        return processInternal(table,rollForward,txn,defaultFamilyBytes,packedColumnBytes,toProcess,constraintChecker,skipConflictDetection);
     }
 
     private MutationStatus getCorrectStatus(MutationStatus status,MutationStatus oldStatus){
@@ -164,9 +164,9 @@ public class SITransactor implements Transactor{
     private MutationStatus[] processInternal(Partition table,
                                              RollForward rollForwardQueue,
                                              TxnView txn,
-                                             byte[] family,byte[] qualifier,
+                                             byte[] family, byte[] qualifier,
                                              Collection<KVPair> mutations,
-                                             ConstraintChecker constraintChecker) throws IOException{
+                                             ConstraintChecker constraintChecker, boolean skipConflictDetection) throws IOException{
 //                if (LOG.isTraceEnabled()) LOG.trace(String.format("processInternal: table = %s, txnId = %s", table.toString(), txn.getTxnId()));
         MutationStatus[] finalStatus=new MutationStatus[mutations.size()];
         Pair<KVPair, Lock>[] lockPairs=new Pair[mutations.size()];
@@ -183,7 +183,7 @@ public class SITransactor implements Transactor{
              * the region can't close until after this method is complete, we don't need the calls.
              */
             IntObjectOpenHashMap<DataPut> writes=checkConflictsForKvBatch(table,rollForwardQueue,lockPairs,
-                    conflictingChildren,txn,family,qualifier,constraintChecker,constraintState,finalStatus);
+                    conflictingChildren,txn,family,qualifier,constraintChecker,constraintState,finalStatus,skipConflictDetection);
 
             //TODO -sf- this can probably be made more efficient
             //convert into array for usefulness
@@ -228,13 +228,13 @@ public class SITransactor implements Transactor{
                                                                    Pair<KVPair, Lock>[] dataAndLocks,
                                                                    LongOpenHashSet[] conflictingChildren,
                                                                    TxnView transaction,
-                                                                   byte[] family,byte[] qualifier,
+                                                                   byte[] family, byte[] qualifier,
                                                                    ConstraintChecker constraintChecker,
                                                                    TxnFilter constraintStateFilter,
-                                                                   MutationStatus[] finalStatus) throws IOException {
+                                                                   MutationStatus[] finalStatus, boolean skipConflictDetection) throws IOException {
         IntObjectOpenHashMap<DataPut> finalMutationsToWrite = IntObjectOpenHashMap.newInstance(dataAndLocks.length, 0.9f);
         DataResult possibleConflicts = null;
-        BitSet bloomInMemoryCheck  = table.getBloomInMemoryCheck(constraintChecker!=null,dataAndLocks);
+        BitSet bloomInMemoryCheck  = skipConflictDetection ? null : table.getBloomInMemoryCheck(constraintChecker!=null,dataAndLocks);
         for(int i=0;i<dataAndLocks.length;i++){
             Pair<KVPair, Lock> baseDataAndLock=dataAndLocks[i];
             if(baseDataAndLock==null) continue;
@@ -242,7 +242,7 @@ public class SITransactor implements Transactor{
             ConflictResults conflictResults=ConflictResults.NO_CONFLICT;
             KVPair kvPair=baseDataAndLock.getFirst();
             KVPair.Type writeType=kvPair.getType();
-            if(constraintChecker!=null || !KVPair.Type.INSERT.equals(writeType)){
+            if(!skipConflictDetection && (constraintChecker!=null || !KVPair.Type.INSERT.equals(writeType))){
                 /*
                  *
                  * If the table has no keys, then the hbase row key is a randomly generated UUID, so it's not


### PR DESCRIPTION
Limitations:
- It only skips conflict detection on base table, support for indexes will be added later
- It skips PK check constraints

Added a new import procedure that uses this flag: IMPORT_DATA_UNSAFE() with the same parameters as the existing one.