### PR TITLE
SPLICE-1500 Skip WAL for unsafe imports

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
@@ -126,6 +126,7 @@ public interface ResultSetFactory {
 								 String statusDirectory,
 								 int failBadRecordCount,
 								 boolean skipConflictDetection,
+								 boolean skipWAL,
                                  double optimizerEstimatedRowCount,
                                  double optimizerEstimatedCost,
                                  String tableVersion,

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InsertNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InsertNode.java
@@ -94,6 +94,7 @@ public final class InsertNode extends DMLModStatementNode {
 	public static final String BAD_RECORDS_ALLOWED = "badRecordsAllowed";
 	public static final String USE_SPARK = "useSpark";
 	public static final String SKIP_CONFLICT_DETECTION = "skipConflictDetection";
+	public static final String SKIP_WAL = "skipWAL";
     public static final String INSERT = "INSERT";
     public static final String PIN = "pin";
 
@@ -110,6 +111,7 @@ public final class InsertNode extends DMLModStatementNode {
     private     String              statusDirectory;
 	private     int              badRecordsAllowed = 0;
 	private     boolean              skipConflictDetection = false;
+	private     boolean              skipWAL = false;
 	private CompilerContext.DataSetProcessorType dataSetProcessorType = CompilerContext.DataSetProcessorType.DEFAULT_CONTROL;
 
 
@@ -727,6 +729,7 @@ public final class InsertNode extends DMLModStatementNode {
 			throw StandardException.newException(SQLState.INSERT_PIN_VIOLATION);
 		}
 		String skipConflictDetectionString = targetProperties.getProperty(SKIP_CONFLICT_DETECTION);
+		String skipWALString = targetProperties.getProperty(SKIP_WAL);
 
 		if (insertModeString != null) {
 			String upperValue = StringUtil.SQLToUpperCase(insertModeString);
@@ -748,6 +751,10 @@ public final class InsertNode extends DMLModStatementNode {
 		}
 		if (skipConflictDetectionString != null) {
 			skipConflictDetection = Boolean.parseBoolean(StringUtil.SQLToUpperCase(skipConflictDetectionString));
+		}
+
+		if (skipWALString != null) {
+			skipWAL = Boolean.parseBoolean(StringUtil.SQLToUpperCase(skipWALString));
 		}
 
 		if (useSparkString != null) {
@@ -992,6 +999,7 @@ public final class InsertNode extends DMLModStatementNode {
                 mb.push(statusDirectory);
 			mb.push(badRecordsAllowed);
 			mb.push(skipConflictDetection);
+			mb.push(skipWAL);
             mb.push((double) this.resultSet.getFinalCostEstimate().getEstimatedRowCount());
             mb.push(this.resultSet.getFinalCostEstimate().getEstimatedCost());
             mb.push(targetTableDescriptor.getVersion());
@@ -1003,7 +1011,7 @@ public final class InsertNode extends DMLModStatementNode {
 			BaseJoinStrategy.pushNullableString(mb,targetTableDescriptor.getLocation());
 			BaseJoinStrategy.pushNullableString(mb,targetTableDescriptor.getCompression());
 			mb.push(partitionReferenceItem);
-			mb.callMethod(VMOpcode.INVOKEINTERFACE, (String) null, "getInsertResultSet", ClassName.ResultSet, 18);
+			mb.callMethod(VMOpcode.INVOKEINTERFACE, (String) null, "getInsertResultSet", ClassName.ResultSet, 19);
 		}
 		else
 		{

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -1894,7 +1894,8 @@ public interface SQLState {
     String EXPORT_PARAMETER_IS_WRONG                               ="XIE0U.S";
     String EXPORT_PARAMETER_VALUE_IS_WRONG                         ="XIE0X.S";
     String UNEXPECTED_IMPORT_READING_ERROR                         ="XIE10.S";
-    String UNEXPECTED_IMPORT_CSV_ERROR                             ="XIE11.S";
+	String UNEXPECTED_IMPORT_CSV_ERROR                             ="XIE11.S";
+	String REGION_SERVER_FAILURE_WITH_NO_WAL_ERROR                 ="XIE12.S";
 
 
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -4689,6 +4689,11 @@ ln=lower-case two-letter ISO-639 language code, CO=upper-case two-letter ISO-316
                 <arg>details</arg>
             </msg>
 
+            <msg>
+                <name>XIE12.S</name>
+                <text>There was {0} RegionServer failures during a write with WAL disabled, the transaction has to rollback to avoid data loss.</text>
+                <arg>details</arg>
+            </msg>
 	    <msg>
                 <name>XIE0S.S</name>
 		<text>The export operation was not performed, because the specified output file ({0}) already exists. Export processing will not overwrite an existing file, even if the process has permissions to write to that file, due to security concerns, and to avoid accidental file damage. Please either change the output file name in the export procedure arguments to specify a file which does not exist, or delete the existing file, then retry the export operation.</text>

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/HBasePipelineEnvironment.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/HBasePipelineEnvironment.java
@@ -43,6 +43,7 @@ import com.splicemachine.si.api.data.OperationStatusFactory;
 import com.splicemachine.si.api.data.TxnOperationFactory;
 import com.splicemachine.si.api.readresolve.KeyedReadResolver;
 import com.splicemachine.si.api.readresolve.RollForward;
+import com.splicemachine.si.api.server.ClusterHealth;
 import com.splicemachine.si.api.txn.KeepAliveScheduler;
 import com.splicemachine.si.api.txn.TxnStore;
 import com.splicemachine.si.api.txn.TxnSupplier;
@@ -204,6 +205,11 @@ public class HBasePipelineEnvironment implements PipelineEnvironment{
     @Override
     public SnowflakeFactory snowflakeFactory() {
         return delegate.snowflakeFactory();
+    }
+
+    @Override
+    public ClusterHealth clusterHealthFactory() {
+        return delegate.clusterHealthFactory();
     }
 
     private static class AvailablePipelineFactory implements WritePipelineFactory{

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/HBaseSIEnvironment.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/HBaseSIEnvironment.java
@@ -20,6 +20,9 @@ import java.net.URISyntaxException;
 import com.splicemachine.access.api.SnowflakeFactory;
 import com.splicemachine.access.hbase.HSnowflakeFactory;
 import com.splicemachine.access.util.ByteComparisons;
+import com.splicemachine.hbase.ZkUtils;
+import com.splicemachine.si.api.server.ClusterHealth;
+import com.splicemachine.storage.HClusterHealthFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hbase.TableName;
@@ -76,6 +79,7 @@ public class HBaseSIEnvironment implements SIEnvironment{
     private final Clock clock;
     private final DistributedFileSystem fileSystem;
     private final SnowflakeFactory snowflakeFactory;
+    private final HClusterHealthFactory clusterHealthFactory;
     private SIDriver siDriver;
 
 
@@ -117,6 +121,7 @@ public class HBaseSIEnvironment implements SIEnvironment{
                 config.getTransactionTimeout(),
                 config.getTransactionKeepAliveThreads(),
                 txnStore);
+        this.clusterHealthFactory = new HClusterHealthFactory(ZkUtils.getRecoverableZooKeeper());
         siDriver = SIDriver.loadDriver(this);
     }
 
@@ -139,6 +144,7 @@ public class HBaseSIEnvironment implements SIEnvironment{
         this.clock = clock;
         this.fileSystem =new HNIOFileSystem(FileSystem.get((Configuration) config.getConfigSource().unwrapDelegate()), exceptionFactory());
         this.snowflakeFactory = new HSnowflakeFactory();
+        this.clusterHealthFactory = new HClusterHealthFactory(rzk);
 
 
         this.keepAlive = new QueuedKeepAliveScheduler(config.getTransactionKeepAliveInterval(),
@@ -238,5 +244,10 @@ public class HBaseSIEnvironment implements SIEnvironment{
     @Override
     public SnowflakeFactory snowflakeFactory() {
         return snowflakeFactory;
+    }
+
+    @Override
+    public ClusterHealth clusterHealthFactory() {
+        return clusterHealthFactory;
     }
 }

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/SIObserver.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/SIObserver.java
@@ -227,7 +227,7 @@ public class SIObserver extends BaseRegionObserver{
                 boolean processed=false;
                 while (!processed) {
                     @SuppressWarnings("unchecked") Iterable<MutationStatus> status =
-                            region.bulkWrite(txn, fam, column.getKey(), operationStatusFactory.getNoOpConstraintChecker(), Collections.singleton(column.getValue()), false);
+                            region.bulkWrite(txn, fam, column.getKey(), operationStatusFactory.getNoOpConstraintChecker(), Collections.singleton(column.getValue()), false, false);
                     Iterator<MutationStatus> itr = status.iterator();
                     if (!itr.hasNext())
                         throw new IllegalStateException();

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HClusterHealthFactory.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HClusterHealthFactory.java
@@ -1,0 +1,86 @@
+/*
+ *
+ *  * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *  *
+ *  * This file is part of Splice Machine.
+ *  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ *  * GNU Affero General Public License as published by the Free Software Foundation, either
+ *  * version 3, or (at your option) any later version.
+ *  * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  * See the GNU Affero General Public License for more details.
+ *  * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ *  * If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.splicemachine.storage;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.derby.hbase.AllocatedFilter;
+import com.splicemachine.si.api.server.ClusterHealth;
+import org.apache.hadoop.hbase.filter.CompareFilter;
+import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
+import org.apache.hadoop.hbase.zookeeper.RecoverableZooKeeper;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+
+import java.io.IOException;
+
+/**
+ * @author Scott Fines
+ *         Date: 12/18/15
+ */
+public class HClusterHealthFactory implements ClusterHealth {
+
+    private final RecoverableZooKeeper rzk;
+
+    public HClusterHealthFactory(RecoverableZooKeeper rzk){
+        this.rzk = rzk;
+    }
+
+    @Override
+    public ClusterHealthWatcher registerWatcher() {
+        HClusterHealthWatcher hw = new HClusterHealthWatcher(rzk);
+        hw.register();
+        return hw;
+    }
+
+    private class HClusterHealthWatcher implements ClusterHealthWatcher, Watcher {
+
+        private final RecoverableZooKeeper rzk;
+        private int failures = 0;
+
+        HClusterHealthWatcher(RecoverableZooKeeper rzk) {
+            this.rzk = rzk;
+        }
+
+        @Override
+        public synchronized int failedServers() {
+            return failures;
+        }
+
+        @Override
+        public void close() {
+            //nothing
+        }
+
+        @Override
+        public synchronized void process(WatchedEvent watchedEvent) {
+            if (watchedEvent.getType() == Event.EventType.NodeChildrenChanged) {
+                failures++;
+            }
+            register();
+        }
+
+        void register() {
+            try {
+                rzk.getChildren("/hbase/rs", this);
+            } catch (Exception e) {
+                throw new RuntimeException("Couldn't register cluster health watcher", e);
+            }
+        }
+    }
+}

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HPut.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HPut.java
@@ -14,11 +14,13 @@
 
 package com.splicemachine.storage;
 
-import org.spark_project.guava.collect.Iterables;
+import org.apache.hadoop.hbase.client.Durability;
 import com.splicemachine.si.constants.SIConstants;
 import com.splicemachine.utils.ByteSlice;
 import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
+import org.spark_project.guava.collect.Iterables;
+
 import java.io.IOException;
 import java.util.Map;
 
@@ -88,6 +90,11 @@ public class HPut implements HMutation,DataPut{
         }catch(IOException e){
             throw new RuntimeException(e); //should never happen
         }
+    }
+
+    @Override
+    public void skipWAL() {
+        put.setDurability(Durability.SKIP_WAL);
     }
 
     @Override

--- a/mem_pipeline/src/main/java/com/splicemachine/pipeline/MPipelineEnv.java
+++ b/mem_pipeline/src/main/java/com/splicemachine/pipeline/MPipelineEnv.java
@@ -35,6 +35,7 @@ import com.splicemachine.si.api.data.OperationStatusFactory;
 import com.splicemachine.si.api.data.TxnOperationFactory;
 import com.splicemachine.si.api.readresolve.KeyedReadResolver;
 import com.splicemachine.si.api.readresolve.RollForward;
+import com.splicemachine.si.api.server.ClusterHealth;
 import com.splicemachine.si.api.txn.KeepAliveScheduler;
 import com.splicemachine.si.api.txn.TxnStore;
 import com.splicemachine.si.api.txn.TxnSupplier;
@@ -184,6 +185,11 @@ public class MPipelineEnv  implements PipelineEnvironment{
     @Override
     public SnowflakeFactory snowflakeFactory() {
         return siEnv.snowflakeFactory();
+    }
+
+    @Override
+    public ClusterHealth clusterHealthFactory() {
+        return siEnv.clusterHealthFactory();
     }
 
     @Override

--- a/mem_storage/src/main/java/com/splicemachine/si/MemSIEnvironment.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/MemSIEnvironment.java
@@ -31,6 +31,7 @@ import com.splicemachine.si.api.data.OperationStatusFactory;
 import com.splicemachine.si.api.data.TxnOperationFactory;
 import com.splicemachine.si.api.readresolve.KeyedReadResolver;
 import com.splicemachine.si.api.readresolve.RollForward;
+import com.splicemachine.si.api.server.ClusterHealth;
 import com.splicemachine.si.api.txn.KeepAliveScheduler;
 import com.splicemachine.si.api.txn.TxnStore;
 import com.splicemachine.si.api.txn.TxnSupplier;
@@ -172,5 +173,10 @@ public class MemSIEnvironment implements SIEnvironment{
     @Override
     public SnowflakeFactory snowflakeFactory() {
         return snowflakeFactory;
+    }
+
+    @Override
+    public ClusterHealth clusterHealthFactory() {
+        return new MClusterHealth();
     }
 }

--- a/mem_storage/src/main/java/com/splicemachine/storage/MClusterHealth.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MClusterHealth.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.storage;
+
+import com.splicemachine.si.api.server.ClusterHealth;
+
+/**
+ * Created by dgomezferro on 3/16/17.
+ */
+public class MClusterHealth implements ClusterHealth{
+    @Override
+    public ClusterHealthWatcher registerWatcher() {
+        return new MClusterHealthWatcher();
+    }
+}

--- a/mem_storage/src/main/java/com/splicemachine/storage/MClusterHealthWatcher.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MClusterHealthWatcher.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.storage;
+
+import com.splicemachine.si.api.server.ClusterHealth;
+
+/**
+ * Created by dgomezferro on 3/16/17.
+ */
+public class MClusterHealthWatcher implements ClusterHealth.ClusterHealthWatcher {
+    @Override
+    public int failedServers() {
+        return 0;
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/mem_storage/src/main/java/com/splicemachine/storage/MPut.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MPut.java
@@ -94,6 +94,11 @@ public class MPut implements DataPut{
     }
 
     @Override
+    public void skipWAL() {
+        // no-op in mem
+    }
+
+    @Override
     public void addAttribute(String key,byte[] value){
         this.attributes.put(key,value);
     }

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/PartitionWritePipeline.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/PartitionWritePipeline.java
@@ -99,7 +99,8 @@ public class PartitionWritePipeline{
 
         WriteContext context;
         try{
-            context=ctxFactory.create(writeBufferFactory,txn,txnRegion,toWrite.getSize(),toWrite.skipIndexWrite(),toWrite.skipConflictDetection(),rce);
+            context=ctxFactory.create(writeBufferFactory,txn,txnRegion,toWrite.getSize(),
+                    toWrite.skipIndexWrite(),toWrite.skipConflictDetection(),toWrite.skipWAL(),rce);
         }catch(InterruptedException e){
             return INTERRUPTED;
         }catch(IndexNotSetUpException e){

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/PartitionBuffer.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/PartitionBuffer.java
@@ -35,13 +35,15 @@ public class PartitionBuffer{
     private PreFlushHook preFlushHook;
     private boolean skipIndexWrites;
     private boolean skipConflictDetection;
+    private boolean skipWAL;
 
-    public PartitionBuffer(Partition partition,PreFlushHook preFlushHook,boolean skipIndexWrites,boolean skipConflictDetection) {
+    public PartitionBuffer(Partition partition, PreFlushHook preFlushHook, boolean skipIndexWrites, boolean skipConflictDetection, boolean skipWAL) {
         this.partition=partition;
         this.buffer = new ArrayList<>();
         this.preFlushHook = preFlushHook;
         this.skipIndexWrites = skipIndexWrites;
         this.skipConflictDetection = skipConflictDetection;
+        this.skipWAL = skipWAL;
     }
 
     public void add(KVPair element) throws Exception {
@@ -74,7 +76,7 @@ public class PartitionBuffer{
     }
 
     public BulkWrite getBulkWrite() throws Exception {
-        return new BulkWrite(heapSize, preFlushHook.transform(buffer), partition.getName(), skipIndexWrites, skipConflictDetection);
+        return new BulkWrite(heapSize, preFlushHook.transform(buffer), partition.getName(), skipIndexWrites, skipConflictDetection, skipWAL);
     }
 
     /**

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/PipingCallBuffer.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/PipingCallBuffer.java
@@ -233,7 +233,8 @@ public class PipingCallBuffer implements RecordingCallBuffer<KVPair>, Rebuildabl
 //                }
 
             	// Create a new PartitionBuffer, add it to the map, and add it to the ServerCallBuffer.
-                PartitionBuffer newBuffer = new PartitionBuffer(region, preFlushHook, skipIndexWrites, writeConfiguration.skipConflictDetection());
+                PartitionBuffer newBuffer = new PartitionBuffer(region, preFlushHook, skipIndexWrites,
+                        writeConfiguration.skipConflictDetection(), writeConfiguration.skipWAL());
                 startKeyToRegionCBMap.put(startKey, Pair.newPair(newBuffer,server));
                 regionServerCB.add(Pair.newPair(startKey, newBuffer));
             } else {

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/client/BulkWrite.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/client/BulkWrite.java
@@ -28,7 +28,8 @@ public class BulkWrite {
 
     enum Flags {
         SKIP_INDEX_WRITE((byte)0x01),
-        SKIP_CONFLICT_DETECTION((byte)0x02);
+        SKIP_CONFLICT_DETECTION((byte)0x02),
+        SKIP_WAL((byte)0x04);
 
         final byte mask;
         Flags(byte mask) {
@@ -44,6 +45,7 @@ public class BulkWrite {
     private String encodedStringName;
     private boolean skipIndexWrite;
     private boolean skipConflictDetection;
+    private boolean skipWAL;
 
     /*non serialized field*/
     private transient long bufferHeapSize = -1;
@@ -56,6 +58,7 @@ public class BulkWrite {
         this(-1, mutations, encodedStringName);
         this.skipIndexWrite = Flags.SKIP_INDEX_WRITE.isSetIn(flags);
         this.skipConflictDetection = Flags.SKIP_CONFLICT_DETECTION.isSetIn(flags);
+        this.skipWAL = Flags.SKIP_WAL.isSetIn(flags);
     }
 
     public BulkWrite(int heapSizeEstimate,Collection<KVPair> mutations,String encodedStringName) {
@@ -66,10 +69,12 @@ public class BulkWrite {
         this.skipIndexWrite = false; // default to false - do not skip
     }
 
-    public BulkWrite(int heapSizeEstimate,Collection<KVPair> mutations,String encodedStringName, boolean skipIndexWrite, boolean skipConflictDetection) {
+    public BulkWrite(int heapSizeEstimate,Collection<KVPair> mutations,String encodedStringName,
+                     boolean skipIndexWrite, boolean skipConflictDetection, boolean skipWAL) {
         this(heapSizeEstimate, mutations, encodedStringName);
         this.skipIndexWrite = skipIndexWrite;
         this.skipConflictDetection = skipConflictDetection;
+        this.skipWAL = skipWAL;
     }
 
     public Collection<KVPair> getMutations() {
@@ -116,10 +121,14 @@ public class BulkWrite {
             result |= Flags.SKIP_INDEX_WRITE.mask;
         if (skipConflictDetection)
             result |= Flags.SKIP_CONFLICT_DETECTION.mask;
+        if (skipWAL)
+            result |= Flags.SKIP_WAL.mask;
         return result;
     }
 
     public boolean skipConflictDetection() {
         return skipConflictDetection;
     }
+
+    public boolean skipWAL() { return skipWAL; }
 }

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/config/BaseWriteConfiguration.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/config/BaseWriteConfiguration.java
@@ -205,4 +205,9 @@ public abstract class BaseWriteConfiguration implements WriteConfiguration {
     public boolean skipConflictDetection() {
         return false;
     }
+
+    @Override
+    public boolean skipWAL() {
+        return false;
+    }
 }

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/config/ForwardingWriteConfiguration.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/config/ForwardingWriteConfiguration.java
@@ -53,6 +53,11 @@ public class ForwardingWriteConfiguration implements WriteConfiguration {
     }
 
     @Override
+    public boolean skipWAL() {
+        return delegate.skipWAL();
+    }
+
+    @Override
     public int getMaximumRetries() {
         return delegate.getMaximumRetries();
     }

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/config/UnsafeWriteConfiguration.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/config/UnsafeWriteConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ *
+ *  * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *  *
+ *  * This file is part of Splice Machine.
+ *  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ *  * GNU Affero General Public License as published by the Free Software Foundation, either
+ *  * version 3, or (at your option) any later version.
+ *  * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  * See the GNU Affero General Public License for more details.
+ *  * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ *  * If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.splicemachine.pipeline.config;
+
+import org.apache.log4j.Logger;
+
+/**
+ *
+ */
+public class UnsafeWriteConfiguration extends ForwardingWriteConfiguration {
+    private static final Logger LOG = Logger.getLogger(UnsafeWriteConfiguration.class);
+    protected boolean skipWAL;
+    protected boolean skipConflictDetection;
+
+    public UnsafeWriteConfiguration(WriteConfiguration delegate,
+                                    boolean skipConflictDetection, boolean skipWAL) {
+        super(delegate);
+        this.skipWAL = skipWAL;
+        this.skipConflictDetection = skipConflictDetection;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("UnsafeWriteConfiguration{delegate=%s}",delegate);
+    }
+
+    @Override
+    public boolean skipConflictDetection() {
+        return skipConflictDetection;
+    }
+
+    @Override
+    public boolean skipWAL() {
+        return skipWAL;
+    }
+}
+

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/config/WriteConfiguration.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/config/WriteConfiguration.java
@@ -54,4 +54,6 @@ public interface WriteConfiguration {
     void setRecordingContext(RecordingContext recordingContext);
 
     boolean skipConflictDetection();
+
+    boolean skipWAL();
 }

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/context/PipelineWriteContext.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/context/PipelineWriteContext.java
@@ -56,6 +56,7 @@ public class PipelineWriteContext implements WriteContext, Comparable<PipelineWr
     private final WriteNode head;
     private final PipelineExceptionFactory pef;
     private final boolean skipConflictDetection;
+    private final boolean skipWAL;
 
     private WriteNode tail;
 
@@ -65,6 +66,7 @@ public class PipelineWriteContext implements WriteContext, Comparable<PipelineWr
                                  TransactionalRegion rce,
                                  boolean skipIndexWrites,
                                  boolean skipConflictDetection,
+                                 boolean skipWAL,
                                  ServerControl env,
                                 PipelineExceptionFactory pef) {
         this.indexSharedCallBuffer = indexSharedCallBuffer;
@@ -77,6 +79,7 @@ public class PipelineWriteContext implements WriteContext, Comparable<PipelineWr
         this.partitionFactory = partitionFactory;
         this.pef = pef;
         this.skipConflictDetection = skipConflictDetection;
+        this.skipWAL = skipWAL;
     }
 
     public void addLast(WriteHandler handler) {
@@ -233,6 +236,11 @@ public class PipelineWriteContext implements WriteContext, Comparable<PipelineWr
     @Override
     public boolean skipConflictDetection() {
         return this.skipConflictDetection;
+    }
+
+    @Override
+    public boolean skipWAL() {
+        return this.skipWAL;
     }
 
     @Override

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/context/WriteContext.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/context/WriteContext.java
@@ -111,6 +111,8 @@ public interface WriteContext {
 
     boolean skipConflictDetection();
 
+    boolean skipWAL();
+
     TransactionalRegion txnRegion();
 
     PipelineExceptionFactory exceptionFactory();

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/context/WriteNode.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/context/WriteNode.java
@@ -155,6 +155,11 @@ public class WriteNode implements WriteContext {
     }
 
     @Override
+    public boolean skipWAL() {
+        return pipelineWriteContext.skipWAL();
+    }
+
+    @Override
     public TransactionalRegion txnRegion(){
         return pipelineWriteContext.txnRegion();
     }

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/LocalWriteContextFactory.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/LocalWriteContextFactory.java
@@ -112,7 +112,7 @@ class LocalWriteContextFactory<TableInfo> implements WriteContextFactory<Transac
         CachedPartitionFactory<TableInfo> pf = new CachedPartitionFactory<TableInfo>(basePartitionFactory){
             @Override protected String infoAsString(TableInfo tableName){ return tableInfoParseFunction.apply(tableName); }
         };
-        PipelineWriteContext context = new PipelineWriteContext(indexSharedCallBuffer,pf, txn, rce, false, false, env,pipelineExceptionFactory);
+        PipelineWriteContext context = new PipelineWriteContext(indexSharedCallBuffer,pf, txn, rce, false, false, false, env,pipelineExceptionFactory);
         BatchConstraintChecker checker = buildConstraintChecker(txn);
         context.addLast(new PartitionWriteHandler(rce, tableWriteLatch, checker));
         addWriteHandlerFactories(1000, context);
@@ -121,13 +121,14 @@ class LocalWriteContextFactory<TableInfo> implements WriteContextFactory<Transac
 
     @Override
     public WriteContext create(SharedCallBufferFactory indexSharedCallBuffer,
-                               TxnView txn, TransactionalRegion region, int expectedWrites, boolean skipIndexWrites, boolean skipConflictDetection,
+                               TxnView txn, TransactionalRegion region, int expectedWrites,
+                               boolean skipIndexWrites, boolean skipConflictDetection, boolean skipWAL,
                                ServerControl env) throws IOException, InterruptedException {
         CachedPartitionFactory<TableInfo> pf = new CachedPartitionFactory<TableInfo>(basePartitionFactory){
             @Override protected String infoAsString(TableInfo tableName){ return tableInfoParseFunction.apply(tableName); }
         };
         PipelineWriteContext context = new PipelineWriteContext(indexSharedCallBuffer,
-                pf,txn, region, skipIndexWrites,skipConflictDetection, env,pipelineExceptionFactory);
+                pf,txn, region, skipIndexWrites,skipConflictDetection, skipWAL, env,pipelineExceptionFactory);
         BatchConstraintChecker checker = buildConstraintChecker(txn);
         context.addLast(new PartitionWriteHandler(region, tableWriteLatch, checker));
         addWriteHandlerFactories(expectedWrites, context);
@@ -158,7 +159,7 @@ class LocalWriteContextFactory<TableInfo> implements WriteContextFactory<Transac
         CachedPartitionFactory<TableInfo> pf = new CachedPartitionFactory<TableInfo>(basePartitionFactory){
             @Override protected String infoAsString(TableInfo tableName){ return tableInfoParseFunction.apply(tableName); }
         };
-        PipelineWriteContext context = new PipelineWriteContext(indexSharedCallBuffer, pf,txn, region, false, false, env,pipelineExceptionFactory);
+        PipelineWriteContext context = new PipelineWriteContext(indexSharedCallBuffer, pf,txn, region, false, false, false, env,pipelineExceptionFactory);
         addWriteHandlerFactories(expectedWrites, context);
         return context;
     }

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/WriteContextFactory.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/WriteContextFactory.java
@@ -38,6 +38,7 @@ public interface WriteContextFactory<T> {
                         int expectedWrites,
                         boolean skipIndexWrites,
                         boolean skipConflictDetection,
+                        boolean skipWAL,
                         ServerControl env) throws IOException, InterruptedException;
 
     /**

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/PartitionWriteHandler.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/PartitionWriteHandler.java
@@ -164,7 +164,8 @@ public class PartitionWriteHandler implements WriteHandler {
                 SIConstants.PACKED_COLUMN_BYTES,
                 constraintChecker,
                 toProcess,
-                ctx.skipConflictDetection()
+                ctx.skipConflictDetection(),
+                ctx.skipWAL()
         );
 
         int i = 0;

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/SharedCallBufferFactory.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/SharedCallBufferFactory.java
@@ -18,6 +18,7 @@ import com.carrotsearch.hppc.ObjectObjectOpenHashMap;
 import com.splicemachine.access.api.PartitionFactory;
 import com.splicemachine.kvpair.KVPair;
 import com.splicemachine.pipeline.callbuffer.CallBuffer;
+import com.splicemachine.pipeline.config.UnsafeWriteConfiguration;
 import com.splicemachine.pipeline.config.WriteConfiguration;
 import com.splicemachine.pipeline.context.WriteContext;
 import com.splicemachine.pipeline.client.WriteCoordinator;
@@ -72,9 +73,12 @@ public class SharedCallBufferFactory{
                                                       TxnView txn) throws IOException{
         SharedPreFlushHook hook = new SharedPreFlushHook();
         WriteConfiguration writeConfiguration=writerPool.defaultWriteConfiguration();
-        SharedWriteConfiguration wc = new SharedWriteConfiguration(writeConfiguration.getMaximumRetries(),
+        WriteConfiguration wc = new SharedWriteConfiguration(writeConfiguration.getMaximumRetries(),
                 writeConfiguration.getPause(),
                 writeConfiguration.getExceptionFactory());
+        if (context.skipConflictDetection() || context.skipWAL()) {
+            wc = new UnsafeWriteConfiguration(wc, context.skipConflictDetection(), context.skipWAL());
+        }
         hook.registerContext(context, indexToMainMutationMap);
         wc.registerContext(context, indexToMainMutationMap);
         CallBuffer<KVPair> writeBuffer;

--- a/splice_access_api/src/main/java/com/splicemachine/storage/DataPut.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/DataPut.java
@@ -33,4 +33,6 @@ public interface DataPut extends DataMutation{
     Iterable<DataCell> cells();
 
     void addCell(DataCell kv);
+
+    void skipWAL();
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/load/HdfsImport.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/load/HdfsImport.java
@@ -188,6 +188,7 @@ public class HdfsImport {
                  true,
                  false,
                  false,
+                 false,
                  results);
     }
 
@@ -269,6 +270,7 @@ public class HdfsImport {
                  false,
                  false,
                  false,
+                 false,
                  results);
     }
 
@@ -303,6 +305,7 @@ public class HdfsImport {
                 false,
                 false,
                 true,
+                true,
                 results);
     }
 
@@ -324,15 +327,16 @@ public class HdfsImport {
                                  boolean isUpsert,
                                  boolean isCheckScan,
                                  boolean skipConflictDetection,
+                                 boolean skipWAL,
                                  ResultSet[] results) throws SQLException {
         if (LOG.isTraceEnabled())
             SpliceLogUtils.trace(LOG, "doImport {schemaName=%s, tableName=%s, insertColumnList=%s, fileName=%s, " +
                                      "columnDelimiter=%s, characterDelimiter=%s, timestampFormat=%s, dateFormat=%s, " +
                 "timeFormat=%s, badRecordsAllowed=%d, badRecordDirectory=%s, oneLineRecords=%s, charset=%s, " +
-                "isUpsert=%s, isCheckScan=%s, skipConflictDetection=%b}",
+                "isUpsert=%s, isCheckScan=%s, skipConflictDetection=%b, skipWAL=%b}",
                                  schemaName, tableName, insertColumnListString, fileName, columnDelimiter, characterDelimiter,
                                  timestampFormat, dateFormat, timeFormat, badRecordsAllowed, badRecordDirectory,
-                                 oneLineRecords, charset, isUpsert, isCheckScan, skipConflictDetection);
+                                 oneLineRecords, charset, isUpsert, isCheckScan, skipConflictDetection, skipWAL);
 
         if (charset == null) {
             charset = StandardCharsets.UTF_8.name();
@@ -414,7 +418,9 @@ public class HdfsImport {
             ColumnInfo columnInfo = new ColumnInfo(conn, schemaName, tableName, insertColumnList);
             String insertSql = "INSERT INTO " + entityName + "(" + columnInfo.getInsertColumnNames() + ") " +
                 "--splice-properties useSpark=true , insertMode=" + (isUpsert ? "UPSERT" : "INSERT") + ", statusDirectory=" +
-                badRecordDirectory + ", badRecordsAllowed=" + badRecordsAllowed + (skipConflictDetection ? ", skipConflictDetection=true" : "") + "\n" +
+                badRecordDirectory + ", badRecordsAllowed=" + badRecordsAllowed +
+                    (skipConflictDetection ? ", skipConflictDetection=true" : "") +
+                    (skipWAL ? ", skipWAL=true" : "") + "\n" +
                 " SELECT "+
                     generateColumnList(((EmbedConnection)conn).getLanguageConnection(),schemaName,tableName,insertColumnList) +
                     " from " +

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
@@ -1117,6 +1117,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                                              String statusDirectory,
                                              int failBadRecordCount,
                                              boolean skipConflictDetection,
+                                             boolean skipWAL,
                                              double optimizerEstimatedRowCount,
                                              double optimizerEstimatedCost,
                                              String tableVersion,
@@ -1132,7 +1133,8 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
         try{
             ConvertedResultSet below = (ConvertedResultSet)source;
             SpliceOperation top = new InsertOperation(below.getOperation(), generationClauses, checkGM, insertMode,
-                    statusDirectory, failBadRecordCount, skipConflictDetection, optimizerEstimatedRowCount,optimizerEstimatedCost, tableVersion,
+                    statusDirectory, failBadRecordCount, skipConflictDetection, skipWAL,
+                    optimizerEstimatedRowCount,optimizerEstimatedCost, tableVersion,
                     delimited,escaped,lines,storedAs,location, compression, partitionBy);
             source.getActivation().getLanguageConnectionContext().getAuthorizer().authorize(source.getActivation(), 1);
             top.markAsTopResultSet();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/WriteCursorConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/WriteCursorConstantOperation.java
@@ -290,6 +290,8 @@ public abstract	class WriteCursorConstantOperation implements ConstantAction, Fo
 	 * @return the conglomerate id.
 	 */
 	public long getConglomerateId() { return conglomId; }
+
+	public long[] getIndexCIDS() { return indexCIDS; }
 		
 	/**
 	 *	Get emptyHeapRow

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DerbyDMLWriteInfo.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DerbyDMLWriteInfo.java
@@ -73,6 +73,11 @@ public class DerbyDMLWriteInfo implements DMLWriteInfo {
     }
 
     @Override
+    public long[] getIndexConglomerateIds() {
+        return ((WriteCursorConstantOperation)getConstantAction()).getIndexCIDS();
+    }
+
+    @Override
 		public ResultDescription getResultDescription() {
 				return activation.getResultDescription();
 		}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/DMLWriteInfo.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/DMLWriteInfo.java
@@ -42,6 +42,8 @@ public interface DMLWriteInfo extends Externalizable {
 
     long getConglomerateId();
 
+    long[] getIndexConglomerateIds();
+
     ResultDescription getResultDescription();
 
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/PermissiveInsertWriteConfiguration.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/PermissiveInsertWriteConfiguration.java
@@ -39,12 +39,14 @@ import java.util.concurrent.ExecutionException;
  */
 public class PermissiveInsertWriteConfiguration extends ForwardingWriteConfiguration {
     private static final Logger LOG = Logger.getLogger(PermissiveInsertWriteConfiguration.class);
+    protected boolean skipWAL;
     protected boolean skipConflictDetection;
     protected OperationContext operationContext;
     protected ThreadLocal<PairDecoder> pairDecoder;
 
     public PermissiveInsertWriteConfiguration(WriteConfiguration delegate, OperationContext operationContext,
-                                              final PairEncoder encoder, final ExecRow execRowDefinition, boolean skipConflictDetection) {
+                                              final PairEncoder encoder, final ExecRow execRowDefinition,
+                                              boolean skipConflictDetection, boolean skipWAL) {
         super(delegate);
         assert operationContext!=null && encoder != null:"Passed in null values to PermissiveInsert";
         this.operationContext = operationContext;
@@ -54,6 +56,7 @@ public class PermissiveInsertWriteConfiguration extends ForwardingWriteConfigura
                 return encoder.getDecoder(execRowDefinition.getClone());
             }
         };
+        this.skipWAL = skipWAL;
         this.skipConflictDetection = skipConflictDetection;
     }
 
@@ -148,6 +151,11 @@ public class PermissiveInsertWriteConfiguration extends ForwardingWriteConfigura
     @Override
     public boolean skipConflictDetection() {
         return skipConflictDetection;
+    }
+
+    @Override
+    public boolean skipWAL() {
+        return skipWAL;
     }
 }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/PermissiveInsertWriteConfiguration.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/PermissiveInsertWriteConfiguration.java
@@ -39,14 +39,11 @@ import java.util.concurrent.ExecutionException;
  */
 public class PermissiveInsertWriteConfiguration extends ForwardingWriteConfiguration {
     private static final Logger LOG = Logger.getLogger(PermissiveInsertWriteConfiguration.class);
-    protected boolean skipWAL;
-    protected boolean skipConflictDetection;
     protected OperationContext operationContext;
     protected ThreadLocal<PairDecoder> pairDecoder;
 
     public PermissiveInsertWriteConfiguration(WriteConfiguration delegate, OperationContext operationContext,
-                                              final PairEncoder encoder, final ExecRow execRowDefinition,
-                                              boolean skipConflictDetection, boolean skipWAL) {
+                                              final PairEncoder encoder, final ExecRow execRowDefinition) {
         super(delegate);
         assert operationContext!=null && encoder != null:"Passed in null values to PermissiveInsert";
         this.operationContext = operationContext;
@@ -56,8 +53,6 @@ public class PermissiveInsertWriteConfiguration extends ForwardingWriteConfigura
                 return encoder.getDecoder(execRowDefinition.getClone());
             }
         };
-        this.skipWAL = skipWAL;
-        this.skipConflictDetection = skipConflictDetection;
     }
 
     @Override
@@ -146,16 +141,6 @@ public class PermissiveInsertWriteConfiguration extends ForwardingWriteConfigura
         }
         sb.append(": " + row);
         return sb.toString();
-    }
-
-    @Override
-    public boolean skipConflictDetection() {
-        return skipConflictDetection;
-    }
-
-    @Override
-    public boolean skipWAL() {
-        return skipWAL;
     }
 }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/insert/InsertPipelineWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/insert/InsertPipelineWriter.java
@@ -94,7 +94,7 @@ public class InsertPipelineWriter extends AbstractPipelineWriter<ExecRow>{
             if(insertOperation!=null && operationContext.isPermissive())
                     writeConfiguration = new PermissiveInsertWriteConfiguration(writeConfiguration,
                             operationContext,
-                            encoder, execRowDefinition, insertOperation.skipConflictDetection());
+                            encoder, execRowDefinition, insertOperation.skipConflictDetection(), insertOperation.skipWAL());
 
             writeConfiguration.setRecordingContext(operationContext);
             this.table =SIDriver.driver().getTableFactory().getTable(Long.toString(heapConglom));

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/insert/InsertPipelineWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/insert/InsertPipelineWriter.java
@@ -26,6 +26,7 @@ import com.splicemachine.derby.impl.sql.execute.sequence.SpliceSequence;
 import com.splicemachine.derby.stream.iapi.OperationContext;
 import com.splicemachine.derby.stream.output.PermissiveInsertWriteConfiguration;
 import com.splicemachine.derby.stream.output.AbstractPipelineWriter;
+import com.splicemachine.pipeline.config.UnsafeWriteConfiguration;
 import com.splicemachine.derby.utils.marshall.*;
 import com.splicemachine.derby.utils.marshall.dvd.DescriptorSerializer;
 import com.splicemachine.derby.utils.marshall.dvd.VersionedSerializers;
@@ -94,7 +95,10 @@ public class InsertPipelineWriter extends AbstractPipelineWriter<ExecRow>{
             if(insertOperation!=null && operationContext.isPermissive())
                     writeConfiguration = new PermissiveInsertWriteConfiguration(writeConfiguration,
                             operationContext,
-                            encoder, execRowDefinition, insertOperation.skipConflictDetection(), insertOperation.skipWAL());
+                            encoder, execRowDefinition);
+            if(insertOperation.skipConflictDetection() || insertOperation.skipWAL()) {
+                writeConfiguration = new UnsafeWriteConfiguration(writeConfiguration, insertOperation.skipConflictDetection(), insertOperation.skipWAL());
+            }
 
             writeConfiguration.setRecordingContext(operationContext);
             this.table =SIDriver.driver().getTableFactory().getTable(Long.toString(heapConglom));

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/server/ClusterHealth.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/server/ClusterHealth.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *  * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *  *
+ *  * This file is part of Splice Machine.
+ *  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ *  * GNU Affero General Public License as published by the Free Software Foundation, either
+ *  * version 3, or (at your option) any later version.
+ *  * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  * See the GNU Affero General Public License for more details.
+ *  * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ *  * If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.splicemachine.si.api.server;
+
+import com.splicemachine.utils.ByteSlice;
+
+/**
+ * Interface to check cluster health.
+ */
+public interface ClusterHealth {
+
+    /**
+     * Create a ClusterHealthWatcher to be notified of health issues in the cluster.
+     */
+    ClusterHealthWatcher registerWatcher();
+
+    interface ClusterHealthWatcher extends AutoCloseable {
+        int failedServers();
+        void close();
+    }
+}

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/server/TransactionalRegion.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/server/TransactionalRegion.java
@@ -67,7 +67,7 @@ public interface TransactionalRegion<InternalScanner> extends AutoCloseable{
     Iterable<MutationStatus> bulkWrite(TxnView txn,
                                        byte[] family, byte[] qualifier,
                                        ConstraintChecker constraintChecker,
-                                       Collection<KVPair> data, boolean skipConflictDetection) throws IOException;
+                                       Collection<KVPair> data, boolean skipConflictDetection, boolean skipWAL) throws IOException;
 
     String getRegionName();
 

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/server/Transactor.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/server/Transactor.java
@@ -48,6 +48,8 @@ public interface Transactor{
                                     byte[] packedColumnBytes,
                                     Collection<KVPair> toProcess,
                                     TxnView txn,
-                                    ConstraintChecker constraintChecker, boolean skipConflictDetection) throws IOException;
+                                    ConstraintChecker constraintChecker,
+                                    boolean skipConflictDetection,
+                                    boolean skipWAL) throws IOException;
 
 }

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/TxnRegion.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/TxnRegion.java
@@ -114,11 +114,12 @@ public class TxnRegion<InternalScanner> implements TransactionalRegion<InternalS
     public Iterable<MutationStatus> bulkWrite(TxnView txn,
                                               byte[] family, byte[] qualifier,
                                               ConstraintChecker constraintChecker, //TODO -sf- can we encapsulate this as well?
-                                              Collection<KVPair> data, boolean skipConflictDetection) throws IOException{
+                                              Collection<KVPair> data, boolean skipConflictDetection, boolean skipWAL) throws IOException{
         /*
          * Designed for subclasses. Override this if you want to bypass transactional writes
          */
-        final MutationStatus[] status = transactor.processKvBatch(region, rollForward, family, qualifier, data,txn,constraintChecker,skipConflictDetection);
+        final MutationStatus[] status = transactor.processKvBatch(region, rollForward, family, qualifier, data,txn,
+                constraintChecker,skipConflictDetection,skipWAL);
         return new Iterable<MutationStatus>(){
             @Override public Iterator<MutationStatus> iterator(){ return Iterators.forArray(status); }
         };

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIDriver.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIDriver.java
@@ -29,6 +29,7 @@ import com.splicemachine.si.api.readresolve.AsyncReadResolver;
 import com.splicemachine.si.api.readresolve.KeyedReadResolver;
 import com.splicemachine.si.api.readresolve.ReadResolver;
 import com.splicemachine.si.api.readresolve.RollForward;
+import com.splicemachine.si.api.server.ClusterHealth;
 import com.splicemachine.si.api.server.TransactionalRegion;
 import com.splicemachine.si.api.server.Transactor;
 import com.splicemachine.si.api.txn.TxnLifecycleManager;
@@ -92,6 +93,7 @@ public class SIDriver {
     private final PartitionInfoCache partitionInfoCache;
     private final SnowflakeFactory snowflakeFactory;
     private final SIEnvironment env;
+    private final ClusterHealth clusterHealth;
 
     public SIDriver(SIEnvironment env){
         this.tableFactory = env.tableFactory();
@@ -123,6 +125,7 @@ public class SIDriver {
         readResolver = initializedReadResolver(config,env.keyedReadResolver());
         this.baseOpFactory = env.baseOperationFactory();
         this.env = env;
+        this.clusterHealth = env.clusterHealthFactory();
     }
 
 
@@ -221,6 +224,10 @@ public class SIDriver {
 
     public DistributedFileSystem getFileSystem(String path) throws URISyntaxException, IOException {
         return SIDriver.driver().getSIEnvironment().fileSystem(path);
+    }
+
+    public ClusterHealth clusterHealth() {
+        return clusterHealth;
     }
 
 

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIEnvironment.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIEnvironment.java
@@ -22,6 +22,7 @@ import com.splicemachine.concurrent.Clock;
 import com.splicemachine.si.api.data.*;
 import com.splicemachine.si.api.readresolve.KeyedReadResolver;
 import com.splicemachine.si.api.readresolve.RollForward;
+import com.splicemachine.si.api.server.ClusterHealth;
 import com.splicemachine.si.api.txn.KeepAliveScheduler;
 import com.splicemachine.si.api.txn.TxnStore;
 import com.splicemachine.si.api.txn.TxnSupplier;
@@ -81,5 +82,7 @@ public interface SIEnvironment{
     OperationFactory baseOperationFactory();
 
     SnowflakeFactory snowflakeFactory();
+
+    ClusterHealth clusterHealthFactory();
 
 }


### PR DESCRIPTION
Basic workflow as described in the JIRA:

1) Start transaction
2) Add detector for RegionServer failures (ZK watcher or Observer)
3) Import a batch of work with no WAL
4) Force a flush synchronously
5) Check there were no RS failures
6a) No failures -> commit transaction
6b) Failures -> abort transaction 

Limitations:
- If we detect a failure we fail the import, we don't automatically retry it
- We flag as failures any changes to the RSs membership, adding nodes for instance 
- Currently only supported for Inserts, we could extend it to Updates and Deletes

