### PR TITLE
DB-5876: Fix a couple of problems that can cause backup to hang(for 2.0)

### DIFF
--- a/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -31,9 +31,6 @@ import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.log4j.Logger;
-import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.ZooDefs;
-
 import java.io.IOException;
 import java.util.List;
 
@@ -44,6 +41,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private static final Logger LOG=Logger.getLogger(BackupEndpointObserver.class);
 
     private volatile boolean isSplitting;
+    private volatile boolean isFlushing;
+    private volatile boolean isCompacting;
+
     private HRegion region;
     private String namespace;
     private String tableName;
@@ -90,8 +90,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         try {
             preparing = true;
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder =
-                    BackupUtils.prepare(region, isSplitting, tableName, regionName, path);
+                    BackupUtils.prepare(request, region, isSplitting, isCompacting, isFlushing, tableName, regionName, path);
+
             preparing = false;
+            assert responseBuilder.hasReadyForBackup();
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
@@ -121,6 +123,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         super.preCompactSelection(c, store, candidates);
     }
 
@@ -130,7 +133,14 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         return super.preCompact(e, store, scanner, scanType);
+    }
+
+    @Override
+    public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
+        super.postCompact(e, store, resultFile);
+        isCompacting = false;
     }
 
     @Override
@@ -138,6 +148,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isFlushing = true;
         super.preFlush(e);
     }
 
@@ -150,6 +161,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
                 return;
             BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
                     tableName, resultFile.getPath().getName(), preparing);
+            isFlushing = false;
         } catch (Exception ex) {
             throw new IOException(ex);
         }

--- a/hbase_sql/hbase1.0.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.0.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -44,6 +44,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private static final Logger LOG=Logger.getLogger(BackupEndpointObserver.class);
 
     private volatile boolean isSplitting;
+    private volatile boolean isFlushing;
+    private volatile boolean isCompacting;
+
     private HRegion region;
     private String namespace;
     private String tableName;
@@ -90,8 +93,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         try {
             preparing = true;
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder =
-                    BackupUtils.prepare(region, isSplitting, tableName, regionName, path);
+                    BackupUtils.prepare(request, region, isSplitting, isCompacting, isFlushing, tableName, regionName, path);
+
             preparing = false;
+            assert responseBuilder.hasReadyForBackup();
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
@@ -121,6 +126,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         super.preCompactSelection(c, store, candidates);
     }
 
@@ -130,14 +136,22 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         return super.preCompact(e, store, scanner, scanType);
     }
 
+    @Override
+    public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
+        super.postCompact(e, store, resultFile);
+        isCompacting = false;
+    }
+    
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isFlushing = true;
         super.preFlush(e);
     }
 
@@ -150,6 +164,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
                 return;
             BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
                     tableName, resultFile.getPath().getName(), preparing);
+            isFlushing = false;
         } catch (Exception ex) {
             throw new IOException(ex);
         }

--- a/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -31,8 +31,6 @@ import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.log4j.Logger;
-import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.ZooDefs;
 
 import java.io.IOException;
 import java.util.List;
@@ -44,6 +42,8 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private static final Logger LOG=Logger.getLogger(BackupEndpointObserver.class);
 
     private volatile boolean isSplitting;
+    private volatile boolean isFlushing;
+    private volatile boolean isCompacting;
     private HRegion region;
     private String namespace;
     private String tableName;
@@ -90,12 +90,14 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         try {
             preparing = true;
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder =
-                    BackupUtils.prepare(region, isSplitting, tableName, regionName, path);
+                    BackupUtils.prepare(request, region, isSplitting, isCompacting, isFlushing, tableName, regionName, path);
             preparing = false;
+            assert responseBuilder.hasReadyForBackup();
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
         }
+
     }
 
     @Override
@@ -121,6 +123,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         super.preCompactSelection(c, store, candidates);
     }
 
@@ -130,7 +133,14 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         return super.preCompact(e, store, scanner, scanType);
+    }
+
+    @Override
+    public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
+        super.postCompact(e, store, resultFile);
+        isCompacting = false;
     }
 
     @Override
@@ -138,6 +148,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isFlushing = true;
         super.preFlush(e);
     }
 
@@ -150,12 +161,12 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
                 return;
             BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
                     tableName, resultFile.getPath().getName(), preparing);
+            isFlushing = false;
         } catch (Exception ex) {
             throw new IOException(ex);
         }
     }
 
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
-
     }
 }

--- a/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -31,8 +31,6 @@ import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.log4j.Logger;
-import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.ZooDefs;
 
 import java.io.IOException;
 import java.util.List;
@@ -44,6 +42,8 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private static final Logger LOG=Logger.getLogger(BackupEndpointObserver.class);
 
     private volatile boolean isSplitting;
+    private volatile boolean isFlushing;
+    private volatile boolean isCompacting;
     private HRegion region;
     private String namespace;
     private String tableName;
@@ -90,12 +90,14 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         try {
             preparing = true;
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder =
-                    BackupUtils.prepare(region, isSplitting, tableName, regionName, path);
+                    BackupUtils.prepare(request, region, isSplitting, isCompacting, isFlushing, tableName, regionName, path);
             preparing = false;
+            assert responseBuilder.hasReadyForBackup();
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
         }
+
     }
 
     @Override
@@ -121,6 +123,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         super.preCompactSelection(c, store, candidates);
     }
 
@@ -130,7 +133,14 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         return super.preCompact(e, store, scanner, scanType);
+    }
+
+    @Override
+    public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
+        super.postCompact(e, store, resultFile);
+        isCompacting = false;
     }
 
     @Override
@@ -138,6 +148,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isFlushing = true;
         super.preFlush(e);
     }
 
@@ -150,12 +161,12 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
                 return;
             BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
                     tableName, resultFile.getPath().getName(), preparing);
+            isFlushing = false;
         } catch (Exception ex) {
             throw new IOException(ex);
         }
     }
 
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
-
     }
 }

--- a/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -42,6 +42,8 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private static final Logger LOG=Logger.getLogger(BackupEndpointObserver.class);
 
     private volatile boolean isSplitting;
+    private volatile boolean isFlushing;
+    private volatile boolean isCompacting;
     private HRegion region;
     private String namespace;
     private String tableName;
@@ -88,12 +90,14 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         try {
             preparing = true;
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder =
-                    BackupUtils.prepare(region, isSplitting, tableName, regionName, path);
+                    BackupUtils.prepare(request, region, isSplitting, isCompacting, isFlushing, tableName, regionName, path);
             preparing = false;
+            assert responseBuilder.hasReadyForBackup();
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
         }
+
     }
 
     @Override
@@ -119,6 +123,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         super.preCompactSelection(c, store, candidates);
     }
 
@@ -128,7 +133,14 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         return super.preCompact(e, store, scanner, scanType);
+    }
+
+    @Override
+    public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
+        super.postCompact(e, store, resultFile);
+        isCompacting = false;
     }
 
     @Override
@@ -136,6 +148,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isFlushing = true;
         super.preFlush(e);
     }
 
@@ -148,12 +161,12 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
                 return;
             BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
                     tableName, resultFile.getPath().getName(), preparing);
+            isFlushing = false;
         } catch (Exception ex) {
             throw new IOException(ex);
         }
     }
 
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
-
     }
 }

--- a/splice_protocol/src/main/protobuf/Splice.proto
+++ b/splice_protocol/src/main/protobuf/Splice.proto
@@ -164,10 +164,12 @@ service BackupCoprocessorService {
 }
 
 message PrepareBackupRequest {
+    optional bytes startKey=1;
+    optional bytes endKey=2;
 }
 
 message PrepareBackupResponse {
-  required bool readyForBackup = 1;
+  optional bool readyForBackup = 1;
 }
 
 message BlockingProbeRequest {


### PR DESCRIPTION
Address a couple of backup issues in this pull request.

Used wrong end key to probe if a region is ready for backup. This caused backup to hang in Cetera's cluster
When backup is done, marked wrong znode to indicate backup is complete. This can block flush, compaction and split.
Set correct hbase.rootdir for spark backup task. Otherwise, incorrect default hbase root dir may be used to create HFileLink to referenced parent file.
Fix an issue in BackupObserverEndpoint that can cause deadlock.
Add more tracing for diagnosis.

**Moderator - Please remember to merge pull request from ee branch together with this one**