### PR TITLE
DB-5876: Fix a couple issues that cause backup to hang(2.5)

### DIFF
--- a/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.log4j.Logger;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -40,6 +41,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private static final Logger LOG=Logger.getLogger(BackupEndpointObserver.class);
 
     private volatile boolean isSplitting;
+    private volatile boolean isFlushing;
+    private volatile boolean isCompacting;
+
     private HRegion region;
     private String namespace;
     private String tableName;
@@ -86,8 +90,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         try {
             preparing = true;
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder =
-                    BackupUtils.prepare(region, isSplitting, tableName, regionName, path);
+                    BackupUtils.prepare(request, region, isSplitting, isCompacting, isFlushing, tableName, regionName, path);
+
             preparing = false;
+            assert responseBuilder.hasReadyForBackup();
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
@@ -117,6 +123,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         super.preCompactSelection(c, store, candidates);
     }
 
@@ -126,7 +133,14 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         return super.preCompact(e, store, scanner, scanType);
+    }
+
+    @Override
+    public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
+        super.postCompact(e, store, resultFile);
+        isCompacting = false;
     }
 
     @Override
@@ -134,6 +148,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isFlushing = true;
         super.preFlush(e);
     }
 
@@ -146,6 +161,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
                 return;
             BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
                     tableName, resultFile.getPath().getName(), preparing);
+            isFlushing = false;
         } catch (Exception ex) {
             throw new IOException(ex);
         }

--- a/hbase_sql/hbase1.0.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.0.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -43,6 +43,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private static final Logger LOG=Logger.getLogger(BackupEndpointObserver.class);
 
     private volatile boolean isSplitting;
+    private volatile boolean isFlushing;
+    private volatile boolean isCompacting;
+
     private HRegion region;
     private String namespace;
     private String tableName;
@@ -89,8 +92,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         try {
             preparing = true;
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder =
-                    BackupUtils.prepare(region, isSplitting, tableName, regionName, path);
+                    BackupUtils.prepare(request, region, isSplitting, isCompacting, isFlushing, tableName, regionName, path);
+
             preparing = false;
+            assert responseBuilder.hasReadyForBackup();
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
@@ -120,6 +125,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         super.preCompactSelection(c, store, candidates);
     }
 
@@ -129,14 +135,22 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         return super.preCompact(e, store, scanner, scanType);
     }
 
+    @Override
+    public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
+        super.postCompact(e, store, resultFile);
+        isCompacting = false;
+    }
+    
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isFlushing = true;
         super.preFlush(e);
     }
 
@@ -149,6 +163,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
                 return;
             BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
                     tableName, resultFile.getPath().getName(), preparing);
+            isFlushing = false;
         } catch (Exception ex) {
             throw new IOException(ex);
         }

--- a/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -41,6 +41,8 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private static final Logger LOG=Logger.getLogger(BackupEndpointObserver.class);
 
     private volatile boolean isSplitting;
+    private volatile boolean isFlushing;
+    private volatile boolean isCompacting;
     private HRegion region;
     private String namespace;
     private String tableName;
@@ -87,12 +89,14 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         try {
             preparing = true;
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder =
-                    BackupUtils.prepare(region, isSplitting, tableName, regionName, path);
+                    BackupUtils.prepare(request, region, isSplitting, isCompacting, isFlushing, tableName, regionName, path);
             preparing = false;
+            assert responseBuilder.hasReadyForBackup();
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
         }
+
     }
 
     @Override
@@ -118,6 +122,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         super.preCompactSelection(c, store, candidates);
     }
 
@@ -127,7 +132,14 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         return super.preCompact(e, store, scanner, scanType);
+    }
+
+    @Override
+    public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
+        super.postCompact(e, store, resultFile);
+        isCompacting = false;
     }
 
     @Override
@@ -135,6 +147,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isFlushing = true;
         super.preFlush(e);
     }
 
@@ -147,12 +160,12 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
                 return;
             BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
                     tableName, resultFile.getPath().getName(), preparing);
+            isFlushing = false;
         } catch (Exception ex) {
             throw new IOException(ex);
         }
     }
 
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
-
     }
 }

--- a/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -41,6 +41,8 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private static final Logger LOG=Logger.getLogger(BackupEndpointObserver.class);
 
     private volatile boolean isSplitting;
+    private volatile boolean isFlushing;
+    private volatile boolean isCompacting;
     private HRegion region;
     private String namespace;
     private String tableName;
@@ -87,8 +89,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         try {
             preparing = true;
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder =
-                    BackupUtils.prepare(region, isSplitting, tableName, regionName, path);
+                    BackupUtils.prepare(request, region, isSplitting, isCompacting, isFlushing, tableName, regionName, path);
             preparing = false;
+            assert responseBuilder.hasReadyForBackup();
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
@@ -119,6 +122,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         super.preCompactSelection(c, store, candidates);
     }
 
@@ -128,7 +132,14 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isCompacting = true;
         return super.preCompact(e, store, scanner, scanType);
+    }
+
+    @Override
+    public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
+        super.postCompact(e, store, resultFile);
+        isCompacting = false;
     }
 
     @Override
@@ -136,6 +147,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isFlushing = true;
         super.preFlush(e);
     }
 
@@ -148,6 +160,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
                 return;
             BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
                     tableName, resultFile.getPath().getName(), preparing);
+            isFlushing = false;
         } catch (Exception ex) {
             throw new IOException(ex);
         }

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/BackupUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/BackupUtils.java
@@ -46,11 +46,20 @@ public class BackupUtils {
     private static final Logger LOG=Logger.getLogger(BackupUtils.class);
 
 
-    public static SpliceMessage.PrepareBackupResponse.Builder prepare(HRegion region, boolean isSplitting,
+    public static SpliceMessage.PrepareBackupResponse.Builder prepare(SpliceMessage.PrepareBackupRequest request,
+                                                                      HRegion region, boolean isSplitting,
+                                                                      boolean isCompacting, boolean isFlushing,
                                                                       String tableName, String regionName, String path) throws Exception{
 
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder = SpliceMessage.PrepareBackupResponse.newBuilder();
+            responseBuilder.setReadyForBackup(false);
+
+            if (shouldIgnore(request, region)) {
+                return responseBuilder;
+            }
+
             boolean canceled = false;
+
             if (isSplitting) {
                 if (LOG.isDebugEnabled()) {
                     SpliceLogUtils.debug(LOG, "%s:%s is being split before trying to prepare for backup", tableName, regionName);
@@ -58,38 +67,42 @@ public class BackupUtils {
                 // return false to client if the region is being split
                 responseBuilder.setReadyForBackup(false);
             } else {
-                // A region might have been in backup
+                if (LOG.isDebugEnabled()) {
+                    SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
+                }
+
+                // A region might have been in backup. This is unlikely to happen unless the previous response ws lost
+                // and the client is retrying
                 if (!BackupUtils.regionIsBeingBackup(tableName, regionName, path)) {
+                    // Flush memsotore and Wait for flush and compaction to be done
+                    HBasePlatformUtils.flush(region);
+                    region.waitForFlushesAndCompactions();
+
                     canceled = BackupUtils.backupCanceled();
                     if (!canceled) {
-                        HBasePlatformUtils.flush(region);
                         // Create a ZNode to indicate that the region is being copied
                         ZkUtils.recursiveSafeCreate(path, HConfiguration.BACKUP_IN_PROGRESS, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-                    }
-                }
-                if (!canceled) {
-                    // check again if the region is being split. If so, return an error
-                    if (isSplitting) {
                         if (LOG.isDebugEnabled()) {
-                            SpliceLogUtils.debug(LOG, "%s:%s is being split when trying to prepare for backup", tableName, regionName);
+                            SpliceLogUtils.debug(LOG,"create node %s to mark backup in progress", path);
                         }
-                        responseBuilder.setReadyForBackup(false);
-                        //delete the ZNode
-                        ZkUtils.recursiveDelete(path);
-                    } else {
-                        //wait for all compaction and flush to complete
-                        if (LOG.isDebugEnabled()) {
-                            SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
+
+                        if (isFlushing || isCompacting || isSplitting) {
+                            if (LOG.isDebugEnabled()) {
+                                SpliceLogUtils.debug(LOG, "table %s region %s is not ready for backup: isSplitting=%s, isCompacting=%s, isFlushing=%s",
+                                        isSplitting, isCompacting, isFlushing);
+                            }
+                            ZkUtils.recursiveDelete(path);
                         }
-                        region.waitForFlushesAndCompactions();
-                        if (LOG.isDebugEnabled()) {
-                            SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
+                        else {
+                            responseBuilder.setReadyForBackup(true);
+                            if (LOG.isDebugEnabled()) {
+                                SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
+                            }
                         }
-                        responseBuilder.setReadyForBackup(true);
                     }
                 }
                 else
-                    responseBuilder.setReadyForBackup(false);
+                    responseBuilder.setReadyForBackup(true);
             }
             return responseBuilder;
     }
@@ -144,7 +157,11 @@ public class BackupUtils {
             try {
                 if (LOG.isDebugEnabled())
                     SpliceLogUtils.debug(LOG, "wait for backup to complete");
-                long waitTime = Math.min(100 * (long) Math.pow(2, i), maxWaitTime);
+                long waitTime = 100 * (long) Math.pow(2, i);
+                if (waitTime <= 0 || waitTime > maxWaitTime) {
+                    waitTime = maxWaitTime;
+                    i = 0;
+                }
                 Thread.sleep(waitTime);
                 i++;
             }
@@ -298,5 +315,21 @@ public class BackupUtils {
                 throw Exceptions.parseException(e);
             }
         }
+    }
+
+    /**
+     * If the end key from the request equals to the region start key, the request is meant for the previous region.
+     * Ignore shuch requests.
+     * @param request
+     * @param region
+     * @return
+     */
+    private static boolean shouldIgnore(SpliceMessage.PrepareBackupRequest request, HRegion region) {
+        byte[] endKey = request.hasEndKey() ? request.getEndKey().toByteArray() : null;
+        byte[] regionStartKey = region.getRegionInfo().getStartKey();
+        if (endKey != null && endKey.length > 0 && Bytes.compareTo(endKey, regionStartKey) == 0)
+            return true;
+
+        return false;
     }
 }

--- a/splice_protocol/src/main/protobuf/Splice.proto
+++ b/splice_protocol/src/main/protobuf/Splice.proto
@@ -164,10 +164,12 @@ service BackupCoprocessorService {
 }
 
 message PrepareBackupRequest {
+    optional bytes startKey=1;
+    optional bytes endKey=2;
 }
 
 message PrepareBackupResponse {
-  required bool readyForBackup = 1;
+  optional bool readyForBackup = 1;
 }
 
 message BlockingProbeRequest {


### PR DESCRIPTION
Address a couple of backup issues in this pull request.

Used wrong end key to probe if a region is ready for backup. This caused backup to hang in Cetera's cluster
When backup is done, marked wrong znode to indicate backup is complete. This can block flush, compaction and split.
Set correct hbase.rootdir for spark backup task. Otherwise, incorrect default hbase root dir may be used to create HFileLink to referenced parent file.
Fix an issue in BackupObserverEndpoint that can cause deadlock.
Add more tracing for diagnosis.

Moderator - Please remember to merge pull request from ee branch together with this one