### PR TITLE
SPLICE-1541,1543: fix IN-list issues with dynamic bindings and char column

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
@@ -142,11 +142,19 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 		 */
 		if (rightOperandList.size() == 1)
 		{
-			BinaryComparisonOperatorNode equal = 
+			ValueNode value = (ValueNode)rightOperandList.elementAt(0);
+            if ((value instanceof CharConstantNode) && (leftOperand instanceof ColumnReference)) {
+				DataTypeDescriptor targetType = leftOperand.getTypeServices();
+				if (targetType.getTypeName().equals(TypeId.CHAR_NAME)) {
+					int maxSize = leftOperand.getTypeServices().getMaximumWidth();
+					ValueNodeList.rightPadCharConstantNode((CharConstantNode) value, maxSize);
+				}
+			}
+			BinaryComparisonOperatorNode equal =
 				(BinaryComparisonOperatorNode) getNodeFactory().getNode(
 						C_NodeTypes.BINARY_EQUALS_OPERATOR_NODE,
 						leftOperand, 
-						(ValueNode) rightOperandList.elementAt(0),
+						value,
 						getContextManager());
 			/* Set type info for the operator node */
 			equal.bindComparisonOperator();
@@ -256,7 +264,7 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 								vn.getTypeServices(), cf);
 					}
 				}
-				rightOperandList.eliminateDuplicates();
+				rightOperandList.eliminateDuplicates(targetType);
 
 				/* Now sort the list in ascending order using the dominant
 				 * type found above.

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperation.java
@@ -34,6 +34,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -177,11 +178,13 @@ public class MultiProbeTableScanOperation extends TableScanOperation  {
              * we're going to sort the values we use clones.  This is not
              * ideal, but it works for now.
              */
-            DataValueDescriptor[] probeValues =
-                    new DataValueDescriptor[probingVals.length];
 
-            for (int i = 0; i < probeValues.length; i++)
-                probeValues[i] = probingVals[i].cloneValue(false);
+            // eliminate duplicates from probeValues
+            HashSet<DataValueDescriptor> vset = new HashSet<DataValueDescriptor>(probingVals.length);
+            for (int i = 0; i < probingVals.length; i++)
+                vset.add(probingVals[i].cloneValue(false));
+
+            DataValueDescriptor[] probeValues = vset.toArray(new DataValueDescriptor[vset.size()]);
 
             if (sortRequired == RowOrdering.ASCENDING)
                 Arrays.sort(probeValues);
@@ -199,7 +202,7 @@ public class MultiProbeTableScanOperation extends TableScanOperation  {
                 sameStartStopPosition,
                 startSearchOperator,
                 stopSearchOperator,
-                probingVals,
+                probeValues,
                 tableVersion
         );
         init();

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/InListMultiprobeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/InListMultiprobeIT.java
@@ -108,7 +108,7 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
                         row(null, null, null, null),
                         row(null, null, null, null),
                         row(null, null, null, null)))
-                .withIndex("create index ix_char on ts_char(c)")
+                .withIndex("create index ix_char on ts_char(c, v)")
                 .create();
 
         new TableCreator(conn)
@@ -193,7 +193,7 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
 
     @Test
     public void testInListWithCharIT() throws Exception {
-        String sqlText = "select count(*) from ts_char where trim(c) in ('a', 'b', 'c', 'd')";
+        String sqlText = "select count(*) from ts_char where c in ('a', 'b', 'c', 'd')";
         ResultSet rs = methodWatcher.executeQuery(sqlText);
         String expected =
                 "1 |\n" +
@@ -203,9 +203,44 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
         assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         rs.close();
 
-        sqlText = "select count(*) from ts_char where trim(c) in ('a', 'b', 'b', 'c', 'a', 'c', 'd')";
+        sqlText = "select count(*) from ts_char where c in ('a', 'b', 'b', 'c', 'a', 'c', 'd')";
         rs = methodWatcher.executeQuery(sqlText);
+        assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
 
+        sqlText = "select count(*) from ts_char where c in ('c')";
+        expected =
+                "1 |\n" +
+                        "----\n" +
+                        " 1 |";
+        rs = methodWatcher.executeQuery(sqlText);
+        assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    }
+
+    @Test
+    public void testInListWithVarCharIT() throws Exception {
+        String sqlText = "select count(*) from ts_char where v in ('cc', 'k')";
+        ResultSet rs = methodWatcher.executeQuery(sqlText);
+        String expected =
+                "1 |\n" +
+                        "----\n" +
+                        " 2 |";
+
+        assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        sqlText = "select count(*) from ts_char where v in ('cc', 'k', 'cc', 'k')";
+        rs = methodWatcher.executeQuery(sqlText);
+        assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        sqlText = "select count(*) from ts_char where v in ('cc')";
+        expected =
+                "1 |\n" +
+                        "----\n" +
+                        " 1 |";
+        rs = methodWatcher.executeQuery(sqlText);
         assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         rs.close();
     }

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/InListMultiprobeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/InListMultiprobeIT.java
@@ -24,6 +24,7 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import static com.splicemachine.test_tools.Rows.row;
@@ -264,6 +265,34 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
         rs.close();
     }
 
+    @Test
+    public void testInListWithDynamicParamsIT() throws Exception {
+        String sqlText = "select count(*) from ts_char where c IN ( ?, ?, ?, ? )";
+        PreparedStatement ps = methodWatcher.prepareStatement(sqlText);
+        ps.setString(1, "c");
+        ps.setString(2, "d");
+        ps.setString(3, "c");
+        ps.setString(4, "d");
+        ResultSet rs = ps.executeQuery();
+
+        rs.next();
+        int val = rs.getInt(1);
+        Assert.assertEquals("Incorrect value returned!", 2, val);
+        rs.close();
+
+        sqlText = "select count(*) from ts_char where c IN ( ?, ?, ?, ? )";
+        ps = methodWatcher.prepareStatement(sqlText);
+        ps.setString(1, "c");
+        ps.setString(2, "c");
+        ps.setString(3, "c");
+        ps.setString(4, "c");
+        rs = ps.executeQuery();
+
+        rs.next();
+        val = rs.getInt(1);
+        Assert.assertEquals("Incorrect value returned!", 1, val);
+        rs.close();
+    }
 
 
 }


### PR DESCRIPTION
Two fixes related to IN-list and multi-probe index scan:
- with dynamic binding prepared statement, the duplicates in the IN-list were not eliminated,
- with char column, there was no correct match happening, it was missing the right space padding in the probevalue list causing the wrong answer.