### PR TITLE
SPLICE-1546 ValueRow.setColumn as an Interface method is more expensive to call than as a virtual one

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexRow.java
@@ -109,7 +109,7 @@ public class IndexRow extends ValueRow implements ExecIndexRow
 		}
 	}
 
-	public ExecRow cloneMe() {
+	public ValueRow cloneMe() {
 		return new IndexRow(nColumns());
 	}
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
@@ -145,7 +145,7 @@ public class ValueRow implements ExecRow, Externalizable {
 		int numColumns = column.length;
 
 		/* Get the right type of row */
-		ExecRow rowClone = cloneMe();
+		ValueRow rowClone = cloneMe();
 
 		for (int colCtr = 0; colCtr < numColumns; colCtr++) {
 			// Copy those columns whose bit isn't set (and there is a FormatableBitSet)
@@ -169,7 +169,7 @@ public class ValueRow implements ExecRow, Externalizable {
 	public ExecRow getNewNullRow()
 	{
 		int numColumns = column.length;
-		ExecRow rowClone = cloneMe();
+		ValueRow rowClone = cloneMe();
 
 
 		for (int colCtr = 0; colCtr < numColumns; colCtr++) 
@@ -183,7 +183,7 @@ public class ValueRow implements ExecRow, Externalizable {
 		return rowClone;
 	}
 
-	public ExecRow cloneMe() {
+	public ValueRow cloneMe() {
 		return new ValueRow(ncols);
 	}
 


### PR DESCRIPTION
While a virtual method call requires only class vtable indexing, an interface method call involves a search for the right itable first and then indexing. For methods that are called many times the difference may become quite noticeable.
ValueRow provides setColumn() as part of ExecRow interface definition. However, the method is called in getClone() for objects returned by virtual cloneMe(), which always returns either ValueRow or its subclass but is declared to return ExecRow. The compiler can't optimize it and generates an interface call where a virtual one would suffice.
Profiler shows total time time spent in ValueRow.getClone(), which calls setColumn(), goes down from 118 sec to 102 sec after promoting cloneMe() to return ValueRow (workload is IMPORT of 2M rows with 600+ columns).