### PR TITLE
SPLICE-1555 Enable optimizer trace info for costing - port to 2.5

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Level2OptimizerTrace.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Level2OptimizerTrace.java
@@ -59,10 +59,14 @@ public class Level2OptimizerTrace implements OptimizerTrace{
         String traceString;
         Object objectParam1 = null;
         Object objectParam2 = null;
-        if (objectParams != null) {
+        Object objectParam3 = null;
+        if (objectParams != null && objectParams.length > 0) {
             objectParam1 = objectParams[0];
             if (objectParams.length >= 2) {
                 objectParam2 = objectParams[1];
+            }
+            if (objectParams.length >= 3) {
+                objectParam3 = objectParams[2];
             }
         }
 
@@ -280,7 +284,7 @@ public class Level2OptimizerTrace implements OptimizerTrace{
                 cd=(ConglomerateDescriptor) objectParam1;
                 cdString=dumpConglomerateDescriptor(cd);
                 traceString="Cost of conglomerate "+cdString+" scan for table number "+intParam1 +
-                    " ("+objectParam2+") is : " + objectParam1;
+                    " ("+objectParam2+") is : " + objectParam3;
                 break;
             case COST_OF_CONGLOMERATE_SCAN3:
                 traceString="\tNumber of extra first column predicates is : "+

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
@@ -841,7 +841,7 @@ public class OptimizerImpl implements Optimizer{
 			 */
             optimizableList.getOptimizable(nextOptimizable).getBestAccessPath().setCostEstimate(null);
 
-            tracer.trace(OptimizerFlag.CONSIDERING_JOIN_ORDER,0,0,0.0);
+            tracer.trace(OptimizerFlag.CONSIDERING_JOIN_ORDER,0,0,0.0, null);
 
             Optimizable nextOpt= optimizableList.getOptimizable(nextOptimizable);
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceLevel2OptimizerImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceLevel2OptimizerImpl.java
@@ -125,7 +125,7 @@ import com.splicemachine.derby.impl.store.access.TempSortController;
  *
  */
 public class SpliceLevel2OptimizerImpl extends Level2OptimizerImpl{
-    private static final Logger TRACE_LOGGER=Logger.getLogger("optimizer.trace");
+    private static final Logger TRACE_LOGGER=Logger.getLogger(SpliceLevel2OptimizerImpl.class);
     private final OptimizerTrace tracer = new Level2OptimizerTrace(null,this){
         @Override
         @SuppressFBWarnings(value = "SF_SWITCH_NO_DEFAULT",justification = "Intentional")


### PR DESCRIPTION
	modified:   db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Level2OptimizerTrace.java
	modified:   db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
	modified:   splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceLevel2OptimizerImpl.java