### PR TITLE
DB-5912: fix incremental backup hang(2.0)

### DIFF
--- a/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -111,6 +111,25 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     }
 
     @Override
+    public void preSplit(ObserverContext<RegionCoprocessorEnvironment> c, byte[] splitRow) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
+
+        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isSplitting = true;
+        super.preSplit(c, splitRow);
+    }
+
+    @Override
+    public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
+
+        isSplitting = false;
+        super.postRollBackSplit(ctx);
+    }
+
+    @Override
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
@@ -150,6 +169,23 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
         isFlushing = true;
         super.preFlush(e);
+    }
+
+    @Override
+    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        if (!BackupUtils.isSpliceTable(namespace, tableName))
+            return;
+        isFlushing = false;
+    }
+
+    @Override
+    public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isFlushing = true;
+        return super.preFlush(e,store,scanner);
     }
 
     @Override

--- a/hbase_sql/hbase1.0.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.0.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -112,6 +112,24 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         isSplitting = true;
         super.preSplit(e);
     }
+    @Override
+    public void preSplit(ObserverContext<RegionCoprocessorEnvironment> c, byte[] splitRow) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
+
+        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isSplitting = true;
+        super.preSplit(c, splitRow);
+    }
+
+    @Override
+    public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
+
+        isSplitting = false;
+        super.postRollBackSplit(ctx);
+    }
 
     @Override
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
@@ -145,6 +163,15 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         super.postCompact(e, store, resultFile);
         isCompacting = false;
     }
+
+    @Override
+    public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isFlushing = true;
+        return super.preFlush(e,store,scanner);
+    }
     
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
@@ -168,5 +195,13 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         } catch (Exception ex) {
             throw new IOException(ex);
         }
+    }
+
+    @Override
+    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        if (!BackupUtils.isSpliceTable(namespace, tableName))
+            return;
+        isFlushing = false;
     }
 }

--- a/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -111,6 +111,25 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     }
 
     @Override
+    public void preSplit(ObserverContext<RegionCoprocessorEnvironment> c, byte[] splitRow) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
+
+        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isSplitting = true;
+        super.preSplit(c, splitRow);
+    }
+
+    @Override
+    public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
+
+        isSplitting = false;
+        super.postRollBackSplit(ctx);
+    }
+    
+    @Override
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
@@ -150,6 +169,23 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
         isFlushing = true;
         super.preFlush(e);
+    }
+
+    @Override
+    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        if (!BackupUtils.isSpliceTable(namespace, tableName))
+            return;
+        isFlushing = false;
+    }
+
+    @Override
+    public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isFlushing = true;
+        return super.preFlush(e,store,scanner);
     }
 
     @Override

--- a/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -111,6 +111,32 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     }
 
     @Override
+    public void preSplit(ObserverContext<RegionCoprocessorEnvironment> c, byte[] splitRow) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
+
+        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isSplitting = true;
+        super.preSplit(c, splitRow);
+    }
+
+    @Override
+    public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
+
+        isSplitting = false;
+        super.postRollBackSplit(ctx);
+    }
+
+    @Override
+    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
+        isSplitting = false;
+    }
+    
+    @Override
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
@@ -153,6 +179,23 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     }
 
     @Override
+    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        if (!BackupUtils.isSpliceTable(namespace, tableName))
+            return;
+        isFlushing = false;
+    }
+
+    @Override
+    public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isFlushing = true;
+        return super.preFlush(e,store,scanner);
+    }
+    
+    @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
         SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
@@ -165,8 +208,5 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         } catch (Exception ex) {
             throw new IOException(ex);
         }
-    }
-
-    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
     }
 }

--- a/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -111,6 +111,32 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     }
 
     @Override
+    public void preSplit(ObserverContext<RegionCoprocessorEnvironment> c, byte[] splitRow) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
+
+        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isSplitting = true;
+        super.preSplit(c, splitRow);
+    }
+
+    @Override
+    public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
+
+        isSplitting = false;
+        super.postRollBackSplit(ctx);
+    }
+
+    @Override
+    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
+        isSplitting = false;
+    }
+
+    @Override
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
@@ -153,6 +179,23 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     }
 
     @Override
+    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        if (!BackupUtils.isSpliceTable(namespace, tableName))
+            return;
+        isFlushing = false;
+    }
+
+    @Override
+    public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isFlushing = true;
+        return super.preFlush(e,store,scanner);
+    }
+
+    @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
         SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
@@ -165,8 +208,5 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         } catch (Exception ex) {
             throw new IOException(ex);
         }
-    }
-
-    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
     }
 }

--- a/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -113,6 +113,32 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     }
 
     @Override
+    public void preSplit(ObserverContext<RegionCoprocessorEnvironment> c, byte[] splitRow) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
+
+        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isSplitting = true;
+        super.preSplit(c, splitRow);
+    }
+
+    @Override
+    public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
+
+        isSplitting = false;
+        super.postRollBackSplit(ctx);
+    }
+
+    @Override
+    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
+        isSplitting = false;
+    }
+
+    @Override
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
@@ -155,6 +181,15 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     }
 
     @Override
+    public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+        isFlushing = true;
+        return super.preFlush(e,store,scanner);
+    }
+
+    @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
         SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
@@ -169,6 +204,11 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         }
     }
 
-    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
+    @Override
+    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        if (!BackupUtils.isSpliceTable(namespace, tableName))
+            return;
+        isFlushing = false;
     }
 }


### PR DESCRIPTION
Make sure coprocessor hooks set and clear flags for flushing and split.

Please also review pull request on ee branch.