### PR TITLE
SPLICE 1430 : remove pin from dictionary and rely on spark cache to get the status of pins & Fix race condition on OlapNIOLayer

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableDescriptor.java
@@ -160,6 +160,8 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
     private String storedAs;
     private String location;
     private String compression;
+    // NOT USED ANYMORE, for backward compatibility only
+    @Deprecated
     private boolean isPinned;
 
 
@@ -279,6 +281,7 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
         this.storedAs = storedAs;
         this.location = location;
         this.compression = compression;
+        // NOT USED ANYMORE, for backward compatibility only
         this.isPinned = isPinned;
 
     }
@@ -370,7 +373,7 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
      * Will tell if the current table is currently pinned in the memory
      * @return
      */
-
+    @Deprecated
     public boolean isPinned() {
         return isPinned;
     }
@@ -379,6 +382,7 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
      * Will mark the table pinned
      * @param pinned
      */
+    @Deprecated
     public void setPinned(boolean pinned) {
         isPinned = pinned;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTABLESRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTABLESRowFactory.java
@@ -77,6 +77,8 @@ public class SYSTABLESRowFactory extends CatalogRowFactory
 	protected static final int		SYSTABLES_STORED_AS = 11;
 	protected static final int		SYSTABLES_LOCATION = 12;
 	protected static final int		SYSTABLES_COMPRESSION = 13;
+	// SYSTABLES_IS_PINNED : NOT USED ANYMORE, for backward compatibility only
+	@Deprecated
 	protected static final int 		SYSTABLES_IS_PINNED = 14;
 	/* End External Tables Columns	*/
 	protected static final int		SYSTABLES_INDEX1_ID = 0;
@@ -155,6 +157,8 @@ public class SYSTABLESRowFactory extends CatalogRowFactory
 		String 					storedAs = null;
 		String 					location = null;
 		String 					compression = null;
+		// NOT USED ANYMORE, for backward compatibility only
+		@Deprecated
 		boolean 				isPinned = false;
 
 		if (td != null)
@@ -230,6 +234,7 @@ public class SYSTABLESRowFactory extends CatalogRowFactory
 			storedAs = descriptor.getStoredAs();
 			location = descriptor.getLocation();
 			compression = descriptor.getCompression();
+			//NOT USED ANYMORE, for backward compatibility only
 			isPinned = descriptor.isPinned();
 		}
 
@@ -268,6 +273,7 @@ public class SYSTABLESRowFactory extends CatalogRowFactory
 		row.setColumn(SYSTABLES_STORED_AS,new SQLVarchar(storedAs));
 		row.setColumn(SYSTABLES_LOCATION,new SQLVarchar(location));
 		row.setColumn(SYSTABLES_COMPRESSION,new SQLVarchar(compression));
+		//NOT USED ANYMORE, for backward compatibility only
 		row.setColumn(SYSTABLES_IS_PINNED,new SQLBoolean(isPinned));
 
 		return row;
@@ -397,6 +403,8 @@ public class SYSTABLESRowFactory extends CatalogRowFactory
 		String storedAs;
 		String location;
 		String compression;
+		// NOT USED ANYMORE, for backward compatibility only
+		@Deprecated
 		boolean isPinned;
 
 
@@ -472,6 +480,8 @@ public class SYSTABLESRowFactory extends CatalogRowFactory
 		DataValueDescriptor storedDVD = row.getColumn(SYSTABLES_STORED_AS);
 		DataValueDescriptor locationDVD = row.getColumn(SYSTABLES_LOCATION);
 		DataValueDescriptor compressionDVD = row.getColumn(SYSTABLES_COMPRESSION);
+		// NOT USED ANYMORE, for backward compatibility only
+		@Deprecated
 		DataValueDescriptor isPinnedDVD = row.getColumn(SYSTABLES_IS_PINNED);
 
 
@@ -538,6 +548,7 @@ public class SYSTABLESRowFactory extends CatalogRowFactory
 			SystemColumnImpl.getColumn("STORED", Types.VARCHAR, true),
 			SystemColumnImpl.getColumn("LOCATION", Types.VARCHAR, true),
 			SystemColumnImpl.getColumn("COMPRESSION", Types.VARCHAR, true),
+			// NOT USED ANYMORE, for backward compatibility only
 			SystemColumnImpl.getColumn("IS_PINNED", Types.BOOLEAN, false)
         };
 	}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DeleteNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DeleteNode.java
@@ -1061,7 +1061,7 @@ public class DeleteNode extends DMLModStatementNode
 		if(targetTable.getProperties()!=null) {
 			Boolean pin = Boolean.parseBoolean(targetTable.getProperties().getProperty(PIN));
 			if (pin) {
-				throw StandardException.newException(SQLState.UPDATE_PIN_VIOLATION);
+				throw StandardException.newException(SQLState.DELETE_PIN_VIOLATION);
 			}
 		}
 		if (targetTableDescriptor.getTableType() == TableDescriptor.EXTERNAL_TYPE)

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -1986,6 +1986,7 @@ public interface SQLState {
 	String TABLE_NOT_PINNED				    						= "EXT32";
 	String DIRECTORY_REQUIRED			    						= "EXT33";
 	String ACCESSING_S3_EXCEPTION                                   = "EXT34";
+	String EXISTING_PIN_VIOLATION									= "EXT35";
 
 }
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -9062,6 +9062,13 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
                <arg>exception</arg>
            </msg>
 
+           <msg>
+               <name>EXT35</name>
+               <text> Table {0} already pinned</text>
+               <arg>tableName</arg>
+           </msg>
+
+
        </family>
     </section>
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -411,6 +411,13 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         }
     }
 
+    @Override
+    public Boolean isCached(long conglomerateId) throws StandardException {
+        return  SpliceSpark.getSession().catalog().tableExists("SPLICE_"+conglomerateId)
+                && SpliceSpark.getSession().catalog().isCached("SPLICE_"+conglomerateId);
+
+    }
+
     private Dataset<Row> processExternalDataset(Dataset<Row> rawDataset,int[] baseColumnMap,Qualifier[][] qualifiers,DataValueDescriptor probeValue) throws StandardException {
         String[] allCols = rawDataset.columns();
         List<Column> cols = new ArrayList();

--- a/hbase_sql/src/main/java/com/splicemachine/olap/AsyncOlapNIOLayer.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/AsyncOlapNIOLayer.java
@@ -283,7 +283,6 @@ public class AsyncOlapNIOLayer implements JobExecutor{
                     LOG.trace("Interrupted exception", ie);
             }
 
-            this.keepAlive = executorService.scheduleWithFixedDelay(this, tickTimeNanos, tickTimeNanos, TimeUnit.NANOSECONDS);
         }
 
         void signal(){
@@ -307,6 +306,10 @@ public class AsyncOlapNIOLayer implements JobExecutor{
         @Override
         public void addListener(Runnable runnable, Executor executor) {
             executionList.add(runnable, executor);
+        }
+
+        public void scheduleStatusCheck() {
+            this.keepAlive = executorService.scheduleWithFixedDelay(this, 0, tickTimeNanos, TimeUnit.NANOSECONDS);
         }
     }
 
@@ -511,6 +514,7 @@ public class AsyncOlapNIOLayer implements JobExecutor{
             ctx.pipeline().remove(this); //we don't want this in the pipeline anymore
             Channel channel=ctx.channel();
             channelPool.release(channel); //release the underlying channel back to the pool cause we're done
+            future.scheduleStatusCheck();
             future.signal();
         }
 

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapRequestHandler.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapRequestHandler.java
@@ -93,6 +93,12 @@ class OlapRequestHandler extends AbstractOlapHandler{
         }
         final Callable<Void> job=jr.toCallable(jobStatus,clock,clientCheckTimeMs);
 
+        // Tell the client it was successfully submitted before we actually schedule it for execution, otherwise
+        // it might send the result before we send the confirmation
+        if(LOG.isTraceEnabled())
+            LOG.trace("Job "+ jobRequest.getUniqueName()+" successfully submitted");
+        writeResponse(e,jr.getUniqueName(),jobStatus);
+
         executionPool.submit(new Callable<Void>() {
             @Override
             public Void call() throws Exception {
@@ -107,9 +113,6 @@ class OlapRequestHandler extends AbstractOlapHandler{
                 return null;
             }
         });
-        if(LOG.isTraceEnabled())
-            LOG.trace("Job "+ jobRequest.getUniqueName()+" successfully submitted");
-        writeResponse(e,jr.getUniqueName(),jobStatus);
     }
 
 

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/PinTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/PinTableIT.java
@@ -46,6 +46,7 @@ public class PinTableIT extends SpliceUnitTest{
     private static final SpliceTableWatcher spliceTableWatcher5 = new SpliceTableWatcher("PinTable5",SCHEMA_NAME,"(col1 int)");
     private static final SpliceTableWatcher spliceTableWatcher6 = new SpliceTableWatcher("PinTable6",SCHEMA_NAME,"(col1 int)");
     private static final SpliceTableWatcher spliceTableWatcher7 = new SpliceTableWatcher("PinTable7",SCHEMA_NAME,"(col1 int)");
+    private static final SpliceTableWatcher spliceTableWatcher8 = new SpliceTableWatcher("PinTable8",SCHEMA_NAME,"(col1 int)");
 
     @Rule
     public SpliceWatcher methodWatcher = new SpliceWatcher(SCHEMA_NAME);
@@ -59,7 +60,8 @@ public class PinTableIT extends SpliceUnitTest{
             .around(spliceTableWatcher4)
             .around(spliceTableWatcher5)
             .around(spliceTableWatcher6)
-            .around(spliceTableWatcher7);
+            .around(spliceTableWatcher7)
+            .around(spliceTableWatcher8);
     @Test
     public void testPinTableDoesNotExist() throws Exception {
         try {
@@ -70,6 +72,7 @@ public class PinTableIT extends SpliceUnitTest{
             Assert.assertEquals("Wrong Exception","X0X05",e.getSQLState());
         }
     }
+
 
     @Test
     public void testPinTable() throws Exception {
@@ -102,33 +105,6 @@ public class PinTableIT extends SpliceUnitTest{
 
 
     @Test
-    public void testPinTableMarkedInDictionnary() throws Exception {
-        methodWatcher.executeUpdate("insert into PinTable3 values (1)");
-        methodWatcher.executeUpdate("pin table PinTable3");
-        ResultSet rs = methodWatcher.executeQuery("select IS_PINNED from SYS.SYSTABLES where TABLENAME='PINTABLE3'");
-        Assert.assertEquals("IS_PINNED |\n" +
-                "------------\n" +
-                "   true    |", TestUtils.FormattedResult.ResultFactory.toString(rs));
-
-        methodWatcher.executeUpdate("unpin table PinTable3");
-        rs = methodWatcher.executeQuery("select IS_PINNED from SYS.SYSTABLES where TABLENAME='PINTABLE3'");
-        Assert.assertEquals("IS_PINNED |\n" +
-                "------------\n" +
-                "   false   |", TestUtils.FormattedResult.ResultFactory.toString(rs));
-    }
-
-
-    @Test
-    public void testPinTableNotMarkedInDictionnary() throws Exception {
-        methodWatcher.executeUpdate("insert into PinTable4 values (1)");
-        ResultSet rs = methodWatcher.executeQuery("select IS_PINNED from SYS.SYSTABLES where TABLENAME='PINTABLE4'");
-        Assert.assertEquals("IS_PINNED |\n" +
-                "------------\n" +
-                "   false   |", TestUtils.FormattedResult.ResultFactory.toString(rs));
-    }
-
-
-    @Test
     public void testPinTableInsertViolation() throws Exception {
         try {
             methodWatcher.executeUpdate("insert into PinTable5  --splice-properties pin=true \n values (1)");
@@ -154,7 +130,7 @@ public class PinTableIT extends SpliceUnitTest{
             methodWatcher.executeUpdate("DELETE FROM PinTable5 --splice-properties pin=true \n");
             Assert.fail("UPDATE is not allowed in pin table but it didn't failed");
         } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT30",e.getSQLState());
+            Assert.assertEquals("Wrong Exception","EXT31",e.getSQLState());
         }
     }
 
@@ -181,5 +157,17 @@ public class PinTableIT extends SpliceUnitTest{
 
         methodWatcher.executeUpdate("unpin table PinTable7");
         methodWatcher.executeUpdate("drop table PinTable7");
+    }
+
+    @Test
+    public void testPinTwice() throws Exception {
+        try {
+            // Row Format not supported for Parquet
+            methodWatcher.executeUpdate("pin table PinTable8");
+            methodWatcher.executeUpdate("pin table PinTable8");
+            Assert.fail("Exception not thrown");
+        } catch (SQLException e) {
+            Assert.assertEquals("Wrong Exception","EXT35",e.getSQLState());
+        }
     }
 }

--- a/hbase_sql/src/test/java/com/splicemachine/olap/OlapClientTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/olap/OlapClientTest.java
@@ -40,7 +40,6 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  *
  * Created by dgomezferro on 3/17/16.
  */
-@Ignore
 @SuppressWarnings("unused")
 public class OlapClientTest {
     private static final Logger LOG = Logger.getLogger(OlapClientTest.class);
@@ -81,6 +80,18 @@ public class OlapClientTest {
         Assert.assertNotNull(result);
         Assert.assertEquals(13, result.order);
     }
+
+    @Test(timeout = 16000)
+    public void manyFastJobsTest() throws Exception {
+        final Random rand = new Random(0);
+        int sleep = 0;
+        for (int i = 0; i < 200; ++i) {
+            DumbOlapResult result = olapClient.execute(new DumbDistributedJob(sleep, i));
+            Assert.assertNotNull(result);
+            Assert.assertEquals(i, result.order);
+        }
+    }
+
 
     @Test(timeout = 20000, expected = IllegalStateException.class)
     public void cantReuseJobsTest() throws Exception {

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/ControlOnlyDataSetProcessorFactory.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/ControlOnlyDataSetProcessorFactory.java
@@ -133,5 +133,13 @@ public class ControlOnlyDataSetProcessorFactory implements DataSetProcessorFacto
             //no-op
             return null;
         }
+
+        @Override
+        public Boolean isCached(long conglomerateId) throws StandardException {
+            if (LOG.isTraceEnabled())
+                SpliceLogUtils.trace(LOG, "DistributedWrapper#isCached()");
+            //no-op
+            return false;
+        }
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreatePinConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreatePinConstantOperation.java
@@ -29,7 +29,10 @@ import com.splicemachine.ddl.DDLMessage;
 import com.splicemachine.derby.ddl.DDLUtils;
 import com.splicemachine.derby.impl.sql.execute.operations.LocatedRow;
 import com.splicemachine.derby.impl.sql.execute.operations.ScanOperation;
+import com.splicemachine.derby.impl.sql.execute.pin.DistributedIsCachedJob;
 import com.splicemachine.derby.impl.sql.execute.pin.DistributedPopulatePinJob;
+import com.splicemachine.derby.impl.sql.execute.pin.GetIsCachedResult;
+import com.splicemachine.derby.impl.sql.execute.pin.RemoteDropPinJob;
 import com.splicemachine.derby.impl.store.access.SpliceTransactionManager;
 import com.splicemachine.derby.impl.store.access.base.SpliceConglomerate;
 import com.splicemachine.derby.stream.iapi.DistributedDataSetProcessor;
@@ -114,55 +117,18 @@ public class CreatePinConstantOperation implements ConstantAction, ScopeNamed {
             throw StandardException.newException(SQLState.LANG_TABLE_NOT_FOUND_DURING_EXECUTION, tableName);
         }
 
-        DistributedDataSetProcessor dsp = EngineDriver.driver().processorFactory().distributedProcessor();
-        TxnView parentTxn = ((SpliceTransactionManager)userTransaction).getActiveStateTxn();
-        /*
-        ** Inform the data dictionary that we are about to write to it.
-        ** There are several calls to data dictionary "get" methods here
-        ** that might be done in "read" mode in the data dictionary, but
-        ** it seemed safer to do this whole operation in "write" mode.
-        **
-        ** We tell the data dictionary we're done writing at the end of
-        ** the transaction.
-        */
-        dd.startWriting(lcc);
-        // Drop the table and then recreate it with the pin marked.
+
         try {
-            dd.dropTableDescriptor(td,sd,userTransaction);
-        } catch (StandardException e) {
-            if (ErrorState.WRITE_WRITE_CONFLICT.getSqlState().equals(e.getSQLState())) {
-                throw ErrorState.DDL_ACTIVE_TRANSACTIONS.newException("Add Pin ()",
-                        e.getMessage());
+            GetIsCachedResult isCachedResult = EngineDriver.driver().getOlapClient().execute(new DistributedIsCachedJob(td.getHeapConglomerateId()));
+            if(isCachedResult.isCached()) {
+                throw StandardException.newException(SQLState.EXISTING_PIN_VIOLATION, tableName);
             }
-            throw e;
+        } catch (Exception e) {
+            throw StandardException.plainWrapException(e);
         }
 
-        // Change the table name of the table descriptor
-        td.setColumnSequence(td.getColumnSequence()+1);
-
-        //Mark the table pinned
-        td.setPinned(true);
-        		    /* Prepare all dependents to invalidate.  (This is their chance
-		     * to say that they can't be invalidated.  For example, an open
-		     * cursor referencing a table/view that the user is attempting to
-		     * alter.) If no one objects, then invalidate any dependent objects.
-		     */
-        dm.invalidateFor(td, DependencyManager.ALTER_TABLE, lcc);
-
-        TransactionController tc = lcc.getTransactionExecute();
-
-        DDLMessage.DDLChange ddlChange = ProtoUtil.createAlterTable(((SpliceTransactionManager) tc).getActiveStateTxn().getTxnId(),
-                (BasicUUID) td.getUUID());
-        // Run Remotely
-        tc.prepareDataDictionaryChange(DDLUtils.notifyMetadataChange(ddlChange));
-
-
-        // Save the TableDescriptor off in the Activation
-        activation.setDDLTableDescriptor(td);
-
-
-        dd.addDescriptor(td,sd,DataDictionary.SYSTABLES_CATALOG_NUM,false,userTransaction);
-
+        DistributedDataSetProcessor dsp = EngineDriver.driver().processorFactory().distributedProcessor();
+        TxnView parentTxn = ((SpliceTransactionManager)userTransaction).getActiveStateTxn();
 
         SpliceConglomerate conglomerate = (SpliceConglomerate) ((SpliceTransactionManager) activation.getTransactionController()).findConglomerate(td.getHeapConglomerateId());
         int[] baseColumnMap = IntArrays.count(conglomerate.getFormat_ids().length);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/DistributedIsCachedJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/DistributedIsCachedJob.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.impl.sql.execute.pin;
+
+import com.splicemachine.concurrent.Clock;
+import com.splicemachine.derby.iapi.sql.olap.DistributedJob;
+import com.splicemachine.derby.iapi.sql.olap.OlapStatus;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.concurrent.Callable;
+
+/**
+ * return true is the table is cached
+ *
+ */
+public class DistributedIsCachedJob extends DistributedJob implements Externalizable {
+    long conglomID;
+
+    public DistributedIsCachedJob() {}
+    public DistributedIsCachedJob(long conglomID) {
+        this.conglomID = conglomID;
+    }
+
+    @Override
+    public Callable<Void> toCallable(OlapStatus jobStatus, Clock clock, long clientTimeoutCheckIntervalMs) {
+        return new IsCachedJob(this, jobStatus, conglomID);
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeLong(conglomID);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        conglomID = in.readLong();
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/GetIsCachedResult.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/GetIsCachedResult.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.impl.sql.execute.pin;
+
+import com.splicemachine.derby.iapi.sql.olap.AbstractOlapResult;
+
+
+
+/**
+ * Created by jfilali on 1/12/17.
+ * PlaceHolder for the schema information provided by Spark.
+ */
+public class GetIsCachedResult extends AbstractOlapResult {
+    private Boolean isCached;
+
+    public GetIsCachedResult(Boolean isCached) {
+        this.isCached = isCached;
+    }
+
+    public  Boolean isCached(){
+        return  isCached;
+    }
+
+    @Override
+    public boolean isSuccess(){
+        return true;
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/IsCachedJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/IsCachedJob.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.impl.sql.execute.pin;
+
+import com.splicemachine.EngineDriver;
+import com.splicemachine.derby.iapi.sql.olap.OlapStatus;
+import com.splicemachine.derby.iapi.sql.olap.SuccessfulOlapResult;
+import com.splicemachine.derby.stream.iapi.DistributedDataSetProcessor;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Class to populate a table into memory.  This still has a bit
+ * of work to do before it will be enabled in the parser.
+ *
+ */
+public class IsCachedJob implements Callable<Void> {
+    private final DistributedIsCachedJob request;
+    private final OlapStatus jobStatus;
+    private long conglomID;
+
+    public IsCachedJob(DistributedIsCachedJob request, OlapStatus jobStatus, long conglomID) {
+        this.request = request;
+        this.jobStatus = jobStatus;
+        this.conglomID = conglomID;
+    }
+
+    @Override
+    public Void call() throws Exception {
+        if (!jobStatus.markRunning()) {
+            //the client has already cancelled us or has died before we could get started, so stop now
+            return null;
+        }
+
+        DistributedDataSetProcessor dsp = EngineDriver.driver().processorFactory().distributedProcessor();
+        Boolean isCached = dsp.isCached(conglomID);
+        jobStatus.markCompleted(new GetIsCachedResult(isCached));
+        return null;
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
@@ -361,4 +361,11 @@ public class ControlDataSetProcessor implements DataSetProcessor{
         DistributedDataSetProcessor proc = EngineDriver.driver().processorFactory().distributedProcessor();
         return proc.getExternalFileSchema(storedAs,location);
     }
+
+
+    @Override
+    public Boolean isCached(long conglomerateId) throws StandardException {
+        DistributedDataSetProcessor proc = EngineDriver.driver().processorFactory().distributedProcessor();
+        return proc.isCached(conglomerateId);
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
@@ -235,4 +235,12 @@ public interface DataSetProcessor {
      */
     void dropPinnedTable(long conglomerateId) throws StandardException;
 
+
+    /**
+     *  Returns true if the table is currently cached in-memory.
+     * @param conglomerateId
+     * @throws StandardException
+     */
+
+    Boolean isCached(long conglomerateId) throws StandardException;
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ForwardingDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ForwardingDataSetProcessor.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.derby.stream.utils;
 
+import com.splicemachine.EngineDriver;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
@@ -171,5 +172,11 @@ public abstract class ForwardingDataSetProcessor implements DataSetProcessor{
     public void dropPinnedTable(long conglomerateId) throws StandardException {
         delegate.dropPinnedTable(conglomerateId);
     }
+
+    @Override
+    public Boolean isCached(long conglomerateId) throws StandardException {
+        return delegate.isCached(conglomerateId);
+    }
+
 }
 


### PR DESCRIPTION

-Remove Pin from dictionary and use Spark instead
-Speedup OlapNIOLayer for very short tasks by scheduling the first status
-check just after receiving the confirmation.