### PR TITLE
SPLICE-1425 :  Fix data type inconsistencies with unary functions and  external table based on TEXT data format

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -36,7 +36,7 @@ import com.splicemachine.si.impl.driver.SIDriver;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.io.orc.OrcNewInputFormat;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
-import org.apache.hadoop.hive.serde2.objectinspector.StructField;
+
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.Text;
@@ -55,6 +55,7 @@ import org.apache.spark.sql.catalyst.expressions.UnsafeProjection;
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext;
 import org.apache.spark.sql.catalyst.expressions.codegen.ExprCode;
 import org.apache.spark.sql.execution.vectorized.ColumnarBatch;
+import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import scala.Tuple2;
 import com.splicemachine.access.HConfiguration;
@@ -81,8 +82,8 @@ import com.splicemachine.derby.stream.utils.StreamUtils;
 import com.splicemachine.mrio.api.core.SMTextInputFormat;
 import com.splicemachine.si.api.txn.TxnView;
 import com.splicemachine.utils.SpliceLogUtils;
-import scala.collection.JavaConverters;
-import scala.collection.Seq;
+
+
 
 /**
  * Spark-based DataSetProcessor.
@@ -510,13 +511,16 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             try {
                 table = SpliceSpark.getSession().read().csv(location);
 
-                //1. spark cvs assume all the columns to be string by default
-                //   we know the schema, no need to use infer schema which is doing a full scan
-                //   so 2 scan , not cheap.
-                //2. There is a annoying underscore with csv in columns names
-                List<Column> correctSchemaSelection = Arrays.stream(execRow.schema().fields())
-                        .map( field -> new Column("_"+field.name()).cast(field.dataType())).collect(Collectors.toList());
-                table = table.select(correctSchemaSelection.toArray(new Column[correctSchemaSelection.size()]));
+
+                for( int index = 0; index< baseColumnMap.length; index++){
+                    if(baseColumnMap[index]!=-1){
+                        StructField ft = table.schema().fields()[index];
+                        Column cl = new Column(ft.name()).cast(execRow.schema().fields()[baseColumnMap[index]].dataType());
+                        table = table.withColumn(ft.name(),cl);
+                    }
+
+                }
+
 
             } catch (Exception e) {
                 return handleExceptionInCaseOfEmptySet(e,location);

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -1053,4 +1053,34 @@ public class ExternalTableIT extends SpliceUnitTest{
         Assert.assertEquals(after, before, after);
 
     }
+
+    @Test
+    public void testBuildInFunctionText()  throws Exception {
+        //
+        String tablePath = getExternalResourceDirectory()+ "EXT_FUNCTION_TEXT";
+        methodWatcher.executeUpdate(String.format("CREATE EXTERNAL TABLE EXT_FUNCTION_TEXT (id INT, c_vchar varchar(30), c_date DATE,  c_num NUMERIC, c_bool BOOLEAN) \n" +
+                "ROW FORMAT DELIMITED \n" +
+                "FIELDS TERMINATED BY ','\n" +
+                "STORED AS TEXTFILE\n" +
+                "location '%s'", tablePath));
+
+
+
+        methodWatcher.execute("insert into EXT_FUNCTION_TEXT (id, c_vchar, c_date, c_num, c_bool) values (1, 'nR-trkDr#,`9DSUbCw C+U8QctPUBy', '7958-05-18', 13691,  true)," +
+                "(2, '$c\">0n`w6b-$O7F`Q6#QWNnivV=6v?', '3450-03-06', 35317, false)," +
+                "(3, 'Q=-DoLR#Bd|(M/![FaN6q Jn>\"CEIW', '4736-03-12', 2877, true)," +
+                "(4, 'eo}+Eyd~%MwIbheQ>aHz;h~Wb{T%5y', '2871-11-07', 71800, true), " +
+                "(5, '@SEulog}9|{]46m~cYDYspt%Z4tZ_4', '2833-03-03', 67859, false)");
+
+        ResultSet rs = methodWatcher.executeQuery("select  DAY(c_date) from EXT_FUNCTION_TEXT  order by 1");
+        Assert.assertEquals("1 |\n" +
+                "----\n" +
+                "12 |\n" +
+                "18 |\n" +
+                " 3 |\n" +
+                " 6 |\n" +
+                " 7 |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+    }
 }


### PR DESCRIPTION


Spark use String Type by default for csv. This fix make sure what we convert the columns in the right format by using the execRow schema and the baseColumnMap
passed in readTextFIle