### PR TITLE
SPLICE-1602 readResolve fetches transactions for a no-op readResolver

### DIFF
--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
@@ -161,13 +161,8 @@ public class SimpleTxnFilter implements TxnFilter{
             return;
         }
 
-        TxnView t=fetchTransaction(ts);
-        assert t!=null:"Could not find a transaction for id "+ts;
-
         //submit it to the resolver to resolve asynchronously
-        if(t.getEffectiveState().isFinal()){
-            doResolve(element,ts);
-        }
+        doResolve(element,ts);
     }
 
     protected void doResolve(DataCell data,long ts){


### PR DESCRIPTION
Splice currently uses NoOpReadResolver by default. SimpleTxnFilter.readResolve() fetches transactions and checks their state before submitting tasks for a generic ReadResolver thus imposing significant overhead for an empty operation. This check is removed from SimpleTxnFilter. If considered necessary or helpful, it should be pushed down to ReadResolver implementation.