### PR TITLE
SPLICE-1597 : Fix issue with cache dictionary when  SYSCS_UTIL.SYSCS_UPDATE_SCHEMA_OWNER is called .

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
@@ -869,6 +869,7 @@ public class SpliceAdmin extends BaseAdminProcedures{
                 throw StandardException.newException(String.format("User '%s' does not exist.", ownerName));
             }
             ((DataDictionaryImpl)dd).updateSchemaAuth(schemaName, ownerName, tc);
+            dd.clearCaches();
         } catch (StandardException se) {
             throw PublicAPI.wrapStandardException(se);
         } catch (Exception e) {

--- a/splice_machine/src/test/java/com/splicemachine/derby/security/SchemaPrivilegeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/security/SchemaPrivilegeIT.java
@@ -592,4 +592,16 @@ public class SchemaPrivilegeIT {
         assertFailed(user2Conn, query, SQLState.AUTH_NOT_OWNER);
 
     }
+
+    @Test
+    public void testChangeOwner() throws Exception {
+        String schemaName = "TEST_SCHEMA";
+        adminConn.execute(String.format("CREATE SCHEMA %s",schemaName));
+        adminConn.execute(String.format("CALL SYSCS_UTIL.SYSCS_UPDATE_SCHEMA_OWNER( '%s', '%s')",schemaName,USER1));
+        //make sure there is no failures
+        user1Conn.execute(String.format("CREATE TABLE %s.%s(a int)",schemaName,USER1));
+        adminConn.execute(String.format("DROP TABLE %s.%s ",schemaName,USER1));
+        adminConn.execute(String.format("DROP SCHEMA %s restrict",schemaName));
+
+    }
 }


### PR DESCRIPTION

Issue : If as splice i create a schema call schema1, then use the command CALL SYSCS_UTIL.SYSCS_UPDATE_SCHEMA_OWNER( 'SCHEMA1', 'bob'); the user bob should now be able to create tables, etc. in schema1.  This is not the case. It says bob cannot create tables in schema1.

Solution : clear the cache after SYSCS_UPDATE_SCHEMA_OWNER get called.