### PR TITLE
DB-5934: do not throw exception for transaction absent in transaction table  because this could happen for restored data(2.0)

### DIFF
--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -1945,6 +1945,7 @@ public interface SQLState {
 	String BACKUP_DOESNOT_EXIST                                    = "BR012";
 	String PARENT_BACKUP_MISSING                                   = "BR013";
 	String EXISTS_CONCURRENT_BACKUP                                = "BR014";
+    String INVALID_RESTORE                                         = "BR015";
 
 	String FILESYSTEM_URI_EXCEPTION				    				= "EXT25";
 	String FILESYSTEM_IO_EXCEPTION				    				= "EXT26";

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -8856,6 +8856,11 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
                <text>A concurrent {0} backup is running. Please wait until it completes or call syscs_util.syscs_cancel_backup() to cancel it.</text>
                <arg>backupType</arg>
            </msg>
+           <msg>
+               <name>BR015</name>
+               <text>The latest restored data is not from backup {0}</text>
+               <arg>backupId</arg>
+           </msg>
 
            <msg>
                <name>EXT25</name>

--- a/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -105,8 +105,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
 
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isSplitting = true;
+        }
         super.preSplit(e);
     }
 
@@ -114,9 +116,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> c, byte[] splitRow) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
-
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isSplitting = true;
+        }
         super.preSplit(c, splitRow);
     }
 
@@ -124,8 +127,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
-
-        isSplitting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isSplitting = false;
+        }
         super.postRollBackSplit(ctx);
     }
 
@@ -133,7 +137,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isSplitting = false;
+        }
         super.postSplit(e, l, r);
     }
 
@@ -141,8 +147,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void preCompactSelection(ObserverContext<RegionCoprocessorEnvironment> c, Store store, List<StoreFile> candidates) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isCompacting = true;
+        }
         super.preCompactSelection(c, store, candidates);
     }
 
@@ -151,55 +159,66 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isCompacting = true;
+        }
         return super.preCompact(e, store, scanner, scanType);
     }
 
     @Override
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
-        isCompacting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isCompacting = false;
+        }
+        super.postCompact(e, store, resultFile);
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isFlushing = true;
+        }
         super.preFlush(e);
-    }
-
-    @Override
-    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
-        if (!BackupUtils.isSpliceTable(namespace, tableName))
-            return;
-        isFlushing = false;
     }
 
     @Override
     public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isFlushing = true;
+        }
         return super.preFlush(e,store,scanner);
     }
 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s: %s", tableName, regionName, resultFile.getPath().toString());
         try {
-            if (!BackupUtils.isSpliceTable(namespace, tableName))
-                return;
-            BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
-                    tableName, resultFile.getPath().getName(), preparing);
-            isFlushing = false;
+            if (BackupUtils.isSpliceTable(namespace, tableName)) {
+                BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
+                        tableName, resultFile.getPath().getName(), preparing);
+                isFlushing = false;
+            }
+            super.postFlush(e, store, resultFile);
         } catch (Exception ex) {
             throw new IOException(ex);
         }
+    }
+
+    @Override
+    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+        SpliceLogUtils.info(LOG, "BackupEndpointObserver.postFlush() %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isFlushing = false;
+        }
+        super.postFlush(e);
     }
 }

--- a/hbase_sql/hbase1.0.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.0.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -108,17 +108,20 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
 
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isSplitting = true;
+        }
         super.preSplit(e);
     }
     @Override
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> c, byte[] splitRow) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
-
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isSplitting = true;
+        }
         super.preSplit(c, splitRow);
     }
 
@@ -126,8 +129,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
-
-        isSplitting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isSplitting = false;
+        }
         super.postRollBackSplit(ctx);
     }
 
@@ -135,7 +139,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isSplitting = false;
+        }
         super.postSplit(e, l, r);
     }
 
@@ -143,8 +149,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void preCompactSelection(ObserverContext<RegionCoprocessorEnvironment> c, Store store, List<StoreFile> candidates) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isCompacting = true;
+        }
         super.preCompactSelection(c, store, candidates);
     }
 
@@ -153,45 +161,55 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isCompacting = true;
+        }
         return super.preCompact(e, store, scanner, scanType);
     }
 
     @Override
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
-        isCompacting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isCompacting = false;
+        }
+        super.postCompact(e, store, resultFile);
+    }
+
+    @Override
+    public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isFlushing = true;
+        }
+        super.preFlush(e);
     }
 
     @Override
     public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isFlushing = true;
+        }
         return super.preFlush(e,store,scanner);
-    }
-    
-    @Override
-    public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
-        super.preFlush(e);
     }
 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s: %s", tableName, regionName, resultFile.getPath().toString());
         try {
-            if (!BackupUtils.isSpliceTable(namespace, tableName))
-                return;
-            BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
-                    tableName, resultFile.getPath().getName(), preparing);
-            isFlushing = false;
+            if (BackupUtils.isSpliceTable(namespace, tableName)) {
+                BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
+                        tableName, resultFile.getPath().getName(), preparing);
+                isFlushing = false;
+            }
+            super.postFlush(e, store, resultFile);
         } catch (Exception ex) {
             throw new IOException(ex);
         }
@@ -199,9 +217,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
-        if (!BackupUtils.isSpliceTable(namespace, tableName))
-            return;
-        isFlushing = false;
+        SpliceLogUtils.info(LOG, "BackupEndpointObserver.postFlush() %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isFlushing = false;
+        }
+        super.postFlush(e);
     }
 }

--- a/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -104,9 +104,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
-
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isSplitting = true;
+        }
         super.preSplit(e);
     }
 
@@ -114,9 +115,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> c, byte[] splitRow) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
-
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isSplitting = true;
+        }
         super.preSplit(c, splitRow);
     }
 
@@ -124,8 +126,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
-
-        isSplitting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isSplitting = false;
+        }
         super.postRollBackSplit(ctx);
     }
     
@@ -133,7 +136,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isSplitting = false;
+        }
         super.postSplit(e, l, r);
     }
 
@@ -141,8 +146,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void preCompactSelection(ObserverContext<RegionCoprocessorEnvironment> c, Store store, List<StoreFile> candidates) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isCompacting = true;
+        }
         super.preCompactSelection(c, store, candidates);
     }
 
@@ -151,58 +158,74 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isCompacting = true;
+        }
         return super.preCompact(e, store, scanner, scanType);
     }
 
     @Override
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
-        isCompacting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isCompacting = false;
+        }
+        super.postCompact(e, store, resultFile);
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isFlushing = true;
+        }
         super.preFlush(e);
-    }
-
-    @Override
-    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
-        if (!BackupUtils.isSpliceTable(namespace, tableName))
-            return;
-        isFlushing = false;
     }
 
     @Override
     public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isFlushing = true;
+        }
         return super.preFlush(e,store,scanner);
     }
 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s: %s", tableName, regionName, resultFile.getPath().toString());
         try {
-            if (!BackupUtils.isSpliceTable(namespace, tableName))
-                return;
-            BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
-                    tableName, resultFile.getPath().getName(), preparing);
-            isFlushing = false;
+            if (BackupUtils.isSpliceTable(namespace, tableName)) {
+                BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
+                        tableName, resultFile.getPath().getName(), preparing);
+                isFlushing = false;
+            }
+            super.postFlush(e, store, resultFile);
         } catch (Exception ex) {
             throw new IOException(ex);
         }
     }
 
+    @Override
+    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+        SpliceLogUtils.info(LOG, "BackupEndpointObserver.postFlush() %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isFlushing = false;
+        }
+        super.postFlush(e);
+    }
+
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isSplitting = false;
+        }
     }
 }

--- a/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -104,9 +104,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
-
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isSplitting = true;
+        }
         super.preSplit(e);
     }
 
@@ -114,9 +115,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> c, byte[] splitRow) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
-
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isSplitting = true;
+        }
         super.preSplit(c, splitRow);
     }
 
@@ -124,8 +126,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
-
-        isSplitting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isSplitting = false;
+        }
         super.postRollBackSplit(ctx);
     }
 
@@ -133,14 +136,18 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isSplitting = false;
+        }
     }
     
     @Override
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isSplitting = false;
+        }
         super.postSplit(e, l, r);
     }
 
@@ -148,8 +155,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void preCompactSelection(ObserverContext<RegionCoprocessorEnvironment> c, Store store, List<StoreFile> candidates) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isCompacting = true;
+        }
         super.preCompactSelection(c, store, candidates);
     }
 
@@ -157,56 +166,66 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner, ScanType scanType) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
-
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isCompacting = true;
+        }
         return super.preCompact(e, store, scanner, scanType);
     }
 
     @Override
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
-        isCompacting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isCompacting = false;
+        }
+        super.postCompact(e, store, resultFile);
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isFlushing = true;
+        }
         super.preFlush(e);
-    }
-
-    @Override
-    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
-        if (!BackupUtils.isSpliceTable(namespace, tableName))
-            return;
-        isFlushing = false;
     }
 
     @Override
     public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isFlushing = true;
+        }
         return super.preFlush(e,store,scanner);
     }
-    
+
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s: %s", tableName, regionName, resultFile.getPath().toString());
         try {
-            if (!BackupUtils.isSpliceTable(namespace, tableName))
-                return;
-            BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
-                    tableName, resultFile.getPath().getName(), preparing);
-            isFlushing = false;
+            if (BackupUtils.isSpliceTable(namespace, tableName)) {
+                BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
+                        tableName, resultFile.getPath().getName(), preparing);
+                isFlushing = false;
+            }
+            super.postFlush(e, store, resultFile);
         } catch (Exception ex) {
             throw new IOException(ex);
         }
+    }
+
+    @Override
+    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+        SpliceLogUtils.info(LOG, "BackupEndpointObserver.postFlush() %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isFlushing = false;
+        }
+        super.postFlush(e);
     }
 }

--- a/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -104,9 +104,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
-
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isSplitting = true;
+        }
         super.preSplit(e);
     }
 
@@ -114,9 +115,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> c, byte[] splitRow) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
-
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isSplitting = true;
+        }
         super.preSplit(c, splitRow);
     }
 
@@ -124,8 +126,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
-
-        isSplitting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isSplitting = false;
+        }
         super.postRollBackSplit(ctx);
     }
 
@@ -133,14 +136,18 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isSplitting = false;
+        }
     }
 
     @Override
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isSplitting = false;
+        }
         super.postSplit(e, l, r);
     }
 
@@ -148,8 +155,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void preCompactSelection(ObserverContext<RegionCoprocessorEnvironment> c, Store store, List<StoreFile> candidates) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isCompacting = true;
+        }
         super.preCompactSelection(c, store, candidates);
     }
 
@@ -157,56 +166,66 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public InternalScanner preCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner, ScanType scanType) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
-
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isCompacting = true;
+        }
         return super.preCompact(e, store, scanner, scanType);
     }
 
     @Override
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
-        isCompacting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isCompacting = false;
+        }
+        super.postCompact(e, store, resultFile);
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isFlushing = true;
+        }
         super.preFlush(e);
-    }
-
-    @Override
-    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
-        if (!BackupUtils.isSpliceTable(namespace, tableName))
-            return;
-        isFlushing = false;
     }
 
     @Override
     public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isFlushing = true;
+        }
         return super.preFlush(e,store,scanner);
     }
 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s: %s", tableName, regionName, resultFile.getPath().toString());
         try {
-            if (!BackupUtils.isSpliceTable(namespace, tableName))
-                return;
-            BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
-                    tableName, resultFile.getPath().getName(), preparing);
-            isFlushing = false;
+            if (BackupUtils.isSpliceTable(namespace, tableName)) {
+                BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
+                        tableName, resultFile.getPath().getName(), preparing);
+                isFlushing = false;
+            }
+            super.postFlush(e, store, resultFile);
         } catch (Exception ex) {
             throw new IOException(ex);
         }
+    }
+
+    @Override
+    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+        SpliceLogUtils.info(LOG, "BackupEndpointObserver.postFlush() %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isFlushing = false;
+        }
+        super.postFlush(e);
     }
 }

--- a/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -106,9 +106,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
-
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isSplitting = true;
+        }
         super.preSplit(e);
     }
 
@@ -117,8 +118,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
 
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isSplitting = true;
+        }
         super.preSplit(c, splitRow);
     }
 
@@ -126,8 +129,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
-
-        isSplitting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isSplitting = false;
+        }
         super.postRollBackSplit(ctx);
     }
 
@@ -135,14 +139,18 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isSplitting = false;
+        }
     }
 
     @Override
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isSplitting = false;
+        }
         super.postSplit(e, l, r);
     }
 
@@ -150,8 +158,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void preCompactSelection(ObserverContext<RegionCoprocessorEnvironment> c, Store store, List<StoreFile> candidates) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isCompacting = true;
+        }
         super.preCompactSelection(c, store, candidates);
     }
 
@@ -160,45 +170,55 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isCompacting = true;
+        }
         return super.preCompact(e, store, scanner, scanType);
     }
 
     @Override
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
-        isCompacting = false;
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isCompacting = false;
+        }
+        super.postCompact(e, store, resultFile);
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isFlushing = true;
+        }
         super.preFlush(e);
     }
 
     @Override
     public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            BackupUtils.waitForBackupToComplete(tableName, regionName, path);
+            isFlushing = true;
+        }
         return super.preFlush(e,store,scanner);
     }
 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s: %s", tableName, regionName, resultFile.getPath().toString());
         try {
-            if (!BackupUtils.isSpliceTable(namespace, tableName))
-                return;
-            BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
-                    tableName, resultFile.getPath().getName(), preparing);
-            isFlushing = false;
+            if (BackupUtils.isSpliceTable(namespace, tableName)) {
+                BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
+                        tableName, resultFile.getPath().getName(), preparing);
+                isFlushing = false;
+            }
+            super.postFlush(e, store, resultFile);
         } catch (Exception ex) {
             throw new IOException(ex);
         }
@@ -206,9 +226,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
-        if (!BackupUtils.isSpliceTable(namespace, tableName))
-            return;
-        isFlushing = false;
+        SpliceLogUtils.info(LOG, "BackupEndpointObserver.postFlush() %s.%s", tableName, regionName);
+        if (BackupUtils.isSpliceTable(namespace, tableName)) {
+            isFlushing = false;
+        }
+        super.postFlush(e);
     }
 }

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/BackupUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/BackupUtils.java
@@ -286,7 +286,15 @@ public class BackupUtils {
         FSDataOutputStream out = null;
         try {
             if (!fs.exists(new Path(backupDir, BackupRestoreConstants.REGION_FILE_NAME))) {
+                if (LOG.isDebugEnabled()) {
+                    SpliceLogUtils.debug(LOG, "creating a new region on file system for %s",
+                            region.getRegionInfo().getEncodedName());
+                }
                 HRegionFileSystem.createRegionOnFileSystem(conf, fs, backupDir.getParent(), region.getRegionInfo());
+            }
+            if (LOG.isDebugEnabled()) {
+                SpliceLogUtils.debug(LOG, "register HFile %s.%s for incremental backup",
+                        region.getRegionInfo().getEncodedName(), fileName);
             }
             out = fs.create(new Path(backupDir.toString() + "/" + SIConstants.DEFAULT_FAMILY_NAME + "/" + fileName));
         }

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/NoOpBackupManager.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/NoOpBackupManager.java
@@ -73,4 +73,9 @@ public class NoOpBackupManager implements BackupManager{
     public void cancelBackup() throws StandardException {
         throw StandardException.newException(SQLState.BACKUP_OPERATIONS_DISABLED);
     }
+
+    @Override
+    public void post_restore_cleanup(long backupId) throws StandardException {
+        throw StandardException.newException(SQLState.BACKUP_OPERATIONS_DISABLED);
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupManager.java
@@ -40,4 +40,6 @@ public interface BackupManager{
     void cancelDailyBackup(long jobId) throws StandardException;
 
     void cancelBackup() throws StandardException;
+
+    void post_restore_cleanup(long backupId) throws StandardException;
 }

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupSystemProcedures.java
@@ -274,6 +274,18 @@ public class BackupSystemProcedures {
         }
     }
 
+    public static void POST_RESTORE_CLEANUP(long backupId, ResultSet[] resultSets) throws StandardException, SQLException {
+
+        try {
+            BackupManager backupManager = EngineDriver.driver().manager().getBackupManager();
+            backupManager.post_restore_cleanup(backupId);
+            resultSets[0] = generateResult("Success", "Rolled back transactions with start timestamp greater than "+backupId);
+        } catch (Throwable t) {
+            resultSets[0] = generateResult("Error", t.getLocalizedMessage());
+            SpliceLogUtils.error(LOG, "post restore cleanup", t);
+        }
+    }
+
     private static ResultSet generateResult(String outcome, String message) throws StandardException, SQLException {
         if (message == null) {
             message = "";

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -749,6 +749,13 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                             .ownerClass(SpliceAdmin.class.getCanonicalName())
                             .sqlControl(RoutineAliasInfo.NO_SQL).returnType(null).isDeterministic(false)
                             .build());
+
+                    procedures.add(Procedure.newBuilder().name("POST_RESTORE_CLEANUP")
+                            .numOutputParams(0)
+                            .numResultSets(1)
+                            .ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                            .bigint("backupId")
+                            .build());
                 }  // End key == sysUUID
 
             } // End iteration through map keys (schema UUIDs)

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
@@ -163,10 +163,9 @@ public class SimpleTxnFilter implements TxnFilter{
         }
 
         TxnView t=fetchTransaction(ts);
-        assert t!=null:"Could not find a transaction for id "+ts;
 
         //submit it to the resolver to resolve asynchronously
-        if(t.getEffectiveState().isFinal()){
+        if(t!=null && t.getEffectiveState().isFinal()){
             doResolve(element,ts);
         }
     }
@@ -211,7 +210,7 @@ public class SimpleTxnFilter implements TxnFilter{
 
     private boolean isVisible(long txnId) throws IOException{
         TxnView toCompare=fetchTransaction(txnId);
-        return myTxn.canSee(toCompare);
+        return toCompare != null ? myTxn.canSee(toCompare) : false;
     }
 
     private TxnView fetchTransaction(long txnId) throws IOException{


### PR DESCRIPTION
Fix a couple problems with restore

Restored data may be written by a transaction that's absent from transaction table. This happens when backup is running concurrently with write workload. The transaction table is copied first before write workload starts, and later data written by the workload get copied. When the backup is restored and data is read and tested for visibility, do not return an error. Ignore them as if they are not visible.

Only do roll back transaction once for a series restores.

code cleanup.

Please also review code changes in ee branch.