### PR TITLE
DB-5898: clean up timeout backup

### DIFF
--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -1951,6 +1951,7 @@ public interface SQLState {
 	String BACKUP_DOESNOT_EXIST                                    = "BR012";
 	String PARENT_BACKUP_MISSING                                   = "BR013";
 	String EXISTS_CONCURRENT_BACKUP                                = "BR014";
+	String BACKUP_TIMEOUT                                          = "BR016";
 
 
 	String ROW_FORMAT_NOT_ALLOWED_WITH_PARQUET					   	= "EXT01";

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -8859,10 +8859,15 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
            </msg>
            <msg>
                <name>BR014</name>
-               <text>A concurrent {0} backup is running. Please wait until it completes or call syscs_util.syscs_cancel_backup() to cancel it.</text>
-               <arg>backupType</arg>
+               <text>A concurrent backup with ID {0} is running. Please wait until it completes or call syscs_util.syscs_cancel_backup() to cancel it.</text>
+               <arg>backupId</arg>
            </msg>
-
+           <msg>
+               <name>BR016</name>
+               <text>Backup timed out for table {0} region {1}.</text>
+               <arg>tableName</arg>
+               <arg>regionName</arg>
+           </msg>
            <msg>
                <name>EXT01</name>
                <text>row format specification not allowed with 'stored as parquet' </text>

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/BackupJobStatus.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/BackupJobStatus.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.hbase;
+
+import java.io.*;
+
+/**
+ * Created by jyuan on 5/5/17.
+ */
+public class BackupJobStatus implements Externalizable{
+    private long backupId;
+    private boolean isIncremental = false;
+    private long lastActiveTimestamp = 0;
+
+    public BackupJobStatus(){}
+
+    public BackupJobStatus(long backupId, boolean isIncremental,long lastActiveTimestamp) {
+        this.backupId = backupId;
+        this.isIncremental = isIncremental;
+        this.lastActiveTimestamp = lastActiveTimestamp;
+    }
+
+    public long getBackupId() {
+        return backupId;
+    }
+
+    public long getLastActiveTimestamp() {
+        return lastActiveTimestamp;
+    }
+
+    public void setLastActiveTimestamp(long lastActiveTimestamp) {
+        this.lastActiveTimestamp = lastActiveTimestamp;
+    }
+
+    public boolean isIncremental() {
+        return isIncremental;
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeLong(backupId);
+        out.writeBoolean(isIncremental);
+        out.writeLong(lastActiveTimestamp);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        backupId = in.readLong();
+        isIncremental = in.readBoolean();
+        lastActiveTimestamp = in.readLong();
+    }
+
+    /**
+     *
+     * @return byte representation of job status
+     * @throws IOException
+     */
+    public byte[] toBytes() throws IOException{
+        ObjectOutput out = null;
+        ByteArrayOutputStream bos = null;
+        try {
+            bos = new ByteArrayOutputStream();
+            out = new ObjectOutputStream(bos);
+            out.writeObject(this);
+            out.flush();
+            byte[] b = bos.toByteArray();
+
+            return b;
+        } finally {
+            if (bos != null) {
+                bos.close();
+            }
+        }
+    }
+
+    /**
+     *
+     * @param bs BackupJobStatus in bytes
+     * @return a BackupJobStatus object
+     * @throws IOException
+     * @throws ClassNotFoundException
+     */
+    public static BackupJobStatus parseFrom(byte[] bs) throws  IOException, ClassNotFoundException {
+        ByteArrayInputStream bis = new ByteArrayInputStream(bs);
+        ObjectInput in = null;
+        try {
+            in = new ObjectInputStream(bis);
+            BackupJobStatus backupJobStatus = (BackupJobStatus) in.readObject();
+            return backupJobStatus;
+        } finally {
+            if (in != null) {
+                in.close();
+            }
+        }
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupRestoreConstants.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupRestoreConstants.java
@@ -28,4 +28,7 @@ public class BackupRestoreConstants {
     public static final String ARCHIVE_DIR = "archive";
     public static final byte[] BACKUP_TYPE_FULL_BYTES = Bytes.toBytes("FULL");
     public static final byte[] BACKUP_TYPE_INCR_BYTES = Bytes.toBytes("INCR");
+    public static final String BACKUP_JOB_GROUP = "Backup";
+    public static final String RESTORE_JOB_GROUP = "Restore";
+    public static final long BACKUP_JOB_TIMEOUT = 30000;
 }


### PR DESCRIPTION
Store backup job status in zookeeper and update its last active timestamp. If a thread(compaction or flush, etc) is blocked, check the last active timestamp. Clean up backup if it times out.

Please also review code changes in ee branch.