### PR TITLE
DB-5872 Bcast implementation dataset vs rdd

### DIFF
--- a/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
@@ -205,6 +205,8 @@ public interface SConfiguration {
 
     long getBroadcastRegionRowThreshold();
 
+    long getBroadcastDatasetCostThreshold();
+
     long getOptimizerPlanMaximumTimeout();
 
     long getOptimizerPlanMinimumTimeout();

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
@@ -111,6 +111,7 @@ public class ConfigurationBuilder {
     public int partitionserverPort;
     public long broadcastRegionMbThreshold;
     public long broadcastRegionRowThreshold;
+    public long broadcastDatasetCostThreshold;
     public long optimizerPlanMaximumTimeout;
     public long optimizerPlanMinimumTimeout;
     public String networkBindAddress;

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
@@ -140,6 +140,7 @@ public final class SConfigurationImpl implements SConfiguration {
     private final  int partitionserverPort;
     private final  long broadcastRegionMbThreshold;
     private final  long broadcastRegionRowThreshold;
+    private final  long broadcastDatasetCostThreshold;
     private final  long optimizerPlanMaximumTimeout;
     private final  long optimizerPlanMinimumTimeout;
     private final  String networkBindAddress;
@@ -503,6 +504,10 @@ public final class SConfigurationImpl implements SConfiguration {
         return broadcastRegionRowThreshold;
     }
     @Override
+    public long getBroadcastDatasetCostThreshold() {
+        return broadcastDatasetCostThreshold;
+    }
+    @Override
     public long getOptimizerPlanMaximumTimeout() {
         return optimizerPlanMaximumTimeout;
     }
@@ -670,6 +675,7 @@ public final class SConfigurationImpl implements SConfiguration {
         partitionserverPort = builder.partitionserverPort;
         broadcastRegionMbThreshold = builder.broadcastRegionMbThreshold;
         broadcastRegionRowThreshold = builder.broadcastRegionRowThreshold;
+        broadcastDatasetCostThreshold = builder.broadcastDatasetCostThreshold;
         optimizerPlanMaximumTimeout = builder.optimizerPlanMaximumTimeout;
         optimizerPlanMinimumTimeout = builder.optimizerPlanMinimumTimeout;
         networkBindAddress = builder.networkBindAddress;

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SQLConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SQLConfiguration.java
@@ -110,6 +110,14 @@ public class SQLConfiguration implements ConfigurationDefault {
     private static final int DEFAULT_BROADCAST_REGION_ROW_THRESHOLD = 1000000;
 
     /**
+     * Threshold in cost for the broadcast Dataset implementation.  Default is 1000 (~ 1s, more than that and the subtree
+     * is executed in parallel in Spark)
+     *
+     */
+    public static final String BROADCAST_DATASET_COST_THRESHOLD = "splice.optimizer.broadcastDatasetCostThreshold";
+    private static final int DEFAULT_BROADCAST_DATASET_COST_THRESHOLD = 1000;
+
+    /**
      * Minimum fixed duration (in millisecomds) that should be allowed to lapse
      * before the optimizer can determine that it should stop trying to find
      * the best plan due to plan time taking longer than the expected
@@ -227,6 +235,7 @@ public class SQLConfiguration implements ConfigurationDefault {
         builder.optimizerPlanMinimumTimeout = configurationSource.getLong(OPTIMIZER_PLAN_MINIMUM_TIMEOUT, DEFAULT_OPTIMIZER_PLAN_MINIMUM_TIMEOUT);
         builder.broadcastRegionMbThreshold = configurationSource.getLong(BROADCAST_REGION_MB_THRESHOLD, DEFAULT_BROADCAST_REGION_MB_THRESHOLD);
         builder.broadcastRegionRowThreshold = configurationSource.getLong(BROADCAST_REGION_ROW_THRESHOLD, DEFAULT_BROADCAST_REGION_ROW_THRESHOLD);
+        builder.broadcastDatasetCostThreshold = configurationSource.getLong(BROADCAST_DATASET_COST_THRESHOLD, DEFAULT_BROADCAST_DATASET_COST_THRESHOLD);
 
         //always disable debug statements by default
         builder.debugLogStatementContext = configurationSource.getBoolean(DEBUG_LOG_STATEMENT_CONTEXT, DEFAULT_LOG_STATEMENT_CONTEXT);


### PR DESCRIPTION
Choose dynamically whether to use the RDD or the Dataset implementation
for Bcast joins

Initialize bcast joins asynchronously