### PR TITLE
DB-5946 Fixing S3 File System Implementation

### DIFF
--- a/hbase_sql/src/main/resources/core-site.xml
+++ b/hbase_sql/src/main/resources/core-site.xml
@@ -29,6 +29,12 @@
     </property>
 
     <property>
+        <name>io.file.buffer.size</name>
+        <value>65536</value>
+    </property>
+
+
+    <property>
         <name>fs.defaultFS</name>
         <value>file:///</value>
     </property>

--- a/hbase_sql/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
+++ b/hbase_sql/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
@@ -197,6 +197,7 @@ class SpliceTestPlatformConfig {
         //config.set("presto.s3.secret-key","");
         config.set("fs.s3a.impl",com.splicemachine.fs.s3.PrestoS3FileSystem.class.getCanonicalName());
         config.set("hive.exec.orc.split.strategy","BI");
+        config.setInt("io.file.buffer.size",65536);
 
         //
         // Splice


### PR DESCRIPTION
Rolling back a performance fix for preventing early aborts when reading ORC files from S3.
Increasing io.file.buffer.size from default 4K to 64K.