### PR TITLE
SPLICE-1639 Fix NPE due to Spark static initialization missing

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkHBaseBulkImport.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkHBaseBulkImport.java
@@ -298,11 +298,8 @@ public class SparkHBaseBulkImport implements HBaseBulkImporter{
      * @throws StandardException
      */
     private void bulkLoad(List<BulkImportPartition> bulkImportPartitions) throws StandardException{
-        List<StandardException> exceptions = SpliceSpark.getContext().parallelize(bulkImportPartitions, bulkImportPartitions.size())
-                .flatMap(new BulkImportFunction(bulkImportDirectory)).collect();
-        if (!exceptions.isEmpty()) {
-            throw  exceptions.get(0);
-        }
+        SpliceSpark.getContext().parallelize(bulkImportPartitions, bulkImportPartitions.size())
+                .foreach(new BulkImportFunction(bulkImportDirectory));
     }
 
     /**


### PR DESCRIPTION
BulkImportFunction was missing the call to SpliceSpark.setupSpliceStaticComponents() That's usually taken care of by the operationContext, but we don't use one here so we have to be explicit.