### PR TITLE
DB-5956 RestoreIT fails in Jenkins intermittently

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
@@ -16,6 +16,10 @@
 package com.splicemachine.derby.impl;
 
 import java.io.IOException;
+
+import com.splicemachine.db.catalog.types.RoutineAliasInfo;
+import com.splicemachine.db.iapi.sql.conn.StatementContext;
+import com.splicemachine.db.impl.jdbc.EmbedConnection;
 import org.apache.log4j.Logger;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -87,6 +91,12 @@ public class SpliceSpark {
 
                 EngineDriver engineDriver = EngineDriver.driver();
                 assert engineDriver!=null: "Not booted yet!";
+
+                // Create a static statement context to enable nested connections
+                EmbedConnection internalConnection = (EmbedConnection)engineDriver.getInternalConnection();
+                StatementContext statementContext = internalConnection.getLanguageConnection()
+                        .pushStatementContext(true, true, "", null, false, 0);
+                statementContext.setSQLAllowed(RoutineAliasInfo.MODIFIES_SQL_DATA, false);
 
                 //boot the pipeline components
                 final Clock clock = driver.getClock();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
@@ -174,8 +174,6 @@ public class SpliceDatabase extends BasicDatabase{
         cm.setLocaleFinder(this);
         pushDbContext(cm);
         LanguageConnectionContext lctx=lcf.newLanguageConnectionContext(cm,tc,lf,this,user,drdaID,dbname,type);
-        cm.setActiveThread();
-        ContextService.getFactory().setCurrentContextManager(cm);
 
         pushClassFactoryContext(cm,lcf.getClassFactory());
         ExecutionFactory ef=lcf.getExecutionFactory();

--- a/splice_machine/src/main/java/com/splicemachine/derby/serialization/SpliceObserverInstructions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/serialization/SpliceObserverInstructions.java
@@ -18,7 +18,6 @@ package com.splicemachine.derby.serialization;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
-import com.splicemachine.EngineDriver;
 import com.splicemachine.SpliceKryoRegistry;
 import com.splicemachine.db.catalog.types.RoutineAliasInfo;
 import com.splicemachine.db.iapi.error.StandardException;
@@ -28,15 +27,12 @@ import com.splicemachine.db.iapi.sql.ParameterValueSet;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.conn.StatementContext;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
-import com.splicemachine.db.impl.jdbc.EmbedConnection;
-import com.splicemachine.db.impl.jdbc.EmbedConnectionContext;
 import com.splicemachine.db.impl.sql.GenericActivationHolder;
 import com.splicemachine.db.impl.sql.GenericStorablePreparedStatement;
 import com.splicemachine.db.impl.sql.execute.TriggerExecutionStack;
 import com.splicemachine.derby.iapi.sql.execute.ConvertedResultSet;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.stream.ActivationHolder;
-import com.splicemachine.tools.EmbedConnectionMaker;
 import com.splicemachine.utils.SpliceLogUtils;
 import com.splicemachine.utils.kryo.KryoObjectInput;
 import com.splicemachine.utils.kryo.KryoObjectOutput;
@@ -257,12 +253,6 @@ public class SpliceObserverInstructions implements Externalizable{
                 StatementContext statementContext = activation.getLanguageConnectionContext().pushStatementContext(statementAtomic,
                         statementReadOnly,stmtText,pvs,stmtRollBackParentContext,stmtTimeout);
                 statementContext.setSQLAllowed(RoutineAliasInfo.MODIFIES_SQL_DATA, false);
-
-                //EmbedConnection internalConnection=(EmbedConnection) new EmbedConnectionMaker().createNew(new Properties());
-                EmbedConnection internalConnection=(EmbedConnection)EngineDriver.driver().getInternalConnection();
-                Context connectionContext = new EmbedConnectionContext(activation.getLanguageConnectionContext().getContextManager(),
-                        (EmbedConnection)internalConnection);
-                internalConnection.getContextManager().pushContext(statementContext);
 
                 return activation;
             }catch(Exception e){

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
@@ -15,7 +15,9 @@
 
 package com.splicemachine.derby.stream;
 
-import com.splicemachine.derby.impl.sql.execute.operations.SpliceBaseOperation;
+import com.splicemachine.EngineDriver;
+import com.splicemachine.db.impl.jdbc.EmbedConnection;
+import com.splicemachine.db.impl.jdbc.EmbedConnectionContext;
 import org.apache.log4j.Logger;
 import org.sparkproject.guava.collect.Maps;
 import com.splicemachine.db.iapi.error.StandardException;
@@ -196,6 +198,10 @@ public class ActivationHolder implements Externalizable {
             impl = new SpliceTransactionResourceImpl();
             prepared =  impl.marshallTransaction(txnView);
             activation = soi.getActivation(this, impl.getLcc());
+
+            // Push internal connection to the current context manager
+            EmbedConnection internalConnection = (EmbedConnection)EngineDriver.driver().getInternalConnection();
+            new EmbedConnectionContext(impl.getLcc().getContextManager(), internalConnection);
 
             if (reinit) {
                 SpliceOperationContext context = SpliceOperationContext.newContext(activation);


### PR DESCRIPTION
This pull request backports an accumulated set of changes for:
- SPLICE-1329: Memory leak in SpliceObserverInstructions
- SPLICE-1362: IndexOOB exceptions loading TPCC data
- DB-5789: redo nested connection onSpark fix (most importantly)
from master to 2.0.
It will fix intermittent failures in Jenkins and a memory leak in 2.0. 