### PR TITLE
SPLICE-1640 apply memory limit check for consecutive outer broadcast …

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CostEstimate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CostEstimate.java
@@ -271,4 +271,8 @@ public interface CostEstimate extends StoreCostResult {
     double localCostPerPartition();
 
     void setLocalCostPerPartition(double localCostPerPartition);
+
+    double getAccumulatedMemory();
+
+    void setAccumulatedMemory(double memorySize);
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizable.java
@@ -428,4 +428,9 @@ public interface Optimizable {
 	 * @exception StandardException		Thrown on error
 	 */
 	double uniqueJoin(OptimizablePredicateList predList) throws StandardException;
+
+	/**
+	 * get the current optimizable's memory usage if its best join plan is a broadcast join
+	 */
+	double getMemoryUsage4BroadcastJoin();
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizer.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizer.java
@@ -386,4 +386,10 @@ public interface Optimizer{
      * loops, and therefore prevent infinite loops from occurring.
      */
     void verifyBestPlanFound() throws StandardException;
+
+    /**
+     * Given the best join sequence planned the current optimizer, if the join sequence ends with consecutive broadcast
+     * joins, return the accumulated memory usage by these broadcast joins
+     */
+    double getAccumulatedMemory();
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CostEstimateImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CostEstimateImpl.java
@@ -564,4 +564,12 @@ public class CostEstimateImpl implements CostEstimate {
 
     @Override
     public double localCostPerPartition(){ return 0;}
+
+    @Override
+    public double getAccumulatedMemory() {
+        return 0.0d;
+    }
+
+    @Override
+    public void setAccumulatedMemory(double memorySize) { }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
@@ -1144,4 +1144,15 @@ public abstract class FromTable extends ResultSetNode implements Optimizable{
     public void setDataSetProcessorType(CompilerContext.DataSetProcessorType dataSetProcessorType) {
         this.dataSetProcessorType = dataSetProcessorType;
     }
+
+    @Override
+    public double getMemoryUsage4BroadcastJoin(){
+        if (trulyTheBestAccessPath == null || trulyTheBestAccessPath.getCostEstimate() == null)
+            return 0.0d;
+
+        if (trulyTheBestAccessPath.getJoinStrategy().getJoinStrategyType() == JoinStrategy.JoinStrategyType.BROADCAST)
+            return trulyTheBestAccessPath.getCostEstimate().getBase().getEstimatedHeapSize();
+
+        return 0.0d;
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IndexToBaseRowNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IndexToBaseRowNode.java
@@ -102,6 +102,11 @@ public class IndexToBaseRowNode extends FromTable{
     }
 
     @Override
+    public double getMemoryUsage4BroadcastJoin(){
+        return source.getMemoryUsage4BroadcastJoin();
+    }
+
+    @Override
     public CostEstimate getCostEstimate(){
         return source.getTrulyTheBestAccessPath().getCostEstimate();
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
@@ -431,6 +431,18 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
     }
 
     @Override
+    public double getMemoryUsage4BroadcastJoin(){
+        if(hasTrulyTheBestAccessPath){
+            return super.getMemoryUsage4BroadcastJoin();
+        }
+
+        if(childResult instanceof Optimizable)
+            return ((Optimizable)childResult).getMemoryUsage4BroadcastJoin();
+
+        return super.getMemoryUsage4BroadcastJoin();
+    }
+
+    @Override
     public void rememberSortAvoidancePath(){
         if(childResult instanceof Optimizable)
             ((Optimizable)childResult).rememberSortAvoidancePath();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SingleChildResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SingleChildResultSetNode.java
@@ -92,6 +92,18 @@ public abstract class SingleChildResultSetNode extends FromTable{
         return super.getTrulyTheBestAccessPath();
     }
 
+    @Override
+    public double getMemoryUsage4BroadcastJoin(){
+        if(hasTrulyTheBestAccessPath){
+            return super.getMemoryUsage4BroadcastJoin();
+        }
+
+        if(childResult instanceof Optimizable)
+            return ((Optimizable)childResult).getMemoryUsage4BroadcastJoin();
+
+        return super.getMemoryUsage4BroadcastJoin();
+    }
+
     /**
      * Return the childResult from this node.
      *

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SimpleCostEstimate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SimpleCostEstimate.java
@@ -51,6 +51,8 @@ public class SimpleCostEstimate implements CostEstimate{
     protected double projectionCost =-1.0d;
     protected double projectionRows =-1.0d;
     private double localCostPerPartition;
+    /* consecutive broadcast joins memory used in bytes */
+    private double accumulatedMemory = 0.0d;
 
     public SimpleCostEstimate(){ }
 
@@ -114,6 +116,7 @@ public class SimpleCostEstimate implements CostEstimate{
         this.projectionCost = other.getProjectionCost();
         this.projectionRows = other.getProjectionRows();
         this.localCostPerPartition = other.localCostPerPartition();
+        this.accumulatedMemory = other.getAccumulatedMemory();
     }
 
     @Override
@@ -476,5 +479,15 @@ public class SimpleCostEstimate implements CostEstimate{
     @Override
     public void setLocalCostPerPartition(double localCostPerPartition) {
         this.localCostPerPartition = localCostPerPartition;
+    }
+
+    @Override
+    public double getAccumulatedMemory() {
+        return accumulatedMemory;
+    }
+
+    @Override
+    public void setAccumulatedMemory(double memorySize) {
+        accumulatedMemory = memorySize;
     }
 }


### PR DESCRIPTION
…join and derived tables:

1. Introduce a new variable accumulatedMemory in the class SimpleCostEstimate to record the accumulated memory usage by a sequence of consecutive broadcast join. This variable is set as part of the outermostCostEstimate when we start planning the joins of a new set of tables, and need to carry the cost from the outer block or the outer tables of an outer join.
2. Add method getAccumulatedMemory() to the interface Optimizer. Given the best join sequence planned by the current optimizer, if the join sequence ends with consecutive broadcast joins, return the accumulated memory usage by these broadcast joins.
3. In the class OptimizerImpl that implements the interface Optimizer, add the actual implementation of the method getAccumulatedMemory().
4. Also in the class OptimizerImpl, apply the memory check in considerCost(),  similar to the check SPLICE-1582 added in the function costBasedCostOptimizable(). The difference between considerCost() and costBasedCostOptimizable() is that, costBasedCostOptimizable()decides for an optimizable corresponding to a base table whether the current cost could be picked up as best cost, while considerCost() decides for an optimizable corresponing to a derived table or some intermedidate result whether the current cost could be picked as best cost.
5. Add method getMemoryUsage4BCJ() to the interface Optimizable, as well as all its class implementations. The implemenation for JoinNode will take care of the consecutive broadcast joins through outer joins or joins of the form table1 (left/inner) join table2 on joincond1 (left/inner) join table3 on joincond2....
