### PR TITLE
Backport DB-5789 from master to 2.5

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextManager.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextManager.java
@@ -198,7 +198,7 @@ public class ContextManager
 	 * the specified Context object does not exist, the call will fail.
 	 * @param theContext the Context object to remove.
 	 */
-	public void popContext(Context theContext)
+	void popContext(Context theContext)
 	{
 		checkInterrupt();
 		if (SanityManager.DEBUG)

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
@@ -15,6 +15,10 @@
 package com.splicemachine.derby.impl;
 
 import java.io.IOException;
+
+import com.splicemachine.db.catalog.types.RoutineAliasInfo;
+import com.splicemachine.db.iapi.sql.conn.StatementContext;
+import com.splicemachine.db.impl.jdbc.EmbedConnection;
 import org.apache.log4j.Logger;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -97,6 +101,12 @@ public class SpliceSpark {
 
                 EngineDriver engineDriver = EngineDriver.driver();
                 assert engineDriver!=null: "Not booted yet!";
+
+                // Create a static statement context to enable nested connections
+                EmbedConnection internalConnection = (EmbedConnection)engineDriver.getInternalConnection();
+                StatementContext statementContext = internalConnection.getLanguageConnection()
+                        .pushStatementContext(true, true, "", null, false, 0);
+                statementContext.setSQLAllowed(RoutineAliasInfo.MODIFIES_SQL_DATA, false);
 
                 //boot the pipeline components
                 final Clock clock = driver.getClock();

--- a/splice_machine/src/main/java/com/splicemachine/derby/jdbc/SpliceTransactionResourceImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/jdbc/SpliceTransactionResourceImpl.java
@@ -43,8 +43,6 @@ public final class SpliceTransactionResourceImpl implements AutoCloseable{
     private String drdaID;
     protected SpliceDatabase database;
     protected LanguageConnectionContext lcc;
-    private boolean generateLcc=true;
-    private ContextManager oldCm;
 
     public SpliceTransactionResourceImpl() throws SQLException{
         this("jdbc:splice:"+ SQLConfiguration.SPLICE_DB+";create=true", new Properties());
@@ -77,7 +75,6 @@ public final class SpliceTransactionResourceImpl implements AutoCloseable{
             SpliceLogUtils.debug(LOG, "marshallTransaction with transactionID %s", txn);
         }
 
-        oldCm=csf.getCurrentContextManager();
         cm=csf.newContextManager();
         csf.setCurrentContextManager(cm);
 
@@ -88,18 +85,11 @@ public final class SpliceTransactionResourceImpl implements AutoCloseable{
 
 
     public void close(){
-        if(generateLcc){
-            while(!cm.isEmpty()){
-                cm.popContext();
-            }
-            csf.resetCurrentContextManager(cm);
-            csf.removeContext(cm);
-            if(oldCm!=null){
-                csf.forceRemoveContext(cm);
-                oldCm.setActiveThread();
-                csf.setCurrentContextManager(oldCm);
-            }
+        while(!cm.isEmpty()){
+            cm.popContext();
         }
+        csf.resetCurrentContextManager(cm);
+        csf.removeContext(cm);
     }
 
     public LanguageConnectionContext getLcc(){

--- a/splice_machine/src/main/java/com/splicemachine/derby/serialization/SpliceObserverInstructions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/serialization/SpliceObserverInstructions.java
@@ -17,7 +17,6 @@ package com.splicemachine.derby.serialization;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
-import com.splicemachine.EngineDriver;
 import com.splicemachine.SpliceKryoRegistry;
 import com.splicemachine.db.catalog.types.RoutineAliasInfo;
 import com.splicemachine.db.iapi.error.StandardException;
@@ -27,8 +26,6 @@ import com.splicemachine.db.iapi.sql.ParameterValueSet;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.conn.StatementContext;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
-import com.splicemachine.db.impl.jdbc.EmbedConnection;
-import com.splicemachine.db.impl.jdbc.EmbedConnectionContext;
 import com.splicemachine.db.impl.sql.GenericActivationHolder;
 import com.splicemachine.db.impl.sql.GenericStorablePreparedStatement;
 import com.splicemachine.db.impl.sql.execute.TriggerExecutionStack;
@@ -250,11 +247,6 @@ public class SpliceObserverInstructions implements Externalizable{
                 StatementContext statementContext = activation.getLanguageConnectionContext().pushStatementContext(statementAtomic,
                         statementReadOnly,stmtText,pvs,stmtRollBackParentContext,stmtTimeout);
                 statementContext.setSQLAllowed(RoutineAliasInfo.MODIFIES_SQL_DATA, false);
-
-                //EmbedConnection internalConnection=(EmbedConnection) new EmbedConnectionMaker().createNew(new Properties());
-                EmbedConnection internalConnection=(EmbedConnection)EngineDriver.driver().getInternalConnection();
-                Context connectionContext = new EmbedConnectionContext(activation.getLanguageConnectionContext().getContextManager(),
-                        (EmbedConnection)internalConnection);
 
                 return activation;
             }catch(Exception e){

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
@@ -15,9 +15,8 @@
 package com.splicemachine.derby.stream;
 
 import com.splicemachine.EngineDriver;
-import com.splicemachine.db.iapi.services.context.Context;
-import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.impl.jdbc.EmbedConnection;
+import com.splicemachine.db.impl.jdbc.EmbedConnectionContext;
 import org.apache.log4j.Logger;
 import org.spark_project.guava.collect.Maps;
 import com.splicemachine.db.iapi.error.StandardException;
@@ -199,12 +198,9 @@ public class ActivationHolder implements Externalizable {
             prepared =  impl.marshallTransaction(txnView);
             activation = soi.getActivation(this, impl.getLcc());
 
-            Context statementContext = activation.getLanguageConnectionContext().getStatementContext();
+            // Push internal connection to the current context manager
             EmbedConnection internalConnection = (EmbedConnection)EngineDriver.driver().getInternalConnection();
-            ContextManager cm = internalConnection.getContextManager();
-            synchronized (cm) {
-                cm.pushContext(statementContext);
-            }
+            new EmbedConnectionContext(impl.getLcc().getContextManager(), internalConnection);
 
             if (reinit) {
                 SpliceOperationContext context = SpliceOperationContext.newContext(activation);
@@ -221,13 +217,6 @@ public class ActivationHolder implements Externalizable {
         if (prepared) {
             impl.close();
             prepared = false;
-        }
-
-        Context statementContext = activation.getLanguageConnectionContext().getStatementContext();
-        EmbedConnection internalConnection=(EmbedConnection)EngineDriver.driver().getInternalConnection();
-        ContextManager cm = internalConnection.getContextManager();
-        synchronized (cm) {
-            cm.popContext(statementContext);
         }
     }
 }


### PR DESCRIPTION
A fix for DB-5956 (RestoreIT fails in Jenkins intermittently), essentially backported 
DB-5789 (Redo SpliceUDTIT.testConnection fix) to 2.0.
This pull request ensures that all three branches, 2.0, 2.5, and master, are aligned with regard to DB-5789, which provided a better fix for:
- SPLICE-1329: Memory leak in SpliceObserverInstructions
- SPLICE-1362: IndexOOB exceptions loading TPCC data.