### PR TITLE
DB-5933 Continue processing tables when one doesn't have a namespace (2.0)

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/Vacuum.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/Vacuum.java
@@ -103,7 +103,7 @@ public class Vacuum{
                     String[] tableName = parseTableName(table.getTableName());
                     if (tableName.length < 2) {
                         LOG.warn("Table name doesn't have two components (namespace : name) ignoring: " + table.getTableName());
-                        return;
+                        continue;
                     }
                     long tableConglom = Long.parseLong(tableName[1]);
                     if(tableConglom < DataDictionary.FIRST_USER_TABLE_NUMBER) {


### PR DESCRIPTION
We should ignore the table, not stop the vacuum process