### PR TITLE
SPLICE-1660 Delete Not Using Index Scan due to index columns being re…

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DeleteNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DeleteNode.java
@@ -968,7 +968,11 @@ public class DeleteNode extends DMLModStatementNode
 		** Adding indexes also takes care of the replication 
 		** requirement of having the primary key.
 		*/
-		DMLModStatementNode.getXAffectedIndexes(baseTable,  null, columnMap, conglomVector );
+
+		// Not Required for dynamic deletes.  It will be required if we attempt to do bulk
+		// deletes from a file (JUN)
+
+		//DMLModStatementNode.getXAffectedIndexes(baseTable,  null, columnMap, conglomVector );
 
 		/*
 	 	** If we have any DELETE triggers, then do one of the following


### PR DESCRIPTION
…quired for the scan.  This will happen most of the time when a table has more than one index