### PR TITLE
DB-5982: disable dictionary cache for hbase master and spark executor(2.5)

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/hbase/RegionServerLifecycleObserver.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/RegionServerLifecycleObserver.java
@@ -17,6 +17,7 @@ package com.splicemachine.hbase;
 
 import java.io.IOException;
 
+import com.splicemachine.client.SpliceClient;
 import com.splicemachine.derby.hbase.HBasePipelineEnvironment;
 import com.splicemachine.derby.lifecycle.ManagerLoader;
 import com.splicemachine.lifecycle.PipelineEnvironmentLoadService;
@@ -61,6 +62,7 @@ public class RegionServerLifecycleObserver extends BaseRegionServerObserver{
     public void start(CoprocessorEnvironment e) throws IOException{
         isHbaseJVM= true;
         lifecycleManager = startEngine(e);
+        SpliceClient.isRegionServer = true;
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/client/SpliceClient.java
+++ b/splice_machine/src/main/java/com/splicemachine/client/SpliceClient.java
@@ -5,5 +5,5 @@ package com.splicemachine.client;
  */
 public class SpliceClient {
     public static boolean isClient = false;
-
+    public static boolean isRegionServer = false;
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -671,8 +671,12 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
 
     @Override
     public boolean canUseCache(TransactionController xactMgr) throws StandardException {
-        if (SpliceClient.isClient)
+        // Only enable dictionary cache for region server.
+        // TODO - enable it for master and spark executor
+        if (!SpliceClient.isRegionServer) {
+            SpliceLogUtils.debug(LOG, "Cannot use dictionary cache.");
             return false;
+        }
         DDLDriver driver=DDLDriver.driver();
         if(driver==null) return false;
         DDLWatcher ddlWatcher=driver.ddlWatcher();

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
@@ -16,6 +16,7 @@ package com.splicemachine.derby.utils;
 
 import com.splicemachine.db.catalog.SystemProcedures;
 import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.sql.depend.DependencyManager;
 import com.splicemachine.db.impl.services.uuid.BasicUUID;
 import com.splicemachine.ddl.DDLMessage;
 import com.splicemachine.derby.ddl.DDLUtils;
@@ -900,13 +901,23 @@ public class SpliceAdmin extends BaseAdminProcedures{
     public static void SET_PURGE_DELETED_ROWS (String schemaName, String tableName, String enable) throws Exception{
         LanguageConnectionContext lcc = ConnectionUtil.getCurrentLCC();
         TransactionController tc  = lcc.getTransactionExecute();
-        tc.elevate("purgeDeleteRows");
         DataDictionary dd = lcc.getDataDictionary();
+        dd.startWriting(lcc);
         SchemaDescriptor sd = dd.getSchemaDescriptor(schemaName, tc, true);
+        if (sd == null)
+        {
+            throw StandardException.newException(SQLState.LANG_SCHEMA_DOES_NOT_EXIST, schemaName);
+        }
         TableDescriptor td = dd.getTableDescriptor(tableName, sd, tc);
+        if (td == null)
+        {
+            throw StandardException.newException(SQLState.TABLE_NOT_FOUND, tableName);
+        }
         DDLMessage.DDLChange ddlChange = ProtoUtil.createAlterTable(((SpliceTransactionManager) tc).getActiveStateTxn().getTxnId(),
                 (BasicUUID) td.getUUID());
-        // Run Remotely
+        DependencyManager dm = dd.getDependencyManager();
+        dm.invalidateFor(td, DependencyManager.ALTER_TABLE, lcc);
+
         tc.prepareDataDictionaryChange(DDLUtils.notifyMetadataChange(ddlChange));
         boolean b = "TRUE".compareToIgnoreCase(enable) == 0 ? true : false;
         td.setPurgeDeletedRows(b);


### PR DESCRIPTION
Disable dictionary cache to fix HFile loading and physical delete problems. For longer term, we should support dictionary cache invalidation for them.