### PR TITLE
DB-5992 Disable Spark block cache and fix broadcast costing

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseJoinStrategy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseJoinStrategy.java
@@ -187,10 +187,10 @@ public abstract class BaseJoinStrategy implements JoinStrategy{
 
         mb.push(
                 innerTable.getTrulyTheBestAccessPath().
-                        getCostEstimate().rowCount());
+                        getCostEstimate().getBase().rowCount());
         mb.push(
                 innerTable.getTrulyTheBestAccessPath().
-                        getCostEstimate().getEstimatedCost());
+                        getCostEstimate().getBase().getEstimatedCost());
         mb.push(tableVersion);
         mb.push(innerTable instanceof ResultSetNode ? ((ResultSetNode)innerTable).printExplainInformationForActivation() : "");
         mb.push(pin);

--- a/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -104,6 +104,7 @@ public class SplitRegionScanner implements RegionScanner {
                             Bytes.compareTo(regionStopKey, stopRow) <= 0) && regionStopKey.length > 0 ? regionStopKey : stopRow;
                     newScan.setStartRow(splitStart);
                     newScan.setStopRow(splitStop);
+                    newScan.setCacheBlocks(false);
                     if (LOG.isDebugEnabled())
                         SpliceLogUtils.debug(LOG, "adding Split Region Scanner for startKey='%s', endKey='%s' on partition ['%s', '%s']",
                                 CellUtils.toHex(splitStart), CellUtils.toHex(splitStop),

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SQLConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SQLConfiguration.java
@@ -100,7 +100,7 @@ public class SQLConfiguration implements ConfigurationDefault {
      *
      */
     public static final String BROADCAST_REGION_MB_THRESHOLD = "splice.optimizer.broadcastRegionMBThreshold";
-    private static final int DEFAULT_BROADCAST_REGION_MB_THRESHOLD = (int) (Runtime.getRuntime().maxMemory() / (1024l * 1024l * 100l));
+    private static final int DEFAULT_BROADCAST_REGION_MB_THRESHOLD = 100;
 
     /**
      * Threshold in rows for the broadcast join region size.  Default is 1 Million Rows
@@ -110,12 +110,12 @@ public class SQLConfiguration implements ConfigurationDefault {
     private static final int DEFAULT_BROADCAST_REGION_ROW_THRESHOLD = 1000000;
 
     /**
-     * Threshold in cost for the broadcast Dataset implementation.  Default is 1000 (~ 1s, more than that and the subtree
+     * Threshold in cost for the broadcast Dataset implementation.  Default is 10000 (~ 10s, more than that and the subtree
      * is executed in parallel in Spark)
      *
      */
     public static final String BROADCAST_DATASET_COST_THRESHOLD = "splice.optimizer.broadcastDatasetCostThreshold";
-    private static final int DEFAULT_BROADCAST_DATASET_COST_THRESHOLD = 1000;
+    private static final int DEFAULT_BROADCAST_DATASET_COST_THRESHOLD = 10000;
 
     /**
      * Minimum fixed duration (in millisecomds) that should be allowed to lapse

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinCache.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinCache.java
@@ -113,6 +113,7 @@ public class BroadcastJoinCache{
     private static class ReferenceCountedJoinTable implements JoinTable{
         private final JoinTable delegate;
         private ReferenceCountingFactory refFactory;
+        private boolean closed = false;
 
         public ReferenceCountedJoinTable(JoinTable delegate,ReferenceCountingFactory refFactory){
             this.delegate=delegate;
@@ -126,6 +127,9 @@ public class BroadcastJoinCache{
 
         @Override
         public void close(){
+            if (closed)
+                return;
+            closed = true;
             refFactory.markClosed();
             delegate.close();
         }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/broadcast/AbstractBroadcastJoinFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/broadcast/AbstractBroadcastJoinFlatMapFunction.java
@@ -56,16 +56,27 @@ public abstract class AbstractBroadcastJoinFlatMapFunction<In, Out> extends Spli
     @Override
     public final Iterator<Out> call(Iterator<In> locatedRows) throws Exception {
         init();
-        return call(locatedRows, joinTable.get()).iterator();
+        JoinTable table = joinTable.get();
+        Iterator<Out> it = call(locatedRows, table).iterator();
+        return new Iterator<Out>() {
+            @Override
+            public boolean hasNext() {
+                boolean result = it.hasNext();
+                if (!result) {
+                    table.close();
+                    joinTable = null; // delete reference for gc
+                }
+                return result;
+            }
+
+            @Override
+            public Out next() {
+                return it.next();
+            }
+        };
     }
 
     protected abstract Iterable<Out> call(Iterator<In> locatedRows, JoinTable joinTable);
-
-    @Override
-    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-        super.readExternal(in);
-        init();
-    }
 
     private synchronized void init() {
         if (init)


### PR DESCRIPTION
Close broadcast tables after use for GC, disable broadcast prefetch