### PR TITLE
DB-5832: fix stats collection on external table

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -519,9 +519,9 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             try {
                 table = SpliceSpark.getSession().read().csv(location);
 
-                if (op == null && baseColumnMap[0] == 1) {
+                if (op == null) {
                     // stats collection scan
-                    for(int index = 0; index< baseColumnMap.length; index++) {
+                    for(int index = 0; index < execRow.schema().fields().length; index++) {
                         StructField ft = table.schema().fields()[index];
                         Column cl = new Column(ft.name()).cast(execRow.schema().fields()[index].dataType());
                         table = table.withColumn(ft.name(), cl);

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -874,7 +874,6 @@ public class ExternalTableIT extends SpliceUnitTest{
     }
 
     @Test
-    @Ignore
     public void testCollectStats() throws Exception {
         methodWatcher.executeUpdate(String.format("create external table t1_orc (col1 int, col2 char(24))" +
                 " STORED AS ORC LOCATION '%s'", getExternalResourceDirectory()+"t1_orc_test"));
@@ -900,7 +899,7 @@ public class ExternalTableIT extends SpliceUnitTest{
         Assert.assertEquals("Error with COLLECT_TABLE_STATISTICS for external table","EXTERNALTABLEIT",  rs.getString(1));
         rs.close();
 
-        ResultSet rs2 = methodWatcher.executeQuery("select total_row_count from sys.systablestatistics where schemaname = 'EXTERNALTABLEIT' ");
+        ResultSet rs2 = methodWatcher.executeQuery("select total_row_count from sys.systablestatistics where schemaname = 'EXTERNALTABLEIT' and tablename = 'T1_ORC'");
         String expected = "TOTAL_ROW_COUNT |\n" +
                 "------------------\n" +
                 "        3        |";
@@ -911,7 +910,7 @@ public class ExternalTableIT extends SpliceUnitTest{
         spliceClassWatcher.executeUpdate("CALL  SYSCS_UTIL.DROP_TABLE_STATISTICS ('EXTERNALTABLEIT', 'T1_ORC')");
 
         // make sure it is clean
-        rs2 = methodWatcher.executeQuery("select total_row_count from sys.systablestatistics where schemaname = 'EXTERNALTABLEIT' ");
+        rs2 = methodWatcher.executeQuery("select total_row_count from sys.systablestatistics where schemaname = 'EXTERNALTABLEIT' and tablename = 'T1_ORC' ");
         Assert.assertEquals("", TestUtils.FormattedResult.ResultFactory.toString(rs2));
         rs2.close();
 
@@ -925,7 +924,7 @@ public class ExternalTableIT extends SpliceUnitTest{
         rs.close();
 
         // check the stats again
-        rs2 = methodWatcher.executeQuery("select total_row_count from sys.systablestatistics where schemaname = 'EXTERNALTABLEIT' ");
+        rs2 = methodWatcher.executeQuery("select total_row_count from sys.systablestatistics where schemaname = 'EXTERNALTABLEIT' and tablename = 'T1_ORC' ");
         Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs2));
         rs2.close();
 
@@ -935,6 +934,62 @@ public class ExternalTableIT extends SpliceUnitTest{
         // make sure it is clean
         rs2 = methodWatcher.executeQuery("select total_row_count from sys.systablestatistics where schemaname = 'EXTERNALTABLEIT' ");
         Assert.assertEquals("", TestUtils.FormattedResult.ResultFactory.toString(rs2));
+        rs2.close();
+    }
+
+    @Test
+     public void testCollectStatsText() throws Exception {
+        methodWatcher.executeUpdate(String.format("create external table t1_csv (col1 int, col2 char(24))" +
+                " STORED AS TEXTFILE LOCATION '%s'", getExternalResourceDirectory()+"t1_csv_test"));
+        int insertCount = methodWatcher.executeUpdate(String.format("insert into t1_csv values (1,'XXXX')," +
+                "(2,'YYYY')," +
+                "(3,'ZZZZ')"));
+        Assert.assertEquals("insertCount is wrong",3,insertCount);
+
+        ResultSet rs;
+        // collect table level stats
+        PreparedStatement ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.COLLECT_TABLE_STATISTICS(?,?,?) ");
+        ps.setString(1, "EXTERNALTABLEIT");
+        ps.setString(2, "T1_CSV");
+        ps.setBoolean(3, true);
+        rs = ps.executeQuery();
+        rs.next();
+        Assert.assertEquals("Error with COLLECT_TABLE_STATISTICS for external table","EXTERNALTABLEIT",  rs.getString(1));
+        rs.close();
+
+        ResultSet rs2 = methodWatcher.executeQuery("select total_row_count from sys.systablestatistics where schemaname = 'EXTERNALTABLEIT' and tablename = 'T1_CSV'");
+        String expected = "TOTAL_ROW_COUNT |\n" +
+                "------------------\n" +
+                "        3        |";
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs2));
+        rs2.close();
+    }
+
+    @Test
+    public void testCollectStatsParquet() throws Exception {
+        methodWatcher.executeUpdate(String.format("create external table t1_parq (col1 int, col2 char(24))" +
+                " STORED AS PARQUET LOCATION '%s'", getExternalResourceDirectory()+"t1_parq_test"));
+        int insertCount = methodWatcher.executeUpdate(String.format("insert into t1_parq values (1,'XXXX')," +
+                "(2,'YYYY')," +
+                "(3,'ZZZZ')"));
+        Assert.assertEquals("insertCount is wrong",3,insertCount);
+
+        ResultSet rs;
+        // collect table level stats
+        PreparedStatement ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.COLLECT_TABLE_STATISTICS(?,?,?) ");
+        ps.setString(1, "EXTERNALTABLEIT");
+        ps.setString(2, "T1_PARQ");
+        ps.setBoolean(3, true);
+        rs = ps.executeQuery();
+        rs.next();
+        Assert.assertEquals("Error with COLLECT_TABLE_STATISTICS for external table","EXTERNALTABLEIT",  rs.getString(1));
+        rs.close();
+
+        ResultSet rs2 = methodWatcher.executeQuery("select total_row_count from sys.systablestatistics where schemaname = 'EXTERNALTABLEIT' and tablename = 'T1_PARQ'");
+        String expected = "TOTAL_ROW_COUNT |\n" +
+                "------------------\n" +
+                "        3        |";
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs2));
         rs2.close();
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
@@ -433,6 +433,7 @@ public class StatisticsAdmin extends BaseAdminProcedures {
                 .delimited(table.getDelimited())
                 .lines(table.getLines())
                 .escaped(table.getEscaped())
+                .partitionByColumns(table.getPartitionBy())
                 ;
     }
 


### PR DESCRIPTION
Fix for stats collection where it was missing partition by info for orc file type, for text file the index was zero based but for stats collection it has tobe one based.
(2.5 back port to follow)