### PR TITLE
SPLICE-1611 TPC-C workload causes many prepared statement recompilations

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -770,6 +770,19 @@ public interface LanguageConnectionContext extends Context {
 	 */
 	int getBindCount();
 
+	/**
+	 * Remember that the DataDictionary is in write mode, so we can take
+	 * it out of write mode at the end of the transaction.
+	 */
+	void setDataDictionaryWriteMode();
+
+	/**
+	 * Return true if the data dictionary is in write mode (that is, this
+	 * context was informed that is is in write mode by the method call
+	 * setDataDictionaryWriteMode().
+	 */
+	boolean dataDictionaryInWriteMode();
+
     /**
 	  *	Reports how many statement levels deep we are.
 	  *

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -404,6 +404,7 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
 
     @Override
     public void startWriting(LanguageConnectionContext lcc,boolean setDDMode) throws StandardException{
+        lcc.setDataDictionaryWriteMode();
         elevateTxnForDictionaryOperations(lcc);
     }
 


### PR DESCRIPTION
It was a regression introduced when DataDistionary was reworked. Basically, I restore the original behavior. With the fix, prepared statement recompilations disappear from performance profiles for TPC-C.