### PR TITLE
DB-6012: avoid deleting a nonexist snapshot

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
@@ -1180,7 +1180,6 @@ public class SpliceAdmin extends BaseAdminProcedures{
             String objectName = rs.getString(1);
             long conglomerateNumber = rs.getLong(2);
             String sname = snapshotName + "_" + conglomerateNumber;
-            snapshotList.add(sname);
             DateTime creationTime = new DateTime(System.currentTimeMillis());
             if (LOG.isDebugEnabled())
             {
@@ -1190,6 +1189,7 @@ public class SpliceAdmin extends BaseAdminProcedures{
                     new SnapshotDescriptor(snapshotName, schemaName, objectName, conglomerateNumber,creationTime, null);
             admin.snapshot(sname, "splice:" + conglomerateNumber);
             dd.addSnapshot(descriptor, tc);
+            snapshotList.add(sname);
             if (LOG.isDebugEnabled())
             {
                 SpliceLogUtils.debug(LOG, "created snapshot %s", sname);


### PR DESCRIPTION
Add a hbase snapshot to a list after it is taken successfully. The list can be used to delete the snapshot if the txn needs to roll back.