### PR TITLE
DB-6023 NoSuchMethodError: org.joda.time.DateTime.now()

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
@@ -919,7 +919,7 @@ public class SpliceAdmin extends BaseAdminProcedures{
         try {
             tc.elevate("sourceCode");
             DataDictionary dd = lcc.getDataDictionary();
-            SourceCodeDescriptor descriptor = new SourceCodeDescriptor(schemaName, objectName, objectType, objectForm, definerName, DateTime.now(), sourceCode);
+            SourceCodeDescriptor descriptor = new SourceCodeDescriptor(schemaName, objectName, objectType, objectForm, definerName, new DateTime(), sourceCode);
             dd.saveSourceCode(descriptor, tc);
 
         } catch (StandardException se) {


### PR DESCRIPTION
In cluster environment, org.joda.time.DateTime is loaded from /opt/cloudera/parcels/CDH-5.8.3-1.cdh5.8.3.p0.2/lib/hbase/lib/jruby-cloudera-1.0.0.jar, where its implementation is outdated and does not have the now() method.
DateTime.now() is implemented as 'new DateTime()', so the fix is trivial. 