### PR TITLE
SPLICE-1682 Perform accumulator check before txn resolution

### DIFF
--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/readresolve/SynchronousReadResolver.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/readresolve/SynchronousReadResolver.java
@@ -75,6 +75,11 @@ public class SynchronousReadResolver implements KeyedReadResolver{
             public void resolve(ByteSlice rowKey,long txnId){
                 SynchronousReadResolver.INSTANCE.resolve(region,rowKey,txnId,txnSupplier,status,failOnError,trafficControl);
             }
+
+            @Override
+            public boolean enabled() {
+                return true;
+            }
         };
     }
 

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/readresolve/AsyncReadResolver.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/readresolve/AsyncReadResolver.java
@@ -158,5 +158,10 @@ public class AsyncReadResolver{
                 ringBuffer.publish(sequence);
             }
         }
+
+        @Override
+        public boolean enabled() {
+            return true;
+        }
     }
 }

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/readresolve/ReadResolver.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/readresolve/ReadResolver.java
@@ -46,4 +46,6 @@ public interface ReadResolver {
      * @param txnId the transaction id (version) of the row to resolve.
      */
     void resolve(ByteSlice rowKey, long txnId);
+
+    boolean enabled();
 }

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
@@ -131,6 +131,9 @@ public class SimpleTxnFilter implements TxnFilter{
 
 
     private void readResolve(DataCell element) throws IOException{
+        if (!readResolver.enabled())
+            return;
+
         /*
 		 * We want to resolve the transaction related
 		 * to this version of the data.

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/readresolve/NoOpReadResolver.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/readresolve/NoOpReadResolver.java
@@ -24,4 +24,9 @@ import com.splicemachine.utils.ByteSlice;
 public class NoOpReadResolver implements ReadResolver {
 		public static final ReadResolver INSTANCE = new NoOpReadResolver();
     @Override public void resolve(ByteSlice rowKey, long txnId) {  }
+
+    @Override
+    public boolean enabled() {
+        return false;
+    }
 }

--- a/splice_si_api/src/test/java/com/splicemachine/si/impl/SimpleTxnFilterTest.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/impl/SimpleTxnFilterTest.java
@@ -276,6 +276,7 @@ public class SimpleTxnFilterTest{
     /*private helper methods*/
     private ReadResolver getRollBackReadResolver(final Pair<ByteSlice, Long> rolledBackTs){
         ReadResolver resolver=mock(ReadResolver.class);
+        when(resolver.enabled()).thenReturn(true);
 
         doAnswer(new Answer<Void>(){
             @Override
@@ -291,6 +292,7 @@ public class SimpleTxnFilterTest{
 
     private ReadResolver getCommitReadResolver(final Pair<ByteSlice, Pair<Long, Long>> committedTs,final TxnSupplier txnStore){
         ReadResolver resolver=mock(ReadResolver.class);
+        when(resolver.enabled()).thenReturn(true);
 
         doAnswer(new Answer<Void>(){
             @Override


### PR DESCRIPTION
This change brings a significant performance improvement in TPC-C workload: https://splice.atlassian.net/browse/SPLICE-1397

The idea is to skip transaction resolution of KeyValues when they only contain columns for which we already have read a later version.