### PR TITLE
SPLICE-774 Support upgrade from K2 (2.5)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/StoredFormatIds.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/StoredFormatIds.java
@@ -1509,8 +1509,13 @@ public interface StoredFormatIds {
     public static final int ACCESS_HEAP_V3_ID =
             (MIN_ID_2 + 467);
 
-    public static final int ACCESS_B2I_V5_ID = 
+    public static final int ACCESS_HEAP_V4_ID =
+            (MIN_ID_2 + 478);
+
+    public static final int ACCESS_B2I_V5_ID =
             (MIN_ID_2 + 470);
+    public static final int ACCESS_B2I_V6_ID =
+            (MIN_ID_2 + 479);
     /******************************************************************
     **
     ** PropertyConglomerate
@@ -1748,7 +1753,7 @@ public interface StoredFormatIds {
      * Make sure this is updated when a new module is added
      */
     public static final int MAX_ID_2 =
-    		(MIN_ID_2 + 477);
+    		(MIN_ID_2 + 479);
 
     // DO NOT USE 4 BYTE IDS ANYMORE
     static public final int MAX_ID_4 =

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
@@ -20,6 +20,7 @@ import com.splicemachine.db.catalog.types.RoutineAliasInfo;
 import com.splicemachine.db.iapi.sql.conn.StatementContext;
 import com.splicemachine.db.impl.jdbc.EmbedConnection;
 import com.splicemachine.client.SpliceClient;
+import com.splicemachine.si.data.hbase.ZkUpgradeK2;
 import org.apache.log4j.Logger;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -117,6 +118,10 @@ public class SpliceSpark {
                     @Override public void markBootFinished() throws IOException{ }
                     @Override public boolean connectAsFirstTime(){ return false; }
                 },config,false).start();
+
+                // Check upgrade from 2.0
+                ZkUpgradeK2 upgrade20 = new ZkUpgradeK2(config.getSpliceRootPath());
+                env.txnStore().setOldTransactions(upgrade20.getOldTransactions());
 
                 EngineDriver engineDriver = EngineDriver.driver();
                 assert engineDriver!=null: "Not booted yet!";

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/RegionServerLifecycleObserver.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/RegionServerLifecycleObserver.java
@@ -23,6 +23,7 @@ import com.splicemachine.derby.lifecycle.ManagerLoader;
 import com.splicemachine.lifecycle.PipelineEnvironmentLoadService;
 import com.splicemachine.pipeline.PipelineEnvironment;
 import com.splicemachine.pipeline.contextfactory.ContextFactoryDriver;
+import com.splicemachine.si.data.hbase.ZkUpgradeK2;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionServerObserver;
@@ -94,6 +95,10 @@ public class RegionServerLifecycleObserver extends BaseRegionServerObserver{
             HBaseConnectionFactory connFactory = HBaseConnectionFactory.getInstance(driver.getConfiguration());
             RegionServerLifecycle distributedStartupSequence=new RegionServerLifecycle(driver.getClock(),connFactory);
             manager.registerEngineService(new MonitoredLifecycleService(distributedStartupSequence,config,false));
+
+            // Check upgrade from 2.0
+            ZkUpgradeK2 upgrade20 = new ZkUpgradeK2(config.getSpliceRootPath());
+            env.txnStore().setOldTransactions(upgrade20.getOldTransactions());
 
             //register the pipeline driver environment load service
             manager.registerGeneralService(new PipelineEnvironmentLoadService() {

--- a/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.derby.utils.UpgradeK2
+++ b/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.derby.utils.UpgradeK2
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+#
+# This file is part of Splice Machine.
+# Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+# GNU Affero General Public License as published by the Free Software Foundation, either
+# version 3, or (at your option) any later version.
+# Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+com.splicemachine.derby.utils.ZkUpgradeK2

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/ZkUpgradeK2.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/ZkUpgradeK2.java
@@ -29,8 +29,8 @@ import java.io.IOException;
 
 public class ZkUpgradeK2 {
     private static final Logger LOG = Logger.getLogger(ZkUpgradeK2.class);
-    private static final String K2_NODE = "isK2";
-    private static final String OLD_TRANSACTIONS_NODE = "oldTxns";
+    private static final String K2_NODE = "/isK2";
+    private static final String OLD_TRANSACTIONS_NODE = "/transactions/v1transactions";
     private final String path;
     private long oldTxns;
     private boolean init = false;
@@ -38,7 +38,7 @@ public class ZkUpgradeK2 {
 
     public ZkUpgradeK2(String spliceRootPath){
         this.spliceRootPath = spliceRootPath;
-        path = spliceRootPath+"/"+K2_NODE;
+        path = spliceRootPath+K2_NODE;
     }
 
     public boolean upgrading() throws IOException {
@@ -58,7 +58,7 @@ public class ZkUpgradeK2 {
     public void upgrade(long timestamp) throws IOException {
         oldTxns = timestamp;
         try {
-            ZkUtils.create(spliceRootPath+"/"+OLD_TRANSACTIONS_NODE, Bytes.toBytes(oldTxns), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            ZkUtils.create(spliceRootPath+OLD_TRANSACTIONS_NODE, Bytes.toBytes(oldTxns), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
             ZkUtils.delete(path);
         } catch (Exception e) {
             throw new IOException(e);
@@ -70,7 +70,7 @@ public class ZkUpgradeK2 {
             return oldTxns;
         init = true;
         try {
-            oldTxns = Bytes.toLong(ZkUtils.getData(spliceRootPath+"/"+OLD_TRANSACTIONS_NODE));
+            oldTxns = Bytes.toLong(ZkUtils.getData(spliceRootPath+OLD_TRANSACTIONS_NODE));
 
             LOG.info("Read old transactions threshold: " + oldTxns);
         } catch (IOException e) {

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/ZkUpgradeK2.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/ZkUpgradeK2.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.si.data.hbase;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.hbase.ZkUtils;
+import com.splicemachine.primitives.Bytes;
+import com.splicemachine.si.impl.driver.SIDriver;
+import com.splicemachine.timestamp.api.TimestampSource;
+import org.apache.log4j.Logger;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+
+import java.io.IOException;
+
+public class ZkUpgradeK2 {
+    private static final Logger LOG = Logger.getLogger(ZkUpgradeK2.class);
+    private static final String K2_NODE = "isK2";
+    private static final String OLD_TRANSACTIONS_NODE = "oldTxns";
+    private final String path;
+    private long oldTxns;
+    private boolean init = false;
+    private final String spliceRootPath;
+
+    public ZkUpgradeK2(String spliceRootPath){
+        this.spliceRootPath = spliceRootPath;
+        path = spliceRootPath+"/"+K2_NODE;
+    }
+
+    public boolean upgrading() throws IOException {
+        try {
+            return ZkUtils.getData(path) != null;
+        } catch (IOException e) {
+            if (e.getCause() instanceof KeeperException) {
+                KeeperException ke = (KeeperException) e.getCause();
+                if (ke.code() == KeeperException.Code.NONODE) {
+                    return false;
+                }
+            }
+            throw e;
+        }
+    }
+
+    public void upgrade(long timestamp) throws IOException {
+        oldTxns = timestamp;
+        try {
+            ZkUtils.create(spliceRootPath+"/"+OLD_TRANSACTIONS_NODE, Bytes.toBytes(oldTxns), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            ZkUtils.delete(path);
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    public synchronized long getOldTransactions() throws IOException {
+        if (init)
+            return oldTxns;
+        init = true;
+        try {
+            oldTxns = Bytes.toLong(ZkUtils.getData(spliceRootPath+"/"+OLD_TRANSACTIONS_NODE));
+
+            LOG.info("Read old transactions threshold: " + oldTxns);
+        } catch (IOException e) {
+            if (e.getCause() instanceof KeeperException) {
+                KeeperException ke = (KeeperException) e.getCause();
+                if (ke.code() == KeeperException.Code.NONODE) {
+                    oldTxns = 0;
+                    return oldTxns;
+                }
+            }
+            throw e;
+        }
+        return oldTxns;
+    }
+}

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/TxnLifecycleEndpoint.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/TxnLifecycleEndpoint.java
@@ -171,7 +171,13 @@ public class TxnLifecycleEndpoint extends TxnMessage.TxnLifecycleService impleme
     public void getTransaction(RpcController controller,TxnMessage.TxnRequest request,RpcCallback<TxnMessage.Txn> done){
         try{
             long txnId=request.getTxnId();
-            TxnMessage.Txn transaction = lifecycleStore.getTransaction(txnId);
+            boolean isOld = request.hasIsOld() && request.getIsOld();
+            TxnMessage.Txn transaction;
+            if (isOld) {
+                transaction = lifecycleStore.getOldTransaction(txnId);
+            } else {
+                transaction = lifecycleStore.getTransaction(txnId);
+            }
             done.run(transaction);
         }catch(IOException ioe){
             ResponseConverter.setControllerException(controller,ioe);

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/region/RegionTxnStore.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/region/RegionTxnStore.java
@@ -91,6 +91,17 @@ public class RegionTxnStore implements TxnPartition{
     }
 
     @Override
+    public TxnMessage.Txn getTransactionV1(long txnId) throws IOException{
+        if(LOG.isTraceEnabled())
+            SpliceLogUtils.trace(LOG,"getTransactionV1 txnId=%d",txnId);
+        Get get=new Get(getOldRowKey(txnId));
+        Result result=region.get(get);
+        if(result==null||result.isEmpty())
+            return null; //no transaction
+        return decodeV1(txnId,result);
+    }
+
+    @Override
     public void addDestinationTable(long txnId,byte[] destinationTable) throws IOException{
         if(LOG.isTraceEnabled())
             SpliceLogUtils.trace(LOG,"addDestinationTable txnId=%d, desinationTable",txnId,destinationTable);
@@ -122,6 +133,10 @@ public class RegionTxnStore implements TxnPartition{
 
     protected byte[] getRowKey(long txnId){
         return TxnUtils.getRowKey(txnId);
+    }
+
+    protected byte[] getOldRowKey(long txnId){
+        return TxnUtils.getOldRowKey(txnId);
     }
 
     @Override
@@ -394,6 +409,14 @@ public class RegionTxnStore implements TxnPartition{
         return txn;
 
     }
+
+    private TxnMessage.Txn decodeV1(long txnId,Result result) throws IOException{
+        TxnMessage.Txn txn=newTransactionDecoder.decodeV1(this,txnId,result);
+        resolveTxn(txn);
+        return txn;
+
+    }
+
 
     private TxnMessage.Txn decode(List<Cell> keyValues) throws IOException{
         TxnMessage.Txn txn=newTransactionDecoder.decode(this,keyValues);

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/region/RegionTxnStore.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/region/RegionTxnStore.java
@@ -412,7 +412,6 @@ public class RegionTxnStore implements TxnPartition{
 
     private TxnMessage.Txn decodeV1(long txnId,Result result) throws IOException{
         TxnMessage.Txn txn=newTransactionDecoder.decodeV1(this,txnId,result);
-        resolveTxn(txn);
         return txn;
 
     }

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/region/TxnDecoder.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/region/TxnDecoder.java
@@ -38,6 +38,8 @@ public interface TxnDecoder {
 
     TxnMessage.Txn decode(RegionTxnStore txnStore,long txnId, Result result) throws IOException;
 
+    TxnMessage.Txn decodeV1(RegionTxnStore txnStore,long txnId, Result result) throws IOException;
+
     TxnMessage.Txn decode(RegionTxnStore txnStore,List<Cell> keyValues) throws IOException;
 
 	Put encodeForPut(TxnMessage.TxnInfo txn,byte[] rowKey) throws IOException;

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/DatabaseVersion.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/DatabaseVersion.java
@@ -58,6 +58,11 @@ public interface DatabaseVersion{
     int getPatchVersionNumber();
 
     /**
+     * @return the Splice sprint number
+     */
+    int getSprintVersionNumber();
+
+    /**
      * @return true if we were unable to determine the version
      */
     boolean isUnknown();

--- a/splice_access_api/src/main/java/com/splicemachine/tools/version/SimpleDatabaseVersion.java
+++ b/splice_access_api/src/main/java/com/splicemachine/tools/version/SimpleDatabaseVersion.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
 /**
  * Represents a version string and provides access to its components.
  *
- * Expects between zero and three version components separated by a period each of which contains some numeric
+ * Expects between zero and four version components separated by a period each of which contains some numeric
  * and (optionally) some non-numeric characters. Examples:
  *
  * 1.2.3
@@ -46,6 +46,7 @@ public class SimpleDatabaseVersion implements DatabaseVersion{
     private final int majorVersion;
     private final int minorVersion;
     private final int patchVersion;
+    private final int sprintVersion;
 
     SimpleDatabaseVersion(Map<String, String> manifestProps) {
         release = safeGet(manifestProps, "Release");
@@ -57,6 +58,7 @@ public class SimpleDatabaseVersion implements DatabaseVersion{
         majorVersion = versionParts.hasNext() ? safeParseInt(versionParts.next()) : UNKNOWN_INT;
         minorVersion = versionParts.hasNext() ? safeParseInt(versionParts.next()) : UNKNOWN_INT;
         patchVersion = versionParts.hasNext() ? safeParseInt(versionParts.next()) : UNKNOWN_INT;
+        sprintVersion = versionParts.hasNext() ? safeParseInt(versionParts.next()) : 0;
     }
 
     @Override
@@ -87,6 +89,11 @@ public class SimpleDatabaseVersion implements DatabaseVersion{
     @Override
     public int getMinorVersionNumber() {
         return minorVersion;
+    }
+
+    @Override
+    public int getSprintVersionNumber() {
+        return sprintVersion;
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -379,7 +379,8 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
         DatabaseVersion databaseVersion=(new ManifestReader()).createVersion();
         if(!databaseVersion.isUnknown()){
             spliceSoftwareVersion=new Splice_DD_Version(this,databaseVersion.getMajorVersionNumber(),
-                    databaseVersion.getMinorVersionNumber(),databaseVersion.getPatchVersionNumber());
+                    databaseVersion.getMinorVersionNumber(),databaseVersion.getPatchVersionNumber(),
+                    databaseVersion.getSprintVersionNumber());
         }
         if(create){
             SpliceAccessManager af=(SpliceAccessManager)Monitor.findServiceModule(this,AccessFactory.MODULE);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -509,7 +509,6 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
     }
 
     private void upgradeIfNecessary(TransactionController tc) throws StandardException{
-
         boolean toUpgrade = Boolean.TRUE.equals(EngineLifecycleService.toUpgrade.get());
         // Only master can upgrade
         if (!toUpgrade) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -18,6 +18,7 @@ import java.util.Comparator;
 import java.util.NavigableSet;
 import java.util.TreeMap;
 
+import com.splicemachine.si.impl.driver.SIDriver;
 import org.apache.log4j.Logger;
 
 import com.splicemachine.EngineDriver;
@@ -73,7 +74,7 @@ public class SpliceCatalogUpgradeScripts{
         // Set the current version to upgrade from.
         // This flag should only be true for the master server.
         Splice_DD_Version currentVersion=catalogVersion;
-        SConfiguration configuration=EngineDriver.driver().getConfiguration();
+        SConfiguration configuration= SIDriver.driver().getConfiguration();
         if(configuration.upgradeForced()) {
 //        if (SpliceConstants.upgradeForced) {
             currentVersion=new Splice_DD_Version(null,configuration.getUpgradeForcedFrom());

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceAccessManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceAccessManager.java
@@ -17,6 +17,7 @@ package com.splicemachine.derby.impl.store.access;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.*;
+
 import org.spark_project.guava.base.Preconditions;
 import com.splicemachine.derby.impl.db.SpliceDatabase;
 import com.splicemachine.derby.utils.ConglomerateUtils;
@@ -628,6 +629,7 @@ public class SpliceAccessManager implements AccessFactory, CacheableFactory, Mod
 
         if(create)
             ((SpliceTransaction)tc.getRawTransaction()).elevate(Bytes.toBytes("boot"));
+
         // set up the transaction properties.  On J9, over NFS, runing on a
         // power PC coprossor, the directories were created fine, but create
         // db would fail when trying to create this first file in seg0.

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/btree/IndexConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/btree/IndexConglomerate.java
@@ -54,7 +54,7 @@ import java.util.Properties;
 
 public class IndexConglomerate extends SpliceConglomerate{
     private static final Logger LOG=Logger.getLogger(IndexConglomerate.class);
-    public static final int FORMAT_NUMBER=StoredFormatIds.ACCESS_B2I_V5_ID;
+    public static final int FORMAT_NUMBER=StoredFormatIds.ACCESS_B2I_V6_ID;
     public static final String PROPERTY_UNIQUE_WITH_DUPLICATE_NULLS="uniqueWithDuplicateNulls";
     private static final long serialVersionUID=4l;
     protected static final String PROPERTY_BASECONGLOMID="baseConglomerateId";
@@ -381,7 +381,7 @@ public class IndexConglomerate extends SpliceConglomerate{
      */
 
     public int getTypeFormatId(){
-        return StoredFormatIds.ACCESS_B2I_V5_ID;
+        return StoredFormatIds.ACCESS_B2I_V6_ID;
     }
 
 
@@ -438,7 +438,8 @@ public class IndexConglomerate extends SpliceConglomerate{
         // First part of ACCESS_B2I_V4_ID format is the ACCESS_B2I_V3_ID format.
         writeExternal_v10_2(out);
         if(conglom_format_id==StoredFormatIds.ACCESS_B2I_V4_ID
-                || conglom_format_id==StoredFormatIds.ACCESS_B2I_V5_ID){
+                || conglom_format_id==StoredFormatIds.ACCESS_B2I_V5_ID
+                || conglom_format_id==StoredFormatIds.ACCESS_B2I_V6_ID){
             // Now append sparse array of collation ids
             ConglomerateUtil.writeCollationIdArray(collation_ids,out);
         }
@@ -458,7 +459,7 @@ public class IndexConglomerate extends SpliceConglomerate{
         if(LOG.isTraceEnabled())
             LOG.trace("writeExternal");
         writeExternal_v10_3(out);
-        if(conglom_format_id==StoredFormatIds.ACCESS_B2I_V5_ID)
+        if(conglom_format_id==StoredFormatIds.ACCESS_B2I_V5_ID || conglom_format_id==StoredFormatIds.ACCESS_B2I_V6_ID)
             out.writeBoolean(isUniqueWithDuplicateNulls());
         int len=(columnOrdering!=null && columnOrdering.length>0)?columnOrdering.length:0;
         out.writeInt(len);
@@ -503,7 +504,8 @@ public class IndexConglomerate extends SpliceConglomerate{
         // below when read from disk.  For version ACCESS_B2I_V3_ID and
         // ACCESS_B2I_V4_ID, this is the default and no resetting is necessary.
         setUniqueWithDuplicateNulls(false);
-        if(conglom_format_id==StoredFormatIds.ACCESS_B2I_V4_ID || conglom_format_id==StoredFormatIds.ACCESS_B2I_V5_ID){
+        if(conglom_format_id==StoredFormatIds.ACCESS_B2I_V4_ID || conglom_format_id==StoredFormatIds.ACCESS_B2I_V5_ID
+                || conglom_format_id==StoredFormatIds.ACCESS_B2I_V6_ID){
             // current format id, read collation info from disk
             if(SanityManager.DEBUG){
                 // length must include row location column and at least
@@ -525,7 +527,7 @@ public class IndexConglomerate extends SpliceConglomerate{
                         "Unexpected format id: "+conglom_format_id);
             }
         }
-        if(conglom_format_id==StoredFormatIds.ACCESS_B2I_V5_ID){
+        if(conglom_format_id==StoredFormatIds.ACCESS_B2I_V5_ID || conglom_format_id==StoredFormatIds.ACCESS_B2I_V6_ID){
             setUniqueWithDuplicateNulls(in.readBoolean());
         }
         int len=in.readInt();
@@ -573,7 +575,7 @@ public class IndexConglomerate extends SpliceConglomerate{
     }
 
     public void btreeWriteExternal(ObjectOutput out) throws IOException{
-        FormatIdUtil.writeFormatIdInteger(out,conglom_format_id);
+        FormatIdUtil.writeFormatIdInteger(out,getTypeFormatId());
         FormatIdUtil.writeFormatIdInteger(out,tmpFlag);
         out.writeLong(containerId);
         out.writeInt((nKeyFields));

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/hbase/HBaseConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/hbase/HBaseConglomerate.java
@@ -316,7 +316,7 @@ public class HBaseConglomerate extends SpliceConglomerate{
      * @see com.splicemachine.db.iapi.services.io.TypedFormat#getTypeFormatId
      **/
     public int getTypeFormatId(){
-        return StoredFormatIds.ACCESS_HEAP_V3_ID;
+        return StoredFormatIds.ACCESS_HEAP_V4_ID;
     }
 
     /**
@@ -328,7 +328,7 @@ public class HBaseConglomerate extends SpliceConglomerate{
      * <p/>
      **/
     public void writeExternal(ObjectOutput out) throws IOException{
-        FormatIdUtil.writeFormatIdInteger(out,conglom_format_id);
+        FormatIdUtil.writeFormatIdInteger(out,getTypeFormatId());
         FormatIdUtil.writeFormatIdInteger(out,tmpFlag);
         out.writeLong(containerId);
         out.writeInt(format_ids.length);
@@ -359,7 +359,6 @@ public class HBaseConglomerate extends SpliceConglomerate{
         int num_columns=in.readInt();
         // read the array of format ids.
         format_ids=ConglomerateUtil.readFormatIdArray(num_columns,in);
-        this.conglom_format_id=getTypeFormatId();
         num_columns=in.readInt();
         collation_ids=ConglomerateUtil.readFormatIdArray(num_columns,in);
         num_columns=in.readInt();

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/ConglomerateUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/ConglomerateUtils.java
@@ -76,7 +76,6 @@ public class ConglomerateUtils{
         SIDriver driver=SIDriver.driver();
         try(Partition partition=driver.getTableFactory().getTable(SQLConfiguration.CONGLOMERATE_TABLE_NAME_BYTES)){
             DataGet get=driver.getOperationFactory().newDataGet(txn,Bytes.toBytes(conglomId),null);
-            get.returnAllVersions();
             get.addColumn(SIConstants.DEFAULT_FAMILY_BYTES,SIConstants.PACKED_COLUMN_BYTES);
             EntryPredicateFilter predicateFilter=EntryPredicateFilter.emptyPredicate();
             get.addAttribute(SIConstants.ENTRY_PREDICATE_LABEL,predicateFilter.toBytes());

--- a/splice_protocol/src/main/protobuf/Txn.proto
+++ b/splice_protocol/src/main/protobuf/Txn.proto
@@ -139,6 +139,7 @@ message TxnLifecycleMessage{
 message TxnRequest{
     required uint64 txnId = 1;
     optional bool includeDestinationTables = 2;
+    optional bool isOld = 3;
 }
 
 message ActiveTxnIdResponse{

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TxnStore.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TxnStore.java
@@ -92,4 +92,5 @@ public interface TxnStore extends TxnSupplier{
 
     void setCache(TxnSupplier cache);
 
+    void setOldTransactions(long oldTransactions);
 }

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/lifecycle/TxnLifecycleStore.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/lifecycle/TxnLifecycleStore.java
@@ -39,6 +39,8 @@ public interface TxnLifecycleStore{
 
     TxnMessage.Txn getTransaction(long txnId) throws IOException;
 
+    TxnMessage.Txn getOldTransaction(long txnId) throws IOException;
+
     long[] getActiveTransactionIds(byte[] destTable, long startId, long endId) throws IOException;
 
     Source<TxnMessage.Txn> getActiveTransactions(byte[] destTable, long startId, long endId) throws IOException;

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/lifecycle/TxnPartition.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/lifecycle/TxnPartition.java
@@ -61,6 +61,15 @@ public interface TxnPartition{
     TxnMessage.Txn getTransaction(long txnId) throws IOException;
 
     /**
+     * Fetch all information about an old transaction.
+     *
+     * @param txnId the transaction id to fetch
+     * @return all recorded transaction information for the specified transaction.
+     * @throws IOException if something goes wrong when fetching transactions
+     */
+    TxnMessage.Txn getTransactionV1(long txnId) throws IOException;
+
+    /**
      * Get a list of transaction ids which are considered ACTIVE <em>at the time that they are visited</em>.
      * <p/>
      * This call does not require explicit synchronization, but it will <em>not</em> return a perfect view

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/TxnUtils.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/TxnUtils.java
@@ -18,23 +18,32 @@ import com.splicemachine.primitives.Bytes;
 import com.splicemachine.si.constants.SIConstants;
 
 import static com.splicemachine.si.constants.SIConstants.TRANSACTION_TABLE_BUCKET_COUNT;
+
 /**
  * @author Scott Fines
  *         Date: 6/20/14
  */
 public class TxnUtils {
 
-		private TxnUtils(){}
+    private TxnUtils() {
+    }
 
-		public static byte[] getRowKey(long txnId) {
-				long beginTS = txnId & SIConstants.TRANSANCTION_ID_MASK;
-				byte[] rowKey = new byte[9];
-				rowKey[0] = (byte)((beginTS / SIConstants.TRASANCTION_INCREMENT) & (TRANSACTION_TABLE_BUCKET_COUNT-1));
-				Bytes.longToBytes(beginTS, rowKey, 1);
-				return rowKey;
-		}
+    public static byte[] getRowKey(long txnId) {
+        long beginTS = txnId & SIConstants.TRANSANCTION_ID_MASK;
+        byte[] rowKey = new byte[9];
+        rowKey[0] = (byte) ((beginTS / SIConstants.TRASANCTION_INCREMENT) & (TRANSACTION_TABLE_BUCKET_COUNT - 1));
+        Bytes.longToBytes(beginTS, rowKey, 1);
+        return rowKey;
+    }
 
-		public static long txnIdFromRowKey(byte[] buffer, int rowOffset, int rowLength) {
-				return Bytes.toLong(buffer, rowOffset + 1, rowLength - 1);
-		}
+    public static long txnIdFromRowKey(byte[] buffer, int rowOffset, int rowLength) {
+        return Bytes.toLong(buffer, rowOffset + 1, rowLength - 1);
+    }
+
+    public static byte[] getOldRowKey(long txnId) {
+        byte[] rowKey = new byte[9];
+        rowKey[0] = (byte) (txnId & (TRANSACTION_TABLE_BUCKET_COUNT - 1));
+        Bytes.longToBytes(txnId, rowKey, 1);
+        return rowKey;
+    }
 }

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/data/StripedTxnLifecycleStore.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/data/StripedTxnLifecycleStore.java
@@ -170,6 +170,20 @@ public class StripedTxnLifecycleStore implements TxnLifecycleStore{
         }
     }
 
+    @Override
+    public TxnMessage.Txn getOldTransaction(long txnId) throws IOException {
+        Lock lock = lockStriper.get(txnId).readLock();
+        acquireLock(lock);
+        try {
+            TxnMessage.Txn txn = baseStore.getTransactionV1(txnId);
+            if (txn == null)
+                txn = NONEXISTENT_TXN;
+
+            return txn;
+        } finally {
+            unlock(lock);
+        }
+    }
 
     @Override
     public TxnMessage.Txn getTransaction(long txnId) throws IOException{

--- a/splice_si_api/src/test/java/com/splicemachine/si/impl/store/TestingTxnStore.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/impl/store/TestingTxnStore.java
@@ -390,4 +390,9 @@ public class TestingTxnStore implements TxnStore{
     public void setCache(TxnSupplier cache){
         // no op
     }
+
+    @Override
+    public void setOldTransactions(long oldTransactions) {
+        // no op
+    }
 }

--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampOracle.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampOracle.java
@@ -78,6 +78,10 @@ public class TimestampOracle implements TimestampOracleStatistics{
 	private void initialize() throws TimestampIOException {
 			synchronized(this) {
                 _maxReservedTimestamp = timestampBlockManager.initialize();
+				// make sure the block boundaries are a multiple of TIMESTAMP_INCREMENT
+				if (_maxReservedTimestamp % TIMESTAMP_INCREMENT != 0) {
+					_maxReservedTimestamp += TIMESTAMP_INCREMENT - (_maxReservedTimestamp % TIMESTAMP_INCREMENT);
+				}
 				_timestampCounter.set(_maxReservedTimestamp + TIMESTAMP_INCREMENT);
 			}
 			try {


### PR DESCRIPTION
Support new conglomerate format, store  V1 transaction threshold in ZK and use it when resolving transactions.