### PR TITLE
DB-6035: cleanup failed backup from old build(2.5)

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/hbase/BackupUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/BackupUtils.java
@@ -346,23 +346,34 @@ public class BackupUtils {
     private static boolean backupTimedout() throws Exception {
         String path = HConfiguration.getConfiguration().getBackupPath();
         byte[] data = ZkUtils.getData(path);
-        BackupJobStatus backupJobStatus = BackupJobStatus.parseFrom(data);
-        long lastActiveTimestamp = backupJobStatus.getLastActiveTimestamp();
-        long currentTimestamp = System.currentTimeMillis();
-        long elapsedTime = currentTimestamp - lastActiveTimestamp;
-        boolean timedout = (lastActiveTimestamp > 0 && elapsedTime > 2 * BackupRestoreConstants.BACKUP_JOB_TIMEOUT);
-        try {
-            if (timedout) {
-                SpliceLogUtils.info(LOG, "Found a timeout backup that were active at %s", new Timestamp(lastActiveTimestamp));
-                ZkUtils.recursiveDelete(path);
+        boolean timedout = true;
+        if (data != null) {
+            BackupJobStatus backupJobStatus = null;
+            long lastActiveTimestamp = 0;
+            try {
+                backupJobStatus = BackupJobStatus.parseFrom(data);
+                lastActiveTimestamp = backupJobStatus.getLastActiveTimestamp();
+                long currentTimestamp = System.currentTimeMillis();
+                long elapsedTime = currentTimestamp - lastActiveTimestamp;
+                timedout = (lastActiveTimestamp > 0 && elapsedTime > 2 * BackupRestoreConstants.BACKUP_JOB_TIMEOUT);
+            } catch (Exception e) {
+                // The data cannot be parsed. It's either corrupted or a leftover from previous version. In either
+                // case, delete the znode.
+                SpliceLogUtils.info(LOG, "Found a backup znode with unreadable data");
+                timedout = true;
             }
-        }catch (KeeperException e) {
-            if (e.code()!=KeeperException.Code.NONODE) {
-                // Ignore NONODE exception because it may be deleted by another thread.
-                throw e;
+            try {
+                if (timedout) {
+                    ZkUtils.recursiveDelete(path);
+                    SpliceLogUtils.info(LOG, "Found a timeout backup that were active at %s", new Timestamp(lastActiveTimestamp));
+                }
+            } catch (KeeperException e) {
+                if (e.code() != KeeperException.Code.NONODE) {
+                    // Ignore NONODE exception because it may be deleted by another thread.
+                    throw e;
+                }
             }
         }
-
         return timedout;
     }
 }


### PR DESCRIPTION
If the data stored in backup znode is not recognizable, the znode is created by a backup on an old build. It should be cleaned up.