### PR TITLE
DB-6018: keep the column indexes zero based for new orc stats collection job

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -462,7 +462,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
     public <V> DataSet<V> readORCFile(int[] baseColumnMap,int[] partitionColumnMap, String location,
                                           OperationContext context, Qualifier[][] qualifiers,
                                       DataValueDescriptor probeValue, ExecRow execRow,
-                                      boolean useSample, double sampleFraction) throws StandardException {
+                                      boolean useSample, double sampleFraction, boolean statsjob) throws StandardException {
         assert baseColumnMap != null:"baseColumnMap Null";
         assert partitionColumnMap != null:"partitionColumnMap Null";
         try {
@@ -472,6 +472,8 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             configuration.set(SpliceOrcNewInputFormat.SPARK_STRUCT,execRow.createStructType().json());
             configuration.set(SpliceOrcNewInputFormat.SPLICE_COLUMNS,intArrayToString(baseColumnMap));
             configuration.set(SpliceOrcNewInputFormat.SPLICE_PARTITIONS,intArrayToString(partitionColumnMap));
+            if (statsjob)
+                configuration.set(SpliceOrcNewInputFormat.SPLICE_COLLECTSTATS, "true");
 
             JavaRDD<Row> rows = SpliceSpark.getContext().newAPIHadoopFile(
                     location,

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkScanSetBuilder.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkScanSetBuilder.java
@@ -83,7 +83,7 @@ public class SparkScanSetBuilder<V> extends TableScannerBuilder<V> {
             else if (storedAs.equals("P"))
                 locatedRows = dsp.readParquetFile(baseColumnMap,partitionByColumns,location,operationContext,qualifiers,null,execRow, useSample, sampleFraction);
             else if (storedAs.equals("O"))
-                locatedRows = dsp.readORCFile(baseColumnMap,partitionByColumns,location,operationContext,qualifiers,null,execRow, useSample, sampleFraction);
+                locatedRows = dsp.readORCFile(baseColumnMap,partitionByColumns,location,operationContext,qualifiers,null,execRow, useSample, sampleFraction, false);
             else {
                 throw new UnsupportedOperationException("storedAs Type not supported -> " + storedAs);
             }

--- a/hbase_sql/src/main/java/com/splicemachine/orc/input/SpliceOrcNewInputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/input/SpliceOrcNewInputFormat.java
@@ -52,6 +52,7 @@ public class SpliceOrcNewInputFormat extends InputFormat<NullWritable,Row>
     public static final double MAX_READ_SIZE_DEFAULT = 8;
     public static final double STREAM_BUFFER_SIZE_DEFAULT = 8;
     public static final long DEFAULT_PARTITION_SIZE = 10000;
+    public static final String SPLICE_COLLECTSTATS ="com.splicemachine.collectstats";
 
 
     @Override
@@ -64,6 +65,7 @@ public class SpliceOrcNewInputFormat extends InputFormat<NullWritable,Row>
         final List<Integer> columns = getReadColumnIDs(SPLICE_COLUMNS,jobContext.getConfiguration());
         final StructType structType = getRowStruct(configuration);
         final SpliceORCPredicate orcPredicate = getSplicePredicate(configuration);
+        boolean isCollectStats = !(configuration.get(SPLICE_COLLECTSTATS, "").isEmpty());
 
         try {
             // Predicate Pruning...
@@ -73,7 +75,7 @@ public class SpliceOrcNewInputFormat extends InputFormat<NullWritable,Row>
                         public boolean apply(@Nullable InputSplit s) {
                             try {
                                 List<String> values = Warehouse.getPartValuesFromPartName(((OrcNewSplit) s).getPath().toString());
-                                Map<Integer,ColumnStatistics> columnStatisticsMap = SpliceORCPredicate.partitionStatsEval(columns,structType,partitions,values.toArray(new String[values.size()]));
+                                Map<Integer,ColumnStatistics> columnStatisticsMap = SpliceORCPredicate.partitionStatsEval(columns,structType,partitions,values.toArray(new String[values.size()]), isCollectStats);
                                 return orcPredicate.matches(10000,columnStatisticsMap);
                             } catch (Exception e) {
                                 throw new RuntimeException(e);

--- a/hbase_sql/src/main/java/com/splicemachine/orc/predicate/SpliceORCPredicate.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/predicate/SpliceORCPredicate.java
@@ -200,7 +200,7 @@ public class SpliceORCPredicate implements OrcPredicate, Externalizable {
     }
 
     public static Map<Integer, ColumnStatistics> partitionStatsEval(List<Integer> baseColumnMap,
-                   StructType rowStruct, List<Integer> partitionColumns, String[] values) {
+                   StructType rowStruct, List<Integer> partitionColumns, String[] values, boolean isCollectStats) {
         try {
             Map<Integer, ColumnStatistics> partitionStatistics = new HashMap<>(partitionColumns.size());
 
@@ -211,6 +211,9 @@ public class SpliceORCPredicate implements OrcPredicate, Externalizable {
                 int j = baseColumnMap.get(storagePos);
                 if (j==-1) // Partition Column Not In List...
                     continue;
+                if (isCollectStats)
+                    j = j -1;  // stats related indexes are passed on one based index but rowStruct array is zero based
+
                 DataType dataType = rowStruct.fields()[j].dataType();
                 if (dataType instanceof BooleanType) {
                     partitionStatistics.put(storagePos, BooleanStatistics.getPartitionColumnStatistics(values[i]));

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -1261,6 +1261,16 @@ public class ExternalTableIT extends SpliceUnitTest{
         Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs2));
         rs2.close();
 
+        // make sure query runs ok after collect stats
+        ResultSet rs3 = methodWatcher.executeQuery("select * from partition_prune_orc");
+        Assert.assertEquals("USER_ID |SERVER_TIMESTAMP |CLICKS |USER_AGENT |USER_ACCEPT_LANGUAGE | URL |REFERRER_URL | PAGE_ID | PAGE_CATEGORY_CSV | PAGE_TAGS_CSV |  AD_INFO  | DATA_DATE |\n" +
+                "----------------------------------------------------------------------------------------------------------------------------------------------------------------\n" +
+                "   100   |       100       |  100  |     x     |          x          |  x  |      x      |    x    |         x         |       x       |[100, 100] | 20160915  |\n" +
+                "   200   |       200       |  200  |     x     |          x          |  x  |      x      |    x    |         x         |       x       |[100, 100] | 20160916  |\n" +
+                "   300   |       300       |  300  |     x     |          x          |  x  |      x      |    x    |         x         |       x       |[100, 100] | 20160917  |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+        rs3.close();
+
+
     }
 
 

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -1243,6 +1243,24 @@ public class ExternalTableIT extends SpliceUnitTest{
 
         //Make sure empty file is created
         Assert.assertTrue(String.format("Table %s hasn't been created",tablePath), new File(tablePath).exists());
+
+        // collect stats
+        PreparedStatement ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.COLLECT_TABLE_STATISTICS(?,?,?) ");
+        ps.setString(1, "EXTERNALTABLEIT");
+        ps.setString(2, "PARTITION_PRUNE_ORC");
+        ps.setBoolean(3, true);
+        rs = ps.executeQuery();
+        rs.next();
+        Assert.assertEquals("Error with COLLECT_TABLE_STATISTICS for external table","EXTERNALTABLEIT",  rs.getString(1));
+        rs.close();
+
+        ResultSet rs2 = methodWatcher.executeQuery("select total_row_count from sys.systablestatistics where schemaname = 'EXTERNALTABLEIT' and tablename = 'PARTITION_PRUNE_ORC'");
+        String expected = "TOTAL_ROW_COUNT |\n" +
+                "------------------\n" +
+                "        3        |";
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs2));
+        rs2.close();
+
     }
 
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
@@ -319,9 +319,9 @@ public class ControlDataSetProcessor implements DataSetProcessor{
 
     @Override
     public <V> DataSet<V> readORCFile(int[] baseColumnMap,int[] partitionColumnMap, String location, OperationContext context,Qualifier[][] qualifiers,DataValueDescriptor probeValue, ExecRow execRow,
-                                      boolean useSample, double sampleFraction) throws StandardException {
+                                      boolean useSample, double sampleFraction, boolean statsjob) throws StandardException {
         DistributedDataSetProcessor proc = EngineDriver.driver().processorFactory().distributedProcessor();
-        return new ControlDataSet(proc.readORCFile(baseColumnMap,partitionColumnMap,location,context,qualifiers,probeValue,execRow, useSample, sampleFraction).toLocalIterator());
+        return new ControlDataSet(proc.readORCFile(baseColumnMap,partitionColumnMap,location,context,qualifiers,probeValue,execRow, useSample, sampleFraction, statsjob).toLocalIterator());
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
@@ -207,7 +207,7 @@ public interface DataSetProcessor {
      */
     <V> DataSet<V> readORCFile(int[] baseColumnMap, int[] partitionColumnMap, String location,
                                OperationContext context, Qualifier[][] qualifiers, DataValueDescriptor probeValue, ExecRow execRow,
-                               boolean useSample, double sampleFraction) throws StandardException;
+                               boolean useSample, double sampleFraction, boolean statsjob) throws StandardException;
 
     /**
      *

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ForwardingDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ForwardingDataSetProcessor.java
@@ -156,8 +156,8 @@ public abstract class ForwardingDataSetProcessor implements DataSetProcessor{
 
     @Override
     public <V> DataSet<V> readORCFile(int[] baseColumnMap,int[] partitionColumnMap, String location, OperationContext context, Qualifier[][] qualifiers, DataValueDescriptor probeValue,ExecRow execRow,
-                                      boolean useSample, double sampleFraction) throws StandardException {
-        return delegate.readORCFile(baseColumnMap, partitionColumnMap, location, context,qualifiers,probeValue,execRow, useSample, sampleFraction);
+                                      boolean useSample, double sampleFraction, boolean statsjob) throws StandardException {
+        return delegate.readORCFile(baseColumnMap, partitionColumnMap, location, context,qualifiers,probeValue,execRow, useSample, sampleFraction, statsjob);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsOperation.java
@@ -93,8 +93,13 @@ public class StatisticsOperation extends SpliceBaseOperation {
                     statsDataSet = dsp.readTextFile(null, builder.getLocation(), builder.getDelimited(), null, builder.getColumnPositionMap(), null, null, null, builder.getTemplate(), useSample, sampleFraction);
                 else if (storedAs.equals("P"))
                     statsDataSet = dsp.readParquetFile(builder.getColumnPositionMap(), builder.getPartitionByColumnMap() , builder.getLocation(), null, null, null, builder.getTemplate(), useSample, sampleFraction);
-                else if (storedAs.equals("O"))
-                    statsDataSet = dsp.readORCFile(builder.getColumnPositionMap(), builder.getPartitionByColumnMap(), builder.getLocation(), null, null, null, builder.getTemplate(), useSample, sampleFraction);
+                else if (storedAs.equals("O")) {
+                    int[] baseColumnMap = builder.getColumnPositionMap();
+                    for (int i = 0; i < baseColumnMap.length; i++) {
+                        baseColumnMap[i] = baseColumnMap[i] - 1;  //make it zero based
+                    }
+                    statsDataSet = dsp.readORCFile(baseColumnMap, builder.getPartitionByColumnMap(), builder.getLocation(), null, null, null, builder.getTemplate(), useSample, sampleFraction);
+                }
                 else {
                     throw new UnsupportedOperationException("storedAs Type not supported -> " + storedAs);
                 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsOperation.java
@@ -93,14 +93,8 @@ public class StatisticsOperation extends SpliceBaseOperation {
                     statsDataSet = dsp.readTextFile(null, builder.getLocation(), builder.getDelimited(), null, builder.getColumnPositionMap(), null, null, null, builder.getTemplate(), useSample, sampleFraction);
                 else if (storedAs.equals("P"))
                     statsDataSet = dsp.readParquetFile(builder.getColumnPositionMap(), builder.getPartitionByColumnMap() , builder.getLocation(), null, null, null, builder.getTemplate(), useSample, sampleFraction);
-                else if (storedAs.equals("O")) {
-                    int[] baseColumnMap = builder.getColumnPositionMap();
-                    for (int i = 0; i < baseColumnMap.length; i++) {
-                        if (baseColumnMap[i] > 0)
-                            baseColumnMap[i] = baseColumnMap[i] - 1;  //make it zero based
-                    }
-                    statsDataSet = dsp.readORCFile(baseColumnMap, builder.getPartitionByColumnMap(), builder.getLocation(), null, null, null, builder.getTemplate(), useSample, sampleFraction);
-                }
+                else if (storedAs.equals("O"))
+                    statsDataSet = dsp.readORCFile(builder.getColumnPositionMap(), builder.getPartitionByColumnMap(), builder.getLocation(), null, null, null, builder.getTemplate(), useSample, sampleFraction, true);
                 else {
                     throw new UnsupportedOperationException("storedAs Type not supported -> " + storedAs);
                 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsOperation.java
@@ -96,7 +96,8 @@ public class StatisticsOperation extends SpliceBaseOperation {
                 else if (storedAs.equals("O")) {
                     int[] baseColumnMap = builder.getColumnPositionMap();
                     for (int i = 0; i < baseColumnMap.length; i++) {
-                        baseColumnMap[i] = baseColumnMap[i] - 1;  //make it zero based
+                        if (baseColumnMap[i] > 0)
+                            baseColumnMap[i] = baseColumnMap[i] - 1;  //make it zero based
                     }
                     statsDataSet = dsp.readORCFile(baseColumnMap, builder.getPartitionByColumnMap(), builder.getLocation(), null, null, null, builder.getTemplate(), useSample, sampleFraction);
                 }


### PR DESCRIPTION
This is an issue in the master branch where new orc input format is being used. The basecolumn map indexes needed to be zero based than the one based indexes to match the expectation in the reader job. Other external table formats were also tested with the last column as a partitioning column, it was not having this array bounds problem while stats collection.