### PR TITLE
DBAAS-608

### DIFF
--- a/assembly/mapr5.1.0/src/main/resources/examples/conf/hbase-site.xml
+++ b/assembly/mapr5.1.0/src/main/resources/examples/conf/hbase-site.xml
@@ -53,7 +53,7 @@
 <property><name>ipc.client.connect.timeout</name><value>300000</value></property>
 <property><name>splice.authentication</name><value>NATIVE</value> </property>
 <property><name>splice.authentication.native.algorithm</name><value>SHA-512</value></property>
-<property><name>splice.authentication.native.create.credentials.database</name><value>true</value></property>
+<property><name>splice.authentication.native.create.credentials.database</name><value>false</value></property>
 <property><name>splice.client.write.maxDependentWrites</name><value>250000</value></property>
 <property><name>splice.client.write.maxIndependentWrites</name><value>250000</value></property>
 <property><name>splice.compression</name><value>snappy</value></property>

--- a/assembly/mapr5.2.0/src/main/resources/examples/conf/hbase-site.xml
+++ b/assembly/mapr5.2.0/src/main/resources/examples/conf/hbase-site.xml
@@ -53,7 +53,7 @@
 <property><name>ipc.client.connect.timeout</name><value>300000</value></property>
 <property><name>splice.authentication</name><value>NATIVE</value> </property>
 <property><name>splice.authentication.native.algorithm</name><value>SHA-512</value></property>
-<property><name>splice.authentication.native.create.credentials.database</name><value>true</value></property>
+<property><name>splice.authentication.native.create.credentials.database</name><value>false</value></property>
 <property><name>splice.client.write.maxDependentWrites</name><value>250000</value></property>
 <property><name>splice.client.write.maxIndependentWrites</name><value>250000</value></property>
 <property><name>splice.compression</name><value>snappy</value></property>

--- a/hbase_storage/src/test/java/com/splicemachine/access/HConfigurationTest.java
+++ b/hbase_storage/src/test/java/com/splicemachine/access/HConfigurationTest.java
@@ -14,14 +14,13 @@
 
 package com.splicemachine.access;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import com.splicemachine.access.api.SConfiguration;
+import org.junit.Test;
 
 import java.util.Map;
 
-import org.junit.Test;
-
-import com.splicemachine.access.api.SConfiguration;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Test getting and using SConfiguration from HConfiguration.
@@ -52,6 +51,6 @@ public class HConfigurationTest {
         key = "splice.authentication.native.create.credentials.database";
         value = auths.get(key);
         assertNotNull(value);
-        assertEquals("true", value);
+        assertEquals("false", value);
     }
 }

--- a/hbase_storage/src/test/resources/splice-site.xml
+++ b/hbase_storage/src/test/resources/splice-site.xml
@@ -25,6 +25,6 @@
   </property>
   <property>
     <name>splice.authentication.native.create.credentials.database</name>
-    <value>true</value>
+    <value>false</value>
   </property>
 </configuration>

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/AuthenticationConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/AuthenticationConfiguration.java
@@ -54,7 +54,7 @@ public class AuthenticationConfiguration implements ConfigurationDefault {
     // In this particular instance, there are Splice beta customers with AnA disabled and they want to
     // switch to using native AnA.  So we allow a manual override here.  See DB-2088 for more details.
     public static final String AUTHENTICATION_NATIVE_CREATE_CREDENTIALS_DATABASE = "splice.authentication.native.create.credentials.database";
-    private static final boolean DEFAULT_AUTHENTICATION_NATIVE_CREATE_CREDENTIALS_DATABASE = true;
+    private static final boolean DEFAULT_AUTHENTICATION_NATIVE_CREATE_CREDENTIALS_DATABASE = false;
 
     public static final String AUTHENTICATION_CUSTOM_PROVIDER = "splice.authentication.custom.provider";
     public static final String DEFAULT_AUTHENTICATION_CUSTOM_PROVIDER = "com.splicemachine.derby.authentication.SpliceUserAuthentication";


### PR DESCRIPTION
Incorrect Configuration Setting.  This is supposed to sparingly used configuration when a customer migrates from LDAP to Native A and A.  Unfortunately, it is set to true by default.

This allows the first user to login to a region server to become the system schema and database owner.  [CRITICAL FIX]