### PR TITLE
SPLICE-1716 Reduce Olap job latency for short tasks

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapCancelHandler.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapCancelHandler.java
@@ -14,9 +14,7 @@
 
 package com.splicemachine.olap;
 
-import com.splicemachine.olap.OlapMessage;
-import org.jboss.netty.channel.ChannelHandlerContext;
-import org.jboss.netty.channel.MessageEvent;
+import io.netty.channel.ChannelHandlerContext;
 
 /**
  * @author Scott Fines
@@ -30,14 +28,13 @@ public class OlapCancelHandler extends AbstractOlapHandler{
     }
 
     @Override
-    public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception{
-        OlapMessage.Command cmd=(OlapMessage.Command)e.getMessage();
-        if(cmd.getType()!=OlapMessage.Command.Type.CANCEL){
-            ctx.sendUpstream(e);
+    protected void channelRead0(ChannelHandlerContext ctx, OlapMessage.Command command) throws Exception {
+        if(command.getType()!=OlapMessage.Command.Type.CANCEL){
+            ctx.fireChannelRead(command);
             return;
         }
 
-        jobRegistry.clear(cmd.getUniqueName());
+        jobRegistry.clear(command.getUniqueName());
         //no response is needed for cancellation
     }
 }

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapPipelineFactory.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapPipelineFactory.java
@@ -15,29 +15,29 @@
 package com.splicemachine.olap;
 
 import com.google.protobuf.ExtensionRegistry;
-import com.splicemachine.olap.OlapMessage;
 import com.splicemachine.utils.SpliceLogUtils;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.LengthFieldPrepender;
+import io.netty.handler.codec.protobuf.ProtobufDecoder;
+import io.netty.handler.codec.protobuf.ProtobufEncoder;
 import org.apache.log4j.Logger;
-import org.jboss.netty.channel.ChannelHandler;
-import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.channel.ChannelPipelineFactory;
-import org.jboss.netty.channel.Channels;
-import org.jboss.netty.handler.codec.frame.LengthFieldBasedFrameDecoder;
-import org.jboss.netty.handler.codec.frame.LengthFieldPrepender;
-import org.jboss.netty.handler.codec.protobuf.ProtobufDecoder;
-import org.jboss.netty.handler.codec.protobuf.ProtobufEncoder;
 
-public class OlapPipelineFactory implements ChannelPipelineFactory {
+public class OlapPipelineFactory extends ChannelInitializer {
 
     private static final Logger LOG = Logger.getLogger(OlapPipelineFactory.class);
 
-    private final ChannelHandler submitHandler;
-    private final ChannelHandler cancelHandler;
-    private final ChannelHandler statusHandler;
+    private final ChannelInboundHandler submitHandler;
+    private final ChannelInboundHandler cancelHandler;
+    private final ChannelInboundHandler statusHandler;
 
     private final ProtobufDecoder decoder;
 
-    public OlapPipelineFactory(ChannelHandler submitHandler,ChannelHandler cancelHandler,ChannelHandler statusHandler){
+    public OlapPipelineFactory(ChannelInboundHandler submitHandler, ChannelInboundHandler cancelHandler, ChannelInboundHandler statusHandler){
         this.submitHandler=submitHandler;
         this.cancelHandler=cancelHandler;
         this.statusHandler=statusHandler;
@@ -45,11 +45,18 @@ public class OlapPipelineFactory implements ChannelPipelineFactory {
         this.decoder = new ProtobufDecoder(OlapMessage.Command.getDefaultInstance(),buildExtensionRegistry());
     }
 
+    private ExtensionRegistry buildExtensionRegistry(){
+        ExtensionRegistry er = ExtensionRegistry.newInstance();
+        er.add(OlapMessage.Submit.command);
+        er.add(OlapMessage.Status.command);
+        er.add(OlapMessage.Cancel.command);
+        return er;
+    }
 
     @Override
-    public ChannelPipeline getPipeline() throws Exception {
+    protected void initChannel(Channel channel) throws Exception {
         SpliceLogUtils.trace(LOG, "Creating new channel pipeline...");
-        ChannelPipeline pipeline = Channels.pipeline();
+        ChannelPipeline pipeline = channel.pipeline();
         pipeline.addLast("frameDecoder",new LengthFieldBasedFrameDecoder(1<<30,0,4,0,4)); //max frame size is 1GB=2^30 bytes
         pipeline.addLast("protobufDecoder",decoder);
         pipeline.addLast("frameEncoder",new LengthFieldPrepender(4));
@@ -58,15 +65,5 @@ public class OlapPipelineFactory implements ChannelPipelineFactory {
         pipeline.addLast("submitHandler", submitHandler);
         pipeline.addLast("cancelHandler",cancelHandler);
         SpliceLogUtils.trace(LOG, "Done creating channel pipeline");
-        return pipeline;
-    }
-
-
-    private ExtensionRegistry buildExtensionRegistry(){
-        ExtensionRegistry er = ExtensionRegistry.newInstance();
-        er.add(OlapMessage.Submit.command);
-        er.add(OlapMessage.Status.command);
-        er.add(OlapMessage.Cancel.command);
-        return er;
     }
 }

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapRequestHandler.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapRequestHandler.java
@@ -16,12 +16,10 @@ package com.splicemachine.olap;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.splicemachine.access.api.SConfiguration;
-import com.splicemachine.olap.OlapMessage;
 import com.splicemachine.concurrent.Clock;
 import com.splicemachine.derby.iapi.sql.olap.DistributedJob;
+import io.netty.channel.ChannelHandlerContext;
 import org.apache.log4j.Logger;
-import org.jboss.netty.channel.ChannelHandlerContext;
-import org.jboss.netty.channel.MessageEvent;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -51,11 +49,10 @@ class OlapRequestHandler extends AbstractOlapHandler{
 
 
     @Override
-    public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception{
-        final OlapMessage.Command jobRequest=((OlapMessage.Command)e.getMessage());
+    protected void channelRead0(ChannelHandlerContext ctx, OlapMessage.Command jobRequest) throws Exception {
         assert jobRequest!=null;
         if(jobRequest.getType()!=OlapMessage.Command.Type.SUBMIT){
-            ctx.sendUpstream(e);
+            ctx.fireChannelRead(jobRequest);
             return;
         }
         OlapMessage.Submit extension=jobRequest.getExtension(OlapMessage.Submit.command);
@@ -74,8 +71,7 @@ class OlapRequestHandler extends AbstractOlapHandler{
             case COMPLETE:
                 if(LOG.isTraceEnabled())
                     LOG.trace("Job "+jobRequest.getUniqueName()+" already in progress, with state "+ state+", returning");
-                writeResponse(e,jr.getUniqueName(),jobStatus);
-                super.messageReceived(ctx,e);
+                writeResponse(ctx.channel(),jr.getUniqueName(),jobStatus);
                 return;
             case NOT_SUBMITTED:
                 if(LOG.isTraceEnabled())
@@ -83,8 +79,7 @@ class OlapRequestHandler extends AbstractOlapHandler{
                 if(!jobStatus.markSubmitted()){
                     if(LOG.isTraceEnabled())
                         LOG.trace("Job submission for job "+jobRequest.getUniqueName()+" did not succeed, returning response");
-                    writeResponse(e,jr.getUniqueName(),jobStatus);
-                    super.messageReceived(ctx,e);
+                    writeResponse(ctx.channel(),jr.getUniqueName(),jobStatus);
                     return;
                 }
                 break;
@@ -97,7 +92,7 @@ class OlapRequestHandler extends AbstractOlapHandler{
         // it might send the result before we send the confirmation
         if(LOG.isTraceEnabled())
             LOG.trace("Job "+ jobRequest.getUniqueName()+" successfully submitted");
-        writeResponse(e,jr.getUniqueName(),jobStatus);
+        writeResponse(ctx.channel(),jr.getUniqueName(),jobStatus);
 
         executionPool.submit(new Callable<Void>() {
             @Override
@@ -126,4 +121,6 @@ class OlapRequestHandler extends AbstractOlapHandler{
         ThreadFactory tf =new ThreadFactoryBuilder().setDaemon(true).setNameFormat("olap-worker-%d").build();
         return Executors.newCachedThreadPool(tf);
     }
+
+
 }

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapStatusHandler.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapStatusHandler.java
@@ -50,6 +50,8 @@ public class OlapStatusHandler extends AbstractOlapHandler{
                 case SUBMITTED:
                 case RUNNING:
                     status.wait(waitTime, TimeUnit.MILLISECONDS);
+                default:
+                    // fall-through, send response without blocking
             }
         }
 

--- a/hbase_sql/src/test/java/com/splicemachine/olap/OlapClientTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/olap/OlapClientTest.java
@@ -63,7 +63,7 @@ public class OlapClientTest {
         olapServer.stopServer();
     }
 
-    @Test(timeout = 3000)
+    @Test
     public void simpleTest() throws Exception {
         final Random rand = new Random(0);
         int sleep = rand.nextInt(200);
@@ -72,7 +72,7 @@ public class OlapClientTest {
         Assert.assertEquals(13, result.order);
     }
 
-    @Test(timeout = 16000)
+    @Test
     public void longRunningTest() throws Exception {
         final Random rand = new Random(0);
         int sleep = 4000;
@@ -81,7 +81,7 @@ public class OlapClientTest {
         Assert.assertEquals(13, result.order);
     }
 
-    @Test(timeout = 3000)
+    @Test
     public void manyFastJobsTest() throws Exception {
         int sleep = 0;
         for (int i = 0; i < 200; ++i) {
@@ -92,7 +92,7 @@ public class OlapClientTest {
     }
 
 
-    @Test(timeout = 20000, expected = IllegalStateException.class)
+    @Test(expected = IllegalStateException.class)
     public void cantReuseJobsTest() throws Exception {
         final Random rand = new Random(0);
         int sleep = rand.nextInt(200);
@@ -104,7 +104,7 @@ public class OlapClientTest {
         Assert.fail("Should have raised exception");
     }
 
-    @Test(timeout = 3000)
+    @Test
     public void failingJobTest() throws Exception {
         try {
             DumbOlapResult result = olapClient.execute(new FailingDistributedJob("failingJob"));
@@ -114,14 +114,14 @@ public class OlapClientTest {
         }
     }
 
-    @Test(timeout = 6000)
+    @Test
     public void repeatedFailingJob() throws Exception{
         for(int i=0;i<100;i++){
             failingJobTest();
         }
     }
 
-    @Test(timeout = 20000)
+    @Test
     public void concurrencyTest() throws Exception {
         int size = 32;
         Thread[] threads = new Thread[size];
@@ -153,7 +153,7 @@ public class OlapClientTest {
         }
     }
 
-    @Test(timeout = 20000)
+    @Test
     public void concurrencySameNameTest() throws Exception {
         int size = 32;
         Thread[] threads = new Thread[size];
@@ -184,7 +184,7 @@ public class OlapClientTest {
         }
     }
 
-    @Test(timeout = 20000)
+    @Test
     public void overflowTest() throws Exception {
         int size = 32;
         Thread[] threads = new Thread[size];
@@ -216,7 +216,7 @@ public class OlapClientTest {
         }
     }
 
-    @Test(timeout=10000)
+    @Test
     public void testServerFailureAfterSubmit() throws Exception{
        /*
         * Tests what would happen if the server went down after we had successfully submitted, but while

--- a/hbase_sql/src/test/java/com/splicemachine/olap/OlapClientTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/olap/OlapClientTest.java
@@ -41,7 +41,6 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  * Created by dgomezferro on 3/17/16.
  */
 @SuppressWarnings("unused")
-@Ignore
 public class OlapClientTest {
     private static final Logger LOG = Logger.getLogger(OlapClientTest.class);
 
@@ -82,9 +81,8 @@ public class OlapClientTest {
         Assert.assertEquals(13, result.order);
     }
 
-    @Test(timeout = 16000)
+    @Test(timeout = 3000)
     public void manyFastJobsTest() throws Exception {
-        final Random rand = new Random(0);
         int sleep = 0;
         for (int i = 0; i < 200; ++i) {
             DumbOlapResult result = olapClient.execute(new DumbDistributedJob(sleep, i));
@@ -107,7 +105,6 @@ public class OlapClientTest {
     }
 
     @Test(timeout = 3000)
-    @Ignore // per sf
     public void failingJobTest() throws Exception {
         try {
             DumbOlapResult result = olapClient.execute(new FailingDistributedJob("failingJob"));
@@ -117,8 +114,7 @@ public class OlapClientTest {
         }
     }
 
-    @Test
-    @Ignore // per sf
+    @Test(timeout = 6000)
     public void repeatedFailingJob() throws Exception{
         for(int i=0;i<100;i++){
             failingJobTest();

--- a/hbase_sql/src/test/java/com/splicemachine/olap/OlapClientTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/olap/OlapClientTest.java
@@ -228,7 +228,7 @@ public class OlapClientTest {
             @Override
             public void run(){
                 try{
-                    results.set(0, olapClient.execute(new DumbDistributedJob(100000,0)));
+                    results.set(0, olapClient.execute(new DumbDistributedJob(10000,0)));
                 }catch(IOException | TimeoutException e){
                     errors.set(0, e);
                     results.set(0, null);
@@ -346,7 +346,7 @@ public class OlapClientTest {
 
     }
 
-    private static void setupServer(){
+    private static void setupServer() throws IOException {
         Clock clock=new SystemClock();
         olapServer = new OlapServer(0,clock); // any port
         olapServer.startServer(HConfiguration.getConfiguration());

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/olap/OlapStatus.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/olap/OlapStatus.java
@@ -14,6 +14,8 @@
 
 package com.splicemachine.derby.iapi.sql.olap;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * @author Scott Fines
  *         Date: 4/1/16
@@ -51,4 +53,6 @@ public interface OlapStatus{
     boolean markRunning();
 
     boolean isRunning();
+
+    boolean wait(long time, TimeUnit unit) throws InterruptedException;
 }

--- a/splice_protocol/src/main/protobuf/Olap.proto
+++ b/splice_protocol/src/main/protobuf/Olap.proto
@@ -20,6 +20,7 @@ message Status{
     extend Command{
         required Status command = 100;
     }
+    optional int64 waitTimeMillis = 10;
 }
 
 message Cancel{


### PR DESCRIPTION
Block on the server the first time we request the status of a job, if
it's short it will be available before we return to the client, lowering
latency for short jobs.