### PR TITLE
DB-5998: clean up backup endpoint to avoid hang(2.0)

### DIFF
--- a/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -31,8 +31,11 @@ import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.log4j.Logger;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.ZooDefs;
+
 import java.io.IOException;
-import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Created by jyuan on 2/18/16.
@@ -40,10 +43,9 @@ import java.util.List;
 public class BackupEndpointObserver extends BackupBaseRegionObserver implements CoprocessorService,Coprocessor {
     private static final Logger LOG=Logger.getLogger(BackupEndpointObserver.class);
 
-    private volatile boolean isSplitting;
-    private volatile boolean isFlushing;
-    private volatile boolean isCompacting;
-
+    private AtomicBoolean isSplitting;
+    private AtomicBoolean isFlushing;
+    private AtomicBoolean isCompacting;
     private HRegion region;
     private String namespace;
     private String tableName;
@@ -53,7 +55,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private Configuration conf;
     private FileSystem fs;
     Path rootDir;
-    private volatile boolean preparing;
+    private AtomicBoolean preparing;
 
     @Override
     public void start(CoprocessorEnvironment e) throws IOException {
@@ -73,7 +75,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         rootDir = FSUtils.getRootDir(conf);
         fs = FSUtils.getCurrentFileSystem(conf);
         backupDir = new Path(rootDir, BackupRestoreConstants.BACKUP_DIR + "/data/splice/" + tableName + "/" + regionName);
-        preparing = false;
+        preparing = new AtomicBoolean(false);
+        isFlushing = new AtomicBoolean(false);
+        isCompacting = new AtomicBoolean(false);
+        isSplitting = new AtomicBoolean(false);
     }
 
     @Override
@@ -88,16 +93,76 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceMessage.PrepareBackupRequest request,
             com.google.protobuf.RpcCallback<SpliceMessage.PrepareBackupResponse> done) {
         try {
-            preparing = true;
+            preparing.set(true);
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder =
-                    BackupUtils.prepare(request, region, isSplitting, isCompacting, isFlushing, tableName, regionName, path);
+                    prepare(request);
 
-            preparing = false;
             assert responseBuilder.hasReadyForBackup();
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
+        } finally {
+            preparing.set(false);
         }
+
+    }
+
+    public SpliceMessage.PrepareBackupResponse.Builder prepare(SpliceMessage.PrepareBackupRequest request) throws Exception{
+
+        SpliceMessage.PrepareBackupResponse.Builder responseBuilder = SpliceMessage.PrepareBackupResponse.newBuilder();
+        responseBuilder.setReadyForBackup(false);
+
+        if (BackupUtils.shouldIgnore(request, region)) {
+            return responseBuilder;
+        }
+
+        boolean canceled = false;
+
+        if (isSplitting.get() || isFlushing.get() || isCompacting.get()) {
+            if (LOG.isDebugEnabled()) {
+                SpliceLogUtils.debug(LOG, "%s:%s is being split before trying to prepare for backup", tableName, regionName);
+            }
+            // return false to client if the region is being split
+            responseBuilder.setReadyForBackup(false);
+        } else {
+            if (LOG.isDebugEnabled()) {
+                SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
+            }
+
+            // A region might have been in backup. This is unlikely to happen unless the previous response ws lost
+            // and the client is retrying
+            if (!BackupUtils.regionIsBeingBackup(tableName, regionName, path)) {
+                // Flush memsotore and Wait for flush and compaction to be done
+                HBasePlatformUtils.flush(region);
+                region.waitForFlushesAndCompactions();
+
+                canceled = BackupUtils.backupCanceled();
+                if (!canceled) {
+                    // Create a ZNode to indicate that the region is being copied
+                    ZkUtils.recursiveSafeCreate(path, HConfiguration.BACKUP_IN_PROGRESS, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+                    if (LOG.isDebugEnabled()) {
+                        SpliceLogUtils.debug(LOG,"create node %s to mark backup in progress", path);
+                    }
+
+                    if (isFlushing.get() || isCompacting.get() || isSplitting.get()) {
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "table %s region %s is not ready for backup: isSplitting=%s, isCompacting=%s, isFlushing=%s",
+                                    isSplitting.get(), isCompacting.get(), isFlushing.get());
+                        }
+                        ZkUtils.recursiveDelete(path);
+                    }
+                    else {
+                        responseBuilder.setReadyForBackup(true);
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
+                        }
+                    }
+                }
+            }
+            else
+                responseBuilder.setReadyForBackup(true);
+        }
+        return responseBuilder;
     }
 
     @Override
@@ -106,44 +171,25 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        isSplitting.set(true);
         super.preSplit(e);
-    }
-
-    @Override
-    public void preSplit(ObserverContext<RegionCoprocessorEnvironment> c, byte[] splitRow) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
-
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
-        super.preSplit(c, splitRow);
     }
 
     @Override
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
-
-        isSplitting = false;
         super.postRollBackSplit(ctx);
+        isSplitting.set(false);
+
     }
 
     @Override
-    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
+    public void postCompleteSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
-        super.postSplit(e, l, r);
-    }
-
-    @Override
-    public void preCompactSelection(ObserverContext<RegionCoprocessorEnvironment> c, Store store, List<StoreFile> candidates) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
-        super.preCompactSelection(c, store, candidates);
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit()");
+        super.postCompleteSplit(ctx);
+        isSplitting.set(false);
     }
 
     @Override
@@ -152,40 +198,25 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        isCompacting.set(true);
         return super.preCompact(e, store, scanner, scanType);
     }
 
     @Override
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
-        isCompacting = false;
+        isCompacting.set(false);
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
-        super.preFlush(e);
-    }
-
-    @Override
-    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
-        isFlushing = false;
-    }
-
-    @Override
-    public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
-        return super.preFlush(e,store,scanner);
+        isFlushing.set(true); // Mark beginning of flush
+        super.preFlush(e);
     }
 
     @Override
@@ -196,10 +227,18 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             if (!BackupUtils.isSpliceTable(namespace, tableName))
                 return;
             BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
-                    tableName, resultFile.getPath().getName(), preparing);
-            isFlushing = false;
+                    tableName, resultFile.getPath().getName(), preparing.get());
         } catch (Exception ex) {
             throw new IOException(ex);
         }
+    }
+
+    @Override
+    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        if (!BackupUtils.isSpliceTable(namespace, tableName))
+            return;
+        super.postFlush(e);
+        isFlushing.set(false); // end of flush
     }
 }

--- a/hbase_sql/hbase1.0.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.0.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -35,7 +35,7 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZooDefs;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Created by jyuan on 2/18/16.
@@ -43,10 +43,9 @@ import java.util.List;
 public class BackupEndpointObserver extends BackupBaseRegionObserver implements CoprocessorService,Coprocessor {
     private static final Logger LOG=Logger.getLogger(BackupEndpointObserver.class);
 
-    private volatile boolean isSplitting;
-    private volatile boolean isFlushing;
-    private volatile boolean isCompacting;
-
+    private AtomicBoolean isSplitting;
+    private AtomicBoolean isFlushing;
+    private AtomicBoolean isCompacting;
     private HRegion region;
     private String namespace;
     private String tableName;
@@ -56,7 +55,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private Configuration conf;
     private FileSystem fs;
     Path rootDir;
-    private volatile boolean preparing;
+    private AtomicBoolean preparing;
 
     @Override
     public void start(CoprocessorEnvironment e) throws IOException {
@@ -76,7 +75,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         rootDir = FSUtils.getRootDir(conf);
         fs = FSUtils.getCurrentFileSystem(conf);
         backupDir = new Path(rootDir, BackupRestoreConstants.BACKUP_DIR + "/data/splice/" + tableName + "/" + regionName);
-        preparing = false;
+        preparing = new AtomicBoolean(false);
+        isFlushing = new AtomicBoolean(false);
+        isCompacting = new AtomicBoolean(false);
+        isSplitting = new AtomicBoolean(false);
     }
 
     @Override
@@ -91,16 +93,76 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceMessage.PrepareBackupRequest request,
             com.google.protobuf.RpcCallback<SpliceMessage.PrepareBackupResponse> done) {
         try {
-            preparing = true;
+            preparing.set(true);
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder =
-                    BackupUtils.prepare(request, region, isSplitting, isCompacting, isFlushing, tableName, regionName, path);
+                    prepare(request);
 
-            preparing = false;
             assert responseBuilder.hasReadyForBackup();
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
+        } finally {
+            preparing.set(false);
         }
+
+    }
+
+    public SpliceMessage.PrepareBackupResponse.Builder prepare(SpliceMessage.PrepareBackupRequest request) throws Exception{
+
+        SpliceMessage.PrepareBackupResponse.Builder responseBuilder = SpliceMessage.PrepareBackupResponse.newBuilder();
+        responseBuilder.setReadyForBackup(false);
+
+        if (BackupUtils.shouldIgnore(request, region)) {
+            return responseBuilder;
+        }
+
+        boolean canceled = false;
+
+        if (isSplitting.get() || isFlushing.get() || isCompacting.get()) {
+            if (LOG.isDebugEnabled()) {
+                SpliceLogUtils.debug(LOG, "%s:%s is being split before trying to prepare for backup", tableName, regionName);
+            }
+            // return false to client if the region is being split
+            responseBuilder.setReadyForBackup(false);
+        } else {
+            if (LOG.isDebugEnabled()) {
+                SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
+            }
+
+            // A region might have been in backup. This is unlikely to happen unless the previous response ws lost
+            // and the client is retrying
+            if (!BackupUtils.regionIsBeingBackup(tableName, regionName, path)) {
+                // Flush memsotore and Wait for flush and compaction to be done
+                HBasePlatformUtils.flush(region);
+                region.waitForFlushesAndCompactions();
+
+                canceled = BackupUtils.backupCanceled();
+                if (!canceled) {
+                    // Create a ZNode to indicate that the region is being copied
+                    ZkUtils.recursiveSafeCreate(path, HConfiguration.BACKUP_IN_PROGRESS, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+                    if (LOG.isDebugEnabled()) {
+                        SpliceLogUtils.debug(LOG,"create node %s to mark backup in progress", path);
+                    }
+
+                    if (isFlushing.get() || isCompacting.get() || isSplitting.get()) {
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "table %s region %s is not ready for backup: isSplitting=%s, isCompacting=%s, isFlushing=%s",
+                                    isSplitting.get(), isCompacting.get(), isFlushing.get());
+                        }
+                        ZkUtils.recursiveDelete(path);
+                    }
+                    else {
+                        responseBuilder.setReadyForBackup(true);
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
+                        }
+                    }
+                }
+            }
+            else
+                responseBuilder.setReadyForBackup(true);
+        }
+        return responseBuilder;
     }
 
     @Override
@@ -109,43 +171,25 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        isSplitting.set(true);
         super.preSplit(e);
-    }
-    @Override
-    public void preSplit(ObserverContext<RegionCoprocessorEnvironment> c, byte[] splitRow) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
-
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
-        super.preSplit(c, splitRow);
     }
 
     @Override
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
-
-        isSplitting = false;
         super.postRollBackSplit(ctx);
+        isSplitting.set(false);
+
     }
 
     @Override
-    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
+    public void postCompleteSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
-        super.postSplit(e, l, r);
-    }
-
-    @Override
-    public void preCompactSelection(ObserverContext<RegionCoprocessorEnvironment> c, Store store, List<StoreFile> candidates) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
-        super.preCompactSelection(c, store, candidates);
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit()");
+        super.postCompleteSplit(ctx);
+        isSplitting.set(false);
     }
 
     @Override
@@ -154,31 +198,24 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        isCompacting.set(true);
         return super.preCompact(e, store, scanner, scanType);
     }
 
     @Override
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
-        isCompacting = false;
+        isCompacting.set(false);
     }
 
-    @Override
-    public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
-        return super.preFlush(e,store,scanner);
-    }
-    
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+        if (!BackupUtils.isSpliceTable(namespace, tableName))
+            return;
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
+        isFlushing.set(true); // Mark beginning of flush
         super.preFlush(e);
     }
 
@@ -190,8 +227,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             if (!BackupUtils.isSpliceTable(namespace, tableName))
                 return;
             BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
-                    tableName, resultFile.getPath().getName(), preparing);
-            isFlushing = false;
+                    tableName, resultFile.getPath().getName(), preparing.get());
         } catch (Exception ex) {
             throw new IOException(ex);
         }
@@ -202,6 +238,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
-        isFlushing = false;
+        super.postFlush(e);
+        isFlushing.set(false); // end of flush
     }
 }

--- a/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
+++ b/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
@@ -97,6 +97,12 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
         for (StoreFile sf : request.getFiles()) {
             files.add(sf.getPath().toString());
         }
+
+        ScanType scanType =
+                request.isAllFiles() ? ScanType.COMPACT_DROP_DELETES : ScanType.COMPACT_RETAIN_DELETES;
+        // trigger MemstoreAwareObserver
+        postCreateCoprocScanner(request, scanType, null);
+
         String regionLocation = getRegionLocation(store);
         SConfiguration config = HConfiguration.getConfiguration();
         DistributedCompaction jobRequest=new DistributedCompaction(
@@ -141,10 +147,6 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
             SpliceLogUtils.trace(LOG, "Paths Returned: %s", sPaths);
 
         this.progress.complete();
-        ScanType scanType =
-                request.isAllFiles() ? ScanType.COMPACT_DROP_DELETES : ScanType.COMPACT_RETAIN_DELETES;
-        // trigger MemstoreAwareObserver
-        postCreateCoprocScanner(request, scanType, null);
 
         SpliceCompactionRequest scr = (SpliceCompactionRequest) request;
         scr.preStorefilesRename();

--- a/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -31,9 +31,11 @@ import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.log4j.Logger;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.ZooDefs;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Created by jyuan on 2/18/16.
@@ -41,9 +43,9 @@ import java.util.List;
 public class BackupEndpointObserver extends BackupBaseRegionObserver implements CoprocessorService,Coprocessor {
     private static final Logger LOG=Logger.getLogger(BackupEndpointObserver.class);
 
-    private volatile boolean isSplitting;
-    private volatile boolean isFlushing;
-    private volatile boolean isCompacting;
+    private AtomicBoolean isSplitting;
+    private AtomicBoolean isFlushing;
+    private AtomicBoolean isCompacting;
     private HRegion region;
     private String namespace;
     private String tableName;
@@ -53,11 +55,11 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private Configuration conf;
     private FileSystem fs;
     Path rootDir;
-    private volatile boolean preparing;
+    private AtomicBoolean preparing;
 
     @Override
     public void start(CoprocessorEnvironment e) throws IOException {
-        region = (HRegion) ((RegionCoprocessorEnvironment) e).getRegion();
+        region = (HRegion)((RegionCoprocessorEnvironment) e).getRegion();
         String[] name = region.getTableDesc().getNameAsString().split(":");
         if (name.length == 2) {
             namespace = name[0];
@@ -73,7 +75,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         rootDir = FSUtils.getRootDir(conf);
         fs = FSUtils.getCurrentFileSystem(conf);
         backupDir = new Path(rootDir, BackupRestoreConstants.BACKUP_DIR + "/data/splice/" + tableName + "/" + regionName);
-        preparing = false;
+        preparing = new AtomicBoolean(false);
+        isFlushing = new AtomicBoolean(false);
+        isCompacting = new AtomicBoolean(false);
+        isSplitting = new AtomicBoolean(false);
     }
 
     @Override
@@ -88,16 +93,76 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceMessage.PrepareBackupRequest request,
             com.google.protobuf.RpcCallback<SpliceMessage.PrepareBackupResponse> done) {
         try {
-            preparing = true;
+            preparing.set(true);
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder =
-                    BackupUtils.prepare(request, region, isSplitting, isCompacting, isFlushing, tableName, regionName, path);
-            preparing = false;
+                    prepare(request);
+
             assert responseBuilder.hasReadyForBackup();
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
+        } finally {
+            preparing.set(false);
         }
 
+    }
+
+    public SpliceMessage.PrepareBackupResponse.Builder prepare(SpliceMessage.PrepareBackupRequest request) throws Exception{
+
+        SpliceMessage.PrepareBackupResponse.Builder responseBuilder = SpliceMessage.PrepareBackupResponse.newBuilder();
+        responseBuilder.setReadyForBackup(false);
+
+        if (BackupUtils.shouldIgnore(request, region)) {
+            return responseBuilder;
+        }
+
+        boolean canceled = false;
+
+        if (isSplitting.get() || isFlushing.get() || isCompacting.get()) {
+            if (LOG.isDebugEnabled()) {
+                SpliceLogUtils.debug(LOG, "%s:%s is being split before trying to prepare for backup", tableName, regionName);
+            }
+            // return false to client if the region is being split
+            responseBuilder.setReadyForBackup(false);
+        } else {
+            if (LOG.isDebugEnabled()) {
+                SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
+            }
+
+            // A region might have been in backup. This is unlikely to happen unless the previous response ws lost
+            // and the client is retrying
+            if (!BackupUtils.regionIsBeingBackup(tableName, regionName, path)) {
+                // Flush memsotore and Wait for flush and compaction to be done
+                HBasePlatformUtils.flush(region);
+                region.waitForFlushesAndCompactions();
+
+                canceled = BackupUtils.backupCanceled();
+                if (!canceled) {
+                    // Create a ZNode to indicate that the region is being copied
+                    ZkUtils.recursiveSafeCreate(path, HConfiguration.BACKUP_IN_PROGRESS, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+                    if (LOG.isDebugEnabled()) {
+                        SpliceLogUtils.debug(LOG,"create node %s to mark backup in progress", path);
+                    }
+
+                    if (isFlushing.get() || isCompacting.get() || isSplitting.get()) {
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "table %s region %s is not ready for backup: isSplitting=%s, isCompacting=%s, isFlushing=%s",
+                                    isSplitting.get(), isCompacting.get(), isFlushing.get());
+                        }
+                        ZkUtils.recursiveDelete(path);
+                    }
+                    else {
+                        responseBuilder.setReadyForBackup(true);
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
+                        }
+                    }
+                }
+            }
+            else
+                responseBuilder.setReadyForBackup(true);
+        }
+        return responseBuilder;
     }
 
     @Override
@@ -106,44 +171,25 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        isSplitting.set(true);
         super.preSplit(e);
-    }
-
-    @Override
-    public void preSplit(ObserverContext<RegionCoprocessorEnvironment> c, byte[] splitRow) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
-
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
-        super.preSplit(c, splitRow);
     }
 
     @Override
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
-
-        isSplitting = false;
         super.postRollBackSplit(ctx);
-    }
-    
-    @Override
-    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
-        super.postSplit(e, l, r);
+        isSplitting.set(false);
+
     }
 
     @Override
-    public void preCompactSelection(ObserverContext<RegionCoprocessorEnvironment> c, Store store, List<StoreFile> candidates) throws IOException {
+    public void postCompleteSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
-        super.preCompactSelection(c, store, candidates);
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit()");
+        super.postCompleteSplit(ctx);
+        isSplitting.set(false);
     }
 
     @Override
@@ -152,40 +198,25 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        isCompacting.set(true);
         return super.preCompact(e, store, scanner, scanType);
     }
 
     @Override
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
-        isCompacting = false;
+        isCompacting.set(false);
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
-        super.preFlush(e);
-    }
-
-    @Override
-    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
-        isFlushing = false;
-    }
-
-    @Override
-    public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
-        return super.preFlush(e,store,scanner);
+        isFlushing.set(true); // Mark beginning of flush
+        super.preFlush(e);
     }
 
     @Override
@@ -196,13 +227,22 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             if (!BackupUtils.isSpliceTable(namespace, tableName))
                 return;
             BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
-                    tableName, resultFile.getPath().getName(), preparing);
-            isFlushing = false;
+                    tableName, resultFile.getPath().getName(), preparing.get());
         } catch (Exception ex) {
             throw new IOException(ex);
         }
     }
 
-    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
+    @Override
+    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        if (!BackupUtils.isSpliceTable(namespace, tableName))
+            return;
+        super.postFlush(e);
+        isFlushing.set(false); // end of flush
+    }
+
+    @Override
+    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e ,Region l, Region r) throws IOException{
     }
 }

--- a/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
+++ b/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
@@ -98,6 +98,12 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
         for (StoreFile sf : request.getFiles()) {
             files.add(sf.getPath().toString());
         }
+
+        ScanType scanType =
+                request.isAllFiles() ? ScanType.COMPACT_DROP_DELETES : ScanType.COMPACT_RETAIN_DELETES;
+        // trigger MemstoreAwareObserver
+        postCreateCoprocScanner(request, scanType, null, user);
+
         String regionLocation = getRegionLocation(store);
         SConfiguration config = HConfiguration.getConfiguration();
         DistributedCompaction jobRequest=new DistributedCompaction(
@@ -142,10 +148,6 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
             SpliceLogUtils.trace(LOG, "Paths Returned: %s", sPaths);
 
         this.progress.complete();
-        ScanType scanType =
-                request.isAllFiles() ? ScanType.COMPACT_DROP_DELETES : ScanType.COMPACT_RETAIN_DELETES;
-        // trigger MemstoreAwareObserver
-        postCreateCoprocScanner(request, scanType, null, user);
 
         SpliceCompactionRequest scr = (SpliceCompactionRequest) request;
         scr.preStorefilesRename();

--- a/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -31,9 +31,11 @@ import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.log4j.Logger;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.ZooDefs;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Created by jyuan on 2/18/16.
@@ -41,9 +43,9 @@ import java.util.List;
 public class BackupEndpointObserver extends BackupBaseRegionObserver implements CoprocessorService,Coprocessor {
     private static final Logger LOG=Logger.getLogger(BackupEndpointObserver.class);
 
-    private volatile boolean isSplitting;
-    private volatile boolean isFlushing;
-    private volatile boolean isCompacting;
+    private AtomicBoolean isSplitting;
+    private AtomicBoolean isFlushing;
+    private AtomicBoolean isCompacting;
     private HRegion region;
     private String namespace;
     private String tableName;
@@ -53,11 +55,11 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private Configuration conf;
     private FileSystem fs;
     Path rootDir;
-    private volatile boolean preparing;
+    private AtomicBoolean preparing;
 
     @Override
     public void start(CoprocessorEnvironment e) throws IOException {
-        region = (HRegion) ((RegionCoprocessorEnvironment) e).getRegion();
+        region = (HRegion)((RegionCoprocessorEnvironment) e).getRegion();
         String[] name = region.getTableDesc().getNameAsString().split(":");
         if (name.length == 2) {
             namespace = name[0];
@@ -73,7 +75,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         rootDir = FSUtils.getRootDir(conf);
         fs = FSUtils.getCurrentFileSystem(conf);
         backupDir = new Path(rootDir, BackupRestoreConstants.BACKUP_DIR + "/data/splice/" + tableName + "/" + regionName);
-        preparing = false;
+        preparing = new AtomicBoolean(false);
+        isFlushing = new AtomicBoolean(false);
+        isCompacting = new AtomicBoolean(false);
+        isSplitting = new AtomicBoolean(false);
     }
 
     @Override
@@ -88,16 +93,76 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceMessage.PrepareBackupRequest request,
             com.google.protobuf.RpcCallback<SpliceMessage.PrepareBackupResponse> done) {
         try {
-            preparing = true;
+            preparing.set(true);
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder =
-                    BackupUtils.prepare(request, region, isSplitting, isCompacting, isFlushing, tableName, regionName, path);
-            preparing = false;
+                    prepare(request);
+
             assert responseBuilder.hasReadyForBackup();
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
+        } finally {
+            preparing.set(false);
         }
 
+    }
+
+    public SpliceMessage.PrepareBackupResponse.Builder prepare(SpliceMessage.PrepareBackupRequest request) throws Exception{
+
+        SpliceMessage.PrepareBackupResponse.Builder responseBuilder = SpliceMessage.PrepareBackupResponse.newBuilder();
+        responseBuilder.setReadyForBackup(false);
+
+        if (BackupUtils.shouldIgnore(request, region)) {
+            return responseBuilder;
+        }
+
+        boolean canceled = false;
+
+        if (isSplitting.get() || isFlushing.get() || isCompacting.get()) {
+            if (LOG.isDebugEnabled()) {
+                SpliceLogUtils.debug(LOG, "%s:%s is being split before trying to prepare for backup", tableName, regionName);
+            }
+            // return false to client if the region is being split
+            responseBuilder.setReadyForBackup(false);
+        } else {
+            if (LOG.isDebugEnabled()) {
+                SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
+            }
+
+            // A region might have been in backup. This is unlikely to happen unless the previous response ws lost
+            // and the client is retrying
+            if (!BackupUtils.regionIsBeingBackup(tableName, regionName, path)) {
+                // Flush memsotore and Wait for flush and compaction to be done
+                HBasePlatformUtils.flush(region);
+                region.waitForFlushesAndCompactions();
+
+                canceled = BackupUtils.backupCanceled();
+                if (!canceled) {
+                    // Create a ZNode to indicate that the region is being copied
+                    ZkUtils.recursiveSafeCreate(path, HConfiguration.BACKUP_IN_PROGRESS, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+                    if (LOG.isDebugEnabled()) {
+                        SpliceLogUtils.debug(LOG,"create node %s to mark backup in progress", path);
+                    }
+
+                    if (isFlushing.get() || isCompacting.get() || isSplitting.get()) {
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "table %s region %s is not ready for backup: isSplitting=%s, isCompacting=%s, isFlushing=%s",
+                                    isSplitting.get(), isCompacting.get(), isFlushing.get());
+                        }
+                        ZkUtils.recursiveDelete(path);
+                    }
+                    else {
+                        responseBuilder.setReadyForBackup(true);
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
+                        }
+                    }
+                }
+            }
+            else
+                responseBuilder.setReadyForBackup(true);
+        }
+        return responseBuilder;
     }
 
     @Override
@@ -106,51 +171,25 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        isSplitting.set(true);
         super.preSplit(e);
-    }
-
-    @Override
-    public void preSplit(ObserverContext<RegionCoprocessorEnvironment> c, byte[] splitRow) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
-
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
-        super.preSplit(c, splitRow);
     }
 
     @Override
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
-
-        isSplitting = false;
         super.postRollBackSplit(ctx);
+        isSplitting.set(false);
+
     }
 
     @Override
-    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
+    public void postCompleteSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
-    }
-    
-    @Override
-    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
-        super.postSplit(e, l, r);
-    }
-
-    @Override
-    public void preCompactSelection(ObserverContext<RegionCoprocessorEnvironment> c, Store store, List<StoreFile> candidates) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
-        super.preCompactSelection(c, store, candidates);
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit()");
+        super.postCompleteSplit(ctx);
+        isSplitting.set(false);
     }
 
     @Override
@@ -159,42 +198,27 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        isCompacting.set(true);
         return super.preCompact(e, store, scanner, scanType);
     }
 
     @Override
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
-        isCompacting = false;
+        isCompacting.set(false);
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+        if (!BackupUtils.isSpliceTable(namespace, tableName))
+            return;
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
+        isFlushing.set(true); // Mark beginning of flush
         super.preFlush(e);
     }
 
-    @Override
-    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
-        if (!BackupUtils.isSpliceTable(namespace, tableName))
-            return;
-        isFlushing = false;
-    }
-
-    @Override
-    public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
-        return super.preFlush(e,store,scanner);
-    }
-    
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
@@ -203,10 +227,22 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             if (!BackupUtils.isSpliceTable(namespace, tableName))
                 return;
             BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
-                    tableName, resultFile.getPath().getName(), preparing);
-            isFlushing = false;
+                    tableName, resultFile.getPath().getName(), preparing.get());
         } catch (Exception ex) {
             throw new IOException(ex);
         }
+    }
+
+    @Override
+    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        if (!BackupUtils.isSpliceTable(namespace, tableName))
+            return;
+        super.postFlush(e);
+        isFlushing.set(false); // end of flush
+    }
+
+    @Override
+    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e ,Region l, Region r) throws IOException{
     }
 }

--- a/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
+++ b/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
@@ -97,6 +97,12 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
         for (StoreFile sf : request.getFiles()) {
             files.add(sf.getPath().toString());
         }
+
+        ScanType scanType =
+                request.isAllFiles() ? ScanType.COMPACT_DROP_DELETES : ScanType.COMPACT_RETAIN_DELETES;
+        // trigger MemstoreAwareObserver
+        postCreateCoprocScanner(request, scanType, null);
+
         String regionLocation = getRegionLocation(store);
         SConfiguration config = HConfiguration.getConfiguration();
         DistributedCompaction jobRequest=new DistributedCompaction(
@@ -141,10 +147,6 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
             SpliceLogUtils.trace(LOG, "Paths Returned: %s", sPaths);
 
         this.progress.complete();
-        ScanType scanType =
-                request.isAllFiles() ? ScanType.COMPACT_DROP_DELETES : ScanType.COMPACT_RETAIN_DELETES;
-        // trigger MemstoreAwareObserver
-        postCreateCoprocScanner(request, scanType, null);
 
         SpliceCompactionRequest scr = (SpliceCompactionRequest) request;
         scr.preStorefilesRename();

--- a/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -31,9 +31,11 @@ import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.log4j.Logger;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.ZooDefs;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Created by jyuan on 2/18/16.
@@ -41,9 +43,9 @@ import java.util.List;
 public class BackupEndpointObserver extends BackupBaseRegionObserver implements CoprocessorService,Coprocessor {
     private static final Logger LOG=Logger.getLogger(BackupEndpointObserver.class);
 
-    private volatile boolean isSplitting;
-    private volatile boolean isFlushing;
-    private volatile boolean isCompacting;
+    private AtomicBoolean isSplitting;
+    private AtomicBoolean isFlushing;
+    private AtomicBoolean isCompacting;
     private HRegion region;
     private String namespace;
     private String tableName;
@@ -53,11 +55,11 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private Configuration conf;
     private FileSystem fs;
     Path rootDir;
-    private volatile boolean preparing;
+    private AtomicBoolean preparing;
 
     @Override
     public void start(CoprocessorEnvironment e) throws IOException {
-        region = (HRegion) ((RegionCoprocessorEnvironment) e).getRegion();
+        region = (HRegion)((RegionCoprocessorEnvironment) e).getRegion();
         String[] name = region.getTableDesc().getNameAsString().split(":");
         if (name.length == 2) {
             namespace = name[0];
@@ -73,7 +75,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         rootDir = FSUtils.getRootDir(conf);
         fs = FSUtils.getCurrentFileSystem(conf);
         backupDir = new Path(rootDir, BackupRestoreConstants.BACKUP_DIR + "/data/splice/" + tableName + "/" + regionName);
-        preparing = false;
+        preparing = new AtomicBoolean(false);
+        isFlushing = new AtomicBoolean(false);
+        isCompacting = new AtomicBoolean(false);
+        isSplitting = new AtomicBoolean(false);
     }
 
     @Override
@@ -88,16 +93,76 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceMessage.PrepareBackupRequest request,
             com.google.protobuf.RpcCallback<SpliceMessage.PrepareBackupResponse> done) {
         try {
-            preparing = true;
+            preparing.set(true);
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder =
-                    BackupUtils.prepare(request, region, isSplitting, isCompacting, isFlushing, tableName, regionName, path);
-            preparing = false;
+                    prepare(request);
+
             assert responseBuilder.hasReadyForBackup();
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
+        } finally {
+            preparing.set(false);
         }
 
+    }
+
+    public SpliceMessage.PrepareBackupResponse.Builder prepare(SpliceMessage.PrepareBackupRequest request) throws Exception{
+
+        SpliceMessage.PrepareBackupResponse.Builder responseBuilder = SpliceMessage.PrepareBackupResponse.newBuilder();
+        responseBuilder.setReadyForBackup(false);
+
+        if (BackupUtils.shouldIgnore(request, region)) {
+            return responseBuilder;
+        }
+
+        boolean canceled = false;
+
+        if (isSplitting.get() || isFlushing.get() || isCompacting.get()) {
+            if (LOG.isDebugEnabled()) {
+                SpliceLogUtils.debug(LOG, "%s:%s is being split before trying to prepare for backup", tableName, regionName);
+            }
+            // return false to client if the region is being split
+            responseBuilder.setReadyForBackup(false);
+        } else {
+            if (LOG.isDebugEnabled()) {
+                SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
+            }
+
+            // A region might have been in backup. This is unlikely to happen unless the previous response ws lost
+            // and the client is retrying
+            if (!BackupUtils.regionIsBeingBackup(tableName, regionName, path)) {
+                // Flush memsotore and Wait for flush and compaction to be done
+                HBasePlatformUtils.flush(region);
+                region.waitForFlushesAndCompactions();
+
+                canceled = BackupUtils.backupCanceled();
+                if (!canceled) {
+                    // Create a ZNode to indicate that the region is being copied
+                    ZkUtils.recursiveSafeCreate(path, HConfiguration.BACKUP_IN_PROGRESS, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+                    if (LOG.isDebugEnabled()) {
+                        SpliceLogUtils.debug(LOG,"create node %s to mark backup in progress", path);
+                    }
+
+                    if (isFlushing.get() || isCompacting.get() || isSplitting.get()) {
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "table %s region %s is not ready for backup: isSplitting=%s, isCompacting=%s, isFlushing=%s",
+                                    isSplitting.get(), isCompacting.get(), isFlushing.get());
+                        }
+                        ZkUtils.recursiveDelete(path);
+                    }
+                    else {
+                        responseBuilder.setReadyForBackup(true);
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
+                        }
+                    }
+                }
+            }
+            else
+                responseBuilder.setReadyForBackup(true);
+        }
+        return responseBuilder;
     }
 
     @Override
@@ -106,51 +171,25 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        isSplitting.set(true);
         super.preSplit(e);
-    }
-
-    @Override
-    public void preSplit(ObserverContext<RegionCoprocessorEnvironment> c, byte[] splitRow) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
-
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
-        super.preSplit(c, splitRow);
     }
 
     @Override
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
-
-        isSplitting = false;
         super.postRollBackSplit(ctx);
+        isSplitting.set(false);
+
     }
 
     @Override
-    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
+    public void postCompleteSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
-    }
-
-    @Override
-    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
-        super.postSplit(e, l, r);
-    }
-
-    @Override
-    public void preCompactSelection(ObserverContext<RegionCoprocessorEnvironment> c, Store store, List<StoreFile> candidates) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
-        super.preCompactSelection(c, store, candidates);
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit()");
+        super.postCompleteSplit(ctx);
+        isSplitting.set(false);
     }
 
     @Override
@@ -159,40 +198,25 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        isCompacting.set(true);
         return super.preCompact(e, store, scanner, scanType);
     }
 
     @Override
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
-        isCompacting = false;
+        isCompacting.set(false);
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
-        super.preFlush(e);
-    }
-
-    @Override
-    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
-        isFlushing = false;
-    }
-
-    @Override
-    public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
-        return super.preFlush(e,store,scanner);
+        isFlushing.set(true); // Mark beginning of flush
+        super.preFlush(e);
     }
 
     @Override
@@ -203,10 +227,22 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             if (!BackupUtils.isSpliceTable(namespace, tableName))
                 return;
             BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
-                    tableName, resultFile.getPath().getName(), preparing);
-            isFlushing = false;
+                    tableName, resultFile.getPath().getName(), preparing.get());
         } catch (Exception ex) {
             throw new IOException(ex);
         }
+    }
+
+    @Override
+    public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        if (!BackupUtils.isSpliceTable(namespace, tableName))
+            return;
+        super.postFlush(e);
+        isFlushing.set(false); // end of flush
+    }
+
+    @Override
+    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e ,Region l, Region r) throws IOException{
     }
 }

--- a/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
+++ b/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
@@ -98,6 +98,14 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
         for (StoreFile sf : request.getFiles()) {
             files.add(sf.getPath().toString());
         }
+
+        ScanType scanType =
+                request.isRetainDeleteMarkers()
+                        ? ScanType.COMPACT_RETAIN_DELETES
+                        : ScanType.COMPACT_DROP_DELETES;
+        // trigger MemstoreAwareObserver
+        postCreateCoprocScanner(request, scanType, null,user);
+
         String regionLocation = getRegionLocation(store);
         SConfiguration config = HConfiguration.getConfiguration();
         DistributedCompaction jobRequest=new DistributedCompaction(
@@ -142,12 +150,7 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
             SpliceLogUtils.trace(LOG, "Paths Returned: %s", sPaths);
 
         this.progress.complete();
-        ScanType scanType =
-                request.isRetainDeleteMarkers()
-                        ? ScanType.COMPACT_RETAIN_DELETES
-                        : ScanType.COMPACT_DROP_DELETES;
-        // trigger MemstoreAwareObserver
-        postCreateCoprocScanner(request, scanType, null,user);
+
 
         SpliceCompactionRequest scr = (SpliceCompactionRequest) request;
         scr.preStorefilesRename();

--- a/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -35,7 +35,7 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZooDefs;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Created by jyuan on 2/18/16.
@@ -43,9 +43,9 @@ import java.util.List;
 public class BackupEndpointObserver extends BackupBaseRegionObserver implements CoprocessorService,Coprocessor {
     private static final Logger LOG=Logger.getLogger(BackupEndpointObserver.class);
 
-    private volatile boolean isSplitting;
-    private volatile boolean isFlushing;
-    private volatile boolean isCompacting;
+    private AtomicBoolean isSplitting;
+    private AtomicBoolean isFlushing;
+    private AtomicBoolean isCompacting;
     private HRegion region;
     private String namespace;
     private String tableName;
@@ -55,7 +55,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     private Configuration conf;
     private FileSystem fs;
     Path rootDir;
-    private volatile boolean preparing;
+    private AtomicBoolean preparing;
 
     @Override
     public void start(CoprocessorEnvironment e) throws IOException {
@@ -75,7 +75,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         rootDir = FSUtils.getRootDir(conf);
         fs = FSUtils.getCurrentFileSystem(conf);
         backupDir = new Path(rootDir, BackupRestoreConstants.BACKUP_DIR + "/data/splice/" + tableName + "/" + regionName);
-        preparing = false;
+        preparing = new AtomicBoolean(false);
+        isFlushing = new AtomicBoolean(false);
+        isCompacting = new AtomicBoolean(false);
+        isSplitting = new AtomicBoolean(false);
     }
 
     @Override
@@ -90,16 +93,76 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceMessage.PrepareBackupRequest request,
             com.google.protobuf.RpcCallback<SpliceMessage.PrepareBackupResponse> done) {
         try {
-            preparing = true;
+            preparing.set(true);
             SpliceMessage.PrepareBackupResponse.Builder responseBuilder =
-                    BackupUtils.prepare(request, region, isSplitting, isCompacting, isFlushing, tableName, regionName, path);
-            preparing = false;
+                    prepare(request);
+
             assert responseBuilder.hasReadyForBackup();
             done.run(responseBuilder.build());
         } catch (Exception e) {
             controller.setFailed(e.getMessage());
+        } finally {
+            preparing.set(false);
         }
 
+    }
+
+    public SpliceMessage.PrepareBackupResponse.Builder prepare(SpliceMessage.PrepareBackupRequest request) throws Exception{
+
+        SpliceMessage.PrepareBackupResponse.Builder responseBuilder = SpliceMessage.PrepareBackupResponse.newBuilder();
+        responseBuilder.setReadyForBackup(false);
+
+        if (BackupUtils.shouldIgnore(request, region)) {
+            return responseBuilder;
+        }
+
+        boolean canceled = false;
+
+        if (isSplitting.get() || isFlushing.get() || isCompacting.get()) {
+            if (LOG.isDebugEnabled()) {
+                SpliceLogUtils.debug(LOG, "%s:%s is being split before trying to prepare for backup", tableName, regionName);
+            }
+            // return false to client if the region is being split
+            responseBuilder.setReadyForBackup(false);
+        } else {
+            if (LOG.isDebugEnabled()) {
+                SpliceLogUtils.debug(LOG, "%s:%s waits for flush and compaction to complete", tableName, regionName);
+            }
+
+            // A region might have been in backup. This is unlikely to happen unless the previous response ws lost
+            // and the client is retrying
+            if (!BackupUtils.regionIsBeingBackup(tableName, regionName, path)) {
+                // Flush memsotore and Wait for flush and compaction to be done
+                HBasePlatformUtils.flush(region);
+                region.waitForFlushesAndCompactions();
+
+                canceled = BackupUtils.backupCanceled();
+                if (!canceled) {
+                    // Create a ZNode to indicate that the region is being copied
+                    ZkUtils.recursiveSafeCreate(path, HConfiguration.BACKUP_IN_PROGRESS, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+                    if (LOG.isDebugEnabled()) {
+                        SpliceLogUtils.debug(LOG,"create node %s to mark backup in progress", path);
+                    }
+
+                    if (isFlushing.get() || isCompacting.get() || isSplitting.get()) {
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "table %s region %s is not ready for backup: isSplitting=%s, isCompacting=%s, isFlushing=%s",
+                                    isSplitting.get(), isCompacting.get(), isFlushing.get());
+                        }
+                        ZkUtils.recursiveDelete(path);
+                    }
+                    else {
+                        responseBuilder.setReadyForBackup(true);
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "%s:%s is ready for backup", tableName, regionName);
+                        }
+                    }
+                }
+            }
+            else
+                responseBuilder.setReadyForBackup(true);
+        }
+        return responseBuilder;
     }
 
     @Override
@@ -108,51 +171,25 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
+        isSplitting.set(true);
         super.preSplit(e);
-    }
-
-    @Override
-    public void preSplit(ObserverContext<RegionCoprocessorEnvironment> c, byte[] splitRow) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
-
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isSplitting = true;
-        super.preSplit(c, splitRow);
     }
 
     @Override
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
-
-        isSplitting = false;
         super.postRollBackSplit(ctx);
+        isSplitting.set(false);
+
     }
 
     @Override
-    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> regionCoprocessorEnvironmentObserverContext, Region region, Region region2) throws IOException {
+    public void postCompleteSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
-    }
-
-    @Override
-    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postSplit()");
-        isSplitting = false;
-        super.postSplit(e, l, r);
-    }
-
-    @Override
-    public void preCompactSelection(ObserverContext<RegionCoprocessorEnvironment> c, Store store, List<StoreFile> candidates) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompactSelection()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
-        super.preCompactSelection(c, store, candidates);
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit()");
+        super.postCompleteSplit(ctx);
+        isSplitting.set(false);
     }
 
     @Override
@@ -161,32 +198,25 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preCompact()");
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isCompacting = true;
+        isCompacting.set(true);
         return super.preCompact(e, store, scanner, scanType);
     }
 
     @Override
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
-        isCompacting = false;
+        isCompacting.set(false);
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+        if (!BackupUtils.isSpliceTable(namespace, tableName))
+            return;
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
+        isFlushing.set(true); // Mark beginning of flush
         super.preFlush(e);
-    }
-
-    @Override
-    public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, InternalScanner scanner) throws IOException {
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
-        BackupUtils.waitForBackupToComplete(tableName, regionName, path);
-        isFlushing = true;
-        return super.preFlush(e,store,scanner);
     }
 
     @Override
@@ -197,8 +227,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
             if (!BackupUtils.isSpliceTable(namespace, tableName))
                 return;
             BackupUtils.captureIncrementalChanges(conf, region, path, fs, rootDir, backupDir,
-                    tableName, resultFile.getPath().getName(), preparing);
-            isFlushing = false;
+                    tableName, resultFile.getPath().getName(), preparing.get());
         } catch (Exception ex) {
             throw new IOException(ex);
         }
@@ -209,6 +238,11 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
-        isFlushing = false;
+        super.postFlush(e);
+        isFlushing.set(false); // end of flush
+    }
+
+    @Override
+    public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e ,Region l, Region r) throws IOException{
     }
 }

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/MemstoreAwareObserver.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/MemstoreAwareObserver.java
@@ -64,7 +64,8 @@ public class MemstoreAwareObserver extends BaseRegionObserver implements Compact
         // memstoreAware is injected into the request, where the blocking logic lives, and where compaction
         // count will be incremented and decremented.
         scr.setMemstoreAware(memstoreAware);
-
+        HRegion region = (HRegion) e.getEnvironment().getRegion();
+        scr.setRegion(region);
         return scanner;
     }
 


### PR DESCRIPTION
- Cleaned up compaction, split and flush hook. Removed unnecessary ones, and make sure even compaction failed, isCompacting is cleared
- make isCompacting, isFlushing, and isSplitting flag atomic variable. 