### PR TITLE
SPLICE-774 Reset statistics during upgrade

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/Aggregate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/Aggregate.java
@@ -61,15 +61,15 @@ public class Aggregate {
         this.javaClassName = javaClassName;
     }
 
-    public void createSystemAggregate(DataDictionary dataDictionary, TransactionController tc)
+    public void createOrUpdateSystemAggregate(DataDictionary dataDictionary, TransactionController tc)
 		throws StandardException {
     	// By default, puts aggregate function into SYSCS_UTIL schema
     	// unless you invoke the method that takes schema UUID argument.
         UUID schemaId = dataDictionary.getSystemUtilSchemaDescriptor().getUUID();
-        createSystemAggregate(dataDictionary, tc, schemaId);
+        createOrUpdateSystemAggregate(dataDictionary, tc, schemaId);
     }
 
-    public void createSystemAggregate(DataDictionary dataDictionary, TransactionController tc, UUID schemaId)
+    public void createOrUpdateSystemAggregate(DataDictionary dataDictionary, TransactionController tc, UUID schemaId)
 		throws StandardException {
 
         char aliasType = AliasInfo.ALIAS_TYPE_AGGREGATE_AS_CHAR;
@@ -78,6 +78,12 @@ public class Aggregate {
         AggregateAliasInfo aliasInfo = new AggregateAliasInfo(inType, returnType);
 
         UUID aggregate_uuid = dataDictionary.getUUIDFactory().createUUID();
+
+
+        AliasDescriptor ad = dataDictionary.getAliasDescriptor(dataDictionary.getSysFunSchemaDescriptor().getUUID().toString(), name, AliasInfo.ALIAS_NAME_SPACE_AGGREGATE_AS_CHAR);
+        if (ad != null) {  // Drop the procedure if it already exists.
+            dataDictionary.dropAliasDescriptor(ad, tc);
+        }
 
         AliasDescriptor ads =
                 new AliasDescriptor(

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -549,7 +549,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
      */
     protected abstract SystemProcedureGenerator getSystemProcedures();
 
-    protected abstract SystemAggregateGenerator getSystemAggregateGenerator();
+    public abstract SystemAggregateGenerator getSystemAggregateGenerator();
 
     /**
      * Find the default message digest algorithm to use for BUILTIN

--- a/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
+++ b/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine;
 
+import java.io.Externalizable;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.Date;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemAggregatorGenerator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemAggregatorGenerator.java
@@ -14,9 +14,11 @@
 
 package com.splicemachine.derby.impl.sql.catalog;
 
+import com.splicemachine.db.catalog.AliasInfo;
 import com.splicemachine.db.catalog.TypeDescriptor;
 import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.dictionary.AliasDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.stats.ColumnStatisticsImpl;
 import com.splicemachine.db.iapi.stats.ColumnStatisticsMerge;
@@ -49,7 +51,7 @@ public class SpliceSystemAggregatorGenerator extends DefaultSystemAggregateGener
                 TypeDescriptor.DOUBLE,
                 SpliceStddevPop.class.getCanonicalName());
 
-        aggregate.createSystemAggregate(dictionary, tc, sysFunUUID);
+        aggregate.createOrUpdateSystemAggregate(dictionary, tc, sysFunUUID);
 
         aggregate = new Aggregate(
                 "STDDEV_SAMP",
@@ -57,14 +59,15 @@ public class SpliceSystemAggregatorGenerator extends DefaultSystemAggregateGener
                 TypeDescriptor.DOUBLE,
                 SpliceStddevSamp.class.getCanonicalName());
 
-        aggregate.createSystemAggregate(dictionary, tc, sysFunUUID);
+        aggregate.createOrUpdateSystemAggregate(dictionary, tc, sysFunUUID);
 
         TypeId mergeTypeId = TypeId.getUserDefinedTypeId(ColumnStatisticsImpl.class.getCanonicalName(), false);
         DataTypeDescriptor dtd = new DataTypeDescriptor(mergeTypeId,true);
         TypeDescriptor mergeTypeDescriptor = dtd.getCatalogType();
         aggregate = new Aggregate("STATS_MERGE", mergeTypeDescriptor,mergeTypeDescriptor,
                 ColumnStatisticsMerge.class.getCanonicalName());
-        aggregate.createSystemAggregate(dictionary,tc,sysFunUUID);
+        aggregate.createOrUpdateSystemAggregate(dictionary,tc,sysFunUUID);
 
     }
+
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/K2UpgradeScript.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/K2UpgradeScript.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.derby.impl.sql.catalog.upgrade;
+
+import com.splicemachine.db.catalog.UUID;
+import com.splicemachine.db.catalog.types.DefaultInfoImpl;
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.dictionary.ColumnDescriptor;
+import com.splicemachine.db.iapi.sql.dictionary.ColumnDescriptorList;
+import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
+import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
+import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+import com.splicemachine.db.iapi.types.SQLBoolean;
+import com.splicemachine.derby.impl.sql.catalog.SpliceDataDictionary;
+import com.splicemachine.pipeline.ErrorState;
+
+import java.sql.Types;
+
+/**
+ * @author Scott Fines
+ *         Date: 2/25/15
+ */
+public class K2UpgradeScript extends UpgradeScriptBase {
+    public K2UpgradeScript(SpliceDataDictionary sdd, TransactionController tc) {
+        super(sdd, tc);
+    }
+
+    @Override
+    protected void upgradeSystemTables() throws StandardException {
+        super.upgradeSystemTables();
+
+        sdd.getSystemAggregateGenerator().createAggregates(tc);
+        sdd.dropStatisticsTables(tc);
+        sdd.createStatisticsTables(tc);
+
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -62,6 +62,7 @@ public class SpliceCatalogUpgradeScripts{
         scripts=new TreeMap<>(ddComparator);
         scripts.put(new Splice_DD_Version(sdd,1,0,0),new UpgradeScriptForFuji(sdd,tc));
         scripts.put(new Splice_DD_Version(sdd,1,1,1),new LassenUpgradeScript(sdd,tc));
+        scripts.put(new Splice_DD_Version(sdd,2,4,9999),new K2UpgradeScript(sdd,tc));
     }
 
     public void run() throws StandardException{


### PR DESCRIPTION
Hopefully the last piece for the upgrade, this change drops and recreates the statistics tables (and views) plus recreates an aggregate definition that also changed.