### PR TITLE
SPLICE-1728 Fixing Data Dictionary Caching

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -44,6 +44,7 @@ import com.splicemachine.db.iapi.sql.execute.ExecutionFactory;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.db.impl.sql.catalog.DataDictionaryCache;
+import com.splicemachine.db.impl.sql.catalog.TabInfoImpl;
 import com.splicemachine.db.impl.sql.execute.TriggerEventDML;
 import java.sql.Types;
 import java.util.Dictionary;
@@ -64,11 +65,6 @@ import java.util.Map;
 
 public interface DataDictionary{
     String MODULE="com.splicemachine.db.iapi.sql.dictionary.DataDictionary";
-
-    /** The conglomerate id of the first user table */
-    // NOTE: JC - this constant is also defined in (splice) EnvUtils. When adding a new sys table, this
-    // number will need to be increased in BOTH places.
-    long FIRST_USER_TABLE_NUMBER = 1568;
 
     /**
      * Special version indicating the database must be upgraded to or created at the current engine level
@@ -2115,4 +2111,20 @@ public interface DataDictionary{
     void addSnapshot(TupleDescriptor descriptor, TransactionController tc) throws StandardException;
 
     void deleteSnapshot(String snapshotName, long conglomeratenumber, TransactionController tc) throws StandardException;
+
+    /**
+     * Used as Helper Methods for the isSystemTable call in Database.
+     *
+     * @return
+     */
+    public TabInfoImpl[] getNoncoreInfo();
+
+    /**
+     * Used as Helper Methods for the isSystemTable call in Database.
+     *
+     * @return
+     */
+    public TabInfoImpl[] getCoreInfo();
+
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/db/BasicDatabase.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/db/BasicDatabase.java
@@ -31,6 +31,7 @@
 
 package com.splicemachine.db.impl.db;
 
+import com.carrotsearch.hppc.LongOpenHashSet;
 import com.splicemachine.db.iapi.reference.*;
 import com.splicemachine.db.iapi.error.PublicAPI;
 import com.splicemachine.db.iapi.sql.compile.CompilerContext;
@@ -66,6 +67,7 @@ import com.splicemachine.db.iapi.services.property.PropertySetCallback;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.jdbc.AuthenticationService;
 import com.splicemachine.db.iapi.services.uuid.UUIDFactory;
+import com.splicemachine.db.impl.sql.catalog.TabInfoImpl;
 import com.splicemachine.db.impl.sql.execute.JarUtil;
 import com.splicemachine.db.io.StorageFile;
 import com.splicemachine.db.catalog.UUID;
@@ -96,6 +98,7 @@ import java.text.DateFormat;
 
 public class BasicDatabase implements ModuleControl, ModuleSupportable, PropertySetCallback, Database, JarReader
 {
+	public static LongOpenHashSet systemConglomerates;
 	protected boolean	active;
 	private AuthenticationService authenticationService;
 	protected AccessFactory af;
@@ -224,7 +227,23 @@ public class BasicDatabase implements ModuleControl, ModuleSupportable, Property
 
 		active = true;
 
+		// Populate System Conglomerates, used to tell if you are a system conglomerate.
+		systemConglomerates = new LongOpenHashSet();
+		populateSystemConglomerates(getDataDictionary().getCoreInfo());
+		populateSystemConglomerates(getDataDictionary().getNoncoreInfo());
+
     }
+
+	private void populateSystemConglomerates(TabInfoImpl[] tabInfos) {
+		for (TabInfoImpl tabInfo: tabInfos) {
+			if (tabInfo!=null) {
+				systemConglomerates.add(tabInfo.getHeapConglomerate());
+				for (int i = 0; i< tabInfo.getNumberOfIndexes();i++) {
+					systemConglomerates.add(tabInfo.getIndexConglomerate(i));
+				}
+			}
+		}
+	}
 
 	public void stop() {
         // The data dictionary is not available if this database has the
@@ -861,6 +880,19 @@ public class BasicDatabase implements ModuleControl, ModuleSupportable, Property
 			util.notifyLoader(true);
 		}
 
-
 	}
+
+	/**
+	 *
+	 * Allows Splice Machine to handle upgrades where system conglomerate numbers are generated after
+	 * system tables.
+	 *
+	 * @param conglomerateId
+	 * @return
+     */
+	public static boolean isSystemConglomerate(long conglomerateId) {
+		// system conglomerates are null during boot upgrades...
+		return systemConglomerates == null || systemConglomerates.contains(conglomerateId);
+	}
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
@@ -43,6 +43,7 @@ import com.splicemachine.db.iapi.sql.depend.Dependent;
 import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.store.access.conglomerate.Conglomerate;
+import com.splicemachine.db.impl.db.BasicDatabase;
 import com.splicemachine.db.impl.sql.GenericStatement;
 import com.splicemachine.db.impl.sql.GenericStorablePreparedStatement;
 import org.apache.log4j.Logger;
@@ -257,8 +258,8 @@ public class DataDictionaryCache {
 
 
     public Conglomerate conglomerateCacheFind(TransactionController xactMgr,Long conglomId) throws StandardException {
-        if (!dd.canUseCache(xactMgr) && conglomId>=DataDictionary.FIRST_USER_TABLE_NUMBER)
-            // Use cache even if dd says we can't as long as it's a system table (conglomID is < FIRST_USER_TABLE_NUMBER)
+        if (!dd.canUseCache(xactMgr) && !BasicDatabase.isSystemConglomerate(conglomId))
+            // Use cache even if dd says we can't as long as it's a system table
             return null;
         if (LOG.isDebugEnabled())
             LOG.debug("conglomerateCacheFind " + conglomId);
@@ -270,7 +271,7 @@ public class DataDictionaryCache {
     }
 
     public void conglomerateCacheAdd(Long conglomId, Conglomerate conglomerate,TransactionController xactMgr) throws StandardException {
-        if (!dd.canUseCache(xactMgr))
+        if (!dd.canUseCache(xactMgr) && !BasicDatabase.isSystemConglomerate(conglomId))
             return;
         if (LOG.isDebugEnabled())
             LOG.debug("conglomerateCacheAdd " + conglomId + " : " + conglomerate);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -31,6 +31,8 @@
 
 package com.splicemachine.db.impl.sql.catalog;
 
+import com.carrotsearch.hppc.LongOpenHashSet;
+import com.splicemachine.db.impl.db.BasicDatabase;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
 import org.apache.log4j.Logger;
 import org.spark_project.guava.base.Function;
@@ -100,7 +102,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
     protected final AliasDescriptor[] sysfunDescriptors=new AliasDescriptor[SYSFUN_FUNCTIONS.length];
 
     // the structure that holds all the core table info
-    protected TabInfoImpl[] coreInfo;
+    volatile protected TabInfoImpl[] coreInfo;
 
     /*
     ** SchemaDescriptors for system and app schemas.  Both
@@ -139,7 +141,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
 	*/
 
     // the structure that holds all the noncore info
-    protected TabInfoImpl[] noncoreInfo;
+    volatile protected TabInfoImpl[] noncoreInfo;
 
     // no other system tables have id's in the configuration.
 
@@ -538,6 +540,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
 
         setDependencyManager();
         booting=false;
+
     }
 
     /**
@@ -1375,7 +1378,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
         if (retval!=null) {
             ConglomerateDescriptor[] conglomerateDescriptors = retval.getConglomerateDescriptors();
             if (conglomerateDescriptors.length > 0 &&
-                    conglomerateDescriptors[0].getConglomerateNumber() < DataDictionary.FIRST_USER_TABLE_NUMBER)
+                    BasicDatabase.isSystemConglomerate(conglomerateDescriptors[0].getConglomerateNumber()))
                 retval.setVersion(SYSTABLESRowFactory.ORIGINAL_TABLE_VERSION);
             dataDictionaryCache.nameTdCacheAdd(tableKey, retval);
         }
@@ -6160,7 +6163,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
                 // to allow it to be garbage-collected. The idea
                 // is that a running database might never need to
                 // reference a non-core table after it was created.
-                clearNoncoreTable(noncoreCtr);
+                //clearNoncoreTable(noncoreCtr);
             }catch(Exception e){
                 e.printStackTrace();
                 System.out.println("Dictionary Table Failure - exiting");
@@ -10250,4 +10253,15 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
             ti.updateRow(keyRow,row,SYSSOURCECODERowFactory.SYSSOURCECODE_INDEX1_ID,bArray,colsToUpdate,tc);
         }
     }
+
+    @Override
+    public TabInfoImpl[] getNoncoreInfo() {
+        return noncoreInfo;
+    }
+
+    @Override
+    public TabInfoImpl[] getCoreInfo() {
+        return coreInfo;
+    }
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/TabInfoImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/TabInfoImpl.java
@@ -132,7 +132,7 @@ public class TabInfoImpl
      *
      * @return long     The conglomerate for the specified index.
      */
-    long getIndexConglomerate(int indexID)
+    public long getIndexConglomerate(int indexID)
     {
         if (SanityManager.DEBUG)
         {

--- a/hbase_sql/src/test/java/com/splicemachine/derby/utils/VacuumIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/utils/VacuumIT.java
@@ -15,6 +15,7 @@
 package com.splicemachine.derby.utils;
 
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
+import com.splicemachine.db.impl.db.BasicDatabase;
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceTableWatcher;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
@@ -85,7 +86,7 @@ public class VacuumIT extends SpliceUnitTest{
             Set<String> deletedTables=getDeletedTables(beforeTables,afterTables);
             for(String t : deletedTables){
                 long conglom=new Long(t);
-                Assert.assertTrue(conglom>=DataDictionary.FIRST_USER_TABLE_NUMBER);
+                Assert.assertTrue(BasicDatabase.isSystemConglomerate(conglom));
             }
         }
     }

--- a/hbase_storage/src/main/java/com/splicemachine/constants/EnvUtils.java
+++ b/hbase_storage/src/main/java/com/splicemachine/constants/EnvUtils.java
@@ -16,6 +16,7 @@ package com.splicemachine.constants;
 
 import com.splicemachine.access.HConfiguration;
 import com.splicemachine.access.api.SConfiguration;
+import com.splicemachine.db.impl.db.BasicDatabase;
 import com.splicemachine.si.data.hbase.coprocessor.TableType;
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.hbase.TableName;
@@ -25,9 +26,6 @@ import org.apache.log4j.Logger;
 
 public class EnvUtils {
 	private static Logger LOG = Logger.getLogger(EnvUtils.class);
-    // NOTE: JC - this constant is also defined in DataDictionary. When adding a new sys table, this
-    // number will need to be increased in BOTH places.
-	private static final long FIRST_USER_TABLE_NUMBER = 1458;
 
     public static TableType getTableType(SConfiguration config,RegionCoprocessorEnvironment e) {
         return EnvUtils.getTableType(config,e.getRegion().getTableDesc().getTableName());
@@ -50,7 +48,7 @@ public class EnvUtils {
         else {
 			try {
 				long tableNumber = Long.parseLong(tableName.getQualifierAsString());
-				if (tableNumber < FIRST_USER_TABLE_NUMBER)
+				if (BasicDatabase.isSystemConglomerate(tableNumber))
 					return TableType.DERBY_SYS_TABLE;
 			} catch(NumberFormatException nfe){
                 return TableType.HBASE_TABLE;

--- a/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MemDatabase.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MemDatabase.java
@@ -24,6 +24,7 @@ import com.splicemachine.access.configuration.ConfigurationDefault;
 import com.splicemachine.access.configuration.ConfigurationSource;
 import com.splicemachine.access.configuration.HConfigurationDefaultsList;
 import com.splicemachine.access.util.ReflectingConfigurationSource;
+import com.splicemachine.client.SpliceClient;
 import com.splicemachine.concurrent.ConcurrentTicker;
 import com.splicemachine.lifecycle.DatabaseLifecycleManager;
 import com.splicemachine.si.MemSIEnvironment;
@@ -47,6 +48,7 @@ public class MemDatabase{
 
         SIDriver.loadDriver(env);
         final SIDriver driver = env.getSIDriver();
+        SpliceClient.isRegionServer = true;
         //start the database sequence
         EngineLifecycleService els = new EngineLifecycleService(new DistributedDerbyStartup(){
             @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/Vacuum.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/Vacuum.java
@@ -32,6 +32,7 @@ import com.splicemachine.db.iapi.error.PublicAPI;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.db.impl.db.BasicDatabase;
 import com.splicemachine.db.impl.jdbc.EmbedConnection;
 import com.splicemachine.derby.impl.sql.execute.actions.ActiveTransactionReader;
 import com.splicemachine.derby.impl.store.access.SpliceTransactionManager;
@@ -105,7 +106,7 @@ public class Vacuum{
                         continue;
                     }
                     long tableConglom = Long.parseLong(tableName[1]);
-                    if(tableConglom < DataDictionary.FIRST_USER_TABLE_NUMBER) {
+                    if(BasicDatabase.isSystemConglomerate(tableConglom)) {
                         if (LOG.isTraceEnabled()) {
                             LOG.trace("Ignoring system table: " + table.getTableName());
                         }


### PR DESCRIPTION
Based on Daniel's recommendation to lose the less than range concept on dictionary conglomerates since that will not be applicable in the case of a system upgrade.  Very good catch.  I implicitly check the conglomerates now in the dictionary.  Also, added a field to memDatabase to speed those tests up a bit with regards to caching.