### PR TITLE
SPLICE-1739: Added CREATE SCHEMA IF NOT EXISTS functionality

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/StatementType.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/StatementType.java
@@ -64,6 +64,9 @@ public interface StatementType
 	int SET_SCHEMA_DYNAMIC = 2;
 
     int SET_ROLE_DYNAMIC = 1;
+
+	int CREATE_IF_NOT_EXISTS = 7;
+	int CREATE_DEFAULT = 8;
 }
 
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -11492,6 +11492,13 @@ schemaDefinition() throws StandardException :
 {
 	String	schemaName = null;
 	String	authName = null;
+	Token ifTok = null;
+	Token notTok = null;
+    Token existsTok = null;
+    Token ifTok2 = null;
+    Token notTok2 = null;
+    Token existsTok2 = null;
+
 }
 {
 	/*
@@ -11500,8 +11507,10 @@ schemaDefinition() throws StandardException :
 	** specifications for schema, or schema bodies.
 	*/
 	<SCHEMA>
-	(	schemaName = identifier(Limits.MAX_IDENTIFIER_LENGTH, true) [ <AUTHORIZATION> authName = identifier(Limits.MAX_IDENTIFIER_LENGTH, true) ]
+	(	[ ifTok = <IF> notTok = <NOT> existsTok = <EXISTS> ] schemaName = identifier(Limits.MAX_IDENTIFIER_LENGTH, true) [ ifTok2 = <IF> notTok2 = <NOT> existsTok2 = <EXISTS> ] [ <AUTHORIZATION> authName = identifier(Limits.MAX_IDENTIFIER_LENGTH, true) ]
 		{
+			boolean ifNotExists = ifTok != null && notTok != null && existsTok != null;
+			boolean ifNotExists2 = ifTok2 != null && notTok2 != null && existsTok2 != null;
 			if (authName != null)
 				checkVersion( DataDictionary.DD_VERSION_DERBY_10_2, "AUTHORIZATION");
 
@@ -11512,6 +11521,9 @@ schemaDefinition() throws StandardException :
 					C_NodeTypes.CREATE_SCHEMA_NODE,
 					schemaName,
 					authName,
+					((ifNotExists || ifNotExists2) ?
+					  new Integer(StatementType.CREATE_IF_NOT_EXISTS) :
+                      new Integer(StatementType.CREATE_DEFAULT)),
 					getContextManager()
 					);
 		}
@@ -15364,7 +15376,7 @@ dropTableStatement() throws StandardException :
 											C_NodeTypes.DROP_TABLE_NODE,
 											tableName,
 											((ifExists || ifExists2) ?
-											  new Integer(StatementType.DROP_IF_EXISTS) : 
+											  new Integer(StatementType.DROP_IF_EXISTS) :
 											  new Integer(StatementType.DROP_DEFAULT)),
 											getContextManager());
         return deleteNode;
@@ -15391,8 +15403,8 @@ dropPinStatement() throws StandardException :
 											C_NodeTypes.DROP_PIN_NODE,
 											tableName,
 											(ifExists ?
-											  new Integer(StatementType.DROP_IF_EXISTS) :
-											  new Integer(StatementType.DROP_DEFAULT)),
+											  new Integer(StatementType.CREATE_IF_NOT_EXISTS) :
+											  new Integer(StatementType.CREATE_DEFAULT)),
 											getContextManager());
         return deleteNode;
 	}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -15403,8 +15403,8 @@ dropPinStatement() throws StandardException :
 											C_NodeTypes.DROP_PIN_NODE,
 											tableName,
 											(ifExists ?
-											  new Integer(StatementType.CREATE_IF_NOT_EXISTS) :
-											  new Integer(StatementType.CREATE_DEFAULT)),
+											  new Integer(StatementType.DROP_IF_EXISTS) :
+											  new Integer(StatementType.DROP_DEFAULT)),
 											getContextManager());
         return deleteNode;
 	}


### PR DESCRIPTION
You can now run CREATE SCHEMA <schemaname> IF NOT EXISTS as well as 
CREATE SCHEMA IF NOT EXISTS <schemaname> 
A warning will throw if the schema exists, else it will create the schema. 