### PR TITLE
SPLICE-1748 Fixing Role Cache Usage

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -9623,7 +9623,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
     public RoleGrantDescriptor getRoleDefinitionDescriptor(String roleName) throws StandardException{
 
         Optional<RoleGrantDescriptor> optional = dataDictionaryCache.roleCacheFind(roleName);
-        if (optional!=null && optional.isPresent())
+        if (optional!=null)
             return optional.orNull();
 
         DataValueDescriptor roleNameOrderable;


### PR DESCRIPTION
Small Nit but the cache used optional to be a negative cache and the logic was slightly off.  The effect is that each connection performed an additional scan.