### PR TITLE
Splice 1748 v5

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -2092,7 +2092,9 @@ public interface DataDictionary{
 
     DataDictionaryCache getDataDictionaryCache();
 
-    boolean canUseCache(TransactionController xactMgr) throws StandardException;
+    boolean canWriteCache(TransactionController xactMgr) throws StandardException;
+
+    boolean canReadCache(TransactionController xactMgr) throws StandardException;
 
     boolean canUseSPSCache() throws StandardException;
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericPreparedStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericPreparedStatement.java
@@ -740,6 +740,7 @@ public class GenericPreparedStatement implements ExecPreparedStatement {
             switch (action) {
                 case DependencyManager.INTERNAL_RECOMPILE_REQUEST:
                 case DependencyManager.DROP_TABLE:
+                case DependencyManager.TRUNCATE_TABLE:
                 case DependencyManager.ALTER_TABLE:
                 case DependencyManager.CHANGED_CURSOR: {
                 /*

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/BaseDataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/BaseDataDictionary.java
@@ -215,6 +215,6 @@ public abstract class BaseDataDictionary implements DataDictionary, ModuleContro
 
 	@Override
 	public boolean canUseSPSCache() throws StandardException{
-		return canUseCache(null);
+		return canWriteCache(null);
 	}
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -9623,7 +9623,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
     public RoleGrantDescriptor getRoleDefinitionDescriptor(String roleName) throws StandardException{
 
         Optional<RoleGrantDescriptor> optional = dataDictionaryCache.roleCacheFind(roleName);
-        if (optional!=null && optional.isPresent())
+        if (optional!=null)
             return optional.orNull();
 
         DataValueDescriptor roleNameOrderable;

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/AsynchronousDDLWatcher.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/AsynchronousDDLWatcher.java
@@ -162,8 +162,13 @@ public class AsynchronousDDLWatcher implements DDLWatcher,CommunicationListener{
     }
 
     @Override
-    public boolean canUseCache(TransactionManager xact_mgr) {
-        return refresher.canUseCache(xact_mgr);
+    public boolean canWriteCache(TransactionManager xact_mgr) {
+        return refresher.canWriteCache(xact_mgr);
+    }
+
+    @Override
+    public boolean canReadCache(TransactionManager xact_mgr) {
+        return refresher.canReadCache(xact_mgr);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLUtils.java
@@ -684,6 +684,25 @@ public class DDLUtils {
         }
     }
 
+    public static void preCreateRole(DDLMessage.DDLChange change, DataDictionary dd, DependencyManager dm) throws StandardException  {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG,"preCreateTrigger with change=%s",change);
+        try {
+            TxnView txn = DDLUtils.getLazyTransaction(change.getTxnId());
+            SpliceTransactionResourceImpl transactionResource = new SpliceTransactionResourceImpl();
+            boolean prepared = false;
+            try{
+                prepared=transactionResource.marshallTransaction(txn);
+                String roleName=change.getCreateRole().getRoleName();
+                dd.getDataDictionaryCache().roleCacheRemove(roleName);
+            }finally{
+                if(prepared)
+                    transactionResource.close();
+            }
+        } catch (Exception e) {
+            throw StandardException.plainWrapException(e);
+        }
+    }
 
 
     public static void preCreateTrigger(DDLMessage.DDLChange change, DataDictionary dd, DependencyManager dm) throws StandardException  {

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatchRefresher.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatchRefresher.java
@@ -162,9 +162,14 @@ public class DDLWatchRefresher{
         return true;
     }
 
-    public boolean canUseCache(TransactionManager xact_mgr) {
+    public boolean canWriteCache(TransactionManager xact_mgr) {
         return cacheIsValid() && canSeeDDLDemarcationPoint(xact_mgr);
     }
+
+    public boolean canReadCache(TransactionManager xact_mgr) {
+        return canSeeDDLDemarcationPoint(xact_mgr);
+    }
+
 
     /* ****************************************************************************************************************/
     /*private helper methods*/

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatcher.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatcher.java
@@ -71,7 +71,24 @@ public interface DDLWatcher {
 
     void unregisterDDLListener(DDLListener listener);
 
-    boolean canUseCache(TransactionManager xact_mgr);
+    /**
+     *
+     * You cannot write to the cache if there are current ddl transactions
+     * or your txn is behind the state of of the ddl view.
+     *
+     * @param xact_mgr
+     * @return
+     */
+    boolean canWriteCache(TransactionManager xact_mgr);
+
+    /**
+     *
+     * You cannot read from the cache if your txn is behind the state of of the ddl view.
+     *
+     * @param xact_mgr
+     * @return
+     */
+    boolean canReadCache(TransactionManager xact_mgr);
 
     boolean canUseSPSCache(TransactionManager txnMgr);
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/SynchronousDDLWatcher.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/SynchronousDDLWatcher.java
@@ -86,8 +86,13 @@ public class SynchronousDDLWatcher implements DDLWatcher, CommunicationListener{
     }
 
     @Override
-    public boolean canUseCache(TransactionManager xact_mgr){
-        return refresher.canUseCache(xact_mgr);
+    public boolean canWriteCache(TransactionManager xact_mgr){
+        return refresher.canWriteCache(xact_mgr);
+    }
+
+    @Override
+    public boolean canReadCache(TransactionManager xact_mgr){
+        return refresher.canReadCache(xact_mgr);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
@@ -341,6 +341,9 @@ public class SpliceDatabase extends BasicDatabase{
                     case CREATE_TRIGGER:
                         DDLUtils.preCreateTrigger(change,dataDictionary,dependencyManager);
                         break;
+                    case CREATE_ROLE:
+                        DDLUtils.preCreateRole(change,dataDictionary,dependencyManager);
+                        break;
                     case DROP_TRIGGER:
                         DDLUtils.preDropTrigger(change,dataDictionary,dependencyManager);
                         break;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -832,7 +832,7 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
     }
 
     @Override
-    public boolean canUseCache(TransactionController xactMgr) throws StandardException {
+    public boolean canWriteCache(TransactionController xactMgr) throws StandardException {
         // Only enable dictionary cache for region server.
         // TODO - enable it for master and spark executor
         if (!SpliceClient.isRegionServer) {
@@ -844,7 +844,23 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
         DDLWatcher ddlWatcher=driver.ddlWatcher();
         if(xactMgr==null)
             xactMgr = getTransactionCompile();
-        return ddlWatcher.canUseCache((TransactionManager)xactMgr);
+        return ddlWatcher.canWriteCache((TransactionManager)xactMgr);
+    }
+
+    @Override
+    public boolean canReadCache(TransactionController xactMgr) throws StandardException {
+        // Only enable dictionary cache for region server.
+        // TODO - enable it for master and spark executor
+        if (!SpliceClient.isRegionServer) {
+            SpliceLogUtils.debug(LOG, "Cannot use dictionary cache.");
+            return false;
+        }
+        DDLDriver driver=DDLDriver.driver();
+        if(driver==null) return false;
+        DDLWatcher ddlWatcher=driver.ddlWatcher();
+        if(xactMgr==null)
+            xactMgr = getTransactionCompile();
+        return ddlWatcher.canReadCache((TransactionManager)xactMgr);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateRoleConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateRoleConstantOperation.java
@@ -27,6 +27,10 @@ import com.splicemachine.db.iapi.sql.execute.ConstantAction;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.impl.jdbc.authentication.BasicAuthenticationServiceImpl;
 import com.splicemachine.db.shared.common.reference.SQLState;
+import com.splicemachine.ddl.DDLMessage;
+import com.splicemachine.derby.ddl.DDLUtils;
+import com.splicemachine.derby.impl.store.access.SpliceTransactionManager;
+import com.splicemachine.protobuf.ProtoUtil;
 import org.apache.log4j.Logger;
 
 import com.splicemachine.utils.SpliceLogUtils;
@@ -95,6 +99,10 @@ public class CreateRoleConstantOperation extends DDLConstantOperation {
                 newException(SQLState.LANG_OBJECT_ALREADY_EXISTS,
                              "User", roleName);
         }
+
+        DDLMessage.DDLChange change = ProtoUtil.createRole(((SpliceTransactionManager) tc).getActiveStateTxn().getTxnId(), roleName);
+        tc.prepareDataDictionaryChange(DDLUtils.notifyMetadataChange(change));
+
 
         rdDef = ddg.newRoleGrantDescriptor(
             dd.getUUIDFactory().createUUID(),

--- a/splice_machine/src/main/java/com/splicemachine/protobuf/ProtoUtil.java
+++ b/splice_machine/src/main/java/com/splicemachine/protobuf/ProtoUtil.java
@@ -406,6 +406,14 @@ public class ProtoUtil {
                 .build();
     }
 
+    public static DDLChange createRole(long txnId, String roleName) {
+        return DDLChange.newBuilder().setDdlChangeType(DDLChangeType.CREATE_ROLE)
+                .setTxnId(txnId)
+                .setCreateRole(CreateRole.newBuilder().setRoleName(roleName).build())
+                .build();
+    }
+
+
     public static DDLChange createTruncateTable(long txnId, BasicUUID basicUUID) {
         return DDLChange.newBuilder().setDdlChangeType(DDLChangeType.TRUNCATE_TABLE)
                 .setTxnId(txnId)

--- a/splice_protocol/src/main/protobuf/DDL.proto
+++ b/splice_protocol/src/main/protobuf/DDL.proto
@@ -91,6 +91,10 @@ message DropRole {
         optional string roleName = 1;
 }
 
+message CreateRole {
+    optional string roleName = 1;
+}
+
 message TruncateTable {
         optional UUID tableId = 1;
 }
@@ -311,7 +315,7 @@ enum DDLChangeType {
     NOTIFY_JAR_LOADER = 34;
     NOTIFY_MODIFY_CLASSPATH = 35;
     REFRESH_ENTRPRISE_FEATURES = 36;
-
+    CREATE_ROLE = 37;
 }
 
 message DDLChange {
@@ -348,4 +352,5 @@ message DDLChange {
     optional NotifyJarLoader notifyJarLoader = 31;
     optional NotifyModifyClasspath notifyModifyClasspath = 32;
     optional RefreshEnterpriseFeatures refreshEnterpriseFeatures = 33;
+    optional CreateRole createRole = 34;
 }


### PR DESCRIPTION
Fixing Read/Write Cache Mechanism.  Based on this fix, truncate dictionary calls were found to be in the wrong order.