### PR TITLE
SPLICE-1621 Fix select from partitioned orc table error

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecRow.java
@@ -109,9 +109,7 @@ public interface ExecRow extends Row, KeyableRow, org.apache.spark.sql.Row, Comp
 	 */
 	void getNewObjectArray();
 
-	StructType createStructType();
-
-	StructType createStructTypeCorrected(int[] baseColumnMap);
+	StructType createStructType(int[] baseColumnMap);
 
 	org.apache.spark.sql.Row getSparkRow();
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecRow.java
@@ -111,6 +111,8 @@ public interface ExecRow extends Row, KeyableRow, org.apache.spark.sql.Row, Comp
 
 	StructType createStructType();
 
+	StructType createStructTypeCorrected(int[] baseColumnMap);
+
 	org.apache.spark.sql.Row getSparkRow();
 
 	ExecRow fromSparkRow(org.apache.spark.sql.Row row);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexValueRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexValueRow.java
@@ -378,21 +378,8 @@ public class IndexValueRow implements ExecIndexRow, Serializable {
     }
 
 	@Override
-	public StructType createStructType() {
-		try {
-			StructField[] fields = new StructField[length()];
-			for (int i = 0; i < length(); i++) {
-				fields[i] = getColumn(i + 1).getStructField("" + i);
-			}
-			return DataTypes.createStructType(fields);
-		} catch (StandardException se) {
-			throw new RuntimeException(se);
-		}
-	}
-
-	@Override
-	public StructType createStructTypeCorrected(int[] baseColumnMap) {
-		return valueRow.createStructTypeCorrected(baseColumnMap);
+	public StructType createStructType(int[] baseColumnMap) {
+		return valueRow.createStructType(baseColumnMap);
 	}
 
 	@Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexValueRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexValueRow.java
@@ -391,6 +391,11 @@ public class IndexValueRow implements ExecIndexRow, Serializable {
 	}
 
 	@Override
+	public StructType createStructTypeCorrected(int[] baseColumnMap) {
+		return valueRow.createStructTypeCorrected(baseColumnMap);
+	}
+
+	@Override
 	public Row getSparkRow() {
 		return valueRow.getSparkRow();
 	}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
@@ -45,6 +45,7 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.sun.tools.javac.util.Assert;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
@@ -631,6 +632,7 @@ public class ValueRow implements ExecRow, Externalizable {
 		for(int i = 0; i < baseColumnMap.length; i++){
 			if (baseColumnMap[i] != -1){
 				// put the selected columns, designated in baseColumnMap, in field
+				Assert.check(j < fields.length);
 				fields[j] = getColumn(j+1).getStructField(getNamedColumn(i));
 				j++;
 			}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
@@ -623,6 +623,21 @@ public class ValueRow implements ExecRow, Externalizable {
 		}
 		return DataTypes.createStructType(fields);
 	}
+
+	@Override // SPLICE-1621
+	public StructType createStructTypeCorrected(int[] baseColumnMap) {
+		StructField[] fields = new StructField[length()];
+		int j = 0;
+		for(int i = 0; i < baseColumnMap.length; i++){
+			if (baseColumnMap[i] != -1){
+				// put the selected columns, designated in baseColumnMap, in field
+				fields[j] = getColumn(j+1).getStructField(getNamedColumn(i));
+				j++;
+			}
+		}
+		return DataTypes.createStructType(fields);
+	}
+
 	@Override
 	public int compare(ExecRow o1, ExecRow o2) {
 		return o1.compareTo(o2);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
@@ -617,16 +617,7 @@ public class ValueRow implements ExecRow, Externalizable {
 	}
 
 	@Override
-	public StructType createStructType() {
-		StructField[] fields = new StructField[length()];
-		for (int i = 0; i < length(); i++) {
-			fields[i] = getColumn(i + 1).getStructField(getNamedColumn(i));
-		}
-		return DataTypes.createStructType(fields);
-	}
-
-	@Override // SPLICE-1621
-	public StructType createStructTypeCorrected(int[] baseColumnMap) {
+	public StructType createStructType(int[] baseColumnMap) {
 		StructField[] fields = new StructField[length()];
 		int j = 0;
 		for(int i = 0; i < baseColumnMap.length; i++){

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -500,10 +500,10 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         assert baseColumnMap != null:"baseColumnMap Null";
         assert partitionColumnMap != null:"partitionColumnMap Null";
         try {
-            SpliceORCPredicate predicate = new SpliceORCPredicate(qualifiers,baseColumnMap,execRow.createStructType());
+            SpliceORCPredicate predicate = new SpliceORCPredicate(qualifiers,baseColumnMap,execRow.createStructTypeCorrected(baseColumnMap));
             Configuration configuration = new Configuration(HConfiguration.unwrapDelegate());
             configuration.set(SpliceOrcNewInputFormat.SPLICE_PREDICATE,predicate.serialize());
-            configuration.set(SpliceOrcNewInputFormat.SPARK_STRUCT,execRow.createStructType().json());
+            configuration.set(SpliceOrcNewInputFormat.SPARK_STRUCT,execRow.createStructTypeCorrected(baseColumnMap).json());
             configuration.set(SpliceOrcNewInputFormat.SPLICE_COLUMNS,intArrayToString(baseColumnMap));
             configuration.set(SpliceOrcNewInputFormat.SPLICE_PARTITIONS,intArrayToString(partitionColumnMap));
             if (statsjob)

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -500,10 +500,10 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         assert baseColumnMap != null:"baseColumnMap Null";
         assert partitionColumnMap != null:"partitionColumnMap Null";
         try {
-            SpliceORCPredicate predicate = new SpliceORCPredicate(qualifiers,baseColumnMap,execRow.createStructTypeCorrected(baseColumnMap));
+            SpliceORCPredicate predicate = new SpliceORCPredicate(qualifiers,baseColumnMap,execRow.createStructType(baseColumnMap));
             Configuration configuration = new Configuration(HConfiguration.unwrapDelegate());
             configuration.set(SpliceOrcNewInputFormat.SPLICE_PREDICATE,predicate.serialize());
-            configuration.set(SpliceOrcNewInputFormat.SPARK_STRUCT,execRow.createStructTypeCorrected(baseColumnMap).json());
+            configuration.set(SpliceOrcNewInputFormat.SPARK_STRUCT,execRow.createStructType(baseColumnMap).json());
             configuration.set(SpliceOrcNewInputFormat.SPLICE_COLUMNS,intArrayToString(baseColumnMap));
             configuration.set(SpliceOrcNewInputFormat.SPLICE_PARTITIONS,intArrayToString(partitionColumnMap));
             if (statsjob)

--- a/hbase_sql/src/main/java/com/splicemachine/orc/StripeReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/StripeReader.java
@@ -416,8 +416,8 @@ public class StripeReader
         Set<Integer> includes = new LinkedHashSet<>();
 
         OrcType root = types.get(0);
-        for (int includedColumn : includedColumns) {
-            includeOrcColumnsRecursive(types, includes, root.getFieldTypeIndex(includedColumn));
+        for (int i = 0; i < root.getFieldCount(); i++) {
+            includeOrcColumnsRecursive(types, includes, root.getFieldTypeIndex(i));
         }
 
         return includes;

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
@@ -1,0 +1,667 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.impl.sql.execute.operations;
+
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.homeless.TestUtils;
+import org.apache.commons.io.FileUtils;
+import org.junit.*;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import java.io.File;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Created by tgildersleeve on 6/30/17.
+ * SPLICE-1621
+ */
+public class ExternalTablePartitionIT {
+
+    private static final String SCHEMA_NAME = ExternalTableIT.class.getSimpleName().toUpperCase();
+    private static final SpliceWatcher spliceClassWatcher = new SpliceWatcher(SCHEMA_NAME);
+    private static final SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(SCHEMA_NAME);
+
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher(SCHEMA_NAME);
+
+    @ClassRule
+    public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
+            .around(spliceSchemaWatcher);
+
+    @BeforeClass
+    public static void cleanoutDirectory() {
+        try {
+            File file = new File(getExternalResourceDirectory());
+            if (file.exists())
+                FileUtils.deleteDirectory(new File(getExternalResourceDirectory()));
+            file.mkdir();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    @Test
+    public void testParquetNoPartition() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/parquet_no_partition";
+            methodWatcher.executeUpdate(String.format("create external table parquet_no_part (col1 int, col2 int) " +
+                    "STORED AS PARQUET LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into parquet_no_part values (1,1), (2,2)");
+            methodWatcher.executeQuery("select * from parquet_no_part");
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test
+    public void testAvroNoPartition() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/avro_no_partition";
+            methodWatcher.executeUpdate(String.format("create external table avro_no_part (col1 int, col2 int) " +
+                    "STORED AS AVRO LOCATION '%s'",tablePath));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test
+    public void testOrcNoPartition() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/orc_no_partition";
+            methodWatcher.executeUpdate(String.format("create external table orc_no_part (col1 int, col2 int) " +
+                    "STORED AS ORC LOCATION '%s'",tablePath));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test
+    public void testTextfileNoPartition() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/textfile_no_partition";
+            methodWatcher.executeUpdate(String.format("create external table textfile_no_part (col1 int, col2 int) " +
+                    "STORED AS TEXTFILE LOCATION '%s'",tablePath));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test
+    public void testParquetPartitionOneCol() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/parquet_one_col_partition";
+            methodWatcher.executeUpdate(String.format("create external table parquet_one_col (col1 int) partitioned by (col1) " +
+                    "STORED AS PARQUET LOCATION '%s'",tablePath));
+        } catch (SQLException e) {
+            Assert.assertEquals("Wrong Exception","XJ001",e.getSQLState());
+            Assert.assertTrue("Wrong Exception", e.getMessage().contains("EXT11"));
+        }
+    }
+
+    @Test
+    public void testAvroPartitionOneCol() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/avro_one_col_partition";
+            methodWatcher.executeUpdate(String.format("create external table avro_one_col (col1 int) partitioned by (col1) " +
+                    "STORED AS AVRO LOCATION '%s'",tablePath));
+        } catch (SQLException e) {
+            Assert.assertEquals("Wrong Exception","XJ001",e.getSQLState());
+            Assert.assertTrue("Wrong Exception", e.getMessage().contains("EXT11"));
+        }
+    }
+
+    @Test
+    public void testOrcPartitionOneCol() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/orc_one_col_partition";
+            methodWatcher.executeUpdate(String.format("create external table orc_one_col (col1 int) partitioned by (col1) " +
+                    "STORED AS ORC LOCATION '%s'",tablePath));
+        } catch (SQLException e) {
+            Assert.assertEquals("Wrong Exception","XJ001",e.getSQLState());
+            Assert.assertTrue("Wrong Exception", e.getMessage().contains("EXT11"));
+        }
+    }
+
+    @Test
+    public void testTextfilePartitionOneCol() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/textfile_one_col_partition";
+            methodWatcher.executeUpdate(String.format("create external table textfile_one_col (col1 int) partitioned by (col1) " +
+                    "STORED AS TEXTFILE LOCATION '%s'",tablePath));
+        } catch (SQLException e) {
+            Assert.assertEquals("Wrong Exception","XJ001",e.getSQLState());
+            Assert.assertTrue("Wrong Exception", e.getMessage().contains("EXT11"));
+        }
+    }
+
+    @Test @Ignore // SPLICE-1764
+    public void testParquetPartitionFirst2() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/parquet_partition_first2";
+            methodWatcher.executeUpdate(String.format("create external table parquet_part_1st_2 (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col1) STORED AS PARQUET LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into parquet_part_1st_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_1st_2");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_1st_2");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_1st_2");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_1st_2");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_1st_2");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test @Ignore // SPLICE-1765
+    public void testAvroPartitionFirst2() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/avro_partition_first2";
+            methodWatcher.executeUpdate(String.format("create external table avro_part_1st_2 (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col1) STORED AS AVRO LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into avro_part_1st_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from avro_part_1st_2");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_1st_2");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_1st_2");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_1st_2");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_1st_2");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test
+    public void testOrcPartitionFirst2() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/orc_partition_first2";
+            methodWatcher.executeUpdate(String.format("create external table orc_part_1st_2 (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col1) STORED AS ORC LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into orc_part_1st_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from orc_part_1st_2");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_1st_2");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_1st_2");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_1st_2");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_1st_2");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test
+    public void testTextfilePartitionFirst2() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/textfile_partition_first2";
+            methodWatcher.executeUpdate(String.format("create external table textfile_part_1st_2 (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col1) STORED AS TEXTFILE LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into textfile_part_1st_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_1st_2");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_1st_2");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_1st_2");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_1st_2");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_1st_2");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test @Ignore // SPLICE-1764
+    public void testParquetPartitionSecond2() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/parquet_partition_second_2";
+            methodWatcher.executeUpdate(String.format("create external table parquet_part_2nd_2 (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col2) STORED AS PARQUET LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into parquet_part_2nd_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_2nd_2");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_2nd_2");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_2nd_2");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_2nd_2");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_2nd_2");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+
+    @Test @Ignore // SPLICE-1765
+    public void testAvroPartitionSecond2() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/avro_partition_second_2";
+            methodWatcher.executeUpdate(String.format("create external table avro_part_2nd_2 (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col2) STORED AS AVRO LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into avro_part_2nd_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from avro_part_2nd_2");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_2nd_2");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_2nd_2");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_2nd_2");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_2nd_2");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+
+    @Test
+    public void testOrcPartitionSecond2() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/orc_partition_second_2";
+            methodWatcher.executeUpdate(String.format("create external table orc_part_2nd_2 (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col2) STORED AS ORC LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into orc_part_2nd_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from orc_part_2nd_2");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_2nd_2");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_2nd_2");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_2nd_2");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_2nd_2");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+
+    @Test
+    public void testTextfilePartitionSecond2() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/textfile_partition_second_2";
+            methodWatcher.executeUpdate(String.format("create external table textfile_part_2nd_2 (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col2) STORED AS TEXTFILE LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into textfile_part_2nd_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_2nd_2");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_2nd_2");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_2nd_2");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_2nd_2");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_2nd_2");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test
+    public void testParquetPartitionLast2() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/parquet_partition_last_2";
+            methodWatcher.executeUpdate(String.format("create external table parquet_part_last_2 (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col3) STORED AS PARQUET LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into parquet_part_last_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_last_2");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_last_2");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_last_2");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_last_2");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_last_2");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+
+    @Test
+    public void testAvroPartitionLast2() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/avro_partition_last_2";
+            methodWatcher.executeUpdate(String.format("create external table avro_part_last_2 (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col3) STORED AS AVRO LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into avro_part_last_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from avro_part_last_2");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_last_2");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_last_2");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_last_2");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_last_2");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test
+    public void testOrcPartitionLast2() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/orc_partition_last_2";
+            methodWatcher.executeUpdate(String.format("create external table orc_part_last_2 (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col3) STORED AS ORC LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into orc_part_last_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from orc_part_last_2");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_last_2");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_last_2");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_last_2");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_last_2");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test
+    public void testTextfilePartitionLast2() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/textfile_partition_last_2";
+            methodWatcher.executeUpdate(String.format("create external table textfile_part_last_2 (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col3) STORED AS TEXTFILE LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into textfile_part_last_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_last_2");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_last_2");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_last_2");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_last_2");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_last_2");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    public static String getExternalResourceDirectory() {
+        return SpliceUnitTest.getHBaseDirectory()+"/target/external/";
+    }
+
+}

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
@@ -153,37 +153,37 @@ public class ExternalTablePartitionIT {
     }
 
     @Test @Ignore // SPLICE-1764
-    public void testParquetPartitionFirst2() throws Exception {
+    public void testParquetPartitionFirst() throws Exception {
         try {
-            String tablePath = getExternalResourceDirectory()+"/parquet_partition_first2";
-            methodWatcher.executeUpdate(String.format("create external table parquet_part_1st_2 (col1 int, col2 int, col3 varchar(10)) " +
+            String tablePath = getExternalResourceDirectory()+"/parquet_partition_first";
+            methodWatcher.executeUpdate(String.format("create external table parquet_part_1st (col1 int, col2 int, col3 varchar(10)) " +
                     "partitioned by (col1) STORED AS PARQUET LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("insert into parquet_part_1st_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-            ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_1st_2");
+            methodWatcher.executeUpdate("insert into parquet_part_1st values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_1st");
             Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-            ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_1st_2");
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_1st");
             Assert.assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-            ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_1st_2");
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_1st");
             Assert.assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-            ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_1st_2");
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_1st");
             Assert.assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_1st_2");
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_1st");
             Assert.assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
@@ -193,39 +193,40 @@ public class ExternalTablePartitionIT {
             Assert.fail("An exception should not be thrown");
         }
     }
+
 
     @Test @Ignore // SPLICE-1765
-    public void testAvroPartitionFirst2() throws Exception {
+    public void testAvroPartitionFirst() throws Exception {
         try {
-            String tablePath = getExternalResourceDirectory()+"/avro_partition_first2";
-            methodWatcher.executeUpdate(String.format("create external table avro_part_1st_2 (col1 int, col2 int, col3 varchar(10)) " +
+            String tablePath = getExternalResourceDirectory()+"/avro_partition_first";
+            methodWatcher.executeUpdate(String.format("create external table avro_part_1st_ (col1 int, col2 int, col3 varchar(10)) " +
                     "partitioned by (col1) STORED AS AVRO LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("insert into avro_part_1st_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-            ResultSet rs = methodWatcher.executeQuery("select * from avro_part_1st_2");
+            methodWatcher.executeUpdate("insert into avro_part_1st values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from avro_part_1st");
             Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-            ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_1st_2");
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_1st");
             Assert.assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-            ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_1st_2");
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_1st");
             Assert.assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-            ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_1st_2");
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_1st");
             Assert.assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_1st_2");
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_1st");
             Assert.assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
@@ -237,37 +238,37 @@ public class ExternalTablePartitionIT {
     }
 
     @Test
-    public void testOrcPartitionFirst2() throws Exception {
+    public void testOrcPartitionFirst() throws Exception {
         try {
-            String tablePath = getExternalResourceDirectory()+"/orc_partition_first2";
-            methodWatcher.executeUpdate(String.format("create external table orc_part_1st_2 (col1 int, col2 int, col3 varchar(10)) " +
+            String tablePath = getExternalResourceDirectory()+"/orc_partition_first";
+            methodWatcher.executeUpdate(String.format("create external table orc_part_1st (col1 int, col2 int, col3 varchar(10)) " +
                     "partitioned by (col1) STORED AS ORC LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("insert into orc_part_1st_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-            ResultSet rs = methodWatcher.executeQuery("select * from orc_part_1st_2");
+            methodWatcher.executeUpdate("insert into orc_part_1st values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from orc_part_1st");
             Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-            ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_1st_2");
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_1st");
             Assert.assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-            ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_1st_2");
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_1st");
             Assert.assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-            ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_1st_2");
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_1st");
             Assert.assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_1st_2");
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_1st");
             Assert.assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
@@ -279,37 +280,37 @@ public class ExternalTablePartitionIT {
     }
 
     @Test
-    public void testTextfilePartitionFirst2() throws Exception {
+    public void testTextfilePartitionFirst() throws Exception {
         try {
-            String tablePath = getExternalResourceDirectory()+"/textfile_partition_first2";
-            methodWatcher.executeUpdate(String.format("create external table textfile_part_1st_2 (col1 int, col2 int, col3 varchar(10)) " +
+            String tablePath = getExternalResourceDirectory()+"/textfile_partition_first";
+            methodWatcher.executeUpdate(String.format("create external table textfile_part_1st (col1 int, col2 int, col3 varchar(10)) " +
                     "partitioned by (col1) STORED AS TEXTFILE LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("insert into textfile_part_1st_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-            ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_1st_2");
+            methodWatcher.executeUpdate("insert into textfile_part_1st values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_1st");
             Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-            ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_1st_2");
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_1st");
             Assert.assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-            ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_1st_2");
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_1st");
             Assert.assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-            ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_1st_2");
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_1st");
             Assert.assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_1st_2");
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_1st");
             Assert.assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
@@ -321,37 +322,37 @@ public class ExternalTablePartitionIT {
     }
 
     @Test @Ignore // SPLICE-1764
-    public void testParquetPartitionSecond2() throws Exception {
+    public void testParquetPartitionFirstSecond() throws Exception {
         try {
-            String tablePath = getExternalResourceDirectory()+"/parquet_partition_second_2";
-            methodWatcher.executeUpdate(String.format("create external table parquet_part_2nd_2 (col1 int, col2 int, col3 varchar(10)) " +
-                    "partitioned by (col2) STORED AS PARQUET LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("insert into parquet_part_2nd_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-            ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_2nd_2");
+            String tablePath = getExternalResourceDirectory()+"/parquet_partition_first_second";
+            methodWatcher.executeUpdate(String.format("create external table parquet_part_1st_2nd (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col1,col2) STORED AS PARQUET LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into parquet_part_1st_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_1st_2nd");
             Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-            ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_2nd_2");
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_1st_2nd");
             Assert.assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-            ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_2nd_2");
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_1st_2nd");
             Assert.assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-            ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_2nd_2");
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_1st_2nd");
             Assert.assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_2nd_2");
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_1st_2nd");
             Assert.assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
@@ -361,40 +362,207 @@ public class ExternalTablePartitionIT {
             Assert.fail("An exception should not be thrown");
         }
     }
-
 
     @Test @Ignore // SPLICE-1765
-    public void testAvroPartitionSecond2() throws Exception {
+    public void testAvroPartitionFirstSecond() throws Exception {
         try {
-            String tablePath = getExternalResourceDirectory()+"/avro_partition_second_2";
+            String tablePath = getExternalResourceDirectory()+"/avro_partition_first_second";
+            methodWatcher.executeUpdate(String.format("create external table avro_part_1st_2nd (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col1,col2) STORED AS AVRO LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into avro_part_1st_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from avro_part_1st_2nd");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_1st_2nd");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_1st_2nd");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_1st_2nd");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_1st_2nd");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test
+    public void testOrcPartitionFirstSecond() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/orc_partition_first_second";
+            methodWatcher.executeUpdate(String.format("create external table orc_part_1st_2nd (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col1,col2) STORED AS ORC LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into orc_part_1st_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from orc_part_1st_2nd");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_1st_2nd");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_1st_2nd");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_1st_2nd");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_1st_2nd");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test
+    public void testTextfilePartitionFirstSecond() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/textfile_partition_first_second";
+            methodWatcher.executeUpdate(String.format("create external table textfile_part_1st_2nd (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col1,col2) STORED AS TEXTFILE LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into textfile_part_1st_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_1st_2nd");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_1st_2nd");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_1st_2nd");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_1st_2nd");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_1st_2nd");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test @Ignore // SPLICE-1764
+    public void testParquetPartitionSecond() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/parquet_partition_second";
+            methodWatcher.executeUpdate(String.format("create external table parquet_part_2nd (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col2) STORED AS PARQUET LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into parquet_part_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_2nd");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_2nd");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_2nd");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_2nd");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_2nd");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test @Ignore // SPLICE-1765
+    public void testAvroPartitionSecond() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/avro_partition_second";
             methodWatcher.executeUpdate(String.format("create external table avro_part_2nd_2 (col1 int, col2 int, col3 varchar(10)) " +
                     "partitioned by (col2) STORED AS AVRO LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("insert into avro_part_2nd_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-            ResultSet rs = methodWatcher.executeQuery("select * from avro_part_2nd_2");
+            methodWatcher.executeUpdate("insert into avro_part_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from avro_part_2nd");
             Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-            ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_2nd_2");
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_2nd");
             Assert.assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-            ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_2nd_2");
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_2nd");
             Assert.assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-            ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_2nd_2");
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_2nd");
             Assert.assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_2nd_2");
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_2nd");
             Assert.assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
@@ -407,37 +575,37 @@ public class ExternalTablePartitionIT {
 
 
     @Test
-    public void testOrcPartitionSecond2() throws Exception {
+    public void testOrcPartitionSecond() throws Exception {
         try {
-            String tablePath = getExternalResourceDirectory()+"/orc_partition_second_2";
-            methodWatcher.executeUpdate(String.format("create external table orc_part_2nd_2 (col1 int, col2 int, col3 varchar(10)) " +
+            String tablePath = getExternalResourceDirectory()+"/orc_partition_second";
+            methodWatcher.executeUpdate(String.format("create external table orc_part_2nd (col1 int, col2 int, col3 varchar(10)) " +
                     "partitioned by (col2) STORED AS ORC LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("insert into orc_part_2nd_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-            ResultSet rs = methodWatcher.executeQuery("select * from orc_part_2nd_2");
+            methodWatcher.executeUpdate("insert into orc_part_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from orc_part_2nd");
             Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-            ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_2nd_2");
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_2nd");
             Assert.assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-            ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_2nd_2");
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_2nd");
             Assert.assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-            ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_2nd_2");
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_2nd");
             Assert.assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_2nd_2");
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_2nd");
             Assert.assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
@@ -450,37 +618,37 @@ public class ExternalTablePartitionIT {
 
 
     @Test
-    public void testTextfilePartitionSecond2() throws Exception {
+    public void testTextfilePartitionSecond() throws Exception {
         try {
-            String tablePath = getExternalResourceDirectory()+"/textfile_partition_second_2";
-            methodWatcher.executeUpdate(String.format("create external table textfile_part_2nd_2 (col1 int, col2 int, col3 varchar(10)) " +
+            String tablePath = getExternalResourceDirectory()+"/textfile_partition_second_";
+            methodWatcher.executeUpdate(String.format("create external table textfile_part_2nd (col1 int, col2 int, col3 varchar(10)) " +
                     "partitioned by (col2) STORED AS TEXTFILE LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("insert into textfile_part_2nd_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-            ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_2nd_2");
+            methodWatcher.executeUpdate("insert into textfile_part_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_2nd");
             Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-            ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_2nd_2");
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_2nd");
             Assert.assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-            ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_2nd_2");
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_2nd");
             Assert.assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-            ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_2nd_2");
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_2nd");
             Assert.assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_2nd_2");
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_2nd");
             Assert.assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
@@ -492,37 +660,37 @@ public class ExternalTablePartitionIT {
     }
 
     @Test
-    public void testParquetPartitionLast2() throws Exception {
+    public void testParquetPartitionLast() throws Exception {
         try {
-            String tablePath = getExternalResourceDirectory()+"/parquet_partition_last_2";
-            methodWatcher.executeUpdate(String.format("create external table parquet_part_last_2 (col1 int, col2 int, col3 varchar(10)) " +
+            String tablePath = getExternalResourceDirectory()+"/parquet_partition_last";
+            methodWatcher.executeUpdate(String.format("create external table parquet_part_last (col1 int, col2 int, col3 varchar(10)) " +
                     "partitioned by (col3) STORED AS PARQUET LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("insert into parquet_part_last_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-            ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_last_2");
+            methodWatcher.executeUpdate("insert into parquet_part_last values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_last");
             Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-            ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_last_2");
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_last");
             Assert.assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-            ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_last_2");
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_last");
             Assert.assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-            ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_last_2");
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_last");
             Assert.assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_last_2");
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_last");
             Assert.assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
@@ -535,37 +703,37 @@ public class ExternalTablePartitionIT {
 
 
     @Test
-    public void testAvroPartitionLast2() throws Exception {
+    public void testAvroPartitionLast() throws Exception {
         try {
-            String tablePath = getExternalResourceDirectory()+"/avro_partition_last_2";
-            methodWatcher.executeUpdate(String.format("create external table avro_part_last_2 (col1 int, col2 int, col3 varchar(10)) " +
+            String tablePath = getExternalResourceDirectory()+"/avro_partition_last";
+            methodWatcher.executeUpdate(String.format("create external table avro_part_last (col1 int, col2 int, col3 varchar(10)) " +
                     "partitioned by (col3) STORED AS AVRO LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("insert into avro_part_last_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-            ResultSet rs = methodWatcher.executeQuery("select * from avro_part_last_2");
+            methodWatcher.executeUpdate("insert into avro_part_last values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from avro_part_last");
             Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-            ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_last_2");
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_last");
             Assert.assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-            ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_last_2");
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_last");
             Assert.assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-            ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_last_2");
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_last");
             Assert.assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_last_2");
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_last");
             Assert.assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
@@ -577,37 +745,37 @@ public class ExternalTablePartitionIT {
     }
 
     @Test
-    public void testOrcPartitionLast2() throws Exception {
+    public void testOrcPartitionLast() throws Exception {
         try {
-            String tablePath = getExternalResourceDirectory()+"/orc_partition_last_2";
-            methodWatcher.executeUpdate(String.format("create external table orc_part_last_2 (col1 int, col2 int, col3 varchar(10)) " +
+            String tablePath = getExternalResourceDirectory()+"/orc_partition_last";
+            methodWatcher.executeUpdate(String.format("create external table orc_part_last (col1 int, col2 int, col3 varchar(10)) " +
                     "partitioned by (col3) STORED AS ORC LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("insert into orc_part_last_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-            ResultSet rs = methodWatcher.executeQuery("select * from orc_part_last_2");
+            methodWatcher.executeUpdate("insert into orc_part_last values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from orc_part_last");
             Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-            ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_last_2");
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_last");
             Assert.assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-            ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_last_2");
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_last");
             Assert.assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-            ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_last_2");
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_last");
             Assert.assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_last_2");
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_last");
             Assert.assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
@@ -619,37 +787,37 @@ public class ExternalTablePartitionIT {
     }
 
     @Test
-    public void testTextfilePartitionLast2() throws Exception {
+    public void testTextfilePartitionLast() throws Exception {
         try {
-            String tablePath = getExternalResourceDirectory()+"/textfile_partition_last_2";
-            methodWatcher.executeUpdate(String.format("create external table textfile_part_last_2 (col1 int, col2 int, col3 varchar(10)) " +
+            String tablePath = getExternalResourceDirectory()+"/textfile_partition_last";
+            methodWatcher.executeUpdate(String.format("create external table textfile_part_last (col1 int, col2 int, col3 varchar(10)) " +
                     "partitioned by (col3) STORED AS TEXTFILE LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("insert into textfile_part_last_2 values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-            ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_last_2");
+            methodWatcher.executeUpdate("insert into textfile_part_last values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_last");
             Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-            ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_last_2");
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_last");
             Assert.assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-            ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_last_2");
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_last");
             Assert.assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-            ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_last_2");
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_last");
             Assert.assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_last_2");
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_last");
             Assert.assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
@@ -659,6 +827,175 @@ public class ExternalTablePartitionIT {
             Assert.fail("An exception should not be thrown");
         }
     }
+
+    @Test @Ignore // SPLICE-1764
+    public void testParquetPartitionThirdSecond() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/parquet_partition_third_second";
+            methodWatcher.executeUpdate(String.format("create external table parquet_part_3rd_2nd (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col3,col2) STORED AS PARQUET LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into parquet_part_3rd_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_3rd_2nd");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_3rd_2nd");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_3rd_2nd");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_3rd_2nd");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_3rd_2nd");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test @Ignore // SPLICE-1765
+    public void testAvroPartitionThirdSecond() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/avro_partition_third_second";
+            methodWatcher.executeUpdate(String.format("create external table avro_part_3rd_2nd (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col3,col2) STORED AS AVRO LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into avro_part_3rd_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from avro_part_3rd_2nd");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_3rd_2nd");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_3rd_2nd");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_3rd_2nd");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_3rd_2nd");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test
+    public void testOrcPartitionThirdSecond() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/orc_partition_third_second";
+            methodWatcher.executeUpdate(String.format("create external table orc_part_3rd_2nd (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col3,col2) STORED AS ORC LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into orc_part_3rd_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from orc_part_3rd_2nd");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_3rd_2nd");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_3rd_2nd");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_3rd_2nd");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_3rd_2nd");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+    @Test
+    public void testTextfilePartitionThirdSecond() throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/textfile_partition_third_second";
+            methodWatcher.executeUpdate(String.format("create external table textfile_part_3rd_2nd (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col3,col2) STORED AS TEXTFILE LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate("insert into textfile_part_3rd_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+            ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_3rd_2nd");
+            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+                    "------------------\n" +
+                    "  1  |  2  | AAA |\n" +
+                    "  3  |  4  | BBB |\n" +
+                    "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_3rd_2nd");
+            Assert.assertEquals("COL1 |\n" +
+                    "------\n" +
+                    "  1  |\n" +
+                    "  3  |\n" +
+                    "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
+            ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_3rd_2nd");
+            Assert.assertEquals("COL2 |\n" +
+                    "------\n" +
+                    "  2  |\n" +
+                    "  4  |\n" +
+                    "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_3rd_2nd");
+            Assert.assertEquals("COL3 |\n" +
+                    "------\n" +
+                    " AAA |\n" +
+                    " BBB |\n" +
+                    " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
+            ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_3rd_2nd");
+            Assert.assertEquals("COL2 |COL3 |\n" +
+                    "------------\n" +
+                    "  2  | AAA |\n" +
+                    "  4  | BBB |\n" +
+                    "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
 
     public static String getExternalResourceDirectory() {
         return SpliceUnitTest.getHBaseDirectory()+"/target/external/";


### PR DESCRIPTION
previously, selecting columns from a partitioned orc table would throw an error if it was partitioned by any column other than the last. in ValueRow, createStructType() could return columns that weren't selected. OrcRecordReader had some index issues where the partitioned column would be listed last in the query results, and the true last column would be chopped off.