### PR TITLE
DB-5934: restore a chain of backup

### DIFF
--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -1960,6 +1960,7 @@ public interface SQLState {
 	String PARENT_BACKUP_MISSING                                   = "BR013";
 	String EXISTS_CONCURRENT_BACKUP                                = "BR014";
 	String BACKUP_TIMEOUT                                          = "BR016";
+	String INCOMPATIBLE_BACKUP                                     = "BR017";
 
 
 	String ROW_FORMAT_NOT_ALLOWED_WITH_PARQUET					   	= "EXT01";

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -1961,7 +1961,8 @@ public interface SQLState {
 	String EXISTS_CONCURRENT_BACKUP                                = "BR014";
 	String BACKUP_TIMEOUT                                          = "BR016";
 	String INCOMPATIBLE_BACKUP                                     = "BR017";
-
+	String MISSING_BACKUP                                          = "BR018";
+	String BACKUP_NOT_IN_CHAIN                                     = "BR019";
 
 	String ROW_FORMAT_NOT_ALLOWED_WITH_PARQUET					   	= "EXT01";
 	String ROW_FORMAT_NOT_ALLOWED_WITH_ORC						   	= "EXT02";

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -8902,6 +8902,10 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
                <arg>regionName</arg>
            </msg>
            <msg>
+               <name>BR017</name>
+               <text>Incompatible backup. Please follow Splice Machine documentation to modify the backup.</text>
+           </msg>
+           <msg>
                <name>EXT01</name>
                <text>row format specification not allowed with 'stored as parquet' </text>
            </msg>

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -8906,6 +8906,16 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
                <text>Incompatible backup. Please follow Splice Machine documentation to modify the backup.</text>
            </msg>
            <msg>
+               <name>BR018</name>
+               <text>Incremental Backup(s) {0} is(are) not included.</text>
+               <arg>backupIds</arg>
+           </msg>
+           <msg>
+               <name>BR019</name>
+               <text>Backup(s) {0} is(are) not valid incremental parent backup(s)</text>
+               <arg>backupIds</arg>
+           </msg>
+           <msg>
                <name>EXT01</name>
                <text>row format specification not allowed with 'stored as parquet' </text>
            </msg>

--- a/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -167,7 +167,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit(): %s", regionName);
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
         isSplitting.set(true);
@@ -177,7 +177,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit(): %s", regionName);
         super.postRollBackSplit(ctx);
         isSplitting.set(false);
 
@@ -186,7 +186,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postCompleteSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit(): %s", regionName);
         super.postCompleteSplit(ctx);
         isSplitting.set(false);
     }
@@ -205,12 +205,17 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
         isCompacting.set(false);
+        if (LOG.isDebugEnabled()) {
+            String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+            SpliceLogUtils.debug(LOG, "Compaction result file %s", filePath);
+        }
+
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s", regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
@@ -221,7 +226,8 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+        SpliceLogUtils.info(LOG, "Flushing store file %s", filePath);
         try {
             if (!BackupUtils.isSpliceTable(namespace, tableName))
                 return;
@@ -234,7 +240,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        SpliceLogUtils.info(LOG, "Flushed region %s.%s", tableName, regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
         super.postFlush(e);

--- a/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -167,7 +167,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit(): %s", regionName);
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
         isSplitting.set(true);
@@ -177,7 +177,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit(): %s", regionName);
         super.postRollBackSplit(ctx);
         isSplitting.set(false);
 
@@ -186,7 +186,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postCompleteSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit(): %s", regionName);
         super.postCompleteSplit(ctx);
         isSplitting.set(false);
     }
@@ -205,12 +205,16 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
         isCompacting.set(false);
+        if (LOG.isDebugEnabled()) {
+            String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+            SpliceLogUtils.debug(LOG, "Compaction result file %s", filePath);
+        }
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s", regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
@@ -221,7 +225,8 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+        SpliceLogUtils.info(LOG, "Flushing store file %s", filePath);
         try {
             if (!BackupUtils.isSpliceTable(namespace, tableName))
                 return;

--- a/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -167,7 +167,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit(): %s", regionName);
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
         isSplitting.set(true);
@@ -177,7 +177,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit(): %s", regionName);
         super.postRollBackSplit(ctx);
         isSplitting.set(false);
 
@@ -186,7 +186,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postCompleteSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit(): %s", regionName);
         super.postCompleteSplit(ctx);
         isSplitting.set(false);
     }
@@ -205,12 +205,16 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
         isCompacting.set(false);
+        if (LOG.isDebugEnabled()) {
+            String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+            SpliceLogUtils.debug(LOG, "Compaction result file %s", filePath);
+        }
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s", regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
@@ -221,7 +225,8 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+        SpliceLogUtils.info(LOG, "Flushing store file %s", filePath);
         try {
             if (!BackupUtils.isSpliceTable(namespace, tableName))
                 return;

--- a/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -167,7 +167,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit(): %s", regionName);
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
         isSplitting.set(true);
@@ -177,7 +177,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit(): %s", regionName);
         super.postRollBackSplit(ctx);
         isSplitting.set(false);
 
@@ -186,7 +186,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postCompleteSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit(): %s", regionName);
         super.postCompleteSplit(ctx);
         isSplitting.set(false);
     }
@@ -205,12 +205,16 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
         isCompacting.set(false);
+        if (LOG.isDebugEnabled()) {
+            String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+            SpliceLogUtils.debug(LOG, "Compaction result file %s", filePath);
+        }
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s", regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
@@ -221,7 +225,8 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+        SpliceLogUtils.info(LOG, "Flushing store file %s", filePath);
         try {
             if (!BackupUtils.isSpliceTable(namespace, tableName))
                 return;

--- a/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -167,7 +167,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit(): %s", regionName);
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
         isSplitting.set(true);
@@ -177,7 +177,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit(): %s", regionName);
         super.postRollBackSplit(ctx);
         isSplitting.set(false);
 
@@ -186,7 +186,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postCompleteSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit(): %s", regionName);
         super.postCompleteSplit(ctx);
         isSplitting.set(false);
     }
@@ -205,12 +205,16 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
         isCompacting.set(false);
+        if (LOG.isDebugEnabled()) {
+            String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+            SpliceLogUtils.debug(LOG, "Compaction result file %s", filePath);
+        }
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s", regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
@@ -221,7 +225,8 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+        SpliceLogUtils.info(LOG, "Flushing store file %s", filePath);
         try {
             if (!BackupUtils.isSpliceTable(namespace, tableName))
                 return;
@@ -234,7 +239,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        SpliceLogUtils.info(LOG, "Flushed region %s.%s", tableName, regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
         super.postFlush(e);

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/BackupBaseRegionObserver.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/BackupBaseRegionObserver.java
@@ -16,6 +16,7 @@ package com.splicemachine.hbase;
 
 import com.google.common.collect.ImmutableList;
 import com.splicemachine.coprocessor.SpliceMessage;
+import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
@@ -36,6 +37,7 @@ import org.apache.hadoop.hbase.regionserver.wal.HLogKey;
 import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.hadoop.hbase.wal.WALKey;
+import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
@@ -45,6 +47,8 @@ import java.util.NavigableSet;
  * Created by jyuan on 2/18/16.
  */
 public abstract class BackupBaseRegionObserver extends SpliceMessage.BackupCoprocessorService implements RegionObserver {
+
+    private static final Logger LOG=Logger.getLogger(BackupBaseRegionObserver.class);
 
     public void start(CoprocessorEnvironment e) throws IOException {
     }
@@ -106,6 +110,13 @@ public abstract class BackupBaseRegionObserver extends SpliceMessage.BackupCopro
     }
 
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
+        HRegion region = (HRegion) ((RegionCoprocessorEnvironment) e).getRegion();
+        if (LOG.isDebugEnabled()) {
+            SpliceLogUtils.debug(LOG, "split %s:%s into %s and %s",
+                    region.getRegionInfo().getTable().getNameAsString(),
+                    region.getRegionInfo().getEncodedName(), l.getRegionInfo().getEncodedName(),
+                    r.getRegionInfo().getEncodedName());
+        }
     }
 
     public void preCompactSelection(ObserverContext<RegionCoprocessorEnvironment> c, Store store, List<StoreFile> candidates) throws IOException {

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/BackupUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/BackupUtils.java
@@ -27,15 +27,12 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.regionserver.HBasePlatformUtils;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.zookeeper.RecoverableZooKeeper;
 import org.apache.log4j.Logger;
-import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.ZooDefs;
 
 import java.io.IOException;
 import java.sql.Timestamp;
@@ -174,13 +171,14 @@ public class BackupUtils {
             RecoverableZooKeeper zooKeeper = ZkUtils.getRecoverableZooKeeper();
             String spliceBackupPath = HConfiguration.getConfiguration().getBackupPath();
             if (zooKeeper.exists(spliceBackupPath, false) != null) {
-                byte[] backupType = ZkUtils.getData(spliceBackupPath);
-                if (Bytes.compareTo(backupType, BackupRestoreConstants.BACKUP_TYPE_FULL_BYTES) == 0) {
+                byte[] data = ZkUtils.getData(spliceBackupPath);
+                BackupJobStatus backupJobStatus = BackupJobStatus.parseFrom(data);
+                if (!backupJobStatus.isIncremental()) {
                     if (!preparing && zooKeeper.exists(path, false) != null) {
                         byte[] status = ZkUtils.getData(path);
                         if (Bytes.compareTo(status, HConfiguration.BACKUP_DONE) == 0) {
                             if (LOG.isDebugEnabled()) {
-                                SpliceLogUtils.debug(LOG, "Table %s is in full backup", tableName);
+                                SpliceLogUtils.debug(LOG, "%s is in full backup", path);
                                 SpliceLogUtils.debug(LOG, "Region %s:%s has just finished full backup", tableName,
                                         region.getRegionInfo().getEncodedName());
                             }
@@ -189,11 +187,17 @@ public class BackupUtils {
                     }
                 }
                 else {
+                    if (LOG.isDebugEnabled()) {
+                        SpliceLogUtils.debug(LOG, "%s is in incremental backup", path);
+                    }
                     shouldRegister = true;
                 }
 
             }
             else if (BackupUtils.existsDatabaseBackup(fs, rootDir)) {
+                if (LOG.isDebugEnabled()) {
+                    SpliceLogUtils.debug(LOG, "There exists a full or incremental backup");
+                }
                 shouldRegister = true;
             }
             if (shouldRegister) {

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceHFileCleaner.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceHFileCleaner.java
@@ -15,6 +15,7 @@
 package com.splicemachine.hbase;
 
 import com.splicemachine.access.HConfiguration;
+import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -49,8 +50,19 @@ public class SpliceHFileCleaner extends BaseHFileCleanerDelegate {
             */
             if (BackupUtils.existsDatabaseBackup(fs, rootDir)) {
                 String p = BackupUtils.getBackupFilePath(fStat.getPath().toString());
-                if (fs.exists(new Path(p)))
+                if (fs.exists(new Path(p))) {
+                    if (LOG.isDebugEnabled()) {
+                        SpliceLogUtils.debug(LOG, "File %s should be kept for incremental backup",
+                                fStat.getPath().toString());
+                    }
                     deletable = false;
+                }
+                else {
+                    if (LOG.isDebugEnabled()) {
+                        SpliceLogUtils.debug(LOG, "File %s can be removed",
+                                fStat.getPath().toString());
+                    }
+                }
             }
         }
         catch(Exception e) {

--- a/hbase_sql/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
+++ b/hbase_sql/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
@@ -186,8 +186,8 @@ class SpliceTestPlatformConfig {
         config.setFloat("hfile.block.cache.size", 0.25f); // set block cache to 25% of heap
         config.setFloat("io.hfile.bloom.error.rate", (float) 0.005);
         config.setBoolean(CacheConfig.CACHE_BLOOM_BLOCKS_ON_WRITE_KEY, true); // hfile.block.bloom.cacheonwrite
-        //config.set("hbase.master.hfilecleaner.plugins", getHFileCleanerAsString());
         config.set("hbase.master.hfilecleaner.plugins", getHFileCleanerAsString());
+        config.setInt("hbase.mapreduce.bulkload.max.hfiles.perRegion.perFamily", 1024);
         //
         // Misc
         //

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/server/SICompactionState.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/server/SICompactionState.java
@@ -141,6 +141,12 @@ public class SICompactionState {
      */
     private boolean mutateCommitTimestamp(long timestamp,Cell element) throws IOException {
         TxnView transaction = transactionStore.getTransaction(timestamp);
+        if (transaction == null) {
+            // If the database is restored from a backup, it may contain data that were written by a transaction which
+            // is not present in SPLICE_TXN table, because SPLICE_TXN table is copied before the transaction begins.
+            // However, the table written by the txn was copied 
+            return false;
+        }
         if(transaction.getEffectiveState()== Txn.State.ROLLEDBACK){
             /*
              * This transaction has been rolled back, so just remove the data

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupRestoreConstants.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupRestoreConstants.java
@@ -23,7 +23,6 @@ public class BackupRestoreConstants {
 
     public static String BACKUP_DIR = "backup";
     public static final String BACKUP_RECORD_FILE_NAME = "SYSBACKUP";
-    public static final String RESTORE_RECORD_FILE_NAME = "SYSRESTORE";
     public static final String REGION_FILE_NAME = ".regioninfo";
     public static final String ARCHIVE_DIR = "archive";
     public static final byte[] BACKUP_TYPE_FULL_BYTES = Bytes.toBytes("FULL");

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
@@ -202,7 +202,10 @@ public class SimpleTxnFilter implements TxnFilter{
 
     private boolean isVisible(long txnId) throws IOException{
         TxnView toCompare=fetchTransaction(txnId);
-        return myTxn.canSee(toCompare);
+        // If the database is restored from a backup, it may contain data that were written by a transaction which
+        // is not present in SPLICE_TXN table, because SPLICE_TXN table is copied before the transaction begins.
+        // However, the table written by the txn was copied
+        return toCompare != null ? myTxn.canSee(toCompare) : false;
     }
 
     private TxnView fetchTransaction(long txnId) throws IOException{


### PR DESCRIPTION
- Given an incremental backup Id, find all of it parent backups and restore all of them.
- Added more logging
- pass hbase.mapreduce.bulkload.max.hfiles.perRegion.perFamily to restore job
- ignore unfound txn during compaction and txn filtering. From a restored database, some data may be wriiten by a txn that cannot be found in txn table.

Please also review ee branch.