### PR TITLE
DB-5934: restore a chain of backup(2.0)

### DIFF
--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -1947,6 +1947,7 @@ public interface SQLState {
 	String PARENT_BACKUP_MISSING                                   = "BR013";
 	String EXISTS_CONCURRENT_BACKUP                                = "BR014";
 	String BACKUP_TIMEOUT                                          = "BR016";
+	String INCOMPATIBLE_BACKUP                                     = "BR017";
 
 	String FILESYSTEM_URI_EXCEPTION				    				= "EXT25";
 	String FILESYSTEM_IO_EXCEPTION				    				= "EXT26";

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -1948,6 +1948,8 @@ public interface SQLState {
 	String EXISTS_CONCURRENT_BACKUP                                = "BR014";
 	String BACKUP_TIMEOUT                                          = "BR016";
 	String INCOMPATIBLE_BACKUP                                     = "BR017";
+	String MISSING_BACKUP                                          = "BR018";
+	String BACKUP_NOT_IN_CHAIN                                     = "BR019";
 
 	String FILESYSTEM_URI_EXCEPTION				    				= "EXT25";
 	String FILESYSTEM_IO_EXCEPTION				    				= "EXT26";

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -8871,12 +8871,20 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
                <text>Incompatible backup. Please follow Splice Machine documentation to modify the backup.</text>
            </msg>
            <msg>
+               <name>BR018</name>
+               <text>Incremental Backup(s) {0} is(are) not included.</text>
+               <arg>backupIds</arg>
+           </msg>
+           <msg>
+               <name>BR019</name>
+               <text>Backup(s) {0} is(are) not valid incremental parent backup(s)</text>
+               <arg>backupIds</arg>
+           </msg>
+           <msg>
                <name>EXT25</name>
                <text>URIException '{0}' when accessing directory</text>
                <arg>exception</arg>
            </msg>
-
-
            <msg>
                <name>EXT26</name>
                <text>IOException '{0}' when accessing directory</text>

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -8867,6 +8867,10 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
                <arg>regionName</arg>
            </msg>
            <msg>
+               <name>BR017</name>
+               <text>Incompatible backup. Please follow Splice Machine documentation to modify the backup.</text>
+           </msg>
+           <msg>
                <name>EXT25</name>
                <text>URIException '{0}' when accessing directory</text>
                <arg>exception</arg>

--- a/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.0.0.x/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -168,7 +168,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit(): %s", regionName);
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
         isSplitting.set(true);
@@ -178,7 +178,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit(): %s", regionName);
         super.postRollBackSplit(ctx);
         isSplitting.set(false);
 
@@ -187,7 +187,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postCompleteSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit(): %s", regionName);
         super.postCompleteSplit(ctx);
         isSplitting.set(false);
     }
@@ -206,12 +206,17 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
         isCompacting.set(false);
+        if (LOG.isDebugEnabled()) {
+            String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+            SpliceLogUtils.debug(LOG, "Compaction result file %s", filePath);
+        }
+
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s", regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
@@ -222,7 +227,8 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+        SpliceLogUtils.info(LOG, "Flushing store file %s", filePath);
         try {
             if (!BackupUtils.isSpliceTable(namespace, tableName))
                 return;
@@ -235,7 +241,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        SpliceLogUtils.info(LOG, "Flushed region %s.%s", tableName, regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
         super.postFlush(e);

--- a/hbase_sql/hbase1.0.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.0.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -168,7 +168,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit(): %s", regionName);
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
         isSplitting.set(true);
@@ -178,7 +178,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit(): %s", regionName);
         super.postRollBackSplit(ctx);
         isSplitting.set(false);
 
@@ -187,7 +187,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postCompleteSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit(): %s", regionName);
         super.postCompleteSplit(ctx);
         isSplitting.set(false);
     }
@@ -206,12 +206,16 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
         isCompacting.set(false);
+        if (LOG.isDebugEnabled()) {
+            String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+            SpliceLogUtils.debug(LOG, "Compaction result file %s", filePath);
+        }
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s", regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
@@ -222,7 +226,8 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+        SpliceLogUtils.info(LOG, "Flushing store file %s", filePath);
         try {
             if (!BackupUtils.isSpliceTable(namespace, tableName))
                 return;

--- a/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -168,7 +168,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit(): %s", regionName);
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
         isSplitting.set(true);
@@ -178,7 +178,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit(): %s", regionName);
         super.postRollBackSplit(ctx);
         isSplitting.set(false);
 
@@ -187,7 +187,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postCompleteSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit(): %s", regionName);
         super.postCompleteSplit(ctx);
         isSplitting.set(false);
     }
@@ -206,12 +206,16 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
         isCompacting.set(false);
+        if (LOG.isDebugEnabled()) {
+            String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+            SpliceLogUtils.debug(LOG, "Compaction result file %s", filePath);
+        }
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s", regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
@@ -222,7 +226,8 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+        SpliceLogUtils.info(LOG, "Flushing store file %s", filePath);
         try {
             if (!BackupUtils.isSpliceTable(namespace, tableName))
                 return;

--- a/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -168,7 +168,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit(): %s", regionName);
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
         isSplitting.set(true);
@@ -178,7 +178,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit(): %s", regionName);
         super.postRollBackSplit(ctx);
         isSplitting.set(false);
 
@@ -187,7 +187,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postCompleteSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit(): %s", regionName);
         super.postCompleteSplit(ctx);
         isSplitting.set(false);
     }
@@ -206,12 +206,16 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
         isCompacting.set(false);
+        if (LOG.isDebugEnabled()) {
+            String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+            SpliceLogUtils.debug(LOG, "Compaction result file %s", filePath);
+        }
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s", regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
@@ -222,7 +226,8 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+        SpliceLogUtils.info(LOG, "Flushing store file %s", filePath);
         try {
             if (!BackupUtils.isSpliceTable(namespace, tableName))
                 return;

--- a/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -168,7 +168,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit(): %s", regionName);
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
         isSplitting.set(true);
@@ -178,7 +178,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit(): %s", regionName);
         super.postRollBackSplit(ctx);
         isSplitting.set(false);
 
@@ -187,7 +187,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postCompleteSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit(): %s", regionName);
         super.postCompleteSplit(ctx);
         isSplitting.set(false);
     }
@@ -206,12 +206,16 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
         isCompacting.set(false);
+        if (LOG.isDebugEnabled()) {
+            String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+            SpliceLogUtils.debug(LOG, "Compaction result file %s", filePath);
+        }
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s", regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
@@ -222,7 +226,8 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+        SpliceLogUtils.info(LOG, "Flushing store file %s", filePath);
         try {
             if (!BackupUtils.isSpliceTable(namespace, tableName))
                 return;

--- a/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -168,7 +168,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void preSplit(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preSplit(): %s", regionName);
 
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
         isSplitting.set(true);
@@ -178,7 +178,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postRollBackSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postRollBackSplit(): %s", regionName);
         super.postRollBackSplit(ctx);
         isSplitting.set(false);
 
@@ -187,7 +187,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postCompleteSplit(ObserverContext<RegionCoprocessorEnvironment> ctx) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.postCompleteSplit(): %s", regionName);
         super.postCompleteSplit(ctx);
         isSplitting.set(false);
     }
@@ -206,12 +206,16 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     public void postCompact(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         super.postCompact(e, store, resultFile);
         isCompacting.set(false);
+        if (LOG.isDebugEnabled()) {
+            String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+            SpliceLogUtils.debug(LOG, "Compaction result file %s", filePath);
+        }
     }
 
     @Override
     public void preFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
         if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush()");
+            SpliceLogUtils.debug(LOG, "BackupEndpointObserver.preFlush(): %s", regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
         BackupUtils.waitForBackupToComplete(tableName, regionName, path);
@@ -222,7 +226,8 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e, Store store, StoreFile resultFile) throws IOException {
         // Register HFiles for incremental backup
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        String filePath =  resultFile != null?resultFile.getFileInfo().getFileStatus().getPath().toString():null;
+        SpliceLogUtils.info(LOG, "Flushing store file %s", filePath);
         try {
             if (!BackupUtils.isSpliceTable(namespace, tableName))
                 return;
@@ -235,7 +240,7 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
 
     @Override
     public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
-        SpliceLogUtils.info(LOG, "Flushing region %s.%s", tableName, regionName);
+        SpliceLogUtils.info(LOG, "Flushed region %s.%s", tableName, regionName);
         if (!BackupUtils.isSpliceTable(namespace, tableName))
             return;
         super.postFlush(e);

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/BackupBaseRegionObserver.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/BackupBaseRegionObserver.java
@@ -17,6 +17,7 @@ package com.splicemachine.hbase;
 
 import com.google.common.collect.ImmutableList;
 import com.splicemachine.coprocessor.SpliceMessage;
+import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
@@ -37,6 +38,7 @@ import org.apache.hadoop.hbase.regionserver.wal.HLogKey;
 import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.hadoop.hbase.wal.WALKey;
+import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
@@ -46,6 +48,8 @@ import java.util.NavigableSet;
  * Created by jyuan on 2/18/16.
  */
 public abstract class BackupBaseRegionObserver extends SpliceMessage.BackupCoprocessorService implements RegionObserver {
+
+    private static final Logger LOG=Logger.getLogger(BackupBaseRegionObserver.class);
 
     public void start(CoprocessorEnvironment e) throws IOException {
     }
@@ -107,6 +111,13 @@ public abstract class BackupBaseRegionObserver extends SpliceMessage.BackupCopro
     }
 
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) throws IOException {
+        HRegion region = (HRegion) ((RegionCoprocessorEnvironment) e).getRegion();
+        if (LOG.isDebugEnabled()) {
+            SpliceLogUtils.debug(LOG, "split %s:%s into %s and %s",
+                    region.getRegionInfo().getTable().getNameAsString(),
+                    region.getRegionInfo().getEncodedName(), l.getRegionInfo().getEncodedName(),
+                    r.getRegionInfo().getEncodedName());
+        }
     }
 
     public void preCompactSelection(ObserverContext<RegionCoprocessorEnvironment> c, Store store, List<StoreFile> candidates) throws IOException {

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceHFileCleaner.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceHFileCleaner.java
@@ -1,6 +1,7 @@
 package com.splicemachine.hbase;
 
 import com.splicemachine.access.HConfiguration;
+import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -35,8 +36,19 @@ public class SpliceHFileCleaner extends BaseHFileCleanerDelegate {
             */
             if (BackupUtils.existsDatabaseBackup(fs, rootDir)) {
                 String p = BackupUtils.getBackupFilePath(fStat.getPath().toString());
-                if (fs.exists(new Path(p)))
+                if (fs.exists(new Path(p))) {
+                    if (LOG.isDebugEnabled()) {
+                        SpliceLogUtils.debug(LOG, "File %s should be kept for incremental backup",
+                                fStat.getPath().toString());
+                    }
                     deletable = false;
+                }
+                else {
+                    if (LOG.isDebugEnabled()) {
+                        SpliceLogUtils.debug(LOG, "File %s can be removed",
+                                fStat.getPath().toString());
+                    }
+                }
             }
         }
         catch(Exception e) {

--- a/hbase_sql/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
+++ b/hbase_sql/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
@@ -182,8 +182,8 @@ class SpliceTestPlatformConfig {
         config.setFloat("hfile.block.cache.size", 0.25f); // set block cache to 25% of heap
         config.setFloat("io.hfile.bloom.error.rate", (float) 0.005);
         config.setBoolean(CacheConfig.CACHE_BLOOM_BLOCKS_ON_WRITE_KEY, true); // hfile.block.bloom.cacheonwrite
-        //config.set("hbase.master.hfilecleaner.plugins", getHFileCleanerAsString());
         config.set("hbase.master.hfilecleaner.plugins", getHFileCleanerAsString());
+        config.setInt("hbase.mapreduce.bulkload.max.hfiles.perRegion.perFamily", 1024);
         //
         // Misc
         //

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/server/SICompactionState.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/server/SICompactionState.java
@@ -120,6 +120,12 @@ public class SICompactionState {
      */
     private boolean mutateCommitTimestamp(long timestamp,Cell element) throws IOException {
         TxnView transaction = transactionStore.getTransaction(timestamp);
+        if (transaction == null) {
+            // If the database is restored from a backup, it may contain data that were written by a transaction which
+            // is not present in SPLICE_TXN table, because SPLICE_TXN table is copied before the transaction begins.
+            // However, the table written by the txn was copied 
+            return false;
+        }
         if(transaction.getEffectiveState()== Txn.State.ROLLEDBACK){
             /*
              * This transaction has been rolled back, so just remove the data

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupRestoreConstants.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupRestoreConstants.java
@@ -9,7 +9,6 @@ public class BackupRestoreConstants {
 
     public static String BACKUP_DIR = "backup";
     public static final String BACKUP_RECORD_FILE_NAME = "SYSBACKUP";
-    public static final String RESTORE_RECORD_FILE_NAME = "SYSRESTORE";
     public static final String REGION_FILE_NAME = ".regioninfo";
     public static final String ARCHIVE_DIR = "archive";
     public static final byte[] BACKUP_TYPE_FULL_BYTES = Bytes.toBytes("FULL");

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
@@ -211,7 +211,10 @@ public class SimpleTxnFilter implements TxnFilter{
 
     private boolean isVisible(long txnId) throws IOException{
         TxnView toCompare=fetchTransaction(txnId);
-        return myTxn.canSee(toCompare);
+        // If the database is restored from a backup, it may contain data that were written by a transaction which
+        // is not present in SPLICE_TXN table, because SPLICE_TXN table is copied before the transaction begins.
+        // However, the table written by the txn was copied
+        return toCompare != null ? myTxn.canSee(toCompare) : false;
     }
 
     private TxnView fetchTransaction(long txnId) throws IOException{


### PR DESCRIPTION
- Given an incremental backup Id, find all of it parent backups and restore all of them.
- Added more logging
- pass hbase.mapreduce.bulkload.max.hfiles.perRegion.perFamily to restore job
- ignore unfound txn during compaction and txn filtering. From a restored database, some data may be wriiten by a txn that cannot be found in txn table.

Please also review ee branch.