### PR TITLE
SPLICE-1759-2.5 HBase Master generates 1.1GB/s of network bandwidth even when cluster is idle (#881)

### DIFF
--- a/hbase_storage/src/main/java/com/splicemachine/access/hbase/H10PartitionAdmin.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/hbase/H10PartitionAdmin.java
@@ -165,11 +165,12 @@ public class H10PartitionAdmin implements PartitionAdmin{
 
     @Override
     public Collection<PartitionServer> allServers() throws IOException{
-        Collection<ServerName> servers=admin.getClusterStatus().getServers();
+        ClusterStatus clusterStatus = admin.getClusterStatus();
+        Collection<ServerName> servers = clusterStatus.getServers();
         return Collections2.transform(servers,new Function<ServerName, PartitionServer>(){
             @Override
             public PartitionServer apply(ServerName input){
-                return new HServer(input,admin);
+                return new HServer(input, clusterStatus);
             }
         });
     }

--- a/hbase_storage/src/main/java/com/splicemachine/access/hbase/HServer.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/hbase/HServer.java
@@ -17,6 +17,7 @@ package com.splicemachine.access.hbase;
 import com.splicemachine.storage.HServerLoad;
 import com.splicemachine.storage.PartitionServer;
 import com.splicemachine.storage.PartitionServerLoad;
+import org.apache.hadoop.hbase.ClusterStatus;
 import org.apache.hadoop.hbase.ServerLoad;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.client.Admin;
@@ -29,11 +30,11 @@ import java.io.IOException;
  */
 public class HServer implements PartitionServer{
     private final ServerName serverName;
-    private final Admin admin;
+    private final ClusterStatus clusterStatus;
 
-    public HServer(ServerName serverName,Admin admin){
-        this.serverName=serverName;
-        this.admin=admin;
+    public HServer(ServerName serverName, ClusterStatus clusterStatus) {
+        this.serverName = serverName;
+        this.clusterStatus = clusterStatus;
     }
 
     @Override
@@ -53,7 +54,7 @@ public class HServer implements PartitionServer{
 
     @Override
     public PartitionServerLoad getLoad() throws IOException{
-        ServerLoad load=admin.getClusterStatus().getLoad(serverName);
+        ServerLoad load = clusterStatus.getLoad(serverName);
         return new HServerLoad(load);
     }
 

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/HBaseConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/HBaseConfiguration.java
@@ -115,7 +115,7 @@ public class HBaseConfiguration implements ConfigurationDefault {
 
 
     public static final String REGION_LOAD_UPDATE_INTERVAL = "splice.statistics.regionLoadUpdateInterval";
-    public static final long DEFAULT_REGION_LOAD_UPDATE_INTERVAL = 5;
+    public static final long DEFAULT_REGION_LOAD_UPDATE_INTERVAL = 900;
 
     protected static final String REGION_MAX_FILE_SIZE = StorageConfiguration.REGION_MAX_FILE_SIZE;
     protected static final String TRANSACTION_LOCK_STRIPES = SIConfigurations.TRANSACTION_LOCK_STRIPES;


### PR DESCRIPTION
Backporting to 2.5