### PR TITLE
SPLICE-1788 Mem Database should traverse the same cache as HBase

### DIFF
--- a/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MemDatabase.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MemDatabase.java
@@ -24,6 +24,7 @@ import com.splicemachine.access.configuration.ConfigurationDefault;
 import com.splicemachine.access.configuration.ConfigurationSource;
 import com.splicemachine.access.configuration.HConfigurationDefaultsList;
 import com.splicemachine.access.util.ReflectingConfigurationSource;
+import com.splicemachine.client.SpliceClient;
 import com.splicemachine.concurrent.ConcurrentTicker;
 import com.splicemachine.lifecycle.DatabaseLifecycleManager;
 import com.splicemachine.si.MemSIEnvironment;
@@ -39,6 +40,7 @@ public class MemDatabase{
 
     public static void main(String...args) throws Exception{
         //load SI
+        SpliceClient.isRegionServer = true;
         MPipelinePartitionFactory tableFactory=new MPipelinePartitionFactory(new MTxnPartitionFactory(new MPartitionFactory()));
         MemSIEnvironment env=new MemSIEnvironment(tableFactory,new ConcurrentTicker(0L));
         MemSIEnvironment.INSTANCE = env;


### PR DESCRIPTION
Without this, memory database is worthless in understanding cache misses.