### PR TITLE
SPLICE-1372 List and kill running operations

### DIFF
--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAConnThread.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAConnThread.java
@@ -788,7 +788,10 @@ class DRDAConnThread extends Thread {
 			correlationID = reader.readDssHeader();
 			int codePoint = reader.readLengthAndCodePoint( false );
 			int writerMark = writer.markDSSClearPoint();
-			
+
+			// Clear the interrupted state in case the thread was interrupted while we were waiting for commands
+			Thread.currentThread().interrupted();
+
 			if (checkSecurityCodepoint)
 				verifyInOrderACCSEC_SECCHK(codePoint,session.getRequiredSecurityCodepoint());
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ResultSet.java
@@ -277,6 +277,13 @@ public interface ResultSet
 	boolean isClosed();
 
 	/**
+	 Find out if the ResultSet is killed or not.
+
+	 @return true if the ResultSet has been killed.
+	 */
+	boolean isKilled();
+
+	/**
 	 * Tells the system that there will be no more access
 	 * to any database information via this result set;
 	 * in particular, no more calls to open().

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedResultSet.java
@@ -4344,6 +4344,9 @@ public abstract class EmbedResultSet extends ConnectionChild
                 markClosed();
 			}
 
+			if (theResults.isKilled()) {
+				throw newSQLException(SQLState.LANG_CANCELLATION_EXCEPTION);
+			}
 			throw newSQLException(SQLState.LANG_RESULT_SET_NOT_OPEN,operation);
 		}
 	}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BasicNoPutResultSetImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BasicNoPutResultSetImpl.java
@@ -601,6 +601,11 @@ implements NoPutResultSet
 	    return ( ! isOpen );
 	}
 
+	@Override
+	public boolean isKilled() {
+		return false;
+	}
+
 	public void	finish() throws StandardException
 	{
 		finishAndRTS();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IteratorNoPutResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IteratorNoPutResultSet.java
@@ -180,7 +180,12 @@ public class IteratorNoPutResultSet implements NoPutResultSet {
 
 		@Override public boolean isClosed() { return nextRow ==null; }
 
-		@Override public void finish() throws StandardException { close(); }
+	@Override
+	public boolean isKilled() {
+		return false;
+	}
+
+	@Override public void finish() throws StandardException { close(); }
 
 		@Override public long getExecuteTime() { return 0; }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TemporaryRowHolderResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TemporaryRowHolderResultSet.java
@@ -883,6 +883,11 @@ class TemporaryRowHolderResultSet implements CursorResultSet, NoPutResultSet, Cl
         return !isOpen;
     }
 
+    @Override
+    public boolean isKilled() {
+        return false;
+    }
+
     /**
      * Tells the system that there will be no more access
      * to any database information via this result set;

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -811,6 +811,8 @@ public interface SQLState {
 	String DBO_FIRST                                                                    = "4251K";
 	String BAD_CREDENTIALS_DB_NAME                                          = "4251L";
 	String AUTH_NO_TABLE_PERMISSION_FOR_ANALYZE                        = "4251M";
+	String AUTH_NO_PERMISSION_FOR_KILLING_OPERATION                    = "4251N";
+	String LANG_NO_SUCH_RUNNING_OPERATION                              = "4251P";
 	String LANG_DB2_NOT_NULL_COLUMN_INVALID_DEFAULT                    = "42601";
 	String LANG_DB2_INVALID_HEXADECIMAL_CONSTANT                    = "42606";
 	String LANG_DB2_STRING_CONSTANT_TOO_LONG                    = "54002";
@@ -1935,6 +1937,7 @@ public interface SQLState {
     String REPLICATION_STOPSLAVE_NOT_INITIATED                     = "XRE43";
 
 	//general SPlice errors
+	String LANG_CANCELLATION_EXCEPTION							   = "SE008";
 	String LANG_INVALID_DAY										   = "SE022";
 	String ERROR_PARSING_EXCEPTION								   = "SE023";
 	/*

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -1377,6 +1377,17 @@ Guide.
                 <arg>tableName</arg>
             </msg>
             <msg>
+                <name>4251N</name>
+                <text>User '{0}' does not have permission to kill operation with UUID '{1}'.</text>
+                <arg>authorizationID</arg>
+                <arg>UUID</arg>
+            </msg>
+            <msg>
+                <name>4251P</name>
+                <text>Operation UUID '{0}' not found, it might have already completed.</text>
+                <arg>UUID</arg>
+            </msg>
+            <msg>
                 <name>42601</name>
                 <text>In an ALTER TABLE statement, the column '{0}' has been specified as NOT NULL and either the DEFAULT clause was not specified or was specified as DEFAULT NULL.</text>
                 <arg>columnName</arg>

--- a/hbase_sql/src/main/java/com/splicemachine/derby/lifecycle/HEngineSqlEnv.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/lifecycle/HEngineSqlEnv.java
@@ -26,6 +26,8 @@ import com.splicemachine.derby.iapi.sql.PartitionLoadWatcher;
 import com.splicemachine.derby.iapi.sql.PropertyManager;
 import com.splicemachine.derby.iapi.sql.PropertyManagerService;
 import com.splicemachine.derby.iapi.sql.execute.DataSetProcessorFactory;
+import com.splicemachine.derby.iapi.sql.execute.OperationManager;
+import com.splicemachine.derby.iapi.sql.execute.OperationManagerImpl;
 import com.splicemachine.derby.iapi.sql.olap.OlapClient;
 import com.splicemachine.derby.impl.sql.HSqlExceptionFactory;
 import com.splicemachine.hbase.HBaseRegionLoads;
@@ -50,6 +52,7 @@ public class HEngineSqlEnv extends EngineSqlEnvironment{
     private SqlExceptionFactory exceptionFactory;
     private DatabaseAdministrator dbAdmin;
     private OlapClient olapClient;
+    private OperationManager operationManager;
 
     @Override
     public void initialize(SConfiguration config,
@@ -64,6 +67,7 @@ public class HEngineSqlEnv extends EngineSqlEnvironment{
         this.exceptionFactory = new HSqlExceptionFactory(SIDriver.driver().getExceptionFactory());
         this.dbAdmin = new JmxDatabaseAdminstrator();
         this.olapClient = initializeOlapClient(config,driver.getClock());
+        this.operationManager = new OperationManagerImpl();
     }
 
     @Override
@@ -121,5 +125,10 @@ public class HEngineSqlEnv extends EngineSqlEnvironment{
     @Override
     public void refreshEnterpriseFeatures() {
         ManagerLoader.clear();
+    }
+
+    @Override
+    public OperationManager getOperationManager() {
+        return operationManager;
     }
 }

--- a/hbase_sql/src/main/java/com/splicemachine/stream/RemoteQueryClientImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/RemoteQueryClientImpl.java
@@ -138,5 +138,6 @@ public class RemoteQueryClientImpl implements RemoteQueryClient {
     @Override
     public void close() throws Exception {
         streamListener.stopAllStreams();
+        olapFuture.cancel(true);
     }
 }

--- a/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MEngineSqlEnv.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MEngineSqlEnv.java
@@ -19,6 +19,8 @@ import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.derby.iapi.sql.PartitionLoadWatcher;
 import com.splicemachine.derby.iapi.sql.PropertyManager;
 import com.splicemachine.derby.iapi.sql.execute.DataSetProcessorFactory;
+import com.splicemachine.derby.iapi.sql.execute.OperationManager;
+import com.splicemachine.derby.iapi.sql.execute.OperationManagerImpl;
 import com.splicemachine.derby.iapi.sql.olap.OlapClient;
 import com.splicemachine.derby.impl.sql.*;
 import com.splicemachine.access.api.DatabaseVersion;
@@ -41,6 +43,7 @@ public class MEngineSqlEnv extends EngineSqlEnvironment{
     private DataSetProcessorFactory dspFactory;
     private SqlExceptionFactory exceptionFactory;
     private DatabaseAdministrator dbAdmin;
+    private OperationManager operationManager;
 
     @Override
     public void initialize(SConfiguration config,
@@ -53,6 +56,7 @@ public class MEngineSqlEnv extends EngineSqlEnvironment{
         this.dspFactory = new ControlOnlyDataSetProcessorFactory();
         this.exceptionFactory = new MSqlExceptionFactory(SIDriver.driver().getExceptionFactory());
         this.dbAdmin = new DirectDatabaseAdministrator();
+        this.operationManager = new OperationManagerImpl();
     }
 
     @Override
@@ -93,5 +97,10 @@ public class MEngineSqlEnv extends EngineSqlEnvironment{
     @Override
     public void refreshEnterpriseFeatures() {
         // No Op
+    }
+
+    @Override
+    public OperationManager getOperationManager() {
+        return operationManager;
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/EngineDriver.java
+++ b/splice_machine/src/main/java/com/splicemachine/EngineDriver.java
@@ -23,6 +23,7 @@ import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.derby.iapi.sql.PartitionLoadWatcher;
 import com.splicemachine.derby.iapi.sql.PropertyManager;
 import com.splicemachine.derby.iapi.sql.execute.DataSetProcessorFactory;
+import com.splicemachine.derby.iapi.sql.execute.OperationManager;
 import com.splicemachine.derby.iapi.sql.olap.OlapClient;
 import com.splicemachine.derby.impl.sql.execute.sequence.SequenceKey;
 import com.splicemachine.derby.impl.sql.execute.sequence.SpliceSequence;
@@ -51,6 +52,7 @@ public class EngineDriver{
     private final SqlExceptionFactory exceptionFactory;
     private final DatabaseAdministrator dbAdmin;
     private final OlapClient olapClient;
+    private final OperationManager operationManager;
     private final SqlEnvironment environment;
     private final ExecutorService threadPool;
 
@@ -79,6 +81,7 @@ public class EngineDriver{
         this.olapClient = environment.getOlapClient();
         this.propertyManager = environment.getPropertyManager();
         this.exceptionFactory = environment.exceptionFactory();
+        this.operationManager = environment.getOperationManager();
         this.dbAdmin = environment.databaseAdministrator();
         this.sequencePool=CachedResourcePool.Builder.<SpliceSequence, SequenceKey>newBuilder()
                 .expireAfterAccess(1,TimeUnit.MINUTES)
@@ -162,4 +165,6 @@ public class EngineDriver{
     public ExecutorService getExecutorService() {
         return threadPool;
     }
+
+    public OperationManager getOperationManager() { return operationManager; }
 }

--- a/splice_machine/src/main/java/com/splicemachine/SqlEnvironment.java
+++ b/splice_machine/src/main/java/com/splicemachine/SqlEnvironment.java
@@ -19,6 +19,7 @@ import com.splicemachine.derby.iapi.sql.PartitionLoadWatcher;
 import com.splicemachine.derby.iapi.sql.PropertyManager;
 import com.splicemachine.derby.iapi.sql.execute.DataSetProcessorFactory;
 import com.splicemachine.access.api.DatabaseVersion;
+import com.splicemachine.derby.iapi.sql.execute.OperationManager;
 import com.splicemachine.derby.iapi.sql.olap.OlapClient;
 import com.splicemachine.management.DatabaseAdministrator;
 import com.splicemachine.management.Manager;
@@ -56,4 +57,6 @@ public interface SqlEnvironment{
     OlapClient getOlapClient();
 
     void refreshEnterpriseFeatures();
+
+    OperationManager getOperationManager();
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/OperationManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/OperationManager.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.derby.iapi.sql.execute;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.utils.Pair;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Created by dgomezferro on 12/07/2017.
+ */
+public interface OperationManager {
+    /**
+     * Register an operation into the manager so that it can be killed
+     * @param operation Operation that started execution
+     * @param executingThread Thread that's responsible for the operation execution (oen DRDAConnThread)
+     * @return UUID given to the operation that can be used for unregistering or killing it at a later time
+     */
+    UUID registerOperation(SpliceOperation operation, Thread executingThread);
+
+
+    /**
+     * Unregister an operation that has been closed
+     * @param uuid Unique identifier provided by the registerOperation() method
+     */
+    void unregisterOperation(UUID uuid);
+
+    /**
+     * Get running operations for the given user, or all running operations if userId is null
+     * @param userId user for which we want the operations, or null for all operations
+     * @return list of running operations for the given user
+     */
+    List<Pair<UUID, SpliceOperation>> runningOperations(String userId);
+
+    /**
+     * Kill a running operation. Only the user that started the operation might kill it. The database owner can kill any
+     * operation. We close the operation and interrupt the executingThread associated with the operation. This might
+     * affect some other operation that could be running on the same thread.
+     *
+     * @param uuid Unique identifier provided by the registerOperation() method
+     * @param userId user that's trying to kill the operation, or null if the user is the database owner
+     * @return true if the operation has been killed, false otherwise (if we don't find it)
+     */
+    boolean killOperation(UUID uuid, String userId) throws StandardException;
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/OperationManagerImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/OperationManagerImpl.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.derby.iapi.sql.execute;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.sql.Activation;
+import com.splicemachine.utils.Pair;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Created by dgomezferro on 12/07/2017.
+ */
+public class OperationManagerImpl implements OperationManager {
+    private ConcurrentMap<UUID, Pair<SpliceOperation, Thread>> operations = new ConcurrentHashMap();
+
+    public UUID registerOperation(SpliceOperation operation, Thread executingThread) {
+        UUID uuid = UUID.randomUUID();
+        operations.put(uuid, new Pair<>(operation, executingThread));
+        return uuid;
+    }
+
+    public void unregisterOperation(UUID uuid) {
+        operations.remove(uuid);
+    }
+
+    public List<Pair<UUID, SpliceOperation>> runningOperations(String userId) {
+        List<Pair<UUID, SpliceOperation>> result = new ArrayList<>(operations.size());
+        for (Map.Entry<UUID, Pair<SpliceOperation, Thread>> entry : operations.entrySet()) {
+            Activation activation = entry.getValue().getFirst().getActivation();
+            String runningUserId = activation.getLanguageConnectionContext().getCurrentUserId(activation);
+            if (userId == null || userId.equals(runningUserId))
+                result.add(new Pair<>(entry.getKey(), entry.getValue().getFirst()));
+        }
+        return result;
+    }
+
+    public boolean killOperation(UUID uuid, String userId) throws StandardException {
+        Pair<SpliceOperation, Thread> pair = operations.get(uuid);
+        if (pair == null)
+            return false;
+        Activation activation = pair.getFirst().getActivation();
+        String databaseOwner = activation.getLanguageConnectionContext().getDataDictionary().getAuthorizationDatabaseOwner();
+        String runningUserId = activation.getLanguageConnectionContext().getCurrentUserId(activation);
+
+        if (!userId.equals(databaseOwner) && !userId.equals(runningUserId))
+            throw StandardException.newException(SQLState.AUTH_NO_PERMISSION_FOR_KILLING_OPERATION, userId, uuid.toString());
+
+        pair.getFirst().kill();
+        pair.getSecond().interrupt();
+        return true;
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/SingleRowCursorResultSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/SingleRowCursorResultSet.java
@@ -143,6 +143,11 @@ public class SingleRowCursorResultSet implements CursorResultSet {
     }
 
     @Override
+    public boolean isKilled() {
+        return false;
+    }
+
+    @Override
     public void finish() throws StandardException {
 
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/SpliceOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/SpliceOperation.java
@@ -379,4 +379,11 @@ public interface SpliceOperation extends StandardCloseable, NoPutResultSet, Conv
      * @return
      */
     String getVTIFileName();
+
+    /**
+     * Forcefully close operation and mark it as killed
+     * @throws StandardException
+     * @throws IOException
+     */
+    void kill() throws StandardException;
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -510,6 +510,27 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                     procedures.add(disableStatsForColumn);
 
 
+        			/*
+        			 * Procedure to get a list of running operations
+        			 */
+                    Procedure runningOperations = Procedure.newBuilder().name("SYSCS_GET_RUNNING_OPERATIONS")
+                            .numOutputParams(0)
+                            .numResultSets(1)
+                            .ownerClass(SpliceAdmin.class.getCanonicalName())
+                            .build();
+                    procedures.add(runningOperations);
+
+
+        			/*
+        			 * Procedure to kill an executing operation
+        			 */
+                    Procedure killOperation = Procedure.newBuilder().name("SYSCS_KILL_OPERATION")
+                            .numOutputParams(0)
+                            .varchar("uuid",128)
+                            .ownerClass(SpliceAdmin.class.getCanonicalName())
+                            .build();
+                    procedures.add(killOperation);
+
 
                     /*
                      * Procedure to elevate a transaction

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/CallStatementOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/CallStatementOperation.java
@@ -122,64 +122,12 @@ public class CallStatementOperation extends NoRowsOperation {
 			activation.getLanguageConnectionContext().getStatementContext());
 		if (!isOpen)
 			return;
-        if (1!=2)
-            return;
-
-        /*
-		ResultSet[][] dynamicResults = activation.getDynamicResults();
-		if (dynamicResults != null) {
-
-			ConnectionContext jdbcContext = null;
-
-			for (int i = 0; i < dynamicResults.length; i++)
-			{
-				ResultSet[] param = dynamicResults[i];
-				ResultSet drs = null;
-				if (param != null) drs = param[0];
-
-				// Can be null if the procedure never set this parameter
-				// or if the dynamic results were processed by JDBC (EmbedStatement).
-				if (drs == null)
-				    continue;
-
-				if (jdbcContext == null)
-					jdbcContext = (ConnectionContext)activation.getLanguageConnectionContext().getContextManager().getContext(ConnectionContext.CONTEXT_ID);
-
-				try {
-					// Is this a valid, open dynamic result set for this connection?
-					if (!jdbcContext.processInaccessibleDynamicResult(drs))
-							continue;
-
-					drs.close();
-				} catch (SQLException e) {
-					SpliceLogUtils.error(LOG, e);
-				} finally {
-					// Remove any reference to the ResultSet to allow
-					// it and any associated resources to be garbage collected.
-					param[0] = null;
-				}
-			}
-		}
-
 		try {
-        	int staLength = (subqueryTrackingArray == null) ? 0 : subqueryTrackingArray.length;
-        
-        	for (int index = 0; index < staLength; index++)
-        	{
-    			if (subqueryTrackingArray[index] == null || subqueryTrackingArray[index].isClosed())
-					continue;
-    
-    			subqueryTrackingArray[index].close();
-        	}
-        
-        	isOpen = false;
-        
-        	if (activation.isSingleExecution())
-        		activation.close();
+			super.close();
 		} catch (Exception e) {
-			SpliceLogUtils.error(LOG, e);
+			throw new RuntimeException(e);
 		}
-        */
+
 
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TemporaryRowHolderOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TemporaryRowHolderOperation.java
@@ -868,6 +868,11 @@ public class TemporaryRowHolderOperation implements CursorResultSet, NoPutResult
         return !isOpen;
     }
 
+    @Override
+    public boolean isKilled() {
+        return false;
+    }
+
     /**
      * Tells the system that there will be no more access
      * to any database information via this result set;

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
@@ -18,10 +18,13 @@ import com.splicemachine.db.catalog.SystemProcedures;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.sql.depend.DependencyManager;
 import com.splicemachine.db.impl.services.uuid.BasicUUID;
+import com.splicemachine.db.impl.sql.catalog.SYSTABLESTATISTICSRowFactory;
 import com.splicemachine.ddl.DDLMessage;
 import com.splicemachine.derby.ddl.DDLUtils;
+import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.store.access.SpliceTransactionManager;
 import com.splicemachine.protobuf.ProtoUtil;
+import com.splicemachine.utils.Pair;
 import com.splicemachine.utils.SpliceLogUtils;
 import org.joda.time.DateTime;
 import org.spark_project.guava.collect.Lists;
@@ -71,6 +74,9 @@ import java.io.IOException;
 import java.sql.*;
 import java.util.*;
 import java.util.Map.Entry;
+
+import static com.splicemachine.db.shared.common.reference.SQLState.LANG_INVALID_FUNCTION_ARGUMENT;
+import static com.splicemachine.db.shared.common.reference.SQLState.LANG_NO_SUCH_RUNNING_OPERATION;
 
 /**
  * @author Jeff Cunningham
@@ -1233,4 +1239,71 @@ public class SpliceAdmin extends BaseAdminProcedures{
             admin.deleteSnapshot(snapshot);
         }
     }
+
+    private static final ResultColumnDescriptor[] GET_RUNNING_OPERATIONS_OUTPUT_COLUMNS = new GenericColumnDescriptor[]{
+            new GenericColumnDescriptor("uuid", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, 40)),
+            new GenericColumnDescriptor("user", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, 40)),
+            new GenericColumnDescriptor("sql", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR)),
+    };
+
+
+    public static void SYSCS_GET_RUNNING_OPERATIONS(final ResultSet[] resultSet) throws SQLException{
+        EmbedConnection conn = (EmbedConnection)getDefaultConn();
+        LanguageConnectionContext lcc = conn.getLanguageConnection();
+        Activation lastActivation = conn.getLanguageConnection().getLastActivation();
+        String userId = lastActivation.getLanguageConnectionContext().getCurrentUserId(lastActivation);
+        if (userId.equals(lastActivation.getLanguageConnectionContext().getDataDictionary().getAuthorizationDatabaseOwner())) {
+            userId = null;
+        }
+
+        List<Pair<UUID, SpliceOperation>> operations = EngineDriver.driver().getOperationManager().runningOperations(userId);
+
+        List<ExecRow> rows = new ArrayList<>(operations.size());
+        for (Pair<UUID, SpliceOperation> pair : operations) {
+            ExecRow row = new ValueRow(2);
+            Activation activation = pair.getSecond().getActivation();
+            row.setColumn(1, new SQLVarchar(pair.getFirst().toString()));
+            row.setColumn(2, new SQLVarchar(activation.getLanguageConnectionContext().getCurrentUserId(activation)));
+            row.setColumn(3, new SQLVarchar(activation.getPreparedStatement().getSource()));
+            rows.add(row);
+        }
+
+        IteratorNoPutResultSet resultsToWrap = new IteratorNoPutResultSet(rows, new GenericColumnDescriptor[]{
+                new GenericColumnDescriptor("uuid", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, 40)),
+                new GenericColumnDescriptor("user", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, 40)),
+                new GenericColumnDescriptor("sql", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR)),
+        },
+                lastActivation);
+        try {
+            resultsToWrap.openCore();
+        } catch (StandardException se) {
+            throw PublicAPI.wrapStandardException(se);
+        }
+        resultSet[0] = new EmbedResultSet40(conn, resultsToWrap, false, null, true);
+    }
+
+    public static void SYSCS_KILL_OPERATION(final String uuidString) throws SQLException{
+        EmbedConnection conn = (EmbedConnection)getDefaultConn();
+        LanguageConnectionContext lcc = conn.getLanguageConnection();
+        Activation lastActivation = conn.getLanguageConnection().getLastActivation();
+
+        String userId = lcc.getCurrentUserId(lastActivation);
+
+        UUID uuid;
+        try {
+            uuid = UUID.fromString(uuidString);
+        } catch (IllegalArgumentException e) {
+            throw  PublicAPI.wrapStandardException(StandardException.newException(LANG_INVALID_FUNCTION_ARGUMENT, uuidString, "SYSCS_KILL_OPERATION"));
+        }
+        boolean killed;
+        try {
+            killed = EngineDriver.driver().getOperationManager().killOperation(uuid, userId);
+        } catch (StandardException se) {
+            throw PublicAPI.wrapStandardException(se);
+        }
+
+        if (!killed)
+            throw  PublicAPI.wrapStandardException(StandardException.newException(LANG_NO_SUCH_RUNNING_OPERATION, uuidString));
+    }
+
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceAdmin_OperationsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceAdmin_OperationsIT.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.derby.utils;
+
+import com.splicemachine.derby.test.framework.SpliceDataWatcher;
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceTableWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.derby.test.framework.TestConnection;
+import com.splicemachine.test.SerialTest;
+import org.apache.log4j.Logger;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@Category(SerialTest.class)
+public class SpliceAdmin_OperationsIT extends SpliceUnitTest{
+    private static final Logger LOG = Logger.getLogger(SpliceAdmin_OperationsIT.class);
+    public static final String CLASS_NAME = SpliceAdmin_OperationsIT.class.getSimpleName().toUpperCase();
+    protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);
+    protected static SpliceTableWatcher bigTableWatcher = new SpliceTableWatcher("TEST_BIG",CLASS_NAME,"(a int)");
+    protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
+    protected static final String USER_NAME = CLASS_NAME+"_USER";
+
+    @ClassRule
+    public static TestRule chain = RuleChain.outerRule(spliceClassWatcher).
+            around(spliceSchemaWatcher).around(bigTableWatcher)
+            .around(new SpliceDataWatcher(){
+                @Override
+                protected void starting(Description description){
+                    try {
+                        spliceClassWatcher.execute(String.format("call SYSCS_UTIL.SYSCS_CREATE_USER('%s', '%s')", USER_NAME, USER_NAME));
+                    } catch (Exception e) {
+                        // ignore if user already exists
+                    }
+
+                    try {
+                        spliceClassWatcher.execute("GRANT EXECUTE ON PROCEDURE SYSCS_UTIL.SYSCS_GET_RUNNING_OPERATIONS TO " + USER_NAME);
+                        spliceClassWatcher.execute("GRANT EXECUTE ON PROCEDURE SYSCS_UTIL.SYSCS_KILL_OPERATION TO " + USER_NAME);
+                        spliceClassWatcher.execute("GRANT ALL PRIVILEGES ON TABLE " + bigTableWatcher + " TO " + USER_NAME);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                    try{
+                        PreparedStatement ps=spliceClassWatcher.prepareStatement(format("insert into %s (a) values (?)",bigTableWatcher));
+                        for(int i=0;i<10;i++){
+                            ps.setInt(1,i);
+                            ps.executeUpdate();
+                        }
+                        ps=spliceClassWatcher.prepareStatement(format("insert into %s select * from %s",bigTableWatcher, bigTableWatcher));
+                        for(int i=0;i<12;i++){
+                            ps.executeUpdate();
+                        }
+                    }catch(Exception e){
+                        throw new RuntimeException(e);
+                    }finally{
+                        spliceClassWatcher.closeAll();
+                    }
+                }
+
+            });
+
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher();
+
+
+    @Test
+    public void testRunningOperations() throws Exception {
+        String sql= "call SYSCS_UTIL.SYSCS_GET_RUNNING_OPERATIONS()";
+
+        PreparedStatement ps = methodWatcher.getOrCreateConnection().prepareStatement(sql);
+        ResultSet rs = ps.executeQuery();
+        // we should have 1 running operation, the call itself
+        assertTrue(rs.next());
+        assertEquals("SPLICE", rs.getString(2)); // check user
+        assertEquals(sql, rs.getString(3)); // check user
+    }
+
+    @Test
+    public void testKillOpenCursorControl() throws Exception {
+        testKillOpenCursor(false);
+    }
+
+    @Test
+    public void testKillOpenCursorSpark() throws Exception {
+        testKillOpenCursor(true);
+    }
+
+    public void testKillOpenCursor(boolean useSpark) throws Exception {
+        String sql= "select * from "+bigTableWatcher + " --splice-properties useSpark="+useSpark;
+
+        PreparedStatement ps = methodWatcher.getOrCreateConnection().prepareStatement(sql);
+        ResultSet rs = ps.executeQuery();
+        assertTrue(rs.next());
+
+        String opsCall= "call SYSCS_UTIL.SYSCS_GET_RUNNING_OPERATIONS()";
+
+        ResultSet opsRs = methodWatcher.getOrCreateConnection().query(opsCall);
+
+        int count = 0;
+        String uuid = null;
+        while(opsRs.next()) {
+            count++;
+            if (opsRs.getString(3).equals(sql)) {
+                uuid = opsRs.getString(1);
+            }
+        }
+        assertEquals(2, count); // 2 running operations, cursor + the procedure call itself
+
+        // kill the cursor
+        String killCall = "call SYSCS_UTIL.SYSCS_KILL_OPERATION('"+uuid+"')";
+        methodWatcher.getOrCreateConnection().execute(killCall);
+
+        // iterate over the cursor, should raise exception
+        int rows = 0;
+        try {
+            while(rs.next()) {
+                rows++;
+            }
+            fail("Should have raised exception");
+        } catch (SQLException se) {
+            LOG.debug("Raised exception after " + rows + " rows.");
+            assertEquals("SE008", se.getSQLState());
+        }
+    }
+
+
+    @Test
+    public void testOtherUsersCantKillOperation() throws Exception {
+        TestConnection connection1 = methodWatcher.getOrCreateConnection();
+        TestConnection connection2 = methodWatcher.createConnection(USER_NAME, USER_NAME);
+
+
+        String sql= "select * from "+bigTableWatcher;
+
+        PreparedStatement ps = connection1.prepareStatement(sql);
+        ResultSet rs = ps.executeQuery();
+        assertTrue(rs.next());
+
+
+        // View from conn1
+        String opsCall= "call SYSCS_UTIL.SYSCS_GET_RUNNING_OPERATIONS()";
+
+        ResultSet opsRs = connection1.query(opsCall);
+
+        int count = 0;
+        String uuid = null;
+        while(opsRs.next()) {
+            count++;
+            if (opsRs.getString(3).equals(sql)) {
+                uuid = opsRs.getString(1);
+            }
+        }
+        assertEquals(2, count); // 2 running operations, cursor + the procedure call itself
+        opsRs.close();
+
+
+        // View from conn2
+        opsRs = connection2.query(opsCall);
+
+        count = 0;
+        while(opsRs.next()) {
+            count++;
+        }
+        assertEquals(1, count); // the open cursor should not be visible
+
+
+        // try to kill the cursor
+        String killCall = "call SYSCS_UTIL.SYSCS_KILL_OPERATION('"+uuid+"')";
+        try {
+            connection2.execute(killCall);
+            fail("Should have raised exception");
+        } catch (SQLException se) {
+            assertEquals("4251N", se.getSQLState());
+        }
+
+
+        // kill the cursor
+        connection1.execute(killCall);
+
+        // iterate over the cursor, should raise exception
+        int rows = 0;
+        try {
+            while(rs.next()) {
+                rows++;
+            }
+            fail("Should have raised exception");
+        } catch (SQLException se) {
+            LOG.debug("Raised exception after " + rows + " rows.");
+            assertEquals("SE008", se.getSQLState());
+        }
+    }
+
+    @Test
+    public void testDbOwnerCanKillOperation() throws Exception {
+        TestConnection connection1 = methodWatcher.createConnection(USER_NAME, USER_NAME);
+        TestConnection connection2 = methodWatcher.getOrCreateConnection();
+
+
+        String sql= "select * from "+bigTableWatcher;
+
+        PreparedStatement ps = connection1.prepareStatement(sql);
+        ResultSet rs = ps.executeQuery();
+        assertTrue(rs.next());
+
+
+        // View from conn1
+        String opsCall= "call SYSCS_UTIL.SYSCS_GET_RUNNING_OPERATIONS()";
+
+        ResultSet opsRs = connection1.query(opsCall);
+
+        int count = 0;
+        String uuid = null;
+        while(opsRs.next()) {
+            count++;
+            if (opsRs.getString(3).equals(sql)) {
+                uuid = opsRs.getString(1);
+            }
+        }
+        assertEquals(2, count); // 2 running operations, cursor + the procedure call itself
+        opsRs.close();
+
+
+        // View from conn2
+        opsRs = connection2.query(opsCall);
+
+        count = 0;
+        while(opsRs.next()) {
+            count++;
+        }
+        assertEquals(2, count); // the open cursor should also be visible to the db owner
+
+
+        // kill the cursor
+        String killCall = "call SYSCS_UTIL.SYSCS_KILL_OPERATION('"+uuid+"')";
+        connection2.execute(killCall);
+
+        // try to kill the cursor again (it should fail)
+        try {
+            connection1.execute(killCall);
+            fail("Should have raised exception");
+        } catch (SQLException se) {
+            assertEquals("4251P", se.getSQLState());
+        }
+
+        // iterate over the cursor, should raise exception
+        int rows = 0;
+        try {
+            while(rs.next()) {
+                rows++;
+            }
+            fail("Should have raised exception");
+        } catch (SQLException se) {
+            LOG.debug("Raised exception after " + rows + " rows.");
+            assertEquals("SE008", se.getSQLState());
+        }
+    }
+
+    @Test
+    public void testKillBadUUID() throws Exception {
+        try {
+            // wrong format for the UUID
+            String killCall = "call SYSCS_UTIL.SYSCS_KILL_OPERATION('')";
+            methodWatcher.getOrCreateConnection().execute(killCall);
+            fail("Should have raised exception");
+        } catch (SQLException se) {
+            assertEquals("22008", se.getSQLState());
+        }
+
+        try {
+            // Invented UUID
+            String killCall = "call SYSCS_UTIL.SYSCS_KILL_OPERATION('00000000-0000-0000-0000-000000000000')";
+            methodWatcher.getOrCreateConnection().execute(killCall);
+            fail("Should have raised exception");
+        } catch (SQLException se) {
+            assertEquals("4251P", se.getSQLState());
+        }
+    }
+
+}

--- a/start-splice-cluster
+++ b/start-splice-cluster
@@ -47,6 +47,7 @@ MEMBERS=2
 DEBUG_PATH=""
 
 MVN='mvn -B'
+MVNDBG='mvnDebug -B'
 
 usage() {
     # $1 is an error, if any
@@ -130,8 +131,9 @@ pushd "${RUN_DIR}" > /dev/null
 
 # Run IN MEMORY
 if [[ ${PROFILE} == ${IN_MEM_PROFILE} ]]; then
-    echo "Starting MEM. Log file is the splice-derby.log<n> in ${RUN_DIR}"
-  (${MVN} exec:java > /dev/null 2>&1) &    ## IN MEMORY
+  MEM_LOG="${RUN_DIR}/spliceMem.log"
+  echo "Starting MEM. Log file is ${MEM_LOG}"
+  (${MVN} exec:java > ${MEM_LOG} 2>&1) &    ## IN MEMORY
   exit 0;
 fi
 


### PR DESCRIPTION
This adds an OperationManager, when an operation is opened it registers itself on the OperationManager and unregisters when it is closed.

There's two new system procedures:
- SYSCS_UTIL.SYSCS_GET_RUNNING_OPERATIONS(): lists all running operations for the current user (or for all users if it is the db owner)
- SYSCS_UTIL.SYSCS_KILL_OPERATION(): kills an operation (either control-mode or spark)

The killing works by closing the operation and interrupting the DRDAConnThread associated with it.

The procedures are local to the region server, they only work on operations running on the given region server.