### PR TITLE
SPLICE-1784 Fixing Serial Cutpoint Generation

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/hbase/BytesCopyTaskSplitter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/BytesCopyTaskSplitter.java
@@ -27,12 +27,12 @@ import java.util.*;
  *         Date: 4/16/14
  */
 public class BytesCopyTaskSplitter {
-    public static List<byte[]> getCutPoints(HRegion region, byte[] start, byte[] end,byte[] expectedRegionEnd) throws IOException {
+    public static List<byte[]> getCutPoints(HRegion region, byte[] start, byte[] end) throws IOException {
         Store store = null;
         try {
             store = region.getStore(SIConstants.DEFAULT_FAMILY_BYTES);
             HRegionUtil.lockStore(store);
-            return HRegionUtil.getCutpoints(store, start, end, expectedRegionEnd);
+            return HRegionUtil.getCutpoints(store, start, end);
         }catch (Throwable t) {
             throw Exceptions.getIOException(t);
         }finally{

--- a/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionUtil.java
+++ b/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionUtil.java
@@ -66,23 +66,18 @@ public class HRegionUtil extends BaseHRegionUtil{
         HBasePlatformUtils.updateReadRequests(region,numReads);
     }
 
-    public static List<byte[]> getCutpoints(Store store, byte[] start, byte[] end, byte[] expectedRegionEnd) throws IOException {
+    public static List<byte[]> getCutpoints(Store store, byte[] start, byte[] end) throws IOException {
         assert Bytes.startComparator.compare(start, end) <= 0 || start.length == 0 || end.length == 0;
         if (LOG.isTraceEnabled())
             SpliceLogUtils.trace(LOG, "getCutpoints");
         Collection<StoreFile> storeFiles;
         storeFiles = store.getStorefiles();
-        HFile.Reader fileReader;
+        HFile.Reader fileReader = null;
         List<byte[]> cutPoints = new ArrayList<byte[]>();
         int carry = 0;
 
         byte[] regionStart = store.getRegionInfo().getStartKey();
         byte[] regionEnd = store.getRegionInfo().getEndKey();
-
-        if ((expectedRegionEnd.length == 0 && regionEnd.length != 0)
-                || Bytes.endComparator.compare(expectedRegionEnd, regionEnd) > 0) {
-            throw new HMissedSplitException("Subplit computation missed region split");
-        }
 
         if (regionStart != null && regionStart.length > 0) {
             if (start == null || Bytes.startComparator.compare(start, regionStart) < 0) {
@@ -101,8 +96,12 @@ public class HRegionUtil extends BaseHRegionUtil{
                 long storeFileInBytes = file.getFileInfo().getFileStatus().getLen();
                 if (LOG.isTraceEnabled())
                     SpliceLogUtils.trace(LOG, "getCutpoints with file=%s with size=%d", file.getPath(), storeFileInBytes);
-                fileReader = file.createReader().getHFileReader();
-                carry = addStoreFileCutpoints(cutPoints, fileReader, storeFileInBytes, carry, range);
+                try {
+                    fileReader = file.createReader().getHFileReader();
+                    carry = addStoreFileCutpoints(cutPoints, fileReader, storeFileInBytes, carry, range);
+                } finally {
+                    fileReader.close();
+                }
             }
         }
 

--- a/splice_protocol/src/main/protobuf/Splice.proto
+++ b/splice_protocol/src/main/protobuf/Splice.proto
@@ -142,11 +142,11 @@ service SpliceDerbyCoprocessorService {
 message SpliceSplitServiceRequest {
     optional bytes beginKey = 1;
     optional bytes endKey = 2;
-    optional bytes regionEndKey = 3;
 }
 
 message SpliceSplitServiceResponse {
     repeated bytes cutPoint = 1;
+    required string hostName = 2;
 }
 
 


### PR DESCRIPTION
Makes cutpoint generation a regular coprocessor vs. a serial coprocessor call from cached regions.  Also, I found a resource leak where the HFile.Reader is not closed.