### PR TITLE
SPLICE-1813 Remove transactions from the savepoint stack (2.6)

### DIFF
--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/SavepointConstantOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/SavepointConstantOperationIT.java
@@ -248,9 +248,9 @@ public class SavepointConstantOperationIT {
         rs.next();
         long txnIdLater = rs.getLong(1);
 
-        // The difference should be 0x400: the batch created one persisted txn, that's 2 timestamps (begin + commit),
+        // The difference should be 0x400: the batch created one or two persisted txn, that's up to 4 timestamps (begin + commit),
         // the user transaction committed (1 ts) and then the new user transaction started (1 ts)
-        Assert.assertEquals("Created more persisted transactions than expected, difference = " + (txnIdLater - txnId), txnId + 0x400, txnIdLater);
+        Assert.assertTrue("Created more persisted transactions than expected, difference = " + (txnIdLater - txnId), txnIdLater <= txnId + 0x600);
     }
 
 
@@ -273,9 +273,9 @@ public class SavepointConstantOperationIT {
         rs.next();
         long txnIdLater = rs.getLong(1);
 
-        // The difference should be 0x1000: the batch created 7 persisted txns, that's 14 timestamps (begin + commit),
+        // The difference should be 0x1000: the batch created up to 14 persisted txns, that's 28 timestamps (begin + commit),
         // the user transaction committed (1 ts) and then the new user transaction started (1 ts)
-        Assert.assertEquals("Created more persisted transactions than expected, difference = " + (txnIdLater - txnId), txnId + 0x1000, txnIdLater);
+        Assert.assertTrue("Created more persisted transactions than expected, difference = " + (txnIdLater - txnId), txnIdLater <= txnId + 0x1E00);
     }
 
 
@@ -299,9 +299,9 @@ public class SavepointConstantOperationIT {
         rs.next();
         long txnIdLater = rs.getLong(1);
 
-        // The difference should be 0x1000: the batch created 7 persisted txns, that's 14 timestamps (begin + commit),
+        // The difference should be 0x1000: the batch created up to 14 persisted txns, that's 28 timestamps (begin + commit),
         // the user transaction committed (1 ts) and then the new user transaction started (1 ts)
-        Assert.assertEquals("Created more persisted transactions than expected, difference = " + (txnIdLater - txnId), txnId + 0x1000, txnIdLater);
+        Assert.assertTrue("Created more persisted transactions than expected, difference = " + (txnIdLater - txnId), txnIdLater <= txnId + 0x1E00);
     }
 
     @Test

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/AbstractTxn.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/AbstractTxn.java
@@ -17,6 +17,7 @@ package com.splicemachine.si.impl.txn;
 import com.carrotsearch.hppc.LongOpenHashSet;
 import com.splicemachine.si.api.txn.Txn;
 import com.splicemachine.si.api.txn.TxnView;
+import com.splicemachine.si.constants.SIConstants;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -103,6 +104,9 @@ public abstract class AbstractTxn extends AbstractTxnView implements Txn {
 
     private boolean internalAllowsSubtransactions() {
         AbstractTxn other = this;
+        if (counter != null && counter.get() >= SIConstants.SUBTRANSANCTION_ID_MASK) {
+            return false;
+        }
         while (true) {
             if (!other.subtransactionsAllowed)
                 return false;
@@ -125,8 +129,9 @@ public abstract class AbstractTxn extends AbstractTxnView implements Txn {
 
     @Override
     public boolean allowsSubtransactions() {
-        if (!subtransactionsAllowed)
+        if (counter != null && counter.get() >= SIConstants.SUBTRANSANCTION_ID_MASK) {
             return false;
+        }
         for (Txn c : children) {
             if (c.getState() == State.ACTIVE) {
                 return false;


### PR DESCRIPTION
Make sure we keep transactions around if needed for in memory
subtransactions

(This has already been merged into master)