### PR TITLE
SPLICE-1785: load more regions per task in last stage of bulk import(2.6)

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BulkDataSetWriter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BulkDataSetWriter.java
@@ -16,6 +16,7 @@ package com.splicemachine.derby.stream.spark;
 import com.clearspring.analytics.util.Lists;
 import com.splicemachine.access.HConfiguration;
 import com.splicemachine.access.api.PartitionAdmin;
+import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
@@ -181,7 +182,10 @@ public class BulkDataSetWriter  {
      * @throws StandardException
      */
     protected void bulkLoad(List<BulkImportPartition> bulkImportPartitions, String bulkImportDirectory) throws StandardException{
-        SpliceSpark.getContext().parallelize(bulkImportPartitions, bulkImportPartitions.size())
+        SConfiguration sConfiguration = HConfiguration.getConfiguration();
+        int regionsPerTask = sConfiguration.getRegionToLoadPerTask();
+        int numTasks = Math.max(bulkImportPartitions.size()/regionsPerTask, 1);
+        SpliceSpark.getContext().parallelize(bulkImportPartitions, numTasks)
                 .foreach(new BulkImportFunction(bulkImportDirectory));
     }
 

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
@@ -139,6 +139,8 @@ public interface SConfiguration {
 
     int getBulkImportTasksPerRegion();
 
+    int getRegionToLoadPerTask();
+
     // SIConfigurations
     int getActiveTransactionCacheSize();
 

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
@@ -142,6 +142,7 @@ public class ConfigurationBuilder {
     public int olapClientRetries;
     public double bulkImportSampleFraction;
     public int bulkImportTasksPerRegion;
+    public int regionToLoadPerTask;
     public long controlExecutionRowLimit;
 
     /**

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/PipelineConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/PipelineConfiguration.java
@@ -162,6 +162,10 @@ public class PipelineConfiguration implements ConfigurationDefault {
     public static final String BULK_IMPORT_TASKS_PER_REGION = "splice.bulkImport.tasks.perRegion";
     private static final int DEFAULT_BULK_IMPORT_TASKS_PER_REGION = 1;
 
+    public static final String REGION_TOLOAD_PER_TASK = "splice.region.toLoad.perTask";
+    private static final int DEFAULT_REGION_TOLOAD_PER_TASK = 10;
+
+
     @Override
     public void setDefaults(ConfigurationBuilder builder, ConfigurationSource configurationSource) {
         builder.ipcThreads = configurationSource.getInt(IPC_THREADS, DEFAULT_IPC_THREADS);
@@ -187,6 +191,6 @@ public class PipelineConfiguration implements ConfigurationDefault {
         builder.reservedSlotsTimeout = configurationSource.getInt(SPARK_RESERVED_SLOTS_TIMEOUT, DEFAULT_SPARK_RESERVED_SLOTS_TIMEOUT);
         builder.bulkImportSampleFraction = configurationSource.getDouble(BULK_IMPORT_SAMPLE_FRACTION, DEFAULT_BULK_IMPORT_SAMPLE_FRACTION);
         builder.bulkImportTasksPerRegion = configurationSource.getInt(BULK_IMPORT_TASKS_PER_REGION, DEFAULT_BULK_IMPORT_TASKS_PER_REGION);
-
+        builder.regionToLoadPerTask = configurationSource.getInt(REGION_TOLOAD_PER_TASK, DEFAULT_REGION_TOLOAD_PER_TASK);
     }
 }

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
@@ -101,6 +101,7 @@ public final class SConfigurationImpl implements SConfiguration {
     private final int reservedSlotsTimeout;
     private final double bulkImportSampleFraction;
     private final int bulkImportTasksPerRegion;
+    private final int regionToLoadPerTask;
 
     // OLAP client/server configurations
     private final int olapClientWaitTime;
@@ -363,6 +364,12 @@ public final class SConfigurationImpl implements SConfiguration {
     public int getBulkImportTasksPerRegion() {
         return bulkImportTasksPerRegion;
     }
+
+    @Override
+    public int getRegionToLoadPerTask() {
+        return regionToLoadPerTask;
+    }
+
     @Override
     public int getSparkResultStreamingBatches() {
         return sparkResultStreamingBatches;
@@ -713,6 +720,7 @@ public final class SConfigurationImpl implements SConfiguration {
         controlExecutionRowLimit = builder.controlExecutionRowLimit;
         bulkImportSampleFraction = builder.bulkImportSampleFraction;
         bulkImportTasksPerRegion = builder.bulkImportTasksPerRegion;
+        regionToLoadPerTask = builder.regionToLoadPerTask;
     }
 
     private static final Logger LOG = Logger.getLogger("splice.config");


### PR DESCRIPTION
Add a new parameter splice.region.toLoad.perTask to control the number of regions to load for each  spark task in the last stage of HFile bulk import.