### PR TITLE
DB-6066: build changes for mapr5.2/vanilla yarn support

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -114,7 +114,7 @@
 
                                 <relocation>
                                     <pattern>io.netty</pattern>
-                                    <shadedPattern>splice.io.netty</shadedPattern>
+                                    <shadedPattern>org.spark_project.io.netty</shadedPattern>
                                 </relocation>
 
                                 <relocation>
@@ -176,7 +176,7 @@
                                 </relocation>
                                 <relocation>
                                     <pattern>io.netty</pattern>
-                                    <shadedPattern>splice.io.netty</shadedPattern>
+                                    <shadedPattern>org.spark_project.io.netty</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>javax.ws</pattern>

--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -256,6 +256,12 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-all</artifactId>
                 </exclusion>
+                <!-- experimenting with direct control
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+                -->
 
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>
@@ -267,6 +273,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+<!--
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${zookeeper.version}</version>
+        </dependency>
+-->
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${scala.binary.version}</artifactId>
@@ -595,7 +608,7 @@
             <relocations>
                 <relocation>
                     <pattern>io.netty</pattern>
-                    <shadedPattern>splice.io.netty</shadedPattern>
+                    <shadedPattern>org.spark_project.io.netty</shadedPattern>
                     <includes>
                         <include>io.netty.**</include>
                     </includes>

--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -256,13 +256,6 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-all</artifactId>
                 </exclusion>
-                <!-- experimenting with direct control
-                <exclusion>
-                    <groupId>org.apache.zookeeper</groupId>
-                    <artifactId>zookeeper</artifactId>
-                </exclusion>
-                -->
-
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-common</artifactId>
@@ -273,13 +266,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-<!--
-        <dependency>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-            <version>${zookeeper.version}</version>
-        </dependency>
--->
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${scala.binary.version}</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.6.2.Final</version>
+                <version>3.6.6.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -1078,6 +1078,7 @@
                 <spark.version>2.1.0</spark.version>
                 <spark-assembly-id>spark-assembly-hadoop2.6.0-cdh5.8.0</spark-assembly-id>
                 <kafka.version>0.9.0-kafka-2.0.2</kafka.version>
+                <netty.version>3.6.2.Final</netty.version>
             </properties>
             <modules>
                 <module>hbase_storage</module>
@@ -1211,6 +1212,7 @@
                 <spark.version>2.1.0</spark.version>
                 <spark-assembly-id>spark-assembly-hadoop${hadoop.version}</spark-assembly-id>
                 <kafka.version>0.9.0.0-mapr-1607</kafka.version>
+                <netty.version>3.6.2.Final</netty.version>
             </properties>
             <modules>
                 <module>hbase_storage</module>

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.6.6.Final</version>
+                <version>3.6.2.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -1206,7 +1206,7 @@
                 <hadoop.tools.version>1.0.3-mapr-5.2.0</hadoop.tools.version>
                 <hbase.version>1.1.1-mapr-1602-5.2.0</hbase.version>
                 <hive.version>0.13.0-mapr-1602</hive.version>
-                <zookeeper.version>3.4.5-mapr-1604</zookeeper.version>
+                <zookeeper.version>3.4.5-mapr-1503</zookeeper.version>
                 <maprfs.version>5.2.0-mapr</maprfs.version>
                 <spark.version>2.1.0</spark.version>
                 <spark-assembly-id>spark-assembly-hadoop${hadoop.version}</spark-assembly-id>


### PR DESCRIPTION
There are three changes here, these worked:
change io.netty shading to match the shading which 'vanilla spark' provides
force netty version to be a perfect match for the version packaged with mapr5.2
modify zookeeper.version to match perfectly mapr5.2 (but zookeeper.version is unused...? )

Its possibly we only need the shading change.

I have *only* tested on mapr5.2 on one setup with secure mapr, splice 2.5 branch.