### PR TITLE
DB-6171: Implement retry for jdbc driver to connect to 2.0 and 2.5 (shared-2.5)

### DIFF
--- a/db-client/src/main/java/com/splicemachine/db/client/net/ClientJDBCObjectFactoryImpl.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/ClientJDBCObjectFactoryImpl.java
@@ -269,7 +269,7 @@ public class ClientJDBCObjectFactoryImpl implements ClientJDBCObjectFactory{
             java.util.Properties properties) throws SqlException {
         return (com.splicemachine.db.client.am.Connection)
         (new NetConnection((NetLogWriter)netLogWriter,driverManagerLoginTimeout,
-                serverName,portNumber,databaseName,properties));
+                serverName,portNumber,databaseName,properties, false));
     }
     /**
      * returns an instance of com.splicemachine.db.client.net.NetConnection
@@ -281,7 +281,7 @@ public class ClientJDBCObjectFactoryImpl implements ClientJDBCObjectFactory{
             int rmId,boolean isXAConn) throws SqlException {
         return (com.splicemachine.db.client.am.Connection)
         (new NetConnection((NetLogWriter)netLogWriter,user,password,dataSource,rmId,
-                isXAConn));
+                isXAConn, false));
     }
     /**
      * returns an instance of com.splicemachine.db.client.net.NetConnection
@@ -320,7 +320,7 @@ public class ClientJDBCObjectFactoryImpl implements ClientJDBCObjectFactory{
             ClientPooledConnection cpc) throws SqlException {
         return (com.splicemachine.db.client.am.Connection)
         (new NetConnection((NetLogWriter)netLogWriter,user,password,dataSource,rmId,
-                isXAConn,cpc));
+                isXAConn,cpc, false));
     }
     /**
      * returns an instance of com.splicemachine.db.client.net.NetResultSet

--- a/db-client/src/main/java/com/splicemachine/db/client/net/ClientJDBCObjectFactoryImpl40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/ClientJDBCObjectFactoryImpl40.java
@@ -29,31 +29,7 @@ import com.splicemachine.db.client.ClientPooledConnection;
 import com.splicemachine.db.client.ClientPooledConnection40;
 import com.splicemachine.db.client.ClientXAConnection;
 import com.splicemachine.db.client.ClientXAConnection40;
-import com.splicemachine.db.client.am.CachingLogicalConnection40;
-import com.splicemachine.db.client.am.CallableStatement;
-import com.splicemachine.db.client.am.CallableStatement40;
-import com.splicemachine.db.client.am.ColumnMetaData;
-import com.splicemachine.db.client.am.ColumnMetaData40;
-import com.splicemachine.db.client.am.ClientJDBCObjectFactory;
-import com.splicemachine.db.client.am.LogicalConnection;
-import com.splicemachine.db.client.am.LogicalConnection40;
-import com.splicemachine.db.client.am.PreparedStatement;
-import com.splicemachine.db.client.am.PreparedStatement40;
-import com.splicemachine.db.client.am.ParameterMetaData;
-import com.splicemachine.db.client.am.ParameterMetaData40;
-import com.splicemachine.db.client.am.LogicalCallableStatement;
-import com.splicemachine.db.client.am.LogicalCallableStatement40;
-import com.splicemachine.db.client.am.LogicalPreparedStatement;
-import com.splicemachine.db.client.am.LogicalPreparedStatement40;
-import com.splicemachine.db.client.am.LogWriter;
-import com.splicemachine.db.client.am.Agent;
-import com.splicemachine.db.client.am.SQLExceptionFactory40;
-import com.splicemachine.db.client.am.Section;
-import com.splicemachine.db.client.am.Statement;
-import com.splicemachine.db.client.am.Statement40;
-import com.splicemachine.db.client.am.StatementCacheInteractor;
-import com.splicemachine.db.client.am.SqlException;
-import com.splicemachine.db.client.am.Cursor;
+import com.splicemachine.db.client.am.*;
 import com.splicemachine.db.client.am.stmtcache.JDBCStatementCache;
 import com.splicemachine.db.client.am.stmtcache.StatementKey;
 import com.splicemachine.db.jdbc.ClientBaseDataSource;
@@ -268,9 +244,20 @@ public class ClientJDBCObjectFactoryImpl40 implements ClientJDBCObjectFactory{
             int driverManagerLoginTimeout,String serverName,
             int portNumber,String databaseName,
             java.util.Properties properties) throws SqlException {
-        return (com.splicemachine.db.client.am.Connection)
-        (new NetConnection40((NetLogWriter)netLogWriter,driverManagerLoginTimeout,
-                serverName,portNumber,databaseName,properties));
+        com.splicemachine.db.client.am.Connection conn;
+        try {
+            conn = (new NetConnection40((NetLogWriter) netLogWriter, driverManagerLoginTimeout,
+                    serverName, portNumber, databaseName, properties, false));
+        } catch (SqlException se) {
+            if (se instanceof DisconnectException) {
+                conn = (new NetConnection40((NetLogWriter) netLogWriter, driverManagerLoginTimeout,
+                        serverName, portNumber, databaseName, properties, true));
+            } else {
+                throw se;
+            }
+        }
+
+        return conn;
     }
     /**
      * returns an instance of com.splicemachine.db.client.net.NetConnection40

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetConfiguration.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetConfiguration.java
@@ -196,11 +196,11 @@ public class NetConfiguration {
     static final int USRID_MAXSIZE = 255;
 
     // Product id of the ClientDNC.
-    public static final String PRDID;
+    public static String PRDID;
 
     // The server release level of this product.
     // It will be prefixed with PRDID
-    static final String SRVRLSLV;
+    static String SRVRLSLV;
 
     // Initialize PRDID and SRVRLSLV
     static {
@@ -213,7 +213,31 @@ public class NetConfiguration {
         // mm = minor version
         // x = protocol MaintenanceVersion
 
-        String prdId = DRDAConstants.DERBY_DRDA_CLIENT_ID;
+        //String prdId = DRDAConstants.DERBY_DRDA_CLIENT_ID;
+        String prdId = "DNC";
+        if (majorVersion < 10) {
+            prdId += "0";
+        }
+        prdId += majorVersion;
+
+        if (minorVersion < 10) {
+            prdId += "0";
+        }
+
+        prdId += minorVersion;
+        prdId += protocolMaintVersion;
+        PRDID = prdId;
+        SRVRLSLV = prdId + "/" + Version.getDriverVersion();
+    }
+    static void updatePrdId()
+    {
+        int majorVersion = Version.getMajorVersion();
+        int minorVersion = Version.getMinorVersion();
+        int protocolMaintVersion = Version.getProtocolMaintVersion();
+
+        //
+        //String prdId = DRDAConstants.DERBY_DRDA_CLIENT_ID;
+        String prdId = "SNC";
         if (majorVersion < 10) {
             prdId += "0";
         }

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetConfiguration.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetConfiguration.java
@@ -213,8 +213,7 @@ public class NetConfiguration {
         // mm = minor version
         // x = protocol MaintenanceVersion
 
-        //String prdId = DRDAConstants.DERBY_DRDA_CLIENT_ID;
-        String prdId = "DNC";
+        String prdId = "SNC";  // Use 2.5 server client ID
         if (majorVersion < 10) {
             prdId += "0";
         }
@@ -235,9 +234,7 @@ public class NetConfiguration {
         int minorVersion = Version.getMinorVersion();
         int protocolMaintVersion = Version.getProtocolMaintVersion();
 
-        //
-        //String prdId = DRDAConstants.DERBY_DRDA_CLIENT_ID;
-        String prdId = "SNC";
+        String prdId = "DNC";  // Use pre 2.5 server client ID
         if (majorVersion < 10) {
             prdId += "0";
         }

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetConnection40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetConnection40.java
@@ -74,16 +74,16 @@ public class  NetConnection40 extends com.splicemachine.db.client.net.NetConnect
                          String serverName,
                          int portNumber,
                          String databaseName,
-                         java.util.Properties properties) throws SqlException{
-	super(netLogWriter,driverManagerLoginTimeout,serverName,portNumber,databaseName,properties);
+                         java.util.Properties properties, boolean use20signature) throws SqlException{
+	super(netLogWriter,driverManagerLoginTimeout,serverName,portNumber,databaseName,properties, use20signature);
      }
      public NetConnection40(NetLogWriter netLogWriter,
                          String user,
                          String password,
                          com.splicemachine.db.jdbc.ClientBaseDataSource dataSource,
                          int rmId,
-                         boolean isXAConn) throws SqlException{
-	super(netLogWriter,user,password,dataSource,rmId,isXAConn);
+                         boolean isXAConn ) throws SqlException{
+	super(netLogWriter,user,password,dataSource,rmId,isXAConn, false);
     }
     public NetConnection40(NetLogWriter netLogWriter,
                          String ipaddr,
@@ -123,7 +123,7 @@ public class  NetConnection40 extends com.splicemachine.db.client.net.NetConnect
                          int rmId,
                          boolean isXAConn,
                          ClientPooledConnection cpc) throws SqlException{
-	super(netLogWriter,user,password,dataSource,rmId,isXAConn,cpc);
+	super(netLogWriter,user,password,dataSource,rmId,isXAConn,cpc, false);
     }
     
 

--- a/db-client/src/main/java/com/splicemachine/db/jdbc/ClientDriver.java
+++ b/db-client/src/main/java/com/splicemachine/db/jdbc/ClientDriver.java
@@ -157,6 +157,7 @@ public class ClientDriver implements java.sql.Driver {
                             database,
                             augmentedProperties);
         } catch (SqlException se) {
+
             throw se.getSQLException();
         }
 


### PR DESCRIPTION
Making jdbc driver compatible for 2.0 server build. Without doing any server side changes, here the driver would connect in two attempts to connect to 2.0 server. If it gets connection exception first time, it would retry with the 2.0 product Id and see it can connect.
Tested on standalone with simple jdbc app for both 2.5 and 2.0, will need more testing on cluster with 2.5 db-client.jar
Needs to apply this PR only for special branch "shared-2.5" since its a one off case.