### PR TITLE
DB-6164 re-apply DB-6164's fix: honor Null ordering specification in …(2.6)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexColumnOrder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexColumnOrder.java
@@ -160,6 +160,7 @@ public class IndexColumnOrder implements ColumnOrdering, Formatable
 	{
 		out.writeInt(colNum);
 		out.writeBoolean(ascending);
+		out.writeBoolean(nullsOrderedLow);
 	}
 
 	/**
@@ -175,6 +176,7 @@ public class IndexColumnOrder implements ColumnOrdering, Formatable
 	{
 		colNum = in.readInt();
 		ascending = in.readBoolean();
+		nullsOrderedLow = in.readBoolean();
 	}
 	
 	/**

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkUtils.java
@@ -29,20 +29,22 @@ import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.Function;
-import org.apache.spark.sql.*;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import scala.collection.JavaConversions;
+
 import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
-import static org.apache.spark.sql.functions.asc;
-import static org.apache.spark.sql.functions.col;
-import static org.apache.spark.sql.functions.desc;
+
+import static org.apache.spark.sql.functions.*;
 
 public class SparkUtils {
     public static final Logger LOG = Logger.getLogger(SparkUtils.class);
@@ -226,8 +228,11 @@ public class SparkUtils {
     public static scala.collection.mutable.Buffer<Column> convertSortColumns(ColumnOrdering[] sortColumns){
         return Arrays
                 .stream(sortColumns)
-                .map(column -> column.getIsAscending() ? asc(ValueRow.getNamedColumn(column.getColumnId()-1)) :
-                        desc(ValueRow.getNamedColumn(column.getColumnId()-1)))
+                .map(column -> column.getIsAscending() ?
+                        (column.getIsNullsOrderedLow() ? asc_nulls_first(ValueRow.getNamedColumn(column.getColumnId()-1)) :
+                                                         asc_nulls_last(ValueRow.getNamedColumn(column.getColumnId()-1))) :
+                        (column.getIsNullsOrderedLow() ? desc_nulls_last(ValueRow.getNamedColumn(column.getColumnId()-1)) :
+                                                         desc_nulls_first(ValueRow.getNamedColumn(column.getColumnId()-1))))
                 .collect(Collectors.collectingAndThen(Collectors.toList(), JavaConversions::asScalaBuffer));
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/DerbyWindowContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/DerbyWindowContext.java
@@ -14,10 +14,6 @@
 
 package com.splicemachine.derby.impl.sql.execute.operations.window;
 
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-
 import com.splicemachine.db.iapi.error.SQLWarningFactory;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.loader.ClassFactory;
@@ -26,10 +22,13 @@ import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.impl.sql.GenericStorablePreparedStatement;
 import com.splicemachine.db.impl.sql.execute.WindowFunctionInfo;
 import com.splicemachine.db.impl.sql.execute.WindowFunctionInfoList;
-
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperationContext;
 import com.splicemachine.derby.impl.SpliceMethod;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 
 /**
  * This class records the window definition (partition, orderby and frame)
@@ -115,6 +114,11 @@ public class DerbyWindowContext implements WindowContext {
     public int[] getPartitionColumns() {
         // Any and all aggregators in a window context share the same over() clause
         return this.windowAggregators[0].getPartitionColumns();
+    }
+
+    @Override
+    public boolean[] getNullOrderings() {
+        return this.windowAggregators[0].getNullOrders();
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/WindowAggregator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/WindowAggregator.java
@@ -44,6 +44,8 @@ public interface WindowAggregator {
 
     boolean[] getKeyOrders();
 
+    boolean[] getNullOrders();
+
     FrameDefinition getFrameDefinition();
 
     String getName();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/WindowAggregatorImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/WindowAggregatorImpl.java
@@ -14,8 +14,6 @@
 
 package com.splicemachine.derby.impl.sql.execute.operations.window;
 
-import java.util.Arrays;
-
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.io.FormatableHashtable;
 import com.splicemachine.db.iapi.services.loader.ClassFactory;
@@ -26,10 +24,12 @@ import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.types.UserDataValue;
 import com.splicemachine.db.impl.sql.execute.WindowFunctionInfo;
-
 import com.splicemachine.derby.impl.sql.execute.operations.window.function.SpliceGenericWindowFunction;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import static com.splicemachine.db.iapi.sql.compile.AggregateDefinition.*;
+
+import java.util.Arrays;
+
+import static com.splicemachine.db.iapi.sql.compile.AggregateDefinition.FunctionType;
 
 /**
  * Container and caching mechanism for window functions and their information container.
@@ -52,6 +52,7 @@ public class WindowAggregatorImpl implements WindowAggregator {
     private int[] sortColumns;
     private int[] keyColumns;
     private boolean[] keyOrders;
+    private boolean[] nullOrders;
     private ColumnOrdering[] orderings;
     private ColumnOrdering[] partition;
     private FunctionType type;
@@ -93,11 +94,13 @@ public class WindowAggregatorImpl implements WindowAggregator {
 
         keyColumns = new int[keys.length];
         keyOrders = new boolean[keys.length];
+        nullOrders = new boolean[keys.length];
         index = 0;
         for (ColumnOrdering key : keys) {
             // coming from Derby, these are 1-based column positions
             // convert to 0-based
             keyColumns[index] = key.getColumnId() -1;
+            nullOrders[index] = key.getIsNullsOrderedLow();
             keyOrders[index++] = key.getIsAscending();
         }
 	}
@@ -204,6 +207,11 @@ public class WindowAggregatorImpl implements WindowAggregator {
     @SuppressFBWarnings(value = "EI_EXPOSE_REP",justification = "Intentional")
     public boolean[] getKeyOrders() {
         return keyOrders;
+    }
+
+    @Override
+    public boolean[] getNullOrders() {
+        return nullOrders;
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/WindowContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/WindowContext.java
@@ -14,12 +14,12 @@
 
 package com.splicemachine.derby.impl.sql.execute.operations.window;
 
-import java.io.Externalizable;
-
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperationContext;
 import com.splicemachine.derby.impl.sql.execute.operations.iapi.WarningCollector;
+
+import java.io.Externalizable;
 
 /**
  * @author  jyuan on 7/25/14.
@@ -63,6 +63,8 @@ public interface WindowContext extends WarningCollector,Externalizable {
      * @return the partition array for all functions in this collection.
      */
     int[] getPartitionColumns();
+
+    boolean[] getNullOrderings();
 
     FrameDefinition getFrameDefinition();
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeWindowFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeWindowFunction.java
@@ -24,7 +24,10 @@ import com.splicemachine.derby.stream.window.WindowFrameBuffer;
 import scala.Tuple2;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
 
 import static java.util.Collections.sort;
 
@@ -48,7 +51,10 @@ public class MergeWindowFunction<Op extends WindowOperation> extends SpliceFlatM
             partitionRows.add(lr);
         }
         WindowContext windowContext = operationContext.getOperation().getWindowContext();
-        sort(partitionRows, new LocatedRowComparator(windowContext.getKeyColumns(), windowContext.getKeyOrders()));
+
+        sort(partitionRows, new LocatedRowComparator(windowContext.getKeyColumns(),
+                                                     windowContext.getKeyOrders(),
+                                                     windowContext.getNullOrderings()));
 
         // window logic
         final WindowFrameBuffer frameBuffer = BaseFrameBuffer.createFrameBuffer(
@@ -66,8 +72,8 @@ public class MergeWindowFunction<Op extends WindowOperation> extends SpliceFlatM
     private class LocatedRowComparator implements Comparator<ExecRow> {
         private final ColumnComparator rowComparator;
 
-        public LocatedRowComparator(int[] keyColumns, boolean[] keyOrders) {
-            this.rowComparator = new ColumnComparator(keyColumns, keyOrders, true);
+        public LocatedRowComparator(int[] keyColumns, boolean[] keyOrders, boolean[] nullOrders) {
+            this.rowComparator = new ColumnComparator(keyColumns, keyOrders, nullOrders);
         }
 
         @Override

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/OrderByIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/OrderByIT.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.impl.sql.execute.operations;
+
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.homeless.TestUtils;
+import com.splicemachine.test_tools.TableCreator;
+import org.junit.*;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+
+import static com.splicemachine.test_tools.Rows.row;
+import static com.splicemachine.test_tools.Rows.rows;
+
+/**
+ * Created by yxia on 5/12/17.
+ */
+public class OrderByIT extends SpliceUnitTest {
+    public static final String CLASS_NAME = OrderByIT.class.getSimpleName().toUpperCase();
+    protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);
+    protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
+
+    @ClassRule
+    public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
+            .around(spliceSchemaWatcher);
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher(CLASS_NAME);
+
+    public static void createData(Connection conn, String schemaName) throws Exception {
+
+        new TableCreator(conn)
+                .withCreate("create table t1 (a1 int, b1 int, c1 int, d1 int, e1 int)")
+                .withInsert("insert into t1 values(?,?,?,?,?)")
+                .withRows(rows(
+                        row(1,1,1,1,1),
+                        row(2,null,null,null,null),
+                        row(1,null,null,null,null),
+                        row(1,2,1,1,1)))
+                .create();
+
+        conn.commit();
+    }
+
+    @BeforeClass
+    public static void createDataSet() throws Exception {
+        createData(spliceClassWatcher.getOrCreateConnection(), spliceSchemaWatcher.toString());
+    }
+
+    @Test
+    public void testOrderByClauseWithNullThroughControlPath() throws Exception {
+        // test default path, where Null ordering is not specified
+        // Nulls is treated as larger than any other value
+        String sqlText = "select a1,b1 from t1 --splice-properties useSpark=false\n order by a1,b1";
+        String expected = "A1 | B1  |\n" +
+                "----------\n" +
+                " 1 |  1  |\n" +
+                " 1 |  2  |\n" +
+                " 1 |NULL |\n" +
+                " 2 |NULL |";
+
+        ResultSet rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        sqlText = "select a1,b1 from t1 --splice-properties useSpark=false\n order by a1,b1 desc";
+        expected = "A1 | B1  |\n" +
+                "----------\n" +
+                " 1 |NULL |\n" +
+                " 1 |  2  |\n" +
+                " 1 |  1  |\n" +
+                " 2 |NULL |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        //Nulls first with asc order
+        sqlText = "select a1,b1 from t1 --splice-properties useSpark=false\n order by a1,b1 nulls first";
+        expected = "A1 | B1  |\n" +
+                "----------\n" +
+                " 1 |NULL |\n" +
+                " 1 |  1  |\n" +
+                " 1 |  2  |\n" +
+                " 2 |NULL |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        //Nulls last with asc order
+        sqlText = "select a1,b1 from t1 --splice-properties useSpark=false\n order by a1,b1 nulls last";
+        expected = "A1 | B1  |\n" +
+                "----------\n" +
+                " 1 |  1  |\n" +
+                " 1 |  2  |\n" +
+                " 1 |NULL |\n" +
+                " 2 |NULL |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        //Nulls first with desc order
+        sqlText = "select a1,b1 from t1 --splice-properties useSpark=false\n order by a1,b1 desc nulls first";
+        expected = "A1 | B1  |\n" +
+                "----------\n" +
+                " 1 |NULL |\n" +
+                " 1 |  2  |\n" +
+                " 1 |  1  |\n" +
+                " 2 |NULL |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        //Nulls last with desc order
+        sqlText = "select a1,b1 from t1 --splice-properties useSpark=false\n order by a1,b1 desc nulls last";
+        expected = "A1 | B1  |\n" +
+                "----------\n" +
+                " 1 |  2  |\n" +
+                " 1 |  1  |\n" +
+                " 1 |NULL |\n" +
+                " 2 |NULL |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    }
+
+    @Test
+    public void testOrderByClauseWithNullThroughSparkPath() throws Exception {
+        // test default path, where Null ordering is not specified
+        // Nulls is treated as larger than any other value
+        String sqlText = "select a1,b1 from t1 --splice-properties useSpark=true\n order by a1,b1";
+        String expected = "A1 | B1  |\n" +
+                "----------\n" +
+                " 1 |  1  |\n" +
+                " 1 |  2  |\n" +
+                " 1 |NULL |\n" +
+                " 2 |NULL |";
+
+        ResultSet rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        sqlText = "select a1,b1 from t1 --splice-properties useSpark=true\n order by a1,b1 desc";
+        expected = "A1 | B1  |\n" +
+                "----------\n" +
+                " 1 |NULL |\n" +
+                " 1 |  2  |\n" +
+                " 1 |  1  |\n" +
+                " 2 |NULL |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        //Nulls first with asc order
+        sqlText = "select a1,b1 from t1 --splice-properties useSpark=true\n order by a1,b1 nulls first";
+        expected = "A1 | B1  |\n" +
+                "----------\n" +
+                " 1 |NULL |\n" +
+                " 1 |  1  |\n" +
+                " 1 |  2  |\n" +
+                " 2 |NULL |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        //Nulls last with asc order
+        sqlText = "select a1,b1 from t1 --splice-properties useSpark=true\n order by a1,b1 nulls last";
+        expected = "A1 | B1  |\n" +
+                "----------\n" +
+                " 1 |  1  |\n" +
+                " 1 |  2  |\n" +
+                " 1 |NULL |\n" +
+                " 2 |NULL |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        //Nulls first with desc order
+        sqlText = "select a1,b1 from t1 --splice-properties useSpark=true\n order by a1,b1 desc nulls first";
+        expected = "A1 | B1  |\n" +
+                "----------\n" +
+                " 1 |NULL |\n" +
+                " 1 |  2  |\n" +
+                " 1 |  1  |\n" +
+                " 2 |NULL |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        //Nulls last with desc order
+        sqlText = "select a1,b1 from t1 --splice-properties useSpark=true\n order by a1,b1 desc nulls last";
+        expected = "A1 | B1  |\n" +
+                "----------\n" +
+                " 1 |  2  |\n" +
+                " 1 |  1  |\n" +
+                " 1 |NULL |\n" +
+                " 2 |NULL |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    }
+
+    @Test
+    public void testOrderByClauseWithNullInWindowFunctionThroughControlPath() throws Exception {
+        // test default path
+        // Nulls is treated as larger than any other value
+        String sqlText = "select a1,b1, row_number() over (partition by a1 order by b1) rnk\n" +
+                "from t1 --splice-properties useSpark=false\n order by a1, rnk";
+        String expected = "A1 | B1  | RNK |\n" +
+                "----------------\n" +
+                " 1 |  1  |  1  |\n" +
+                " 1 |  2  |  2  |\n" +
+                " 1 |NULL |  3  |\n" +
+                " 2 |NULL |  1  |";
+        ResultSet rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        sqlText = "select a1,b1, row_number() over (partition by a1 order by b1 desc) rnk\n" +
+                "from t1 --splice-properties useSpark=false\n order by a1, rnk";
+        expected = "A1 | B1  | RNK |\n" +
+                "----------------\n" +
+                " 1 |NULL |  1  |\n" +
+                " 1 |  2  |  2  |\n" +
+                " 1 |  1  |  3  |\n" +
+                " 2 |NULL |  1  |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        //Nulls first with asc order
+        sqlText = "select a1,b1, row_number() over (partition by a1 order by b1 nulls first) rnk\n" +
+                "from t1 --splice-properties useSpark=false\n order by a1, rnk";
+        expected = "A1 | B1  | RNK |\n" +
+                "----------------\n" +
+                " 1 |NULL |  1  |\n" +
+                " 1 |  1  |  2  |\n" +
+                " 1 |  2  |  3  |\n" +
+                " 2 |NULL |  1  |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        //Nulls last with asc order
+        sqlText = "select a1,b1, row_number() over (partition by a1 order by b1 nulls last) rnk\n" +
+                "from t1 --splice-properties useSpark=false\n order by a1, rnk";
+        expected = "A1 | B1  | RNK |\n" +
+                "----------------\n" +
+                " 1 |  1  |  1  |\n" +
+                " 1 |  2  |  2  |\n" +
+                " 1 |NULL |  3  |\n" +
+                " 2 |NULL |  1  |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        //Nulls first with desc order
+        sqlText = "select a1,b1, row_number() over (partition by a1 order by b1 desc nulls first) rnk\n" +
+                "from t1 --splice-properties useSpark=false\n order by a1, rnk";
+        expected = "A1 | B1  | RNK |\n" +
+                "----------------\n" +
+                " 1 |NULL |  1  |\n" +
+                " 1 |  2  |  2  |\n" +
+                " 1 |  1  |  3  |\n" +
+                " 2 |NULL |  1  |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        //Nulls last with desc order
+        sqlText = "select a1,b1, row_number() over (partition by a1 order by b1 desc nulls last) rnk\n" +
+                "from t1 --splice-properties useSpark=false\n order by a1, rnk";
+        expected = "A1 | B1  | RNK |\n" +
+                "----------------\n" +
+                " 1 |  2  |  1  |\n" +
+                " 1 |  1  |  2  |\n" +
+                " 1 |NULL |  3  |\n" +
+                " 2 |NULL |  1  |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    }
+
+    @Test
+    public void testOrderByClauseWithNullInWindowFunctionThroughSparkPath() throws Exception {
+        // test default path
+        // Nulls is treated as larger than any other value
+        String sqlText = "select a1,b1, row_number() over (partition by a1 order by b1) rnk\n" +
+                "from t1 --splice-properties useSpark=true\n order by a1, rnk";
+        String expected = "A1 | B1  | RNK |\n" +
+                "----------------\n" +
+                " 1 |  1  |  1  |\n" +
+                " 1 |  2  |  2  |\n" +
+                " 1 |NULL |  3  |\n" +
+                " 2 |NULL |  1  |";
+        ResultSet rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        sqlText = "select a1,b1, row_number() over (partition by a1 order by b1 desc) rnk\n" +
+                "from t1 --splice-properties useSpark=true\n order by a1, rnk";
+        expected = "A1 | B1  | RNK |\n" +
+                "----------------\n" +
+                " 1 |NULL |  1  |\n" +
+                " 1 |  2  |  2  |\n" +
+                " 1 |  1  |  3  |\n" +
+                " 2 |NULL |  1  |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        //Nulls first with asc order
+        sqlText = "select a1,b1, row_number() over (partition by a1 order by b1 nulls first) rnk\n" +
+                "from t1 --splice-properties useSpark=true\n order by a1, rnk";
+        expected = "A1 | B1  | RNK |\n" +
+                "----------------\n" +
+                " 1 |NULL |  1  |\n" +
+                " 1 |  1  |  2  |\n" +
+                " 1 |  2  |  3  |\n" +
+                " 2 |NULL |  1  |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        //Nulls last with asc order
+        sqlText = "select a1,b1, row_number() over (partition by a1 order by b1 nulls last) rnk\n" +
+                "from t1 --splice-properties useSpark=true\n order by a1, rnk";
+        expected = "A1 | B1  | RNK |\n" +
+                "----------------\n" +
+                " 1 |  1  |  1  |\n" +
+                " 1 |  2  |  2  |\n" +
+                " 1 |NULL |  3  |\n" +
+                " 2 |NULL |  1  |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        //Nulls first with desc order
+        sqlText = "select a1,b1, row_number() over (partition by a1 order by b1 desc nulls first) rnk\n" +
+                "from t1 --splice-properties useSpark=true\n order by a1, rnk";
+        expected = "A1 | B1  | RNK |\n" +
+                "----------------\n" +
+                " 1 |NULL |  1  |\n" +
+                " 1 |  2  |  2  |\n" +
+                " 1 |  1  |  3  |\n" +
+                " 2 |NULL |  1  |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        //Nulls last with desc order
+        sqlText = "select a1,b1, row_number() over (partition by a1 order by b1 desc nulls last) rnk\n" +
+                "from t1 --splice-properties useSpark=true\n order by a1, rnk";
+        expected = "A1 | B1  | RNK |\n" +
+                "----------------\n" +
+                " 1 |  2  |  1  |\n" +
+                " 1 |  1  |  2  |\n" +
+                " 1 |NULL |  3  |\n" +
+                " 2 |NULL |  1  |";
+        rs = methodWatcher.executeQuery(sqlText);
+        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    }
+
+}

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WindowFunctionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WindowFunctionIT.java
@@ -14,36 +14,28 @@
 
 package com.splicemachine.derby.impl.sql.execute.operations;
 
-import static com.splicemachine.test_tools.Rows.row;
-import static com.splicemachine.test_tools.Rows.rows;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.Collection;
-
+import com.splicemachine.derby.test.framework.*;
+import com.splicemachine.homeless.TestUtils;
+import com.splicemachine.test_dao.TableDAO;
+import com.splicemachine.test_tools.TableCreator;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
-
-import com.splicemachine.derby.test.framework.SpliceDataWatcher;
-import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
-import com.splicemachine.derby.test.framework.SpliceTableWatcher;
-import com.splicemachine.derby.test.framework.SpliceUnitTest;
-import com.splicemachine.derby.test.framework.SpliceViewWatcher;
-import com.splicemachine.derby.test.framework.SpliceWatcher;
-import com.splicemachine.homeless.TestUtils;
-import com.splicemachine.test_dao.TableDAO;
-import com.splicemachine.test_tools.TableCreator;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.spark_project.guava.collect.Lists;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+
+import static com.splicemachine.test_tools.Rows.row;
+import static com.splicemachine.test_tools.Rows.rows;
+import static org.junit.Assert.*;
 
 /**
  *
@@ -3439,8 +3431,8 @@ public class WindowFunctionIT extends SpliceUnitTest {
                         "  40   |2013-06-06 | 52000 |          3          |  2  |          3          |\n" +
                         "  44   |2013-12-20 | 52000 |          4          |  2  |          4          |\n" +
                         "  100  |2010-04-12 | 55000 |          1          |  3  |          1          |\n" +
-                        "  33   |2010-08-09 | NULL  |          2          |  3  |          2          |\n" +
-                        "  30   |2010-08-09 | 84000 |          3          |  3  |          3          |\n" +
+                        "  30   |2010-08-09 | 84000 |          2          |  3  |          2          |\n" +
+                        "  33   |2010-08-09 | NULL  |          3          |  3  |          3          |\n" +
                         "  120  |2012-04-03 | 75000 |          4          |  3  |          4          |\n" +
                         "  80   |2013-04-24 | 79000 |          5          |  3  |          5          |";
         assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
@@ -3528,23 +3520,23 @@ public class WindowFunctionIT extends SpliceUnitTest {
         String expected =
                 "EMPNUM |SALARY | DENSERANK |DEPT | ROWNUMBER |\n" +
                         "----------------------------------------------\n" +
-                        "  10   | 50000 |     2     |  1  |     1     |\n" +
-                        "  20   | 75000 |     6     |  1  |     2     |\n" +
-                        "  32   | NULL  |     1     |  1  |     3     |\n" +
-                        "  50   | 52000 |     3     |  1  |     4     |\n" +
-                        "  55   | 52000 |     4     |  1  |     5     |\n" +
-                        "  60   | 78000 |     8     |  1  |     6     |\n" +
-                        "  70   | 76000 |     7     |  1  |     7     |\n" +
-                        "  110  | 53000 |     5     |  1  |     8     |\n" +
+                        "  10   | 50000 |     1     |  1  |     1     |\n" +
+                        "  20   | 75000 |     5     |  1  |     2     |\n" +
+                        "  32   | NULL  |     8     |  1  |     3     |\n" +
+                        "  50   | 52000 |     2     |  1  |     4     |\n" +
+                        "  55   | 52000 |     3     |  1  |     5     |\n" +
+                        "  60   | 78000 |     7     |  1  |     6     |\n" +
+                        "  70   | 76000 |     6     |  1  |     7     |\n" +
+                        "  110  | 53000 |     4     |  1  |     8     |\n" +
                         "  40   | 52000 |     2     |  2  |     1     |\n" +
                         "  44   | 52000 |     3     |  2  |     2     |\n" +
                         "  49   | 53000 |     4     |  2  |     3     |\n" +
                         "  90   | 51000 |     1     |  2  |     4     |\n" +
-                        "  30   | 84000 |     5     |  3  |     1     |\n" +
-                        "  33   | NULL  |     1     |  3  |     2     |\n" +
-                        "  80   | 79000 |     4     |  3  |     3     |\n" +
-                        "  100  | 55000 |     2     |  3  |     4     |\n" +
-                        "  120  | 75000 |     3     |  3  |     5     |";
+                        "  30   | 84000 |     4     |  3  |     1     |\n" +
+                        "  33   | NULL  |     5     |  3  |     2     |\n" +
+                        "  80   | 79000 |     3     |  3  |     3     |\n" +
+                        "  100  | 55000 |     1     |  3  |     4     |\n" +
+                        "  120  | 75000 |     2     |  3  |     5     |";
         assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         rs.close();
     }


### PR DESCRIPTION
…Spark and Control path for Window function

by reverting commit 817a09dfe3560ac71b9f2cf74eec7d6782c699d8.