### PR TITLE
DB-6183: clean up rpc for backup

### DIFF
--- a/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -111,7 +111,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         SpliceMessage.PrepareBackupResponse.Builder responseBuilder = SpliceMessage.PrepareBackupResponse.newBuilder();
         responseBuilder.setReadyForBackup(false);
 
-        if (BackupUtils.shouldIgnore(request, region)) {
+        if (!BackupUtils.regionKeysMatch(request, region)) {
+            // if the start/end key of the request does not match this region, return false to the client, because
+            // region has been split. The client should retry.
+
             return responseBuilder;
         }
 

--- a/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -111,7 +111,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         SpliceMessage.PrepareBackupResponse.Builder responseBuilder = SpliceMessage.PrepareBackupResponse.newBuilder();
         responseBuilder.setReadyForBackup(false);
 
-        if (BackupUtils.shouldIgnore(request, region)) {
+        if (!BackupUtils.regionKeysMatch(request, region)) {
+            // if the start/end key of the request does not match this region, return false to the client, because
+            // region has been split. The client should retry.
+
             return responseBuilder;
         }
 

--- a/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -111,7 +111,10 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         SpliceMessage.PrepareBackupResponse.Builder responseBuilder = SpliceMessage.PrepareBackupResponse.newBuilder();
         responseBuilder.setReadyForBackup(false);
 
-        if (BackupUtils.shouldIgnore(request, region)) {
+        if (!BackupUtils.regionKeysMatch(request, region)) {
+            // if the start/end key of the request does not match this region, return false to the client, because
+            // region has been split. The client should retry.
+
             return responseBuilder;
         }
 

--- a/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -111,7 +111,9 @@ public class BackupEndpointObserver extends BackupBaseRegionObserver implements 
         SpliceMessage.PrepareBackupResponse.Builder responseBuilder = SpliceMessage.PrepareBackupResponse.newBuilder();
         responseBuilder.setReadyForBackup(false);
 
-        if (BackupUtils.shouldIgnore(request, region)) {
+        if (!BackupUtils.regionKeysMatch(request, region)) {
+            // if the start/end key of the request does not match this region, return false to the client, because
+            // region has been split. The client should retry.
             return responseBuilder;
         }
 

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/BackupUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/BackupUtils.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -282,11 +283,16 @@ public class BackupUtils {
      * @param region
      * @return
      */
-    public static boolean shouldIgnore(SpliceMessage.PrepareBackupRequest request, HRegion region) {
-        byte[] endKey = request.hasEndKey() ? request.getEndKey().toByteArray() : null;
-        byte[] regionStartKey = region.getRegionInfo().getStartKey();
-        return endKey != null && endKey.length > 0 && Bytes.compareTo(endKey, regionStartKey) == 0;
+    public static boolean regionKeysMatch(SpliceMessage.PrepareBackupRequest request, HRegion region) {
+        byte[] requestStartKey = request.hasStartKey() ? request.getStartKey().toByteArray() : new byte[0];
+        byte[] requestEndKey = request.hasEndKey() ? request.getEndKey().toByteArray() : new byte[0];
 
+        HRegionInfo regionInfo = region.getRegionInfo();
+        byte[] regionStartKey = regionInfo.getStartKey() != null? regionInfo.getStartKey() : new byte[0];
+        byte[] regionEndKey = regionInfo.getEndKey() != null ? regionInfo.getEndKey() : new byte[0];
+
+        return Bytes.compareTo(requestStartKey, regionStartKey) ==0 &&
+                Bytes.compareTo(requestEndKey, regionEndKey) == 0;
     }
 
     private static boolean backupTimedout() throws Exception {


### PR DESCRIPTION
Clean up rpc for backup, so it won't accidentally trying to prob a missing region and gets stuck.