### PR TITLE
SPLICE-1784: Fixing cutpoint generation

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/hbase/BytesCopyTaskSplitter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/BytesCopyTaskSplitter.java
@@ -27,12 +27,12 @@ import java.util.*;
  *         Date: 4/16/14
  */
 public class BytesCopyTaskSplitter {
-    public static List<byte[]> getCutPoints(HRegion region, byte[] start, byte[] end,byte[] expectedRegionEnd) throws IOException {
+    public static List<byte[]> getCutPoints(HRegion region, byte[] start, byte[] end) throws IOException {
         Store store = null;
         try {
             store = region.getStore(SIConstants.DEFAULT_FAMILY_BYTES);
             HRegionUtil.lockStore(store);
-            return HRegionUtil.getCutpoints(store, start, end, expectedRegionEnd);
+            return HRegionUtil.getCutpoints(store, start, end);
         }catch (Throwable t) {
             throw Exceptions.getIOException(t);
         }finally{

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/AbstractSMInputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/AbstractSMInputFormat.java
@@ -103,7 +103,22 @@ public abstract class AbstractSMInputFormat<K,V> extends InputFormat<K, V> imple
                 }
                 SubregionSplitter splitter = new HBaseSubregionSplitter();
 
-                return splitter.getSubSplits(table, splits, s.getStartRow(), s.getStopRow());
+                List<InputSplit> lss= splitter.getSubSplits(table, splits, s.getStartRow(), s.getStopRow());
+                //check if split count changed in-between
+                List<Partition>  newSplits = clientPartition.subPartitions(s.getStartRow(), s.getStopRow(), refresh);
+                if (splits.size() != newSplits.size()) {
+                    // retry
+                    refresh = true;
+                    LOG.warn("mismatched splits: earlier" + splits + ", later: " + newSplits + " for region " + clientPartition);
+                    retryCounter++;
+                    if (retryCounter > MAX_RETRIES) {
+                        throw new RuntimeException("MAX_RETRIES exceeded during getSplits");
+                    }
+                } else {
+                   return lss;
+                }
+
+
             } catch (HMissedSplitException e) {
                 // retry;
                 refresh = true;

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/AbstractSMInputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/AbstractSMInputFormat.java
@@ -105,11 +105,11 @@ public abstract class AbstractSMInputFormat<K,V> extends InputFormat<K, V> imple
 
                 List<InputSplit> lss= splitter.getSubSplits(table, splits, s.getStartRow(), s.getStopRow());
                 //check if split count changed in-between
-                List<Partition>  newSplits = clientPartition.subPartitions(s.getStartRow(), s.getStopRow(), refresh);
+                List<Partition>  newSplits = clientPartition.subPartitions(s.getStartRow(), s.getStopRow(), true);
                 if (splits.size() != newSplits.size()) {
                     // retry
                     refresh = true;
-                    LOG.warn("mismatched splits: earlier" + splits + ", later: " + newSplits + " for region " + clientPartition);
+                    LOG.warn("mismatched splits: earlier [" + splits.size() + "], later [" + newSplits.size() + "] for region " + clientPartition);
                     retryCounter++;
                     if (retryCounter > MAX_RETRIES) {
                         throw new RuntimeException("MAX_RETRIES exceeded during getSplits");

--- a/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionUtil.java
+++ b/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionUtil.java
@@ -96,12 +96,8 @@ public class HRegionUtil extends BaseHRegionUtil{
                 long storeFileInBytes = file.getFileInfo().getFileStatus().getLen();
                 if (LOG.isTraceEnabled())
                     SpliceLogUtils.trace(LOG, "getCutpoints with file=%s with size=%d", file.getPath(), storeFileInBytes);
-                try {
-                    fileReader = file.createReader().getHFileReader();
-                    carry = addStoreFileCutpoints(cutPoints, fileReader, storeFileInBytes, carry, range);
-                } finally {
-                    fileReader.close();
-                }
+                fileReader = file.createReader().getHFileReader();
+                carry = addStoreFileCutpoints(cutPoints, fileReader, storeFileInBytes, carry, range);
             }
         }
 

--- a/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionUtil.java
+++ b/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionUtil.java
@@ -66,23 +66,18 @@ public class HRegionUtil extends BaseHRegionUtil{
         HBasePlatformUtils.updateReadRequests(region,numReads);
     }
 
-    public static List<byte[]> getCutpoints(Store store, byte[] start, byte[] end, byte[] expectedRegionEnd) throws IOException {
+    public static List<byte[]> getCutpoints(Store store, byte[] start, byte[] end) throws IOException {
         assert Bytes.startComparator.compare(start, end) <= 0 || start.length == 0 || end.length == 0;
         if (LOG.isTraceEnabled())
             SpliceLogUtils.trace(LOG, "getCutpoints");
         Collection<StoreFile> storeFiles;
         storeFiles = store.getStorefiles();
-        HFile.Reader fileReader;
+        HFile.Reader fileReader = null;
         List<byte[]> cutPoints = new ArrayList<byte[]>();
         int carry = 0;
 
         byte[] regionStart = store.getRegionInfo().getStartKey();
         byte[] regionEnd = store.getRegionInfo().getEndKey();
-
-        if ((expectedRegionEnd.length == 0 && regionEnd.length != 0)
-                || Bytes.endComparator.compare(expectedRegionEnd, regionEnd) > 0) {
-            throw new HMissedSplitException("Subplit computation missed region split");
-        }
 
         if (regionStart != null && regionStart.length > 0) {
             if (start == null || Bytes.startComparator.compare(start, regionStart) < 0) {
@@ -101,8 +96,12 @@ public class HRegionUtil extends BaseHRegionUtil{
                 long storeFileInBytes = file.getFileInfo().getFileStatus().getLen();
                 if (LOG.isTraceEnabled())
                     SpliceLogUtils.trace(LOG, "getCutpoints with file=%s with size=%d", file.getPath(), storeFileInBytes);
-                fileReader = file.createReader().getHFileReader();
-                carry = addStoreFileCutpoints(cutPoints, fileReader, storeFileInBytes, carry, range);
+                try {
+                    fileReader = file.createReader().getHFileReader();
+                    carry = addStoreFileCutpoints(cutPoints, fileReader, storeFileInBytes, carry, range);
+                } finally {
+                    fileReader.close();
+                }
             }
         }
 

--- a/splice_protocol/src/main/protobuf/Splice.proto
+++ b/splice_protocol/src/main/protobuf/Splice.proto
@@ -142,11 +142,11 @@ service SpliceDerbyCoprocessorService {
 message SpliceSplitServiceRequest {
     optional bytes beginKey = 1;
     optional bytes endKey = 2;
-    optional bytes regionEndKey = 3;
 }
 
 message SpliceSplitServiceResponse {
     repeated bytes cutPoint = 1;
+    required string hostName = 2;
 }
 
 


### PR DESCRIPTION
Earlier reverted due to tpc1g intermittent regressions. Now added the retry coprocessor while getting subsplits for the region during that interval. Tested with tpch1g 15 runs consecutively, and more manual testing.