### PR TITLE
SPLICE-1373 Extended query logging

### DIFF
--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/NetworkServerControlImpl.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/NetworkServerControlImpl.java
@@ -70,6 +70,7 @@ import java.util.StringTokenizer;
 import java.util.Vector;
 
 import com.splicemachine.db.drda.NetworkServerControl;
+import com.splicemachine.db.iapi.services.stream.HeaderPrintWriter;
 import com.splicemachine.db.security.SystemPermission;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.jdbc.DRDAServerStarter;
@@ -224,7 +225,7 @@ public final class NetworkServerControlImpl {
 											
 	
 	protected PrintWriter logWriter;                        // console
-	protected PrintWriter cloudscapeLogWriter;              // db.log
+	protected HeaderPrintWriter cloudscapeLogWriter;              // db.log
 	private static Driver cloudscapeDriver;
 
 	// error types
@@ -590,11 +591,10 @@ public final class NetworkServerControlImpl {
 			e.printStackTrace();
 		}
 		
-		lw = cloudscapeLogWriter;
-		if (lw != null)
+		if (cloudscapeLogWriter != null)
 		{
-			synchronized(lw) {
-				e.printStackTrace(lw);
+			synchronized(cloudscapeLogWriter) {
+				cloudscapeLogWriter.printThrowable(e);
 			}
 		}
 	}
@@ -623,9 +623,8 @@ public final class NetworkServerControlImpl {
 			}
 		}
 		// always print to db.log
-		lw = cloudscapeLogWriter;
-		if (lw != null)
-			synchronized(lw)
+		if (cloudscapeLogWriter != null)
+			synchronized(cloudscapeLogWriter)
 			{
 				if (printTimeStamp) {
                     Monitor.logMessage(new Date() + " : " + msg);
@@ -715,7 +714,7 @@ public final class NetworkServerControlImpl {
 	{
 		startNetworkServer();
 		setLogWriter(consoleWriter);
-		cloudscapeLogWriter = Monitor.getStream().getPrintWriter();
+		cloudscapeLogWriter = Monitor.getStream();
 		if (SanityManager.DEBUG && debugOutput)
 		{
 			memCheck.showmem();

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/DRDAServerStarter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/DRDAServerStarter.java
@@ -31,6 +31,7 @@
 
 package com.splicemachine.db.iapi.jdbc;
 
+import com.splicemachine.db.iapi.services.i18n.MessageService;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.services.monitor.Monitor;
 import com.splicemachine.db.iapi.services.monitor.ModuleControl;
@@ -210,9 +211,7 @@ public final class DRDAServerStarter implements ModuleControl, Runnable
             catch( PrivilegedActionException e)
             {
                 Exception e1 = e.getException();
-                Monitor.logTextMessage(
-									   MessageId.CONN_NETWORK_SERVER_START_EXCEPTION, e1.getMessage());
-				e.printStackTrace(Monitor.getStream().getPrintWriter());
+                Monitor.getStream().printThrowable(MessageService.getTextMessage(MessageId.CONN_NETWORK_SERVER_START_EXCEPTION, e1.getMessage()), e);
                 return;
 
             }
@@ -233,9 +232,8 @@ public final class DRDAServerStarter implements ModuleControl, Runnable
         }
         catch( Exception e)
         {
-			Monitor.logTextMessage( MessageId.CONN_NETWORK_SERVER_START_EXCEPTION, e.getMessage());
 			server = null;
-			e.printStackTrace(Monitor.getStream().getPrintWriter());
+            Monitor.getStream().printThrowable(MessageService.getTextMessage(MessageId.CONN_NETWORK_SERVER_START_EXCEPTION, e.getMessage()), e);
         }
     } // end of boot
 
@@ -248,17 +246,13 @@ public final class DRDAServerStarter implements ModuleControl, Runnable
         }
         catch( InvocationTargetException ite)
         {
-            Monitor.logTextMessage(
-								   MessageId.CONN_NETWORK_SERVER_START_EXCEPTION, ite.getTargetException().getMessage());
-			ite.printStackTrace(Monitor.getStream().getPrintWriter());
-
+            Monitor.getStream().printThrowable(MessageService.getTextMessage(MessageId.CONN_NETWORK_SERVER_START_EXCEPTION, ite.getTargetException().getMessage()), ite);
             server = null;
         }
         catch( Exception e)
         {
-            Monitor.logTextMessage( MessageId.CONN_NETWORK_SERVER_START_EXCEPTION, e.getMessage());
             server = null;
-			e.printStackTrace(Monitor.getStream().getPrintWriter());
+            Monitor.getStream().printThrowable(MessageService.getTextMessage(MessageId.CONN_NETWORK_SERVER_START_EXCEPTION, e.getMessage()), e);
         }
     }
     
@@ -282,15 +276,11 @@ public final class DRDAServerStarter implements ModuleControl, Runnable
 		}
 		catch( InvocationTargetException ite)
         {
-			Monitor.logTextMessage(
-								   MessageId.CONN_NETWORK_SERVER_SHUTDOWN_EXCEPTION, ite.getTargetException().getMessage());
-			ite.printStackTrace(Monitor.getStream().getPrintWriter());
-			
+            Monitor.getStream().printThrowable(MessageService.getTextMessage( MessageId.CONN_NETWORK_SERVER_SHUTDOWN_EXCEPTION, ite.getTargetException().getMessage()), ite);
         }
         catch( Exception e)
         {
-            Monitor.logTextMessage( MessageId.CONN_NETWORK_SERVER_SHUTDOWN_EXCEPTION, e.getMessage());
-			e.printStackTrace(Monitor.getStream().getPrintWriter());
+            Monitor.getStream().printThrowable(MessageService.getTextMessage( MessageId.CONN_NETWORK_SERVER_SHUTDOWN_EXCEPTION, e.getMessage()), e);
 		}
 			
 		serverThread = null;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextManager.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextManager.java
@@ -368,8 +368,7 @@ cleanup:	for (int index = holder.size() - 1; index >= 0; index--) {
 							error = se;
 							reportError = reportError(se);
 							if (reportError) {
-								errorStream.println("New exception raised during cleanup " + error.getMessage());
-								errorStream.flush();
+								errorStream.printThrowable("New exception raised during cleanup", error);
 							}
 							continue forever;
 						}
@@ -398,8 +397,7 @@ cleanup:	for (int index = holder.size() - 1; index >= 0; index--) {
 						 */
 						error = t;
 						if (reportError) {
-							errorStream.println("New exception raised during cleanup " + error.getMessage());
-							errorStream.flush();
+							errorStream.printThrowable("New exception raised during cleanup", error);
 						}
 						continue forever;
 					}
@@ -432,7 +430,6 @@ cleanup:	for (int index = holder.size() - 1; index >= 0; index--) {
 
 			if (reportError) {
 				errorStream.println("Cleanup action completed");
-				errorStream.flush();
 			}
 
 			if (seenThreadDeath != null)
@@ -500,8 +497,7 @@ cleanup:	for (int index = holder.size() - 1; index >= 0; index--) {
 	 */
 	private void flushErrorString()
 	{
-		errorStream.print(errorStringBuilder.get().toString());
-		errorStream.flush();
+		errorStream.println(errorStringBuilder.get().toString());
 		errorStringBuilder.reset();
 	}
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/monitor/Monitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/monitor/Monitor.java
@@ -814,6 +814,6 @@ public class Monitor {
      * Logs the stack trace of the specified throwable object.
      */
     public static void logThrowable(Throwable t) {
-        t.printStackTrace(getStream().getPrintWriter());
+		getStream().printThrowable(t);
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/stream/HeaderPrintWriter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/stream/HeaderPrintWriter.java
@@ -62,6 +62,8 @@ public interface HeaderPrintWriter
 	 */
 	String getName();
 
+	void printStatement(String statement);
+
 	/**
 	 * @see java.io.PrintWriter#println
 	 */

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/stream/HeaderPrintWriter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/stream/HeaderPrintWriter.java
@@ -56,45 +56,20 @@ public interface HeaderPrintWriter
 	 * Return the header for the stream.
 	 */
 	PrintWriterGetHeader getHeader();
-	
-	/**
-	 * Gets a PrintWriter object for writing to this HeaderPrintWriter.
-	 * Users may use the HeaderPrintWriter to access methods not included
-	 * in this interface or to invoke methods or constructors which require
-	 * a PrintWriter. 
-	 *
-	 * Interleaving calls to a printWriter and its associated HeaderPrintWriter
-	 * is not supported.
-	 * 
-	 */
-	PrintWriter getPrintWriter();
 
 	/**
 	 * Gets the name of the wrapped writer or stream
 	 */
 	String getName();
 
-	/*
-	 * The routines that mimic java.io.PrintWriter...
-	 */
-	/**
-	 * @see java.io.PrintWriter#print
-	 */
-	void print(String message);
-
 	/**
 	 * @see java.io.PrintWriter#println
 	 */
 	void println(String message);
 
-	/**
-	 * @see java.io.PrintWriter#println
-	 */
-	void println(Object message);
 
-	/**
-	* @see java.io.PrintWriter#flush
-	 */
-	void flush();
+	void printThrowable(String message, Throwable t);
+
+	void printThrowable(Throwable t);
 }
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -88,7 +88,7 @@ public interface LanguageConnectionContext extends Context {
 	String dbnameStr = "(DATABASE = ";
 	String drdaStr = "(DRDAID = ";
 	String uuidStr = "(UUID = ";
-	String execStr = "(EXEC = ";
+	String execStr = "(ENGINE = ";
 
 	// Lock Management
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -87,6 +87,8 @@ public interface LanguageConnectionContext extends Context {
 	String lccStr = "(SESSIONID = ";
 	String dbnameStr = "(DATABASE = ";
 	String drdaStr = "(DRDAID = ";
+	String uuidStr = "(UUID = ";
+	String execStr = "(EXEC = ";
 
 	// Lock Management
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/db/BasicDatabase.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/db/BasicDatabase.java
@@ -235,7 +235,7 @@ public class BasicDatabase implements ModuleControl, ModuleSupportable, Property
                 // the sequence generators.
                 dd.clearSequenceCaches();
             } catch (StandardException se) {
-                se.printStackTrace(Monitor.getStream().getPrintWriter());
+				Monitor.getStream().printThrowable(se);
             }
         }
 		active = false;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/Util.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/Util.java
@@ -155,10 +155,9 @@ public abstract class Util  {
     		return;
     	}
     	ErrorStringBuilder	errorStringBuilder = new ErrorStringBuilder(errorStream.getHeader());
-    	errorStringBuilder.append("\nERROR " +  sqlstate + ": "  + se.getMessage() + "\n");
+    	errorStringBuilder.append("\nERROR " +  sqlstate + ": "  + se.getMessage());
     	errorStringBuilder.stackTrace(se);
-    	errorStream.print(errorStringBuilder.get().toString());
-    	errorStream.flush();
+    	errorStream.println(errorStringBuilder.get().toString());
     	errorStringBuilder.reset();
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/BaseMonitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/BaseMonitor.java
@@ -77,6 +77,7 @@ import com.splicemachine.db.iapi.services.i18n.MessageService;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.BufferedInputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -347,7 +348,7 @@ abstract class BaseMonitor
 			systemStreams = (InfoStreams) Monitor.startSystemModule("com.splicemachine.db.iapi.services.stream.InfoStreams");
 
 			if (SanityManager.DEBUG) {
-				SanityManager.SET_DEBUG_STREAM(systemStreams.stream().getPrintWriter());
+				SanityManager.SET_DEBUG_STREAM(new PrintWriter(new OutputStreamWriter(System.err)));
 			}
 
 			contextService = ContextService.getService();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/stream/BasicGetLogHeader.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/stream/BasicGetLogHeader.java
@@ -44,10 +44,6 @@ import com.splicemachine.db.iapi.services.stream.PrintWriterGetHeader;
 
 class BasicGetLogHeader implements PrintWriterGetHeader
 {
-	
-	private boolean doThreadId;
-	private boolean doTimeStamp;
-	private String tag;
 
 	/* 
 	 * STUB: This should take a header template. Check if
@@ -69,31 +65,11 @@ class BasicGetLogHeader implements PrintWriterGetHeader
 	BasicGetLogHeader(boolean doThreadId,
 				boolean doTimeStamp,
 				String tag){
-		this.doThreadId = doThreadId;
-		this.doTimeStamp = doTimeStamp;
-		this.tag = tag;
-	}	
+	}
 	
 	public String getHeader()
 	{
-		StringBuilder header = new StringBuilder(48);
-
-		if (tag != null) {
-			header.append(tag);
-			header.append(' ');
-		}
-
-		if (doTimeStamp) {
-			header.append(new Date());
-			header.append(' ');
-		}
-
-		if (doThreadId) {
-			header.append(Thread.currentThread().toString());
-			header.append(' ');
-		}
-
-		return header.toString();
+		return ""; // no need for headers
 	}
 }
 	

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/stream/BasicHeaderPrintWriter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/stream/BasicHeaderPrintWriter.java
@@ -33,6 +33,7 @@ package com.splicemachine.db.impl.services.stream;
 
 import com.splicemachine.db.iapi.services.stream.HeaderPrintWriter;
 import com.splicemachine.db.iapi.services.stream.PrintWriterGetHeader;
+import org.apache.log4j.Logger;
 
 import java.io.PrintWriter;
 import java.io.Writer;
@@ -47,33 +48,14 @@ import java.io.OutputStream;
  *
  */
 class BasicHeaderPrintWriter 
-	extends PrintWriter
 	implements HeaderPrintWriter
 {
+	private static final Logger LOG = Logger.getLogger("splice-derby");
 
 	private final PrintWriterGetHeader headerGetter;
-	private final boolean canClose;
 	private final String name;
 
 	// constructors
-
-	/**
-	 * the constructor sets up the HeaderPrintWriter. 
-	 * <p>
-	 * @param writeTo       Where to write to.
-	 * @param headerGetter	Object to get headers for output lines.
-	 * @param canClose      If true, {@link #complete} will also close writeTo
-	 * @param streamName    Name of writeTo, e.g. a file name
-	 *
-	 * @see	PrintWriterGetHeader
-	 */
-	BasicHeaderPrintWriter(OutputStream writeTo,
-			PrintWriterGetHeader headerGetter,  boolean canClose, String streamName){
-		super(writeTo, true);
-		this.headerGetter = headerGetter;
-		this.canClose = canClose;
-		this.name = streamName;
-	}
 
 	/**
 	 * the constructor sets up the HeaderPrintWriter. 
@@ -87,9 +69,7 @@ class BasicHeaderPrintWriter
 	 */
 	BasicHeaderPrintWriter(Writer writeTo,
 			PrintWriterGetHeader headerGetter, boolean canClose, String writerName){
-		super(writeTo, true);
 		this.headerGetter = headerGetter;
-		this.canClose = canClose;
 		this.name = writerName;
 	}
 
@@ -98,9 +78,8 @@ class BasicHeaderPrintWriter
 	 * come from the PrintWriter supertype).
 	 */
 	public synchronized void printlnWithHeader(String message)
-	{ 
-		print(headerGetter.getHeader());
-		println(message);
+	{
+		LOG.info(headerGetter.getHeader() + message);
 	}
 
 	public PrintWriterGetHeader getHeader()
@@ -108,12 +87,23 @@ class BasicHeaderPrintWriter
 		return headerGetter;
 	}
 
-	public PrintWriter getPrintWriter(){
-		return this;
-	}
-
 	public String getName(){
 		return name;
+	}
+
+	@Override
+	public void println(String message) {
+		LOG.info(message);
+	}
+
+	@Override
+	public void printThrowable(String message, Throwable t) {
+		LOG.error(message, t);
+	}
+
+	@Override
+	public void printThrowable(Throwable t) {
+		printThrowable("Unexpected exception", t);
 	}
 
 	/**
@@ -122,10 +112,6 @@ class BasicHeaderPrintWriter
 	 */
 
 	void complete() {
-		flush();
-		if (canClose) {
-			close();
-		}
 	}
 }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/stream/BasicHeaderPrintWriter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/stream/BasicHeaderPrintWriter.java
@@ -51,6 +51,7 @@ class BasicHeaderPrintWriter
 	implements HeaderPrintWriter
 {
 	private static final Logger LOG = Logger.getLogger("splice-derby");
+	private static final Logger LOG_STATEMENT = Logger.getLogger("splice-derby.statement");
 
 	private final PrintWriterGetHeader headerGetter;
 	private final String name;
@@ -89,6 +90,11 @@ class BasicHeaderPrintWriter
 
 	public String getName(){
 		return name;
+	}
+
+	@Override
+	public void printStatement(String statement) {
+		LOG_STATEMENT.info(statement);
 	}
 
 	@Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/stream/SingleStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/stream/SingleStream.java
@@ -76,7 +76,7 @@ import com.splicemachine.db.shared.common.reference.MessageId;
  * remains stable in JDK1.1)
  *
  */
-public class SingleStream implements InfoStreams, ModuleControl, java.security.PrivilegedAction {
+public class SingleStream implements InfoStreams, ModuleControl {
 
 	/*
 	** Instance fields
@@ -173,59 +173,6 @@ public class SingleStream implements InfoStreams, ModuleControl, java.security.P
 		return null;
 	}
 
-	/**
-		Make a header print writer out of a file name. If it is a relative
-		path name then it is taken as relative to db.system.home if that is set,
-		otherwise relative to the current directory. If the path name is absolute
-		then it is taken as absolute.
-	*/
-	private HeaderPrintWriter PBmakeFileHPW(String fileName,
-											PrintWriterGetHeader header) {
-
-		boolean appendInfoLog = PropertyUtil.getSystemBoolean(Property.LOG_FILE_APPEND);
-
-		File streamFile = new File(fileName);
-
-		// See if this needs to be made relative to something ...
-		if (!streamFile.isAbsolute()) {
-			Object monitorEnv = Monitor.getMonitor().getEnvironment();
-			if (monitorEnv instanceof File)
-				streamFile = new File((File) monitorEnv, fileName);
-		}
-
-		boolean archived = archiveLogFileIfNeeded(streamFile);
-
-		FileOutputStream	fos;
-
-		try {
-			if (streamFile.exists() && appendInfoLog && !archived)
-				fos = new FileOutputStream(streamFile.getPath(), true);
-			else
-				fos = new FileOutputStream(streamFile);
-            FileUtil.limitAccessToOwner(streamFile);
-		} catch (IOException | SecurityException ioe) {
-			return useDefaultStream(header, ioe);
-		}
-
-        return new BasicHeaderPrintWriter(new BufferedOutputStream(fos), header,
-			true, streamFile.getPath());
-	}
-
-	/**
-	 * Returns <code>true</code> if it was determined that the existing log file
-	 * should be archived and that this operation was successful. Otherwise,
-	 * returns <code>false</code>.
-	 */
-	protected boolean archiveLogFileIfNeeded(File logFile) {
-		// Default Derby behavior is to return false,
-		// which means we don't archive the log file,
-		// just truncate it or append to it depending
-		// on the configuration.
-		//
-		// This is generally only to be called as a hook
-		// from PBmakeFileHPW method.
-		return false;
-	}
 	
 	private HeaderPrintWriter makeMethodHPW(String methodInvocation,
 											PrintWriterGetHeader header) {
@@ -319,19 +266,7 @@ public class SingleStream implements InfoStreams, ModuleControl, java.security.P
 	private HeaderPrintWriter makeValueHPW(Member whereFrom, Object value,
 		PrintWriterGetHeader header, String name) {
 
-		if (value instanceof OutputStream)
-			 return new BasicHeaderPrintWriter((OutputStream) value, header, false, name);
-		else if (value instanceof Writer)
-			 return new BasicHeaderPrintWriter((Writer) value, header, false, name);
-		
-		HeaderPrintWriter hpw = useDefaultStream(header);
-
-		if (value == null)
-			hpw.printlnWithHeader(whereFrom.toString() + "=null");
-		else
-			hpw.printlnWithHeader(whereFrom.toString() + " instanceof " + value.getClass().getName());
-
-		return hpw;
+		return new BasicHeaderPrintWriter(null, header, false, name);
 	}
  
 
@@ -347,7 +282,7 @@ public class SingleStream implements InfoStreams, ModuleControl, java.security.P
 	*/
 	private HeaderPrintWriter useDefaultStream(PrintWriterGetHeader header) {
 
-		return new BasicHeaderPrintWriter(System.err, header, false, "System.err");
+		return new BasicHeaderPrintWriter(null, header, false, "System.err");
 	}
 
 	private HeaderPrintWriter useDefaultStream(PrintWriterGetHeader header, Throwable t) {
@@ -377,14 +312,7 @@ public class SingleStream implements InfoStreams, ModuleControl, java.security.P
     {
         this.PBfileName = fileName;
         this.PBheader = header;
-        return (HeaderPrintWriter) java.security.AccessController.doPrivileged(this);
-    }
-
-
-    public final Object run()
-    {
-        // SECURITY PERMISSION - OP4, OP5
-        return PBmakeFileHPW(PBfileName, PBheader);
+        return new BasicHeaderPrintWriter(null, header, false, fileName);
     }
 }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericPreparedStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericPreparedStatement.java
@@ -320,32 +320,6 @@ public class GenericPreparedStatement implements ExecPreparedStatement {
 
             LanguageConnectionContext lccToUse = activation.getLanguageConnectionContext();
 
-            if (lccToUse.getLogStatementText()) {
-                HeaderPrintWriter istream = Monitor.getStream();
-                String xactId = lccToUse.getTransactionExecute().getActiveStateTxIdString();
-                String pvsString = "";
-                ParameterValueSet pvs = activation.getParameterValueSet();
-                if (pvs != null && pvs.getParameterCount() > 0) {
-                    pvsString = " with " + pvs.getParameterCount() +
-                            " parameters " + pvs.toString();
-                }
-                istream.printlnWithHeader(LanguageConnectionContext.xidStr +
-                        xactId +
-                        "), " +
-                        LanguageConnectionContext.lccStr +
-                        lccToUse.getInstanceNumber() +
-                        "), " +
-                        LanguageConnectionContext.dbnameStr +
-                        lccToUse.getDbname() +
-                        "), " +
-                        LanguageConnectionContext.drdaStr +
-                        lccToUse.getDrdaID() +
-                        "), Executing prepared statement: " +
-                        getSource() +
-                        " :End prepared statement" +
-                        pvsString);
-            }
-
             ParameterValueSet pvs = activation.getParameterValueSet();
 
             /* put it in try block to unlock the PS in any case

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -336,7 +336,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         /* Find out whether or not to log info on executing statements to error log
          */
         String logStatementProperty=PropertyUtil.getServiceProperty(getTransactionCompile(),"derby.language.logStatementText");
-        logStatementText=Boolean.valueOf(logStatementProperty);
+        logStatementText=logStatementProperty == null || Boolean.valueOf(logStatementProperty); // log statements by default
 
         String logQueryPlanProperty=PropertyUtil.getServiceProperty(getTransactionCompile(),"derby.language.logQueryPlan");
         logQueryPlan=Boolean.valueOf(logQueryPlanProperty);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/UserDefinedAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/UserDefinedAggregator.java
@@ -226,11 +226,7 @@ public final class UserDefinedAggregator  extends UDTBase implements ExecAggrega
              t.getMessage()
              );
 
-		Monitor.getStream().println( errorMessage );
-
-        Exception   e = new Exception( errorMessage, t );
-
-        e.printStackTrace( Monitor.getStream().getPrintWriter() );
+		Monitor.getStream().printThrowable( errorMessage , t);
     }
 
     @Override

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/BasicUnitTestManager.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/BasicUnitTestManager.java
@@ -197,7 +197,7 @@ public class BasicUnitTestManager implements UnitTestManager, ModuleControl
 		} catch (Throwable t) {
 			if (t instanceof ThreadDeath)
 			{
-				t.printStackTrace(output.getPrintWriter());
+				output.printThrowable(t);
 				Runtime.getRuntime().exit(1);
 			}
 
@@ -205,7 +205,7 @@ public class BasicUnitTestManager implements UnitTestManager, ModuleControl
 			String  msg = t.getMessage();
 			if (msg == null) msg = t.getClass().getName();
 			emitAMessage("Test '" + thisTestName + "' failed with exception '" + msg +"'.");
-			t.printStackTrace(output.getPrintWriter());
+			output.printThrowable(t);
 		} finally {
 
 			if (contextService != null) {

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/T_Generic.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/T_Generic.java
@@ -126,7 +126,7 @@ public abstract class T_Generic implements UnitTest, ModuleControl
 		catch (Throwable t)
 		{
 			FAIL(t.toString());
-			t.printStackTrace(out.getPrintWriter());
+			out.printThrowable(t);
 			return false;
 		}
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/T_MultiThreadedIterations.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/T_MultiThreadedIterations.java
@@ -200,8 +200,7 @@ public abstract class T_MultiThreadedIterations extends T_MultiIterations implem
 		}
 		catch (ThreadDeath death) // some other thread has died and want to see my stack 
 		{
-			out.println(threadName + "caught thread death, printing stack");
-			death.printStackTrace(out.getPrintWriter());
+			out.printThrowable(threadName + "caught thread death, printing stack", death);
 			Thread.dumpStack();
 
 			throw death;
@@ -217,7 +216,7 @@ public abstract class T_MultiThreadedIterations extends T_MultiIterations implem
 		{
 			inError = true;
 
-			error.printStackTrace(out.getPrintWriter());
+			out.printThrowable(error);
 			for (int i = 0; i < numThreads; i++)
 			{
 				if (this != TestObjects[i]) // don't kill myself again

--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -1291,7 +1291,7 @@
                                 <!-- Setting the updateSystemProcs option to true causes all of the system stored procedures to be re-created on server startup. -->
                                 <argument>-Dderby.language.updateSystemProcs=false</argument>
                                 <!-- Setting the logStatementText option to true enables logging of all statements. -->
-                                <argument>-Dderby.language.logStatementText=false</argument>
+                                <argument>-Dderby.language.logStatementText=true</argument>
                                 <argument>-Dderby.infolog.append=true</argument>
                                 <argument>com.splicemachine.test.SpliceTestPlatform</argument>
                                 <argument>file://${project.build.directory}/hbase</argument>

--- a/hbase_sql/src/main/resources/hbase-log4j.properties
+++ b/hbase_sql/src/main/resources/hbase-log4j.properties
@@ -23,6 +23,14 @@ log4j.appender.Console1=org.apache.log4j.ConsoleAppender
 log4j.appender.Console1.layout=org.apache.log4j.EnhancedPatternLayout
 log4j.appender.Console1.layout.ConversionPattern=%d{HH:mm:ss,SSS} (%t) %-5p [%c{1.}] - %m%n
 
+log4j.appender.spliceDerby=org.apache.log4j.FileAppender
+log4j.appender.spliceDerby.File=splice-derby.log
+log4j.appender.spliceDerby.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.spliceDerby.layout.ConversionPattern=%d{EEE MMM d HH:mm:ss,SSS} Thread[%t] %m%n
+
+log4j.logger.splice-derby=INFO, spliceDerby
+log4j.additivity.splice-derby=false
+
 log4j.logger.com=TRACE
 
 log4j.logger.org.apache=TRACE

--- a/hbase_sql/src/main/resources/info-log4j.properties
+++ b/hbase_sql/src/main/resources/info-log4j.properties
@@ -23,6 +23,14 @@ log4j.appender.Console1=org.apache.log4j.ConsoleAppender
 log4j.appender.Console1.layout=org.apache.log4j.EnhancedPatternLayout
 log4j.appender.Console1.layout.ConversionPattern=%d{HH:mm:ss,SSS} (%t) %-5p [%c{1.}] - %m%n
 
+log4j.appender.spliceDerby=org.apache.log4j.FileAppender
+log4j.appender.spliceDerby.File=splice-derby.log
+log4j.appender.spliceDerby.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.spliceDerby.layout.ConversionPattern=%d{EEE MMM d HH:mm:ss,SSS} Thread[%t] %m%n
+
+log4j.logger.splice-derby=INFO, spliceDerby
+log4j.additivity.splice-derby=false
+
 #log4j.logger.com=WARN
 #log4j.logger.com.splicemachine.derby.stream.utils=TRACE
 #log4j.logger.com.splicemachine.derby.stream.spark=TRACE

--- a/hbase_sql/src/main/resources/info-log4j.properties
+++ b/hbase_sql/src/main/resources/info-log4j.properties
@@ -28,8 +28,18 @@ log4j.appender.spliceDerby.File=splice-derby.log
 log4j.appender.spliceDerby.layout=org.apache.log4j.EnhancedPatternLayout
 log4j.appender.spliceDerby.layout.ConversionPattern=%d{EEE MMM d HH:mm:ss,SSS} Thread[%t] %m%n
 
+log4j.appender.spliceStatement=org.apache.log4j.FileAppender
+log4j.appender.spliceStatement.File=splice-statement.log
+log4j.appender.spliceStatement.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.spliceStatement.layout.ConversionPattern=%d{EEE MMM d HH:mm:ss,SSS} Thread[%t] %m%n
+
 log4j.logger.splice-derby=INFO, spliceDerby
 log4j.additivity.splice-derby=false
+
+# Uncomment to log statements to a different file
+#log4j.logger.splice-derby.statement=INFO, spliceStatement
+# Uncomment to not replicate statements to the spliceDerby file
+#log4j.additivity.splice-derby.statement=false
 
 #log4j.logger.com=WARN
 #log4j.logger.com.splicemachine.derby.stream.utils=TRACE

--- a/hbase_sql/src/main/resources/log4j.properties
+++ b/hbase_sql/src/main/resources/log4j.properties
@@ -18,6 +18,15 @@ log4j.appender.Console=org.apache.log4j.ConsoleAppender
 log4j.appender.Console.layout=org.apache.log4j.EnhancedPatternLayout
 log4j.appender.Console.layout.ConversionPattern=%d{HH:mm:ss,SSS} (%t) %-5p [%c{1.}] - %m%n
 
+
+log4j.appender.spliceDerby=org.apache.log4j.FileAppender
+log4j.appender.spliceDerby.File=splice-derby.log
+log4j.appender.spliceDerby.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.spliceDerby.layout.ConversionPattern=%d{EEE MMM d HH:mm:ss,SSS} Thread[%t] %m%n
+
+log4j.logger.splice-derby=INFO, spliceDerby
+log4j.additivity.splice-derby=false
+
 #log4j.logger.org.apache=WARN
 log4j.logger.org.apache.zookeeper=WARN
 log4j.logger.org.apache.hadoop.hbase.wal=ERROR

--- a/hbase_sql/src/main/resources/trace-log4j.properties
+++ b/hbase_sql/src/main/resources/trace-log4j.properties
@@ -23,6 +23,14 @@ log4j.appender.Console1=org.apache.log4j.ConsoleAppender
 log4j.appender.Console1.layout=org.apache.log4j.EnhancedPatternLayout
 log4j.appender.Console1.layout.ConversionPattern=%d{HH:mm:ss,SSS} (%t) %-5p [%c{1.}] - %m%n
 
+log4j.appender.spliceDerby=org.apache.log4j.FileAppender
+log4j.appender.spliceDerby.File=splice-derby.log
+log4j.appender.spliceDerby.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.spliceDerby.layout.ConversionPattern=%d{EEE MMM d HH:mm:ss,SSS} Thread[%t] %m%n
+
+log4j.logger.splice-derby=INFO, spliceDerby
+log4j.additivity.splice-derby=false
+
 log4j.logger.com=TRACE
 
 log4j.logger.org.apache=TRACE

--- a/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/storage/ClientPartition.java
+++ b/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/storage/ClientPartition.java
@@ -226,7 +226,7 @@ public class ClientPartition extends SkeletonHBaseClientPartition{
      * @throws java.io.IOException
      */
     @Override
-    public void compact() throws IOException{
+    public void compact(boolean isMajor) throws IOException{
         HExceptionFactory exceptionFactory = HExceptionFactory.INSTANCE;
         try(Admin admin = connection.getAdmin()){
             admin.majorCompact(tableName);

--- a/splice_machine/src/main/java/com/splicemachine/EngineDriver.java
+++ b/splice_machine/src/main/java/com/splicemachine/EngineDriver.java
@@ -23,7 +23,9 @@ import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.derby.iapi.sql.PartitionLoadWatcher;
 import com.splicemachine.derby.iapi.sql.PropertyManager;
 import com.splicemachine.derby.iapi.sql.execute.DataSetProcessorFactory;
+import com.splicemachine.derby.iapi.sql.execute.FileStatementLogger;
 import com.splicemachine.derby.iapi.sql.execute.OperationManager;
+import com.splicemachine.derby.iapi.sql.execute.StatementLogger;
 import com.splicemachine.derby.iapi.sql.olap.OlapClient;
 import com.splicemachine.derby.impl.sql.execute.sequence.SequenceKey;
 import com.splicemachine.derby.impl.sql.execute.sequence.SpliceSequence;
@@ -56,6 +58,7 @@ public class EngineDriver{
     private final OperationManager operationManager;
     private final SqlEnvironment environment;
     private final ExecutorService threadPool;
+    private final StatementLogger statementLogger;
 
     public static void loadDriver(SqlEnvironment environment){
         INSTANCE=new EngineDriver(environment);
@@ -112,6 +115,7 @@ public class EngineDriver{
         tpe.allowCoreThreadTimeOut(false);
         tpe.prestartAllCoreThreads();
         this.threadPool = new ManagedThreadPool(tpe);
+        this.statementLogger = new FileStatementLogger();
     }
 
     public DatabaseAdministrator dbAdministrator(){
@@ -171,4 +175,8 @@ public class EngineDriver{
     }
 
     public OperationManager getOperationManager() { return operationManager; }
+
+    public StatementLogger getStatementLogger() {
+        return statementLogger;
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/FileStatementLogger.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/FileStatementLogger.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.derby.iapi.sql.execute;
+
+import com.splicemachine.db.iapi.services.monitor.Monitor;
+import com.splicemachine.db.iapi.services.stream.HeaderPrintWriter;
+import com.splicemachine.db.iapi.sql.ParameterValueSet;
+import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
+import com.splicemachine.db.iapi.sql.execute.ExecPreparedStatement;
+import com.splicemachine.derby.stream.iapi.DataSetProcessor;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Created by dgomezferro on 24/08/2017.
+ */
+public class FileStatementLogger implements StatementLogger {
+    @Override
+    public void logExecutionStart(@Nonnull String xactId, int sessionId, String dbName, String drdaId, String uuid, DataSetProcessor.Type processorType, ExecPreparedStatement ps, ParameterValueSet pvs) {
+        HeaderPrintWriter istream = Monitor.getStream();
+        String pvsString = "";
+        if (pvs != null && pvs.getParameterCount() > 0) {
+            pvsString = " with " + pvs.getParameterCount() +
+                    " parameters " + pvs.toString();
+        }
+        istream.printlnWithHeader(LanguageConnectionContext.xidStr +
+                xactId +
+                "), " +
+                LanguageConnectionContext.lccStr +
+                sessionId +
+                "), " +
+                LanguageConnectionContext.dbnameStr +
+                dbName +
+                "), " +
+                LanguageConnectionContext.drdaStr +
+                drdaId +
+                "), " +
+                LanguageConnectionContext.uuidStr +
+                uuid +
+                "), " +
+                LanguageConnectionContext.execStr +
+                processorType +
+                "), Executing prepared statement: " +
+                ps.getSource() +
+                " :End prepared statement" +
+                pvsString);
+    }
+
+    @Override
+    public void logExecutionEnd(@Nonnull String xactId, int sessionId, String dbName, String drdaId, String uuid) {
+        HeaderPrintWriter istream = Monitor.getStream();
+        istream.printlnWithHeader(LanguageConnectionContext.xidStr +
+                xactId +
+                "), " +
+                LanguageConnectionContext.lccStr +
+                sessionId +
+                "), " +
+                LanguageConnectionContext.dbnameStr +
+                dbName +
+                "), " +
+                LanguageConnectionContext.drdaStr +
+                drdaId +
+                "), " +
+                LanguageConnectionContext.uuidStr +
+                uuid +
+                "), Finished executing prepared statement");
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/FileStatementLogger.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/FileStatementLogger.java
@@ -36,7 +36,7 @@ public class FileStatementLogger implements StatementLogger {
             pvsString = " with " + pvs.getParameterCount() +
                     " parameters " + pvs.toString();
         }
-        istream.printlnWithHeader(LanguageConnectionContext.xidStr +
+        istream.printStatement(LanguageConnectionContext.xidStr +
                 xactId +
                 "), " +
                 LanguageConnectionContext.lccStr +
@@ -62,7 +62,7 @@ public class FileStatementLogger implements StatementLogger {
     @Override
     public void logExecutionEnd(@Nonnull String xactId, int sessionId, String dbName, String drdaId, String uuid) {
         HeaderPrintWriter istream = Monitor.getStream();
-        istream.printlnWithHeader(LanguageConnectionContext.xidStr +
+        istream.printStatement(LanguageConnectionContext.xidStr +
                 xactId +
                 "), " +
                 LanguageConnectionContext.lccStr +

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/StatementLogger.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/StatementLogger.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.derby.iapi.sql.execute;
+
+import com.splicemachine.db.iapi.sql.ParameterValueSet;
+import com.splicemachine.db.iapi.sql.execute.ExecPreparedStatement;
+import com.splicemachine.derby.stream.iapi.DataSetProcessor;
+
+import javax.annotation.Nonnull;
+
+public interface StatementLogger {
+
+    void logExecutionStart(@Nonnull String xactId, int sessionId, String dbName, String drdaId, String uuid, DataSetProcessor.Type processorType, ExecPreparedStatement ps, ParameterValueSet pvs);
+    void logExecutionEnd(@Nonnull String xactId, int sessionId, String dbName, String drdaId, String uuid);
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/services/streams/ConfiguredStream.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/services/streams/ConfiguredStream.java
@@ -54,40 +54,4 @@ public class ConfiguredStream extends SingleStream {
 
         return super.makeStream();
     }
-
-    protected boolean archiveLogFileIfNeeded(File logFile) {
-		boolean archived = false;
-		String logFileName = logFile.getName();
-		if (!SPLICE_DERBY_LOG.equalsIgnoreCase(logFileName)) {
-			return false;
-		}
-		if (logFile.exists()) {
-			int maxFileCount = PropertyUtil.getSystemInt("splice.log.file.max", 100);
-			boolean validTarget = false;
-			Path targetPath = null;
-			String baseName = logFileName + ".%s";
-			Path logFilePath = logFile.toPath();
-			for (int i = 1; !validTarget && i < maxFileCount; i++) {
-				targetPath = logFilePath.resolveSibling(String.format(baseName, i));
-				if (!Files.exists(targetPath)) {
-					validTarget = true;
-				}
-			}
-			try {
-				if (validTarget) {
-					Files.move(logFilePath, targetPath);
-					archived = true;
-				}
-			} catch (IOException ioe) {
-				archived = false;
-				LOG.error(String.format("IOException trying to archive log file %s. We will proceed without archiving it.",
-					logFileName), ioe);
-			} catch (SecurityException se) {
-				archived = false;
-				LOG.error(String.format("SecurityException trying to archive log file %s. We will proceed without archiving it.",
-					logFileName), se);
-			}
-		}
-		return archived;
-	}
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
@@ -19,7 +19,10 @@ import com.splicemachine.client.SpliceClient;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
+import com.splicemachine.db.iapi.services.monitor.Monitor;
+import com.splicemachine.db.iapi.services.stream.HeaderPrintWriter;
 import com.splicemachine.db.iapi.sql.Activation;
+import com.splicemachine.db.iapi.sql.ParameterValueSet;
 import com.splicemachine.db.iapi.sql.ResultColumnDescriptor;
 import com.splicemachine.db.iapi.sql.ResultDescription;
 import com.splicemachine.db.iapi.sql.ResultSet;
@@ -205,8 +208,10 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
 
     @Override
     public void close() throws StandardException {
-        if (uuid != null)
+        if (uuid != null) {
             EngineDriver.driver().getOperationManager().unregisterOperation(uuid);
+            logExecutionEnd();
+        }
         try{
             if(LOG_CLOSE.isTraceEnabled())
                 LOG_CLOSE.trace(String.format("closing operation %s",this));
@@ -271,7 +276,16 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
     public void open() throws StandardException{
         if(LOG.isTraceEnabled())
             LOG.trace(String.format("open operation %s",this));
-        openCore();
+        try {
+            uuid = EngineDriver.driver().getOperationManager().registerOperation(this, Thread.currentThread());
+            DataSetProcessor dsp = EngineDriver.driver().processorFactory().chooseProcessor(activation, this);
+            logExecutionStart(dsp);
+            openCore();
+        } catch (Exception e) {
+            EngineDriver.driver().getOperationManager().unregisterOperation(uuid);
+            checkInterruptedException(e);
+            throw e;
+        }
     }
 
     //	@Override
@@ -445,21 +459,74 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
 
     @Override
     public void openCore() throws StandardException{
-        try {
-            uuid = EngineDriver.driver().getOperationManager().registerOperation(this, Thread.currentThread());
-            DataSetProcessor dsp = EngineDriver.driver().processorFactory().chooseProcessor(activation, this);
-            if (dsp.getType() == DataSetProcessor.Type.SPARK && !isOlapServer() && !SpliceClient.isClient) {
-                remoteQueryClient = EngineDriver.driver().processorFactory().getRemoteQueryClient(this);
-                remoteQueryClient.submit();
-                execRowIterator = remoteQueryClient.getIterator();
-            } else {
-                openCore(dsp);
-            }
-        } catch (Exception e) {
-            EngineDriver.driver().getOperationManager().unregisterOperation(uuid);
-            checkInterruptedException(e);
-            throw e;
+        DataSetProcessor dsp = EngineDriver.driver().processorFactory().chooseProcessor(activation, this);
+        if (dsp.getType() == DataSetProcessor.Type.SPARK && !isOlapServer() && !SpliceClient.isClient) {
+            remoteQueryClient = EngineDriver.driver().processorFactory().getRemoteQueryClient(this);
+            remoteQueryClient.submit();
+            execRowIterator = remoteQueryClient.getIterator();
+        } else {
+            openCore(dsp);
         }
+    }
+
+    private void logExecutionStart(DataSetProcessor dsp) {
+        LanguageConnectionContext lccToUse = activation.getLanguageConnectionContext();
+        if (lccToUse.getLogStatementText()) {
+            HeaderPrintWriter istream = Monitor.getStream();
+            String xactId = lccToUse.getTransactionExecute().getActiveStateTxIdString();
+            String pvsString = "";
+            ParameterValueSet pvs = activation.getParameterValueSet();
+            if (pvs != null && pvs.getParameterCount() > 0) {
+                pvsString = " with " + pvs.getParameterCount() +
+                        " parameters " + pvs.toString();
+            }
+            istream.printlnWithHeader(LanguageConnectionContext.xidStr +
+                    xactId +
+                    "), " +
+                    LanguageConnectionContext.lccStr +
+                    lccToUse.getInstanceNumber() +
+                    "), " +
+                    LanguageConnectionContext.dbnameStr +
+                    lccToUse.getDbname() +
+                    "), " +
+                    LanguageConnectionContext.drdaStr +
+                    lccToUse.getDrdaID() +
+                    "), " +
+                    LanguageConnectionContext.uuidStr +
+                    uuid +
+                    "), " +
+                    LanguageConnectionContext.execStr +
+                    dsp.getType() +
+                    "), Executing prepared statement: " +
+                    activation.getPreparedStatement().getSource() +
+                    " :End prepared statement" +
+                    pvsString);
+        }
+
+    }
+
+    private void logExecutionEnd() {
+        LanguageConnectionContext lccToUse = activation.getLanguageConnectionContext();
+        if (lccToUse.getLogStatementText()) {
+            HeaderPrintWriter istream = Monitor.getStream();
+            String xactId = lccToUse.getTransactionExecute().getActiveStateTxIdString();
+            istream.printlnWithHeader(LanguageConnectionContext.xidStr +
+                    xactId +
+                    "), " +
+                    LanguageConnectionContext.lccStr +
+                    lccToUse.getInstanceNumber() +
+                    "), " +
+                    LanguageConnectionContext.dbnameStr +
+                    lccToUse.getDbname() +
+                    "), " +
+                    LanguageConnectionContext.drdaStr +
+                    lccToUse.getDrdaID() +
+                    "), " +
+                    LanguageConnectionContext.uuidStr +
+                    uuid +
+                    "), Finished executing prepared statement");
+        }
+
     }
 
     protected void computeModifiedRows() throws StandardException {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
@@ -208,6 +208,8 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
 
     @Override
     public void close() throws StandardException {
+        if (isClosed())
+            return;
         if (uuid != null) {
             EngineDriver.driver().getOperationManager().unregisterOperation(uuid);
             logExecutionEnd();
@@ -472,35 +474,8 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
     private void logExecutionStart(DataSetProcessor dsp) {
         LanguageConnectionContext lccToUse = activation.getLanguageConnectionContext();
         if (lccToUse.getLogStatementText()) {
-            HeaderPrintWriter istream = Monitor.getStream();
             String xactId = lccToUse.getTransactionExecute().getActiveStateTxIdString();
-            String pvsString = "";
-            ParameterValueSet pvs = activation.getParameterValueSet();
-            if (pvs != null && pvs.getParameterCount() > 0) {
-                pvsString = " with " + pvs.getParameterCount() +
-                        " parameters " + pvs.toString();
-            }
-            istream.printlnWithHeader(LanguageConnectionContext.xidStr +
-                    xactId +
-                    "), " +
-                    LanguageConnectionContext.lccStr +
-                    lccToUse.getInstanceNumber() +
-                    "), " +
-                    LanguageConnectionContext.dbnameStr +
-                    lccToUse.getDbname() +
-                    "), " +
-                    LanguageConnectionContext.drdaStr +
-                    lccToUse.getDrdaID() +
-                    "), " +
-                    LanguageConnectionContext.uuidStr +
-                    uuid +
-                    "), " +
-                    LanguageConnectionContext.execStr +
-                    dsp.getType() +
-                    "), Executing prepared statement: " +
-                    activation.getPreparedStatement().getSource() +
-                    " :End prepared statement" +
-                    pvsString);
+            EngineDriver.driver().getStatementLogger().logExecutionStart(xactId, lccToUse.getInstanceNumber(), lccToUse.getDbname(), lccToUse.getDrdaID(), uuid.toString(), dsp.getType(), activation.getPreparedStatement(), activation.getParameterValueSet());
         }
 
     }
@@ -508,23 +483,8 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
     private void logExecutionEnd() {
         LanguageConnectionContext lccToUse = activation.getLanguageConnectionContext();
         if (lccToUse.getLogStatementText()) {
-            HeaderPrintWriter istream = Monitor.getStream();
             String xactId = lccToUse.getTransactionExecute().getActiveStateTxIdString();
-            istream.printlnWithHeader(LanguageConnectionContext.xidStr +
-                    xactId +
-                    "), " +
-                    LanguageConnectionContext.lccStr +
-                    lccToUse.getInstanceNumber() +
-                    "), " +
-                    LanguageConnectionContext.dbnameStr +
-                    lccToUse.getDbname() +
-                    "), " +
-                    LanguageConnectionContext.drdaStr +
-                    lccToUse.getDrdaID() +
-                    "), " +
-                    LanguageConnectionContext.uuidStr +
-                    uuid +
-                    "), Finished executing prepared statement");
+            EngineDriver.driver().getStatementLogger().logExecutionEnd(xactId, lccToUse.getInstanceNumber(), lccToUse.getDbname(), lccToUse.getDrdaID(), uuid.toString());
         }
 
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
@@ -87,7 +87,7 @@ public class ControlDataSetProcessor implements DataSetProcessor{
 
     @Override
     public Type getType() {
-        return Type.LOCAL;
+        return Type.CONTROL;
     }
 
     public static final Partitioner NOOP_PARTITIONER = new Partitioner() {

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
@@ -33,7 +33,7 @@ import java.util.Iterator;
  *
  */
 public interface DataSetProcessor {
-    enum Type {LOCAL,SPARK}
+    enum Type {CONTROL,SPARK}
 
     Type getType();
 

--- a/start-splice-cluster
+++ b/start-splice-cluster
@@ -35,7 +35,7 @@ _kill_em_all () {
 export -f _kill_em_all
 
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-DEFAULT_PROFILE="cdh5.6.0"  # default hbase platform profile
+DEFAULT_PROFILE="cdh5.8.0"  # default hbase platform profile
 PROFILE=$DEFAULT_PROFILE
 IN_MEM_PROFILE="mem"
 RUN_DIR="${BASE_DIR}/hbase_sql"


### PR DESCRIPTION
Added more information to query logging:
1. Operation UUID, same as used int GET_RUNNING_OPERATIONS, unique for each statement execution
2. Execution mode: local vs Spark
3. Execution end time

Moved splice-derby.log to use log4j to allow log rotation, etc.