### PR TITLE
SPLICE-1879 Modify Key By function to look more like map()

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
@@ -201,7 +201,13 @@ public class ControlDataSet<V> implements DataSet<V> {
 
     @Override
     public <Op extends SpliceOperation, K> PairDataSet<K, V> keyBy(final SpliceFunction<Op, V, K> function) {
-        return new ControlPairDataSet<>(entryToTuple(Multimaps.index(limit(iterator, function.operationContext),function).entries()));
+            return new ControlPairDataSet<>(Iterators.<V,Tuple2<K, V>>transform(iterator, new Function<V, Tuple2<K, V>>() {
+                @Nullable
+                @Override
+                public Tuple2<K, V> apply(@Nullable V v) {
+                    return Tuple2.apply(function.apply(v),v);
+                }
+            }));
     }
 
     @Override


### PR DESCRIPTION
The KeyBy piece is not correct.  I modified it to behave more like a map call to transform V to PairDataSet<K,V>.