### PR TITLE
DB-6203 honor Spark dataset processor once picked, and fix regression…

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ActivationClassBuilder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ActivationClassBuilder.java
@@ -183,6 +183,9 @@ public class ActivationClassBuilder	extends	ExpressionClassBuilder {
         if (currentType.equals(CompilerContext.DataSetProcessorType.FORCED_CONTROL) ||
                 currentType.equals(CompilerContext.DataSetProcessorType.FORCED_SPARK))
             return; // Already Forced
+		// if current type has already been set to Spark, we should honor it
+		if (currentType.equals(CompilerContext.DataSetProcessorType.SPARK))
+			return;
         myCompCtx.setDataSetProcessorType(type);
 		constructor.pushThis();
 		constructor.push(type.ordinal());

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -3414,7 +3414,10 @@ public class FromBaseTable extends FromTable {
     private void determineSpark() {
         // Set Spark Baby...
         if (dataSetProcessorType.equals(CompilerContext.DataSetProcessorType.DEFAULT_CONTROL) &&
-                getTrulyTheBestAccessPath().getCostEstimate().getScannedBaseTableRows() > 20000) {
+            // we need to check not only the number of row scanned, but also the number of output rows for the
+            // join result
+            (getTrulyTheBestAccessPath().getCostEstimate().getScannedBaseTableRows() > 20000 ||
+             getTrulyTheBestAccessPath().getCostEstimate().getEstimatedRowCount() > 20000)) {
             dataSetProcessorType = CompilerContext.DataSetProcessorType.SPARK;
         }
     }


### PR DESCRIPTION
… in SPLICE-1874.

Please see [DB-6203](https://splicemachine.atlassian.net/browse/DB-6203) for details. 

For the regression in SPLICE-1874, the problem is that we replace the check of getEstimatedRowCount() with getScannedBaseTableRows() in FromBaseTable.determineSpark(). However, getEstimatedRowCount() could represent the join result row count also, by changing it to getScannedBaseTableRows(), we may miss the case to send query for Spark execution when base table row count is less than the spark path threshold (20000), but the join result is above. 