### PR TITLE
DB-6226 Adding Serde for Serialization registration with Kryo

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
@@ -489,8 +489,9 @@ public class SpliceSparkKryoRegistrator implements KryoRegistrator, KryoPool.Kry
         instance.register(UserDefinedAggregator.class, EXTERNALIZABLE_SERIALIZER);
         instance.register(BulkWrite.class,EXTERNALIZABLE_SERIALIZER);
         instance.register(KVPair.class,EXTERNALIZABLE_SERIALIZER);
-        instance.register(SpliceStddevPop.class);
-        instance.register(SpliceStddevSamp.class);
+        instance.register(SpliceStddevPop.class,EXTERNALIZABLE_SERIALIZER);
+        instance.register(SpliceStddevSamp.class,EXTERNALIZABLE_SERIALIZER);
+        instance.register(SpliceUDAVariance.class,EXTERNALIZABLE_SERIALIZER);
         instance.register(Properties.class, new MapSerializer());
 
 //        instance.register(com.splicemachine.derby.client.sql.execute.ValueRow.class,EXTERNALIZABLE_SERIALIZER);

--- a/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
+++ b/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
@@ -620,8 +620,8 @@ public class SpliceKryoRegistry implements KryoPool.KryoRegistry{
                 return new KVPair(rowKey,value,t);
             }
         },143);
-        instance.register(SpliceStddevPop.class,144);
-        instance.register(SpliceStddevSamp.class,145);
+        instance.register(SpliceStddevPop.class,EXTERNALIZABLE_SERIALIZER,144);
+        instance.register(SpliceStddevSamp.class,EXTERNALIZABLE_SERIALIZER,145);
         instance.register(Properties.class,new MapSerializer(),146);
 
         //instance.register(com.splicemachine.derby.client.sql.execute.ValueRow.class,EXTERNALIZABLE_SERIALIZER,147);
@@ -831,5 +831,8 @@ public class SpliceKryoRegistry implements KryoPool.KryoRegistry{
         instance.register(DistinctAggregateKeyCreation.class,EXTERNALIZABLE_SERIALIZER, 290);
         instance.register(MergeStatisticsHolder.class,EXTERNALIZABLE_SERIALIZER,291);
         instance.register(ColumnStatisticsMerge.class,EXTERNALIZABLE_SERIALIZER,292);
+        instance.register(SpliceUDAVariance.class,EXTERNALIZABLE_SERIALIZER,293);
+
+
     }
 }


### PR DESCRIPTION
We were seeing a lot of object creation on the Spark side and it seems like we are spilling to disk.  The serde I think was missing for the base class...