### PR TITLE
DB-6214: reserve a valid backup chain when deleting old backups

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupSystemProcedures.java
@@ -246,15 +246,21 @@ public class BackupSystemProcedures {
 
             //Get backups that are more than backupWindow days old
             List<Long> backupIdList=new ArrayList<>();
-            String sqlText = "select backup_id from sys.sysbackup where begin_timestamp<?";
+            String sqlText = "select backup_id, begin_timestamp, incremental_backup from sys.sysbackup order by begin_timestamp desc";
             try(PreparedStatement ps = conn.prepareStatement(sqlText)){
-                ps.setTimestamp(1,ts);
-
                 BackupManager backupManager = EngineDriver.driver().manager().getBackupManager();
                 try(ResultSet rs=ps.executeQuery()){
+                    int fullBackupCount = 0;
                     while(rs.next()){
                         long backupId=rs.getLong(1);
-                        backupIdList.add(backupId);
+                        Timestamp beginTimestamp = rs.getTimestamp(2);
+                        boolean isFullBackup = !rs.getBoolean(3);
+                        if (fullBackupCount > 0 && beginTimestamp.compareTo(ts) < 0) {
+                            backupIdList.add(backupId);
+                        }
+                        if (isFullBackup) {
+                            fullBackupCount++;
+                        }
                     }
                 }
                 backupManager.removeBackup(backupIdList);


### PR DESCRIPTION
- Make sure there is always a valid backup chain with a full backup after purging old backups.
- When there is no valid backup chain, and a user is requesting an incremental backup, promote it to a full backup.
