### PR TITLE
DB-6124 fix conglomerate average row width estimation, also use local…(2.5)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CostEstimate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CostEstimate.java
@@ -107,6 +107,8 @@ public interface CostEstimate extends StoreCostResult {
      */
     double compare(CostEstimate other);
 
+    double compareLocal(CostEstimate other);
+
     /**
      * Add this cost estimate to another one.  This presumes that any row
      * ordering is destroyed.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CostEstimateImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CostEstimateImpl.java
@@ -190,6 +190,10 @@ public class CostEstimateImpl implements CostEstimate {
         return 0.0d;
     }
 
+    public double compareLocal(CostEstimate other) {
+        return compare(other);
+    }
+
     /** @see CostEstimate#add */
     public CostEstimate add(CostEstimate other, CostEstimate retval) {
         if (SanityManager.DEBUG) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
@@ -462,9 +462,17 @@ public class OptimizerImpl implements Optimizer{
 		 * circuit if both currentCost and currentSortAvoidanceCost
 		 * (if the latter is applicable) are greater than bestCost.
 		 */
+		/* the total cost of a plan = localcost of all conglomerates participated in the join
+		 * + remotecost of the last join in the join sequence.
+		 * total cost is not monotonically increasing as we add more joins due to the remotecost
+		 * of the last join which is affected by the number of output rows of the last join
+		 * and could vary from join to join. To use the alreadyCostsMore flag to prune the join order
+		 * search space, we can not use the totalcost but just the sum of local cost, which should
+		 * be monotonically increasing.
+		 */
         boolean alreadyCostsMore=!bestCost.isUninitialized() &&
-                (currentCost.compare(bestCost)>0) &&
-                ((requiredRowOrdering==null) || (currentSortAvoidanceCost.compare(bestCost)>0));
+                (currentCost.compareLocal(bestCost)>0) &&
+                ((requiredRowOrdering==null) || (currentSortAvoidanceCost.compareLocal(bestCost)>0));
 
         if((joinPosition<(numOptimizables-1)) && !alreadyCostsMore && (!timeExceeded)){
 			/*

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SimpleCostEstimate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SimpleCostEstimate.java
@@ -329,6 +329,28 @@ public class SimpleCostEstimate implements CostEstimate{
     }
 
     @Override
+    public double compareLocal(CostEstimate other){
+        assert other!=null: "Cannot compare with a null CostEstimate";
+
+        double thisCost=this.localCost();
+        double otherCost=other.localCost();
+
+        if((thisCost!=Double.POSITIVE_INFINITY) || (otherCost!= Double.POSITIVE_INFINITY)){
+            return thisCost-otherCost;
+        }
+
+        if((this.numRows !=Double.POSITIVE_INFINITY)|| (other.rowCount()!=Double.POSITIVE_INFINITY)){
+            return this.numRows-other.rowCount();
+        }
+
+        if((this.singleScanRowCount != Double.POSITIVE_INFINITY)||
+                (other.singleScanRowCount() != Double.POSITIVE_INFINITY)){
+            return this.singleScanRowCount - other.singleScanRowCount();
+        }
+        return 0.0d;
+    }
+
+    @Override
     public CostEstimate add(CostEstimate addend,CostEstimate retval){
         assert addend!=null: "Cannot add a null cost estimate";
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/stats/StoreCostControllerImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/stats/StoreCostControllerImpl.java
@@ -92,8 +92,13 @@ public class StoreCostControllerImpl implements StoreCostController {
         fallbackRemoteLatencyRatio =config.getFallbackRemoteLatencyRatio();
         String tableId = Long.toString(td.getBaseConglomerateDescriptor().getConglomerateNumber());
         baseTableRow = td.getEmptyExecRow();
-        if (conglomerateDescriptor.getIndexDescriptor() != null && conglomerateDescriptor.getIndexDescriptor().getIndexDescriptor() != null) {
-            conglomerateColumns = conglomerateDescriptor.getIndexDescriptor().numberOfOrderedColumns();
+        if (conglomerateDescriptor.getIndexDescriptor() != null &&
+            conglomerateDescriptor.getIndexDescriptor().getIndexDescriptor() != null)
+        {
+            if (conglomerateDescriptor.getIndexDescriptor().isPrimaryKey())
+                conglomerateColumns = td.getNumberOfColumns();
+            else
+                conglomerateColumns = conglomerateDescriptor.getIndexDescriptor().numberOfOrderedColumns();
         } else {
             conglomerateColumns = (conglomerateDescriptor.getColumnNames() == null) ? 2 : conglomerateDescriptor.getColumnNames().length;
         }

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/IndexSelectivityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/IndexSelectivityIT.java
@@ -24,7 +24,6 @@ import org.junit.rules.TestRule;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.Timestamp;
 
 import static com.splicemachine.test_tools.Rows.row;
@@ -142,6 +141,31 @@ public class IndexSelectivityIT extends SpliceUnitTest {
                 "call SYSCS_UTIL.COLLECT_SCHEMA_STATISTICS('%s',false)",
                 spliceSchemaWatcher));
         conn.commit();
+
+        new TableCreator(conn)
+                .withCreate("create table t1 (c1 int, c2 int, c3 int, c4 int, c5 int, c6 int, c7 int, c8 int, c9 int, c10 int, c11 int, c12 int, primary key (c1))")
+                .withInsert("insert into t1 values(?,?,?,?,?,?,?,?,?,?,?,?)")
+                .withRows(rows(
+                        row(0,0,0,0,0,0,0,0,0,0,0,0),
+                        row(1,1,1,1,1,1,1,1,1,1,1,1),
+                        row(2,2,2,2,2,2,2,2,2,2,2,2),
+                        row(3,3,3,3,3,3,3,3,3,3,3,3),
+                        row(4,4,4,4,4,4,4,4,4,4,4,4),
+                        row(5,5,5,5,5,5,5,5,5,5,5,5),
+                        row(6,6,6,6,6,6,6,6,6,6,6,6),
+                        row(7,7,7,7,7,7,7,7,7,7,7,7),
+                        row(8,8,8,8,8,8,8,8,8,8,8,8),
+                        row(9,9,9,9,9,9,9,9,9,9,9,9)))
+                .withIndex("create index t1_idx on t1(c3,c4,c5)")
+                .create();
+
+        // we purposely leave t1 out from stats collection, as the test case is to test the plan selection without stats.
+        int factor = 10;
+        for (int i = 1; i <= 12; i++) {
+            spliceClassWatcher.executeUpdate(format("insert into t1 select c1+%d, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12 from t1", factor));
+            factor = factor * 2;
+        }
+        conn.commit();
     }
 
     @Test
@@ -150,6 +174,15 @@ public class IndexSelectivityIT extends SpliceUnitTest {
         rowContainsQuery(3,"explain select c1,c2 from ts_low_cardinality where c1 = 1","IndexScan[TS_LOW_CARDINALITY_IX_3",methodWatcher);
         rowContainsQuery(3,"explain select c2 from ts_low_cardinality where c2 = '1'","IndexScan[TS_LOW_CARDINALITY_IX_2",methodWatcher);
         rowContainsQuery(6,"explain select count(*) from ts_low_cardinality where c2 = '1'","IndexScan[TS_LOW_CARDINALITY_IX_2",methodWatcher);
+    }
+
+    @Test
+    public void testCoveringIndexOverBaseTableScanWithoutStats () throws Exception {
+        //covering index should be picked
+        rowContainsQuery(3, "explain select c3, c4, c5 from t1 where c4=10", "IndexScan[T1_IDX", methodWatcher);
+        //if not covering index, base table scan should be picked
+        rowContainsQuery(3, "explain select c3, c4, c5, c6 from t1 where c4=10", "TableScan[T1", methodWatcher);
+
     }
 
     @Test @Ignore


### PR DESCRIPTION
…cost to prune join plan search space

This is a replacement of PR #1062 to fix intermittent IT failure. More details please see PR #1078 .