### PR TITLE
SPLICE-1896 Primary Key Bind Lookup is O(n) where n is the number of …

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -5056,6 +5056,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
             ti = getNonCoreTI(baseNum);
         }else if(constraint.getConstraintType() == DataDictionary.PRIMARYKEY_CONSTRAINT){
             ti=getPkTable();
+            faultInTabInfo(ti);
             indexNum=0;
         } else{
             baseNum=SYSKEYS_CATALOG_NUM;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -89,28 +89,6 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
         return new SpliceSystemProcedures(this);
     }
 
-    @Override
-    public SubKeyConstraintDescriptor getSubKeyConstraint(UUID constraintId,
-                                                          int type) throws StandardException{
-        if(type==DataDictionary.PRIMARYKEY_CONSTRAINT){
-            DataValueDescriptor constraintIDOrderable=getIDValueAsCHAR(constraintId);
-
-            TabInfoImpl ti=getPkTable();
-            faultInTabInfo(ti);
-
-            ScanQualifier[][] scanQualifiers=exFactory.getScanQualifier(1);
-            scanQualifiers[0][0].setQualifier(
-                    SYSPRIMARYKEYSRowFactory.SYSPRIMARYKEYS_CONSTRAINTID-1,
-                    constraintIDOrderable,
-                    Orderable.ORDER_OP_EQUALS,
-                    false,false,false);
-            return (SubKeyConstraintDescriptor)getDescriptorViaHeap(
-                    null,scanQualifiers,ti,null,null);
-        }
-        /*If it's a foreign key or unique constraint, then just do the derby default*/
-        return super.getSubKeyConstraint(constraintId,type);
-    }
-
 
     @Override
     protected void addSubKeyConstraint(KeyConstraintDescriptor descriptor,


### PR DESCRIPTION
…primary keys.  Should use scan begin and end key and instead qualifies the record after retrieving from dictionary