### PR TITLE
DB-6217: make table level select privileges to column level (2.5)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -1819,6 +1819,12 @@ public interface DataDictionary{
     ColPermsDescriptor getColumnPermissions(UUID tableUUID,int privType,boolean forGrant,String authorizationId) throws StandardException;
 
     /**
+     * is Enterprise Edition Manager is enabled
+     * @return true if enabled
+     */
+    public boolean isEEManagerEnabled();
+
+    /**
      * Get one user's column privileges on a table using colPermsUUID
      *
      * @param colPermsUUID the uuid of the column permissions to fetch

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BasicPrivilegesNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BasicPrivilegesNode.java
@@ -100,7 +100,9 @@ public class BasicPrivilegesNode extends QueryTreeNode
 	public void bind( TableDescriptor td, boolean isGrant) throws StandardException
 	{
 		this.td = td;
-			
+		LanguageConnectionContext lcc = getLanguageConnectionContext();
+		DataDictionary dd = lcc.getDataDictionary();
+
 		for( int action = 0; action < TablePrivilegeInfo.ACTION_COUNT; action++)
 		{
 			if( columnLists[ action] != null)
@@ -111,7 +113,20 @@ public class BasicPrivilegesNode extends QueryTreeNode
 				if (actionAllowed[action])
 					throw StandardException.newException(SQLState.AUTH_GRANT_REVOKE_NOT_ALLOWED,
 									td.getQualifiedName());
-		}
+
+			if (dd.isEEManagerEnabled() && action == TablePrivilegeInfo.SELECT_ACTION)
+				// Make table level privileges to column level
+				if (columnBitSets[action] == null) {
+					int size = td.getColumnDescriptorList().size();
+					FormatableBitSet keys = new FormatableBitSet(size + 1);
+					for (int j = 0; j < size; j++) {
+						int colPos = td.getColumnDescriptorList().get(j).getPosition() - 1;
+						keys.set(colPos);
+					}
+					columnBitSets[action] = keys;
+				}
+
+			}
 		
 		if (isGrant && td.getTableType() == TableDescriptor.VIEW_TYPE)
 		{

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -15,33 +15,28 @@
 package com.splicemachine.derby.impl.sql.catalog;
 
 import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
-import com.splicemachine.client.SpliceClient;
-import com.splicemachine.db.iapi.reference.SQLState;
-import com.splicemachine.db.iapi.sql.depend.DependencyManager;
-import com.splicemachine.db.iapi.sql.dictionary.*;
-import com.splicemachine.db.iapi.types.*;
-import com.splicemachine.db.impl.sql.catalog.*;
-import com.splicemachine.derby.lifecycle.EngineLifecycleService;
-import com.splicemachine.management.Manager;
-import org.apache.log4j.Logger;
 import com.splicemachine.EngineDriver;
 import com.splicemachine.access.api.DatabaseVersion;
 import com.splicemachine.access.api.PartitionFactory;
 import com.splicemachine.access.api.SConfiguration;
+import com.splicemachine.client.SpliceClient;
 import com.splicemachine.db.catalog.AliasInfo;
 import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.context.ContextService;
 import com.splicemachine.db.iapi.services.monitor.Monitor;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
+import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.sql.execute.ScanQualifier;
 import com.splicemachine.db.iapi.store.access.AccessFactory;
 import com.splicemachine.db.iapi.store.access.ColumnOrdering;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.store.access.conglomerate.TransactionManager;
-import com.splicemachine.db.impl.sql.execute.IndexColumnOrder;
+import com.splicemachine.db.iapi.types.*;
+import com.splicemachine.db.impl.sql.catalog.*;
 import com.splicemachine.derby.ddl.DDLDriver;
 import com.splicemachine.derby.ddl.DDLWatcher;
 import com.splicemachine.derby.impl.sql.catalog.upgrade.SpliceCatalogUpgradeScripts;
@@ -49,12 +44,16 @@ import com.splicemachine.derby.impl.sql.depend.SpliceDependencyManager;
 import com.splicemachine.derby.impl.sql.execute.sequence.SequenceKey;
 import com.splicemachine.derby.impl.sql.execute.sequence.SpliceSequence;
 import com.splicemachine.derby.impl.store.access.*;
+import com.splicemachine.derby.lifecycle.EngineLifecycleService;
+import com.splicemachine.management.Manager;
 import com.splicemachine.pipeline.Exceptions;
 import com.splicemachine.primitives.Bytes;
 import com.splicemachine.si.api.data.TxnOperationFactory;
 import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.tools.version.ManifestReader;
 import com.splicemachine.utils.SpliceLogUtils;
+import org.apache.log4j.Logger;
+
 import java.sql.Types;
 import java.util.Collections;
 import java.util.List;
@@ -946,5 +945,15 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
         return manager.isEnabled()?manager.getColPermsManager().getColumnPermissions(this,tableUUID,privType,forGrant,authorizationId):null;
     } // end of getColumnPermissions
 
+    /**
+     * is Enterprise Edition Manager enabled
+     * @return true if enabled
+     */
+    @Override
+    public boolean isEEManagerEnabled()  {
+        Manager manager = EngineDriver.driver().manager();
+        return manager.isEnabled();
+
+    }
 
 }


### PR DESCRIPTION
Add the column list from table as column level privileges so that users can revoke few columns later. Also see spliceengine-ee for ITs