### PR TITLE
DB-6217: make table level select privileges to column level (2.6)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -1820,6 +1820,12 @@ public interface DataDictionary{
     ColPermsDescriptor getColumnPermissions(UUID tableUUID,int privType,boolean forGrant,String authorizationId) throws StandardException;
 
     /**
+     * is Enterprise Edition Manager is enabled
+     * @return true if enabled
+     */
+    public boolean isEEManagerEnabled();
+
+    /**
      * Get one user's column privileges on a table using colPermsUUID
      *
      * @param colPermsUUID the uuid of the column permissions to fetch

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BasicPrivilegesNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BasicPrivilegesNode.java
@@ -100,7 +100,9 @@ public class BasicPrivilegesNode extends QueryTreeNode
 	public void bind( TableDescriptor td, boolean isGrant) throws StandardException
 	{
 		this.td = td;
-			
+		LanguageConnectionContext lcc = getLanguageConnectionContext();
+		DataDictionary dd = lcc.getDataDictionary();
+
 		for( int action = 0; action < TablePrivilegeInfo.ACTION_COUNT; action++)
 		{
 			if( columnLists[ action] != null)
@@ -111,7 +113,20 @@ public class BasicPrivilegesNode extends QueryTreeNode
 				if (actionAllowed[action])
 					throw StandardException.newException(SQLState.AUTH_GRANT_REVOKE_NOT_ALLOWED,
 									td.getQualifiedName());
-		}
+
+			if (dd.isEEManagerEnabled() && action == TablePrivilegeInfo.SELECT_ACTION)
+				// Make table level privileges to column level
+				if (columnBitSets[action] == null) {
+					int size = td.getColumnDescriptorList().size();
+					FormatableBitSet keys = new FormatableBitSet(size + 1);
+					for (int j = 0; j < size; j++) {
+						int colPos = td.getColumnDescriptorList().get(j).getPosition() - 1;
+						keys.set(colPos);
+					}
+					columnBitSets[action] = keys;
+				}
+
+			}
 		
 		if (isGrant && td.getTableType() == TableDescriptor.VIEW_TYPE)
 		{

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -883,5 +883,15 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
         return manager.isEnabled()?manager.getColPermsManager().getColumnPermissions(this,tableUUID,privType,forGrant,authorizationId):null;
     } // end of getColumnPermissions
 
+    /**
+     * is Enterprise Edition Manager enabled
+     * @return true if enabled
+     */
+    @Override
+    public boolean isEEManagerEnabled()  {
+        Manager manager = EngineDriver.driver().manager();
+        return manager.isEnabled();
+
+    }
 
 }


### PR DESCRIPTION
Add the column list from table as column level privileges so that users can revoke few columns later. Also see spliceengine-ee for ITs.