### PR TITLE
DB-6274 Add more logging on Spark scanners close()

### DIFF
--- a/hbase_sql/src/main/resources/info-log4j.properties
+++ b/hbase_sql/src/main/resources/info-log4j.properties
@@ -127,6 +127,7 @@ log4j.logger.org.apache.hadoop.hbase.regionserver.HRegionServer=INFO
 log4j.logger.com.splicemachine=WARN
 
 log4j.logger.com.splicemachine.storage=INFO
+log4j.logger.com.splicemachine.access.client=INFO
 
 log4j.logger.DataNucleus.ValueGeneration=INFO
 #log4j.logger.com.splicemachine.pipeline=DEBUG,Console1

--- a/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -38,6 +38,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
     protected Cell[] cells;
     int cellScannerIndex=0;
     private boolean closed=false;
+    private long rows = 0;
 
     public MemstoreKeyValueScanner(ResultScanner resultScanner) throws IOException{
         assert resultScanner!=null:"Passed Result Scanner is null";
@@ -60,6 +61,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
         if(currentResult!=null){
             cells=currentResult.rawCells();
             peakKeyValue=(KeyValue)current();
+            rows++;
             return true;
         }else{
             cells=null;
@@ -144,6 +146,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
     @Override
     public void close(){
         if(closed) return;
+        LOG.info("Closed MemstoreScanner after reading " + rows + " rows.");
         if(LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG,"close");
         resultScanner.close();

--- a/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.hbase.CellUtils;
 import com.splicemachine.pipeline.utils.PipelineUtils;
+import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.regionserver.ScannerContext;
 import org.spark_project.guava.base.Throwables;
 import com.splicemachine.access.client.HBase10ClientSideRegionScanner;
@@ -63,6 +64,7 @@ public class SplitRegionScanner implements RegionScanner {
     private Partition clientPartition;
     private Scan initialScan;
     private volatile boolean closed = true;
+    private Cell lastCell = null;
 
     public SplitRegionScanner(Scan scan,
                               Table table,
@@ -141,6 +143,9 @@ public class SplitRegionScanner implements RegionScanner {
                 throw new IOException("Scanner is closed");
             }
             boolean next = currentScanner.nextRaw(results);
+            if (!results.isEmpty()) {
+                lastCell = results.get(0);
+            }
             scannerCount++;
             totalScannerCount++;
             if (!next && scannerPosition < regionScanners.size()) {
@@ -173,7 +178,8 @@ public class SplitRegionScanner implements RegionScanner {
 
     @Override
     public void close() throws IOException {
-        SpliceLogUtils.info(LOG, "close split scanner with table [%s], scan [%s] with rowCount=%d, reinitCount=%d, scannerExceptionCount=%d",htable.getName().toString(),initialScan,totalScannerCount,reInitCount,scanExceptionCount);
+        String lastRow = lastCell != null ? CellUtil.getCellKeyAsString(lastCell) : null;
+        LOG.info(String.format("close split scanner with table [%s], scan [%s] with rowCount=%d, reinitCount=%d, scannerExceptionCount=%d, lastRows=%s",htable.getName().toString(),initialScan,totalScannerCount,reInitCount,scanExceptionCount,lastRow), new RuntimeException());
         closed = true;
         for (RegionScanner rs : regionScanners) {
             rs.close();

--- a/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -37,6 +37,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
     protected Cell[] cells;
     int cellScannerIndex=0;
     private boolean closed=false;
+    private long rows = 0;
 
     public MemstoreKeyValueScanner(ResultScanner resultScanner) throws IOException{
         assert resultScanner!=null:"Passed Result Scanner is null";
@@ -59,6 +60,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
         if(currentResult!=null){
             cells=currentResult.rawCells();
             peakKeyValue=(KeyValue)current();
+            rows++;
             return true;
         }else{
             cells=null;
@@ -148,6 +150,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
     @Override
     public void close(){
         if(closed) return;
+        LOG.info("Closed MemstoreScanner after reading " + rows + " rows.");
         if(LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG,"close");
         resultScanner.close();

--- a/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -27,6 +27,7 @@ import com.splicemachine.access.client.SkeletonClientSideRegionScanner;
 import com.splicemachine.concurrent.Clock;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.client.*;
@@ -61,6 +62,7 @@ public class SplitRegionScanner implements RegionScanner {
     private Partition clientPartition;
     private Scan initialScan;
     private volatile boolean closed = true;
+    private Cell lastCell = null;
 
     public SplitRegionScanner(Scan scan,
                               Table table,
@@ -138,6 +140,9 @@ public class SplitRegionScanner implements RegionScanner {
                 throw new IOException("Scanner is closed");
             }
             boolean next = currentScanner.nextRaw(results);
+            if (!results.isEmpty()) {
+                lastCell = results.get(0);
+            }
             scannerCount++;
             totalScannerCount++;
             if (!next && scannerPosition < regionScanners.size()) {
@@ -170,7 +175,8 @@ public class SplitRegionScanner implements RegionScanner {
 
     @Override
     public void close() throws IOException {
-        SpliceLogUtils.info(LOG, "close split scanner with table [%s], scan [%s] with rowCount=%d, reinitCount=%d, scannerExceptionCount=%d",htable.getName().toString(),initialScan,totalScannerCount,reInitCount,scanExceptionCount);
+        String lastRow = lastCell != null ? CellUtil.getCellKeyAsString(lastCell) : null;
+        LOG.info(String.format("close split scanner with table [%s], scan [%s] with rowCount=%d, reinitCount=%d, scannerExceptionCount=%d, lastRows=%s",htable.getName().toString(),initialScan,totalScannerCount,reInitCount,scanExceptionCount,lastRow), new RuntimeException());
         closed = true;
         for (RegionScanner rs : regionScanners) {
             rs.close();

--- a/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -39,6 +39,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
     protected Cell[] cells;
     int cellScannerIndex=0;
     private boolean closed=false;
+    private long rows = 0;
 
     public MemstoreKeyValueScanner(ResultScanner resultScanner) throws IOException{
         assert resultScanner!=null:"Passed Result Scanner is null";
@@ -61,6 +62,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
         if(currentResult!=null){
             cells=currentResult.rawCells();
             peakKeyValue=(KeyValue)current();
+            rows++;
             return true;
         }else{
             cells=null;
@@ -145,6 +147,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
     @Override
     public void close(){
         if(closed) return;
+        LOG.info("Closed MemstoreScanner after reading " + rows + " rows.");
         if(LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG,"close");
         resultScanner.close();

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -39,6 +39,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
     protected Cell[] cells;
     int cellScannerIndex=0;
     private boolean closed=false;
+    private long rows = 0;
 
     public MemstoreKeyValueScanner(ResultScanner resultScanner) throws IOException{
         assert resultScanner!=null:"Passed Result Scanner is null";
@@ -61,6 +62,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
         if(currentResult!=null){
             cells=currentResult.rawCells();
             peakKeyValue=(KeyValue)current();
+            rows++;
             return true;
         }else{
             cells=null;
@@ -145,6 +147,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
     @Override
     public void close(){
         if(closed) return;
+        LOG.info("Closed MemstoreScanner after reading " + rows + " rows.");
         if(LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG,"close");
         resultScanner.close();

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.hbase.CellUtils;
 import com.splicemachine.pipeline.utils.PipelineUtils;
+import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.regionserver.ScannerContext;
 import org.spark_project.guava.base.Throwables;
 import com.splicemachine.access.client.HBase10ClientSideRegionScanner;
@@ -63,6 +64,7 @@ public class SplitRegionScanner implements RegionScanner {
     private Partition clientPartition;
     private Scan initialScan;
     private volatile boolean closed = true;
+    private Cell lastCell = null;
 
     public SplitRegionScanner(Scan scan,
                               Table table,
@@ -136,6 +138,9 @@ public class SplitRegionScanner implements RegionScanner {
     public boolean nextInternal(List<Cell> results) throws IOException {
         try {
             boolean next = currentScanner.nextRaw(results);
+            if (!results.isEmpty()) {
+                lastCell = results.get(0);
+            }
             if (closed) {
                 LOG.error("Called next() on closed scanner");
                 throw new IOException("Scanner is closed");
@@ -172,7 +177,8 @@ public class SplitRegionScanner implements RegionScanner {
 
     @Override
     public void close() throws IOException {
-        SpliceLogUtils.info(LOG, "close split scanner with table [%s], scan [%s] with rowCount=%d, reinitCount=%d, scannerExceptionCount=%d",htable.getName().toString(),initialScan,totalScannerCount,reInitCount,scanExceptionCount);
+        String lastRow = lastCell != null ? CellUtil.getCellKeyAsString(lastCell) : null;
+        LOG.info(String.format("close split scanner with table [%s], scan [%s] with rowCount=%d, reinitCount=%d, scannerExceptionCount=%d, lastRows=%s",htable.getName().toString(),initialScan,totalScannerCount,reInitCount,scanExceptionCount,lastRow), new RuntimeException());
         closed = true;
         for (RegionScanner rs : regionScanners) {
             rs.close();

--- a/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -39,6 +39,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
     protected Cell[] cells;
     int cellScannerIndex=0;
     private boolean closed=false;
+    private long rows = 0;
 
     public MemstoreKeyValueScanner(ResultScanner resultScanner) throws IOException{
         assert resultScanner!=null:"Passed Result Scanner is null";
@@ -61,6 +62,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
         if(currentResult!=null){
             cells=currentResult.rawCells();
             peakKeyValue=(KeyValue)current();
+            rows++;
             return true;
         }else{
             cells=null;
@@ -145,6 +147,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
     @Override
     public void close(){
         if(closed) return;
+        LOG.info("Closed MemstoreScanner after reading " + rows + " rows.");
         if(LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG,"close");
         resultScanner.close();

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -38,6 +38,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
     protected Cell[] cells;
     int cellScannerIndex=0;
     private boolean closed=false;
+    private long rows = 0;
 
     public MemstoreKeyValueScanner(ResultScanner resultScanner) throws IOException{
         assert resultScanner!=null:"Passed Result Scanner is null";
@@ -60,6 +61,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
         if(currentResult!=null){
             cells=currentResult.rawCells();
             peakKeyValue=(KeyValue)current();
+            rows++;
             return true;
         }else{
             cells=null;
@@ -144,6 +146,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
     @Override
     public void close(){
         if(closed) return;
+        LOG.info("Closed MemstoreScanner after reading " + rows + " rows.");
         if(LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG,"close");
         resultScanner.close();

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.hbase.CellUtils;
 import com.splicemachine.pipeline.utils.PipelineUtils;
+import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.regionserver.ScannerContext;
 import org.spark_project.guava.base.Throwables;
 import com.splicemachine.access.client.HBase10ClientSideRegionScanner;
@@ -63,6 +64,7 @@ public class SplitRegionScanner implements RegionScanner {
     private Partition clientPartition;
     private Scan initialScan;
     private volatile boolean closed = true;
+    private Cell lastCell = null;
 
     public SplitRegionScanner(Scan scan,
                               Table table,
@@ -141,6 +143,9 @@ public class SplitRegionScanner implements RegionScanner {
                     throw new IOException("Scanner is closed");
                 }
                 boolean next = currentScanner.nextRaw(results);
+                if (!results.isEmpty()) {
+                    lastCell = results.get(0);
+                }
                 scannerCount++;
                 totalScannerCount++;
                 if (!next && scannerPosition < regionScanners.size()) {
@@ -174,7 +179,8 @@ public class SplitRegionScanner implements RegionScanner {
 
     @Override
     public void close() throws IOException {
-        SpliceLogUtils.info(LOG, "close split scanner with table [%s], scan [%s] with rowCount=%d, reinitCount=%d, scannerExceptionCount=%d",htable.getName().toString(),initialScan,totalScannerCount,reInitCount,scanExceptionCount);
+        String lastRow = lastCell != null ? CellUtil.getCellKeyAsString(lastCell) : null;
+        LOG.info(String.format("close split scanner with table [%s], scan [%s] with rowCount=%d, reinitCount=%d, scannerExceptionCount=%d, lastRows=%s",htable.getName().toString(),initialScan,totalScannerCount,reInitCount,scanExceptionCount,lastRow), new RuntimeException());
         closed = true;
         for (RegionScanner rs : regionScanners) {
             rs.close();

--- a/hbase_storage/hbase1.2.0_cdh5.12/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.2.0_cdh5.12/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -38,6 +38,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
     protected Cell[] cells;
     int cellScannerIndex=0;
     private boolean closed=false;
+    private long rows = 0;
 
     public MemstoreKeyValueScanner(ResultScanner resultScanner) throws IOException{
         assert resultScanner!=null:"Passed Result Scanner is null";
@@ -60,6 +61,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
         if(currentResult!=null){
             cells=currentResult.rawCells();
             peakKeyValue=(KeyValue)current();
+            rows++;
             return true;
         }else{
             cells=null;
@@ -144,6 +146,7 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
     @Override
     public void close(){
         if(closed) return;
+        LOG.info("Closed MemstoreScanner after reading " + rows + " rows.");
         if(LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG,"close");
         resultScanner.close();

--- a/hbase_storage/hbase1.2.0_cdh5.12/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.2.0_cdh5.12/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.hbase.CellUtils;
 import com.splicemachine.pipeline.utils.PipelineUtils;
+import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.regionserver.ScannerContext;
 import org.spark_project.guava.base.Throwables;
 import com.splicemachine.access.client.HBase10ClientSideRegionScanner;
@@ -63,6 +64,7 @@ public class SplitRegionScanner implements RegionScanner {
     private Partition clientPartition;
     private Scan initialScan;
     private volatile boolean closed = true;
+    private Cell lastCell = null;
 
     public SplitRegionScanner(Scan scan,
                               Table table,
@@ -141,6 +143,9 @@ public class SplitRegionScanner implements RegionScanner {
                     throw new IOException("Scanner is closed");
                 }
                 boolean next = currentScanner.nextRaw(results);
+                if (!results.isEmpty()) {
+                    lastCell = results.get(0);
+                }
                 scannerCount++;
                 totalScannerCount++;
                 if (!next && scannerPosition < regionScanners.size()) {
@@ -174,7 +179,8 @@ public class SplitRegionScanner implements RegionScanner {
 
     @Override
     public void close() throws IOException {
-        SpliceLogUtils.info(LOG, "close split scanner with table [%s], scan [%s] with rowCount=%d, reinitCount=%d, scannerExceptionCount=%d",htable.getName().toString(),initialScan,totalScannerCount,reInitCount,scanExceptionCount);
+        String lastRow = lastCell != null ? CellUtil.getCellKeyAsString(lastCell) : null;
+        LOG.info(String.format("close split scanner with table [%s], scan [%s] with rowCount=%d, reinitCount=%d, scannerExceptionCount=%d, lastRows=%s",htable.getName().toString(),initialScan,totalScannerCount,reInitCount,scanExceptionCount,lastRow), new RuntimeException());
         closed = true;
         for (RegionScanner rs : regionScanners) {
             rs.close();

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/CountingRegionScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/CountingRegionScanner.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.access.client;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.regionserver.ScannerContext;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Created by dgomezferro on 06/10/2017.
+ */
+public class CountingRegionScanner implements RegionScanner {
+    private static final Logger LOG = Logger.getLogger(CountingRegionScanner.class);
+
+    private final RegionScanner delegate;
+    private final Scan scan;
+    private final HRegion region;
+    private long rows;
+
+    public CountingRegionScanner(RegionScanner delegate, HRegion region, Scan scan) {
+        this.delegate = delegate;
+        this.scan = scan;
+        this.region = region;
+    }
+    @Override
+    public HRegionInfo getRegionInfo() {
+        return delegate.getRegionInfo();
+    }
+
+    @Override
+    public boolean isFilterDone() throws IOException {
+        return delegate.isFilterDone();
+    }
+
+    @Override
+    public boolean reseek(byte[] row) throws IOException {
+        return delegate.reseek(row);
+    }
+
+    @Override
+    public long getMaxResultSize() {
+        return delegate.getMaxResultSize();
+    }
+
+    @Override
+    public long getMvccReadPoint() {
+        return delegate.getMvccReadPoint();
+    }
+
+    @Override
+    public int getBatch() {
+        return delegate.getBatch();
+    }
+
+    @Override
+    public boolean nextRaw(List<Cell> result) throws IOException {
+        rows++;
+        return delegate.nextRaw(result);
+    }
+
+    @Override
+    public boolean nextRaw(List<Cell> result, ScannerContext scannerContext) throws IOException {
+        return delegate.nextRaw(result, scannerContext);
+    }
+
+    @Override
+    public boolean next(List<Cell> results) throws IOException {
+        return delegate.nextRaw(results);
+    }
+
+    @Override
+    public boolean next(List<Cell> result, ScannerContext scannerContext) throws IOException {
+        return delegate.nextRaw(result, scannerContext);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (LOG.isInfoEnabled()) {
+            StringBuilder sb = new StringBuilder();
+            for (Store s : region.getStores()) {
+                sb.append(s.getStorefiles());
+            }
+            LOG.info("Closing RegionScanner with scan " + scan + " after " + rows + " rows with storefiles" + sb.toString());
+        }
+
+        delegate.close();
+    }
+}

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/SkeletonClientSideRegionScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/SkeletonClientSideRegionScanner.java
@@ -157,7 +157,7 @@ public abstract class SkeletonClientSideRegionScanner implements RegionScanner{
             }
             memScannerList.add(getMemStoreScanner());
             this.region = openHRegion();
-            RegionScanner regionScanner = BaseHRegionUtil.getScanner(region, scan, memScannerList);
+            RegionScanner regionScanner = new CountingRegionScanner(BaseHRegionUtil.getScanner(region, scan, memScannerList), region, scan);
             if (flushed) {
                 if (scanner != null)
                     scanner.close();


### PR DESCRIPTION
This is a temporary addition of logging information meant to debug DB-6274, it should be reverted once the problem is fixed.