### PR TITLE
SPLICE-1913: NullPointerException happen when DumpOptimizedTree

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
@@ -846,7 +846,7 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
                 restriction.treePrint(depth+1);
             }
 
-            if(restrictionList!=null){
+            if(restrictionList!=null  && !restrictionList.isEmpty()){
                 printLabel(depth,"restrictionList: ");
                 restrictionList.treePrint(depth+1);
             }


### PR DESCRIPTION
restrictionList has always been initialized as "null" instant with empty list. It should check whether it's empty before printing the restriction list.