### PR TITLE
DB-6274 Re-init SplitRegionScanner if MemstoreKVScanner returns null

### DIFF
--- a/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -56,6 +56,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
 	   protected boolean endRowNeedsToBeReturned = false;
 	   protected boolean flushAlreadyReturned = false;
 	   protected int counter = 0;
+	   private final byte[] stopRow;
 
 		public MemStoreFlushAwareScanner(HRegion region, Store store, ScanInfo scanInfo, Scan scan,
 				final NavigableSet<byte[]> columns, long readPt, AtomicReference<MemstoreAware> memstoreAware, MemstoreAware initialValue) throws IOException {
@@ -65,7 +66,17 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
 			this.memstoreAware = memstoreAware;
 			this.initialValue = initialValue;
 			this.region = region;
+			this.stopRow = Bytes.equals(scan.getStopRow(), HConstants.EMPTY_END_ROW) ? null : scan.getStopRow();
 		}
+		
+	protected boolean isStopRow(Cell peek) {
+		byte[] currentRow = peek.getRowArray();
+		int offset = peek.getRowOffset();
+		short length = peek.getRowLength();
+		return (stopRow!= null &&
+				region.getComparator().compareRows(stopRow, 0, stopRow.length,
+						currentRow, offset, length) <= 0);
+	}
 
 		@Override
 		public KeyValue peek() {
@@ -85,7 +96,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
 				return ClientRegionConstants.MEMSTORE_BEGIN;
 			}
 			Cell peek = super.peek();
-			if (peek == null) {
+			if (peek == null || isStopRow(peek)) {
 				endRowNeedsToBeReturned = true;
                 return new KeyValue(Bytes.toBytes(counter),ClientRegionConstants.HOLD,ClientRegionConstants.HOLD, HConstants.LATEST_TIMESTAMP,ClientRegionConstants.HOLD);
 			}

--- a/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -16,6 +16,7 @@ package com.splicemachine.access.client;
 
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
@@ -64,9 +65,8 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
             rows++;
             return true;
         }else{
-            cells=null;
-            peakKeyValue=null;
-            return false;
+            // This shouldn't happen, throw exception and re-init the scanner
+            throw new DoNotRetryIOException("Memstore scanner shouldn't end prematurely");
         }
     }
 

--- a/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -166,7 +166,7 @@ public class SplitRegionScanner implements RegionScanner {
                     scan.setStartRow(Bytes.add(topCell.getRow(), new byte[]{0})); // set to previous start row
                 }
                 close();
-                SpliceLogUtils.warn(LOG, "re-init split scanner with scan=%s, table=%s",scan,htable);
+                LOG.warn(String.format("re-init split scanner with scan=%s, table=%s", scan, htable), ioe);
                 init(true); // Refresh
                 results.clear();
                 return nextInternal(results);

--- a/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -72,6 +72,15 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
 			this.region = region;
 			this.stopRow = Bytes.equals(scan.getStopRow(), HConstants.EMPTY_END_ROW) ? null : scan.getStopRow();
 		}
+		
+	protected boolean isStopRow(Cell peek) {
+		byte[] currentRow = peek.getRowArray();
+		int offset = peek.getRowOffset();
+		short length = peek.getRowLength();
+		return (stopRow!= null &&
+				region.getComparator().compareRows(stopRow, 0, stopRow.length,
+						currentRow, offset, length) <= 0);
+	}
 
 		@Override
 		public KeyValue peek() {
@@ -91,7 +100,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
 				return ClientRegionConstants.MEMSTORE_BEGIN;
 			}
 			Cell peek = super.peek();
-			if (peek == null) {
+			if (peek == null || isStopRow(peek)) {
 				endRowNeedsToBeReturned = true;
                 return new KeyValue(Bytes.toBytes(counter),ClientRegionConstants.HOLD,ClientRegionConstants.HOLD, HConstants.LATEST_TIMESTAMP,ClientRegionConstants.HOLD);
 			}

--- a/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -60,6 +60,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
 	   protected boolean endRowNeedsToBeReturned = false;
 	   protected boolean flushAlreadyReturned = false;
 	   protected int counter = 0;
+	   private final byte[] stopRow;
 
 		public MemStoreFlushAwareScanner(HRegion region, Store store, ScanInfo scanInfo, Scan scan,
                                          final NavigableSet<byte[]> columns, long readPt, AtomicReference<MemstoreAware> memstoreAware, MemstoreAware initialValue) throws IOException {
@@ -69,6 +70,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
 			this.memstoreAware = memstoreAware;
 			this.initialValue = initialValue;
 			this.region = region;
+			this.stopRow = Bytes.equals(scan.getStopRow(), HConstants.EMPTY_END_ROW) ? null : scan.getStopRow();
 		}
 
 		@Override

--- a/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -16,6 +16,7 @@ package com.splicemachine.access.client;
 
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
@@ -63,9 +64,8 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
             rows++;
             return true;
         }else{
-            cells=null;
-            peakKeyValue=null;
-            return false;
+            // This shouldn't happen, throw exception and re-init the scanner
+            throw new DoNotRetryIOException("Memstore scanner shouldn't end prematurely");
         }
     }
 

--- a/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -163,7 +163,7 @@ public class SplitRegionScanner implements RegionScanner {
                     scan.setStartRow(Bytes.add(topCell.getRow(), new byte[]{0})); // set to previous start row
                 }
                 close();
-                SpliceLogUtils.warn(LOG, "re-init split scanner with scan=%s, table=%s",scan,htable);
+                LOG.warn(String.format("re-init split scanner with scan=%s, table=%s", scan, htable), ioe);
                 init(true); // Refresh
                 results.clear();
                 return nextInternal(results);

--- a/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -56,6 +56,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
     protected boolean endRowNeedsToBeReturned = false;
     protected boolean flushAlreadyReturned = false;
     protected int counter = 0;
+    private final byte[] stopRow;
 
     public MemStoreFlushAwareScanner(HRegion region, Store store, ScanInfo scanInfo, Scan scan,
                                      final NavigableSet<byte[]> columns, long readPt, AtomicReference<MemstoreAware> memstoreAware, MemstoreAware initialValue) throws IOException {
@@ -65,6 +66,16 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
         this.memstoreAware = memstoreAware;
         this.initialValue = initialValue;
         this.region = region;
+        this.stopRow = Bytes.equals(scan.getStopRow(), HConstants.EMPTY_END_ROW) ? null : scan.getStopRow();
+    }
+
+    protected boolean isStopRow(Cell peek) {
+        byte[] currentRow = peek.getRowArray();
+        int offset = peek.getRowOffset();
+        short length = peek.getRowLength();
+        return (stopRow!= null &&
+                region.getComparator().compareRows(stopRow, 0, stopRow.length,
+                        currentRow, offset, length) <= 0);
     }
 
     @Override
@@ -85,7 +96,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
             return ClientRegionConstants.MEMSTORE_BEGIN;
         }
         Cell peek = super.peek();
-        if (peek == null) {
+        if (peek == null || isStopRow(peek)) {
             endRowNeedsToBeReturned = true;
             return new KeyValue(Bytes.toBytes(counter),ClientRegionConstants.HOLD,ClientRegionConstants.HOLD, HConstants.LATEST_TIMESTAMP,ClientRegionConstants.HOLD);
         }

--- a/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -16,6 +16,7 @@ package com.splicemachine.access.client;
 
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
@@ -65,9 +66,8 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
             rows++;
             return true;
         }else{
-            cells=null;
-            peakKeyValue=null;
-            return false;
+            // This shouldn't happen, throw exception and re-init the scanner
+            throw new DoNotRetryIOException("Memstore scanner shouldn't end prematurely");
         }
     }
 

--- a/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -165,7 +165,7 @@ public class SplitRegionScanner implements RegionScanner {
                     scan.setStartRow(Bytes.add(topCell.getRow(), new byte[]{0})); // set to previous start row
                 }
                 close();
-                SpliceLogUtils.warn(LOG, "re-init split scanner with scan=%s, table=%s",scan,htable);
+                LOG.warn(String.format("re-init split scanner with scan=%s, table=%s", scan, htable), ioe);
                 init(true); // Refresh
                 results.clear();
                 return nextInternal(results);

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -56,6 +56,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
     protected boolean endRowNeedsToBeReturned = false;
     protected boolean flushAlreadyReturned = false;
     protected int counter = 0;
+    private final byte[] stopRow;
 
     public MemStoreFlushAwareScanner(HRegion region, Store store, ScanInfo scanInfo, Scan scan,
                                      final NavigableSet<byte[]> columns, long readPt, AtomicReference<MemstoreAware> memstoreAware, MemstoreAware initialValue) throws IOException {
@@ -65,6 +66,16 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
         this.memstoreAware = memstoreAware;
         this.initialValue = initialValue;
         this.region = region;
+        this.stopRow = Bytes.equals(scan.getStopRow(), HConstants.EMPTY_END_ROW) ? null : scan.getStopRow();
+    }
+
+    protected boolean isStopRow(Cell peek) {
+        byte[] currentRow = peek.getRowArray();
+        int offset = peek.getRowOffset();
+        short length = peek.getRowLength();
+        return (stopRow!= null &&
+                region.getComparator().compareRows(stopRow, 0, stopRow.length,
+                        currentRow, offset, length) <= 0);
     }
 
     @Override
@@ -85,7 +96,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
             return ClientRegionConstants.MEMSTORE_BEGIN;
         }
         Cell peek = super.peek();
-        if (peek == null) {
+        if (peek == null || isStopRow(peek)) {
             endRowNeedsToBeReturned = true;
             return new KeyValue(Bytes.toBytes(counter),ClientRegionConstants.HOLD,ClientRegionConstants.HOLD, HConstants.LATEST_TIMESTAMP,ClientRegionConstants.HOLD);
         }

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -16,6 +16,7 @@ package com.splicemachine.access.client;
 
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
@@ -65,9 +66,8 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
             rows++;
             return true;
         }else{
-            cells=null;
-            peakKeyValue=null;
-            return false;
+            // This shouldn't happen, throw exception and re-init the scanner
+            throw new DoNotRetryIOException("Memstore scanner shouldn't end prematurely");
         }
     }
 

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -165,7 +165,7 @@ public class SplitRegionScanner implements RegionScanner {
                     scan.setStartRow(Bytes.add(topCell.getRow(), new byte[]{0})); // set to previous start row
                 }
                 close();
-                SpliceLogUtils.warn(LOG, "re-init split scanner with scan=%s, table=%s",scan,htable);
+                LOG.warn(String.format("re-init split scanner with scan=%s, table=%s", scan, htable), ioe);
                 init(true); // Refresh
                 results.clear();
                 return nextInternal(results);

--- a/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -56,6 +56,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
     protected boolean endRowNeedsToBeReturned = false;
     protected boolean flushAlreadyReturned = false;
     protected int counter = 0;
+    private final byte[] stopRow;
 
     public MemStoreFlushAwareScanner(HRegion region, Store store, ScanInfo scanInfo, Scan scan,
                                      final NavigableSet<byte[]> columns, long readPt, AtomicReference<MemstoreAware> memstoreAware, MemstoreAware initialValue) throws IOException {
@@ -65,6 +66,16 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
         this.memstoreAware = memstoreAware;
         this.initialValue = initialValue;
         this.region = region;
+        this.stopRow = Bytes.equals(scan.getStopRow(), HConstants.EMPTY_END_ROW) ? null : scan.getStopRow();
+    }
+
+    protected boolean isStopRow(Cell peek) {
+        byte[] currentRow = peek.getRowArray();
+        int offset = peek.getRowOffset();
+        short length = peek.getRowLength();
+        return (stopRow!= null &&
+                region.getComparator().compareRows(stopRow, 0, stopRow.length,
+                        currentRow, offset, length) <= 0);
     }
 
     @Override
@@ -85,7 +96,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
             return ClientRegionConstants.MEMSTORE_BEGIN;
         }
         Cell peek = super.peek();
-        if (peek == null) {
+        if (peek == null || isStopRow(peek)) {
             endRowNeedsToBeReturned = true;
             return new KeyValue(Bytes.toBytes(counter),ClientRegionConstants.HOLD,ClientRegionConstants.HOLD, HConstants.LATEST_TIMESTAMP,ClientRegionConstants.HOLD);
         }

--- a/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -16,6 +16,7 @@ package com.splicemachine.access.client;
 
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
@@ -65,9 +66,8 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
             rows++;
             return true;
         }else{
-            cells=null;
-            peakKeyValue=null;
-            return false;
+            // This shouldn't happen, throw exception and re-init the scanner
+            throw new DoNotRetryIOException("Memstore scanner shouldn't end prematurely");
         }
     }
 

--- a/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -165,7 +165,7 @@ public class SplitRegionScanner implements RegionScanner {
                     scan.setStartRow(Bytes.add(topCell.getRow(), new byte[]{0})); // set to previous start row
                 }
                 close();
-                SpliceLogUtils.warn(LOG, "re-init split scanner with scan=%s, table=%s",scan,htable);
+                LOG.warn(String.format("re-init split scanner with scan=%s, table=%s", scan, htable), ioe);
                 init(true); // Refresh
                 results.clear();
                 return nextInternal(results);

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -63,6 +63,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
     protected boolean endRowNeedsToBeReturned = false;
     protected boolean flushAlreadyReturned = false;
     protected int counter = 0;
+    private final byte[] stopRow;
 
     public MemStoreFlushAwareScanner(HRegion region, Store store, ScanInfo scanInfo, Scan scan,
                                      final NavigableSet<byte[]> columns, long readPt, AtomicReference<MemstoreAware> memstoreAware, MemstoreAware initialValue) throws IOException {
@@ -72,6 +73,16 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
         this.memstoreAware = memstoreAware;
         this.initialValue = initialValue;
         this.region = region;
+        this.stopRow = Bytes.equals(scan.getStopRow(), HConstants.EMPTY_END_ROW) ? null : scan.getStopRow();
+    }
+    
+    protected boolean isStopRow(Cell peek) {
+        byte[] currentRow = peek.getRowArray();
+        int offset = peek.getRowOffset();
+        short length = peek.getRowLength();
+        return (stopRow!= null &&
+                region.getComparator().compareRows(stopRow, 0, stopRow.length,
+                        currentRow, offset, length) <= 0);
     }
 
     @Override
@@ -92,7 +103,7 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
             return ClientRegionConstants.MEMSTORE_BEGIN;
         }
         Cell peek = super.peek();
-        if (peek == null) {
+        if (peek == null || isStopRow(peek)) {
             endRowNeedsToBeReturned = true;
             return new KeyValue(Bytes.toBytes(counter),ClientRegionConstants.HOLD,ClientRegionConstants.HOLD, HConstants.LATEST_TIMESTAMP,ClientRegionConstants.HOLD);
         }

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -16,6 +16,7 @@ package com.splicemachine.access.client;
 
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
@@ -64,9 +65,8 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
             rows++;
             return true;
         }else{
-            cells=null;
-            peakKeyValue=null;
-            return false;
+            // This shouldn't happen, throw exception and re-init the scanner
+            throw new DoNotRetryIOException("Memstore scanner shouldn't end prematurely");
         }
     }
 

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -166,7 +166,7 @@ public class SplitRegionScanner implements RegionScanner {
                         scan.setStartRow(Bytes.add(topCell.getRow(), new byte[]{0})); // set to previous start row
                     }
                     close();
-                    SpliceLogUtils.warn(LOG, "re-init split scanner with scan=%s, table=%s", scan, htable);
+                    LOG.warn(String.format("re-init split scanner with scan=%s, table=%s", scan, htable), ioe);
                     init(true); // Refresh
                     results.clear();
                     continue;

--- a/hbase_storage/hbase1.2.0_cdh5.12/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.2.0_cdh5.12/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -16,6 +16,7 @@ package com.splicemachine.access.client;
 
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
@@ -64,9 +65,8 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
             rows++;
             return true;
         }else{
-            cells=null;
-            peakKeyValue=null;
-            return false;
+            // This shouldn't happen, throw exception and re-init the scanner
+            throw new DoNotRetryIOException("Memstore scanner shouldn't end prematurely");
         }
     }
 

--- a/hbase_storage/hbase1.2.0_cdh5.12/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.2.0_cdh5.12/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -166,7 +166,7 @@ public class SplitRegionScanner implements RegionScanner {
                         scan.setStartRow(Bytes.add(topCell.getRow(), new byte[]{0})); // set to previous start row
                     }
                     close();
-                    SpliceLogUtils.warn(LOG, "re-init split scanner with scan=%s, table=%s", scan, htable);
+                    LOG.warn(String.format("re-init split scanner with scan=%s, table=%s", scan, htable), ioe);
                     init(true); // Refresh
                     results.clear();
                     continue;


### PR DESCRIPTION
Previous merge had some IT failures

Now we make sure we don't close the MemstoreFlushAwareScanner if it reaches the scan's stopRow