### PR TITLE
SPLICE-1351 Upgrade Sketching Library from 0.8.1 - 0.8.4 (2.5)

### DIFF
--- a/db-engine/pom.xml
+++ b/db-engine/pom.xml
@@ -63,12 +63,12 @@
         <dependency>
             <groupId>com.yahoo.datasketches</groupId>
             <artifactId>sketches-core</artifactId>
-            <version>0.8.1</version>
+            <version>0.8.4</version>
         </dependency>
         <dependency>
             <groupId>com.yahoo.datasketches</groupId>
             <artifactId>memory</artifactId>
-            <version>0.8.1</version>
+            <version>0.8.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This is a backport of SPLICE-1351 to 2.5.