### PR TITLE
SPLICE-1930: Fixes an issue where maven uses platform installed protobuf to compile proto2 files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -462,9 +462,9 @@
                     <version>2.0.11</version>
                 </plugin>
                 <plugin>
-                    <groupId>net.dongliu</groupId>
-                    <artifactId>maven-protoc-plugin</artifactId>
-                    <version>0.3.5</version>
+                    <groupId>org.xolstice.maven.plugins</groupId>
+                    <artifactId>protobuf-maven-plugin</artifactId>
+                    <version>0.5.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/splice_protocol/pom.xml
+++ b/splice_protocol/pom.xml
@@ -29,12 +29,20 @@
         </dependency>
     </dependencies>
     <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.5.0.Final</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
-                <groupId>net.dongliu</groupId>
-                <artifactId>maven-protoc-plugin</artifactId>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocExecutable>protoc</protocExecutable>
+                    <protocArtifact>com.google.protobuf:protoc:2.5.0:exe:${os.detected.classifier}</protocArtifact>
+                    <pluginId>protobuf-java</pluginId>
                     <protoSourceRoot>${project.basedir}/src/main/protobuf</protoSourceRoot>
                 </configuration>
                 <executions>


### PR DESCRIPTION
[ERROR] protoc failed error: [libprotobuf WARNING google/protobuf/compiler/parser.cc:546] No syntax specified for the proto file: Backup.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[libprotobuf WARNING google/protobuf/compiler/parser.cc:546] No syntax specified for the proto file: Txn.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[libprotobuf WARNING google/protobuf/compiler/parser.cc:546] No syntax specified for the proto file: Derby.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[libprotobuf WARNING google/protobuf/compiler/parser.cc:546] No syntax specified for the proto file: Olap.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
Olap.proto:21:18: Message extensions cannot have required fields.
Olap.proto:28:18: Message extensions cannot have required fields.
Olap.proto:34:18: Message extensions cannot have required fields.
Olap.proto:53:18: Message extensions cannot have required fields.
Olap.proto:60:18: Message extensions cannot have required fields.
Olap.proto:67:18: Message extensions cannot have required fields.