### PR TITLE
SPLICE-1928: decode region start/end key by fetching actual rowkey

### DIFF
--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/ClientPartition.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/ClientPartition.java
@@ -14,6 +14,8 @@
 
 package com.splicemachine.storage;
 
+import com.splicemachine.si.api.data.TxnOperationFactory;
+import com.splicemachine.si.impl.driver.SIDriver;
 import org.spark_project.guava.base.Function;
 import com.splicemachine.si.data.HExceptionFactory;
 import com.splicemachine.si.impl.HNotServingRegion;

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HScan.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HScan.java
@@ -162,4 +162,9 @@ public class HScan implements DataScan{
     public Scan unwrapDelegate(){
         return scan;
     }
+
+    @Override
+    public void setSmall(boolean small) {
+        scan.setSmall(small);
+    }
 }

--- a/mem_storage/src/main/java/com/splicemachine/storage/MScan.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MScan.java
@@ -133,4 +133,8 @@ public class MScan implements DataScan{
     public void setAllAttributes(Map<String, byte[]> attrMap){
         attrs.putAll(attrMap);
     }
+
+    @Override
+    public void setSmall(boolean small) {
+    }
 }

--- a/splice_access_api/src/main/java/com/splicemachine/storage/DataScan.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/DataScan.java
@@ -53,5 +53,5 @@ public interface DataScan extends Attributable{
 
     void returnAllVersions();
 
-
+    void setSmall(boolean small);
 }

--- a/splice_access_api/src/main/java/com/splicemachine/storage/Partition.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/Partition.java
@@ -167,5 +167,4 @@ public interface Partition extends AutoCloseable{
      * @throws IOException
      */
     BitSet getBloomInMemoryCheck(boolean hasConstraintChecker, Pair<KVPair, Lock>[] dataAndLocks) throws IOException;
-
 }


### PR DESCRIPTION
If a region start/end key cannot be decoded, fetch the first/last row of the region and decode it.