### PR TITLE
DB-6354 Fix automatic DROP of temp tables

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -772,7 +772,7 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
                 "Programmer Error: Cannot perform a data dictionary write with a non-SpliceTransaction";
         // No subtransactions from here on, since we are modifying the data dictionary we rely on persisted
         // transactions for coordination
-        ((SpliceTransaction) rawTransaction).getTxn().forbidSubtransactions();
+        ((SpliceTransaction) rawTransaction).getActiveStateTxn().forbidSubtransactions();
         /*
          * This is a bit of an awkward hack--at this stage, we need to ensure that the transaction
          * allows writes, but we don't really know where it's going, except to the data dictionary (and

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/TempTableIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/TempTableIT.java
@@ -45,7 +45,6 @@ import com.splicemachine.homeless.TestUtils;
  * @author Jeff Cunningham
  *         Date: 1/25/15
  */
-@Ignore("DB-4272")
 public class TempTableIT {
     public static final String CLASS_NAME = TempTableIT.class.getSimpleName().toUpperCase();
     private static SpliceSchemaWatcher tableSchema = new SpliceSchemaWatcher(CLASS_NAME);
@@ -798,7 +797,7 @@ public class TempTableIT {
         connection1.commit();
         methodWatcher.closeAll();
 
-        Thread.sleep(1000);  // TODO: JC - This is what the bug is about now. We have to wait for table drop before connecting.
+        Thread.sleep(5000);  // TODO: JC - This is what the bug is about now. We have to wait for table drop before connecting.
         Connection connection2 = methodWatcher.createConnection();
         try {
             SQLClosures.query(connection2, String.format("select id from %s.%s", tableSchema.schemaName, MY_TABLE),


### PR DESCRIPTION
ITs already existed for the feature but were ignored, I'm reenabling them.