### PR TITLE
SPLICE-1944 fix interaction between flattening where subquery and SSQ…

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromList.java
@@ -1227,8 +1227,13 @@ public class FromList extends QueryTreeNodeVector<QueryTreeNode> implements Opti
 		 */
         if(dependencyMap.getFirstSetBit()==-1){
             int outerSize=outerFromList.size();
-            for(int outer=0;outer<outerSize;outer++)
-                dependencyMap.or(((FromTable)outerFromList.elementAt(outer)).getReferencedTableMap());
+            for(int outer=0;outer<outerSize;outer++) {
+                FromTable ft = (FromTable) outerFromList.elementAt(outer);
+                // SSQ need to be processed after all the joins (including the join with where subquery) ar done,
+                // so we should not include SSQs in the where subquery's dependencyMap
+                if (!ft.fromSSQ)
+                    dependencyMap.or(ft.getReferencedTableMap());
+            }
         }
 
 		/* Do the marking */

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
@@ -2502,8 +2502,13 @@ public class SubqueryNode extends ValueNode{
         // in the dependencyMap, not all the tabled in the outer block. this could be a performance enhancement
         JBitSet dependencyMap=new JBitSet(numTables);
         int outerSize=outerFromList.size();
-        for(int outer=0;outer<outerSize;outer++)
-            dependencyMap.or(((FromTable)outerFromList.elementAt(outer)).getReferencedTableMap());
+        for(int outer=0;outer<outerSize;outer++) {
+            FromTable ft = (FromTable) outerFromList.elementAt(outer);
+            // SSQ need to be processed after all the joins (including the join with where subquery) ar done,
+            // so we should not include SSQs in the where subquery's dependencyMap
+            if (!ft.fromSSQ)
+                dependencyMap.or(((FromTable) outerFromList.elementAt(outer)).getReferencedTableMap());
+        }
         ((FromTable) newPRN).setExistsTable(true, dependencyMap, false, false);
 
         // add the current subquery as a FromSubquery(DT) in the outer block's fromList


### PR DESCRIPTION
… in select clause. 
This is a fix for the regression caused by DB-6286. More details is in [SPLICE-1944](https://splice.atlassian.net/browse/SPLICE-1944)