### PR TITLE
DB-6362 Large variance in simple select query execution time

### DIFF
--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampOracle.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampOracle.java
@@ -48,7 +48,7 @@ public class TimestampOracle implements TimestampOracleStatistics{
     private AtomicLong _numTimestampsCreated = new AtomicLong(0);
 
     private TimestampBlockManager timestampBlockManager;
-    private int blockSize;
+    private long blockSize;
 
     public static TimestampOracle getInstance(TimestampBlockManager timestampBlockManager, int blockSize) throws TimestampIOException{
 		TimestampOracle to = _instance;
@@ -66,7 +66,7 @@ public class TimestampOracle implements TimestampOracleStatistics{
 	
 	private TimestampOracle(TimestampBlockManager timestampBlockManager, int blockSize) throws TimestampIOException {
         this.timestampBlockManager=timestampBlockManager;
-        this.blockSize = blockSize;
+        this.blockSize = blockSize * TIMESTAMP_INCREMENT;
 		initialize();
 	}
 


### PR DESCRIPTION
Previous behavior, when "splice.timestamp_server.blocksize" was interpreted as roughly the number of transactions, is restored. The default value for "splice.timestamp_server.blocksize" remains intact (32768).