### PR TITLE
SPLICE-1951: Remove protobuf installation instructions from GETTING-STARTED

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -32,23 +32,6 @@ Note: JDK 1.8 is required for the master branch.
 
 * [Java 1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
 * [Apache Maven 3.3.x (Jenkins uses 3.3.9)](https://maven.apache.org/download.cgi)
-* [Google Protocol Buffers 2.5.0 (source download)](https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.bz2)
-
-> **Instructions to compile protobufs**<br />
-1. Download the proper version of protocol buffers<br />
-`wget https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.bz2`<br />
-2. Untar the tar.bz2 file<br />
-`tar xfvj protobuf-2.5.0.tar.bz2`<br />
-3. Configure the protobuf.<br />
-`cd protobuf-2.5.0`<br />
-On Linux:<br />
-`./configure`<br />
-On OS X/macOS:<br />
-`./configure CC=clang CXX=clang++ CXXFLAGS='-std=c++11 -stdlib=libc++ -O3 -g' LDFLAGS='-stdlib=libc++' LIBS="-lc++ -lc++abi"`<br />
-4. Build the source<br />
-`make -j4`<br />
-5. Install the compiled binaries<br />
-`sudo make install`<br />
 
 #### Helpful Environment Variables, etc. (example assumes Mac OS X developer machine)
 ```bash


### PR DESCRIPTION
Protobuf installation instructions should be removed from GETTING-STARTED as it's not needed anymore. Fixed by SPLICE-1930