### PR TITLE
DB-6367: null checking for region operations

### DIFF
--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -2009,5 +2009,6 @@ public interface SQLState {
 	String REGION_DOESNOT_EXIST 									= "TS003";
 	String WRONG_REGION_NAME_TYPE 									= "TS004";
 	String REGION_NOT_ADJACENT                                      = "TS005";
+	String SPLIT_KEY_CANNOT_BE_NULL									= "TS006";
 }
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -9174,6 +9174,10 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
                <arg>regionName2</arg>
            </msg>
 
+           <msg>
+               <name>TS006</name>
+               <text>SplitKey cannot be null.</text>
+           </msg>
        </family>
     </section>
 

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/SpliceRegionAdminIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/SpliceRegionAdminIT.java
@@ -346,6 +346,21 @@ public class SpliceRegionAdminIT {
             String sqlcode = e.getSQLState();
             Assert.assertEquals(sqlcode, SQLState.TABLE_NAME_CANNOT_BE_NULL.substring(0,5));
         }
+
+        sql = "CALL SYSCS_UTIL.GET_ENCODED_REGION_NAME(?, ?, ?, null, '|', null, null, null, null)";
+        ps = methodWatcher.prepareStatement(sql);
+
+        try {
+            ps.setString(1, SCHEMA_NAME);
+            ps.setString(2, LINEITEM);
+            ps.setString(3, null);
+            ps.execute();
+        }
+        catch (SQLException e) {
+            String sqlcode = e.getSQLState();
+            Assert.assertEquals(sqlcode, SQLState.SPLIT_KEY_CANNOT_BE_NULL);
+        }
+
     }
 
     private static String getResource(String name) {

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/SpliceRegionAdminIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/SpliceRegionAdminIT.java
@@ -234,6 +234,16 @@ public class SpliceRegionAdminIT {
             Assert.assertEquals(sqlcode, SQLState.LANG_INDEX_NOT_FOUND);
         }
 
+        try{
+            ps.setString(1, SCHEMA_NAME);
+            ps.setString(2, null);
+            ps.setString(3, null);
+            ps.execute();
+        }catch (SQLException e) {
+            String sqlcode = e.getSQLState();
+            Assert.assertEquals(sqlcode, SQLState.TABLE_NAME_CANNOT_BE_NULL.substring(0,5));
+        }
+
         sql = "CALL SYSCS_UTIL.GET_START_KEY(?, ?, ?, ?)";
         ps = methodWatcher.prepareStatement(sql);
 
@@ -281,6 +291,60 @@ public class SpliceRegionAdminIT {
         }catch (SQLException e) {
             String sqlcode = e.getSQLState();
             Assert.assertEquals(sqlcode, SQLState.REGION_DOESNOT_EXIST);
+        }
+
+        try {
+            ps.setString(1, SCHEMA_NAME);
+            ps.setString(2, null);
+            ps.setString(3, SHIPDATE_IDX);
+            ps.setString(4, "region");
+            ps.execute();
+        }
+        catch (SQLException e) {
+            String sqlcode = e.getSQLState();
+            Assert.assertEquals(sqlcode, SQLState.TABLE_NAME_CANNOT_BE_NULL.substring(0,5));
+        }
+
+        sql = "CALL SYSCS_UTIL.COMPACT_REGION(?, ?, ?, ?)";
+        ps = methodWatcher.prepareStatement(sql);
+        try {
+            ps.setString(1, null);
+            ps.setString(2, null);
+            ps.setString(3, SHIPDATE_IDX);
+            ps.setString(4, "region");
+            ps.execute();
+        }
+        catch (SQLException e) {
+            String sqlcode = e.getSQLState();
+            Assert.assertEquals(sqlcode, SQLState.TABLE_NAME_CANNOT_BE_NULL.substring(0,5));
+        }
+
+        sql = "CALL SYSCS_UTIL.GET_REGIONS(?, ?, ?, 'start', 'end', '|', null, null, null, null)";
+        ps = methodWatcher.prepareStatement(sql);
+        try {
+            ps.setString(1, null);
+            ps.setString(2, null);
+            ps.setString(3, SHIPDATE_IDX);
+            ps.execute();
+        }
+        catch (SQLException e) {
+            String sqlcode = e.getSQLState();
+            Assert.assertEquals(sqlcode, SQLState.TABLE_NAME_CANNOT_BE_NULL.substring(0,5));
+        }
+
+        sql = "CALL SYSCS_UTIL.MERGE_REGIONS(?, ?, ?, ?, ?)";
+        ps = methodWatcher.prepareStatement(sql);
+        try {
+            ps.setString(1, SCHEMA_NAME);
+            ps.setString(2, null);
+            ps.setString(3, SHIPDATE_IDX);
+            ps.setString(4, "region1");
+            ps.setString(5, "region2");
+            ps.execute();
+        }
+        catch (SQLException e) {
+            String sqlcode = e.getSQLState();
+            Assert.assertEquals(sqlcode, SQLState.TABLE_NAME_CANNOT_BE_NULL.substring(0,5));
         }
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
@@ -340,6 +340,9 @@ public class SpliceRegionAdmin {
                                                String timeFormat,
                                                ResultSet[] results) throws Exception {
 
+        if(splitKey == null)
+            throw StandardException.newException(SQLState.SPLIT_KEY_CANNOT_BE_NULL);
+
         TableDescriptor td = getTableDescriptor(schemaName, tableName);
         ConglomerateDescriptor index = null;
         if (indexName != null) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
@@ -93,14 +93,10 @@ public class SpliceRegionAdmin {
                                    String timeFormat,
                                    ResultSet[] results) throws Exception {
 
-        // Check parameters
-        schemaName = schemaName.toUpperCase();
-        tableName = tableName.toUpperCase();
-
         TableDescriptor td = getTableDescriptor(schemaName, tableName);
         ConglomerateDescriptor index = null;
         if (indexName != null) {
-            indexName = indexName.toUpperCase();
+            indexName = indexName.trim();
             index = getIndex(td, indexName);
             if (index == null) {
                 throw StandardException.newException(SQLState.LANG_INDEX_NOT_FOUND, indexName);
@@ -238,14 +234,10 @@ public class SpliceRegionAdmin {
                                      String regionName1,
                                      String regionName2) throws Exception {
 
-        // Check parameters
-        schemaName = schemaName.toUpperCase();
-        tableName = tableName.toUpperCase();
-
         TableDescriptor td = getTableDescriptor(schemaName, tableName);
         ConglomerateDescriptor index = null;
         if (indexName != null) {
-            indexName = indexName.toUpperCase();
+            indexName = indexName.trim();
             index = getIndex(td, indexName);
             if (index == null) {
                 throw StandardException.newException(SQLState.LANG_INDEX_NOT_FOUND, indexName);
@@ -285,14 +277,11 @@ public class SpliceRegionAdmin {
                                String indexName,
                                String regionName,
                                boolean isMajor) throws Exception {
-        // Check parameters
-        schemaName = schemaName.toUpperCase();
-        tableName = tableName.toUpperCase();
 
         TableDescriptor td = getTableDescriptor(schemaName, tableName);
         ConglomerateDescriptor index = null;
         if (indexName != null) {
-            indexName = indexName.toUpperCase();
+            indexName = indexName.trim();
             index = getIndex(td, indexName);
             if (index == null) {
                 throw StandardException.newException(SQLState.LANG_INDEX_NOT_FOUND, indexName);
@@ -351,14 +340,10 @@ public class SpliceRegionAdmin {
                                                String timeFormat,
                                                ResultSet[] results) throws Exception {
 
-        // Check parameters
-        schemaName = schemaName.toUpperCase();
-        tableName = tableName.toUpperCase();
-
         TableDescriptor td = getTableDescriptor(schemaName, tableName);
         ConglomerateDescriptor index = null;
         if (indexName != null) {
-            indexName = indexName.toUpperCase();
+            indexName = indexName.trim();
             index = getIndex(td, indexName);
             if (index == null) {
                 throw StandardException.newException(SQLState.LANG_INDEX_NOT_FOUND, indexName);
@@ -425,15 +410,11 @@ public class SpliceRegionAdmin {
                                      String indexName,
                                      String encodedRegionName,
                                      ResultSet[] results) throws Exception {
-
-        // Validate parameters
-        schemaName = schemaName.toUpperCase();
-        tableName = tableName.toUpperCase();
         TableDescriptor td = getTableDescriptor(schemaName, tableName);
 
         ConglomerateDescriptor index = null;
         if (indexName != null) {
-            indexName = indexName.toUpperCase();
+            indexName = indexName.trim();
             index = getIndex(td, indexName);
             if (index == null) {
                 throw StandardException.newException(SQLState.LANG_INDEX_NOT_FOUND, indexName);
@@ -552,6 +533,20 @@ public class SpliceRegionAdmin {
         LanguageConnectionContext lcc = lastActivation.getLanguageConnectionContext();
         SpliceTransactionManager tc = (SpliceTransactionManager)lcc.getTransactionExecute();
         DataDictionary dd = lcc.getDataDictionary();
+
+        // Check parameters
+        if (schemaName == null) {
+            schemaName = lcc.getCurrentSchemaName();
+        } else {
+            schemaName = schemaName.trim();
+        }
+
+        if (tableName != null) {
+            tableName = tableName.trim();
+        }
+        else {
+            throw StandardException.newException(SQLState.TABLE_NAME_CANNOT_BE_NULL);
+        }
 
         SchemaDescriptor sd = dd.getSchemaDescriptor(schemaName, tc, true);
         if (sd == null){


### PR DESCRIPTION
If table name or split key is null, return a meaningful error message rather than a null pointer exception.

If schema name is null, use the current schema.