### PR TITLE
DB-6349: allow distributed execution for splice client

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/lifecycle/CostChoosingDataSetProcessorFactory.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/lifecycle/CostChoosingDataSetProcessorFactory.java
@@ -130,6 +130,7 @@ public class CostChoosingDataSetProcessorFactory implements DataSetProcessorFact
 
     private boolean allowsDistributedExecution(){ // corresponds to master_dataset isRunningOnSpark
         if (isHBase()) return true;
+        if (SpliceClient.isClient) return true;
         else if(Thread.currentThread().getName().startsWith("olap-worker")) return true; //we are on the OlapServer thread
         else if(Thread.currentThread().getName().contains("ScalaTest")) return true; //we are on the OlapServer thread
         else if(Thread.currentThread().getName().contains("Executor task launch worker")) return false; //we are definitely in spark


### PR DESCRIPTION
If Splice.isClient is true, allow execution go to spark. This is needed if splice spark adapter is launched from a spark task with a thread name of "Executor task launch worker"