### PR TITLE
SPLICE-1948 Resolve conflicts and some IT bugs

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
@@ -304,7 +304,7 @@ public class SpliceSpark {
         SpliceSpark.getContext().setLocalProperty("spark.rdd.scope.noOverride", null);
     }
 
-    public static void setContext(SparkContext sparkContext) {
+    public synchronized static void setContext(SparkContext sparkContext) {
         session = SparkSession.builder().config(sparkContext.getConf()).getOrCreate(); // Claims this is a singleton from documentation
         ctx = new JavaSparkContext(sparkContext);
         initialized = true;

--- a/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/TestStreamingContext.scala
+++ b/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/TestStreamingContext.scala
@@ -126,7 +126,6 @@ trait TestStreamingContext extends BeforeAndAfterAll { self: Suite =>
   }
 
   override def afterAll() {
-    if (ssc != null) ssc.stop()
   }
 
   def deleteInternalRow(key: Int): Unit = {
@@ -163,7 +162,7 @@ trait TestStreamingContext extends BeforeAndAfterAll { self: Suite =>
             val l:Timestamp = new Timestamp(i)
             val m:String = if (i < 8) "sometestinfo" + i else null
             Row(a,b,c,d,e,f,g,h,j,k,l,m)
-        }).sliding(batchSize).foreach(s => queue.enqueue(ssc.sparkContext.parallelize(s)))
+        }).sliding(batchSize,batchSize).foreach(s => queue.enqueue(ssc.sparkContext.parallelize(s)))
   }
 
   /**


### PR DESCRIPTION
The ITs from the previous PR had some issues that were resolved when backporting to 2.5, I fix them here.

I've also made SpliceSpark.setContext() synchronized to guarantee correctness under concurrency.