### PR TITLE
SPLICE-1961 Missing splice_spark module in pom.xml

### DIFF
--- a/platforms/cdh5.12.0/pom.xml
+++ b/platforms/cdh5.12.0/pom.xml
@@ -43,6 +43,7 @@
         <module>../../hbase_storage</module>
         <module>../../hbase_pipeline</module>
         <module>../../hbase_sql</module>
+        <module>../../splice_spark</module>
         <module>../../assembly</module>
     </modules>
 </project>

--- a/platforms/cdh5.8.3/pom.xml
+++ b/platforms/cdh5.8.3/pom.xml
@@ -43,6 +43,7 @@
         <module>../../hbase_storage</module>
         <module>../../hbase_pipeline</module>
         <module>../../hbase_sql</module>
+        <module>../../splice_spark</module>
         <module>../../assembly</module>
     </modules>
 </project>


### PR DESCRIPTION
Added missing module to cdh5.8.3 and cdh5.12.0