### PR TITLE
DB-6428 adjust selectivity estimation by excluding skewed default values(2.5)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
@@ -643,4 +643,8 @@ public interface CompilerContext extends Context
 
 	public Vector<Integer> getSkipStatsTableList();
 
+	public boolean getSelectivityEstimationIncludingSkewedDefault();
+
+	public void setSelectivityEstimationIncludingSkewedDefault(boolean onOff);
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/EffectivePartitionStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/EffectivePartitionStatisticsImpl.java
@@ -261,4 +261,11 @@ public class EffectivePartitionStatisticsImpl implements PartitionStatistics {
     public <T extends Comparator<T>> long rangeSelectivity(T start, T stop, boolean includeStart, boolean includeStop, int positionNumber) {
         throw new UnsupportedOperationException("Use Range Selectivity on the table vs. agains the effective partition.");
     }
+
+
+    @Override
+    public <T extends Comparator<T>> long selectivityExcludingValueIfSkewed(T element, int positionNumber) {
+        ItemStatistics stats = positionNumber >= itemStatistics.length?null:itemStatistics[positionNumber];
+        return stats==null?(long) (( (double) rowCount()) * extraQualifierMultiplier ):stats.selectivityExcludingValueIfSkewed((T) element);
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/FakePartitionStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/FakePartitionStatisticsImpl.java
@@ -232,4 +232,9 @@ public class FakePartitionStatisticsImpl implements PartitionStatistics {
     public <T extends Comparator<T>> long rangeSelectivity(T start, T stop, boolean includeStart, boolean includeStop, int positionNumber) {
         return (long) (extraQualifierMultiplier * (double) rowCount());
     }
+
+    @Override
+    public <T extends Comparator<T>> long selectivityExcludingValueIfSkewed(T element, int positionNumber) {
+        return 0l;
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/ItemStatistics.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/ItemStatistics.java
@@ -135,4 +135,11 @@ public interface ItemStatistics<T extends Comparator<T>> extends Serializable, E
      */
     ItemStatistics<T> getClone();
 
+    /**
+     * get the row count excluding the specified value
+     * @param value
+     * @return
+     */
+    long selectivityExcludingValueIfSkewed(T value);
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/NonUniqueKeyStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/NonUniqueKeyStatisticsImpl.java
@@ -147,5 +147,10 @@ public class NonUniqueKeyStatisticsImpl implements ItemStatistics<ExecRow> {
         return Type.NONUNIQUEKEY;
     }
 
+    @Override
+    public long selectivityExcludingValueIfSkewed(ExecRow value) {
+        throw new UnsupportedOperationException("selectivityExcludingValueIfSkewed");
+    }
+
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/PartitionStatistics.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/PartitionStatistics.java
@@ -111,5 +111,10 @@ public interface PartitionStatistics {
 
     PartitionStatisticsDescriptor getPartitionStatistics();
 
+    /**
+     * @param element the element to exclude
+     * @return average rows per value excluding the element if it is skewed
+     */
+    <T extends Comparator<T>> long selectivityExcludingValueIfSkewed(T element, int positionNumber);
 }
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/PartitionStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/PartitionStatisticsImpl.java
@@ -164,4 +164,10 @@ public class PartitionStatisticsImpl implements PartitionStatistics {
         else
             return stats.rangeSelectivity((T) start, (T) stop, includeStart, includeStop);
     }
+
+    @Override
+    public <T extends Comparator<T>> long selectivityExcludingValueIfSkewed(T element, int positionNumber) {
+        ItemStatistics stats = positionNumber >= itemStatistics.size()?null:itemStatistics.get(positionNumber);
+        return stats==null?(long) (( (double) rowCount()) * extraQualifierMultiplier ):stats.selectivityExcludingValueIfSkewed((T) element);
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/PrimaryKeyStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/PrimaryKeyStatisticsImpl.java
@@ -139,4 +139,8 @@ public class PrimaryKeyStatisticsImpl implements ItemStatistics<ExecRow> {
         return Type.PRIMARYKEY;
     }
 
+    @Override
+    public long selectivityExcludingValueIfSkewed(ExecRow value) {
+        throw new UnsupportedOperationException("selectivityExcludingValueIfSkewed");
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/TableStatistics.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/TableStatistics.java
@@ -152,5 +152,6 @@ public interface TableStatistics {
      */
     <T extends Comparator<T>> double rangeSelectivity(T start,T stop, boolean includeStart,boolean includeStop,int positionNumber);
 
+    <T extends Comparator<T>> double selectivityExcludingValueIfSkewed(T element, int positionNumber);
 }
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/TableStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/TableStatisticsImpl.java
@@ -250,7 +250,7 @@ public class TableStatisticsImpl implements TableStatistics {
      */
     @Override
     public <T extends Comparator<T>> double selectivity(T element, int positionNumber) {
-        return getEffectivePartitionStatistics().selectivity(element,positionNumber)/getEffectivePartitionStatistics().rowCount();
+        return (double)(getEffectivePartitionStatistics().selectivity(element,positionNumber))/getEffectivePartitionStatistics().rowCount();
     }
 
     /**
@@ -286,5 +286,9 @@ public class TableStatisticsImpl implements TableStatistics {
             return partitionStatistics.size();
     }
 
+    @Override
+    public <T extends Comparator<T>> double selectivityExcludingValueIfSkewed(T element, int positionNumber) {
+        return (double)(getEffectivePartitionStatistics().selectivityExcludingValueIfSkewed(element,positionNumber))/getEffectivePartitionStatistics().rowCount();
+    }
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/UniqueKeyStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/UniqueKeyStatisticsImpl.java
@@ -139,4 +139,9 @@ public class UniqueKeyStatisticsImpl implements ItemStatistics<ExecRow> {
         return Type.UNIQUEKEY;
     }
 
+    @Override
+    public long selectivityExcludingValueIfSkewed(ExecRow value) {
+        throw new UnsupportedOperationException("selectivityExcludingValueIfSkewed");
+    }
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/StoreCostController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/StoreCostController.java
@@ -263,4 +263,6 @@ public interface StoreCostController extends RowCountable{
     DataValueDescriptor minValue(int columnNumber);
 
     DataValueDescriptor maxValue(int columnNumber) ;
+
+    double getSelectivityExcludingValueIfSkewed(int columnNumber, DataValueDescriptor value);
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -32,9 +32,11 @@
 package com.splicemachine.db.impl.sql;
 
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.Property;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.loader.GeneratedClass;
 import com.splicemachine.db.iapi.services.monitor.Monitor;
+import com.splicemachine.db.iapi.services.property.PropertyUtil;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.services.stream.HeaderPrintWriter;
 import com.splicemachine.db.iapi.sql.PreparedStatement;
@@ -419,6 +421,13 @@ public class GenericStatement implements Statement{
                     (spsSchema!=null) && (spsSchema.isSystemSchema()) && (spsSchema.equals(compilationSchema))){
                 cc.setReliability(CompilerContext.INTERNAL_SQL_LEGAL);
             }
+
+            /* get the selectivity estimation property so that we know what strategy to use to estimate selectivity */
+            String selectivityEstimationString = PropertyUtil.getServiceProperty(lcc.getTransactionCompile(),
+                    Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED_DEFAULT);
+            Boolean selectivityEstimationIncludingSkewedDefault = Boolean.valueOf(selectivityEstimationString);
+
+            cc.setSelectivityEstimationIncludingSkewedDefault(selectivityEstimationIncludingSkewedDefault);
 
             fourPhasePrepare(lcc,paramDefaults,timestamps,beginTimestamp,foundInCache,cc);
         }catch(StandardException se){

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
@@ -1436,7 +1436,7 @@ public class BinaryRelationalOperatorNode
         switch(operatorType){
             case RelationalOperator.EQUALS_RELOP:
                 double selectivity = getReferenceSelectivity(optTable);
-                if (selectivity ==-1.0d) // No Stats, lets just guess 10%
+                if (selectivity < 0.0d) // No Stats, lets just guess 10%
                     return 0.1;
                 return selectivity;
             case RelationalOperator.NOT_EQUALS_RELOP:

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
@@ -137,6 +137,7 @@ public class CompilerContextImpl extends ContextImpl
         referencedSequences = null;
         dataSetProcessorType = DataSetProcessorType.DEFAULT_CONTROL;
         skipStatsTableList.clear();
+        selectivityEstimationIncludingSkewedDefault = false;
 	}
 
 	//
@@ -197,6 +198,13 @@ public class CompilerContextImpl extends ContextImpl
 		maximalPossibleTableCount = num;
 	}
 
+	public boolean getSelectivityEstimationIncludingSkewedDefault() {
+		return selectivityEstimationIncludingSkewedDefault;
+	}
+
+	public void setSelectivityEstimationIncludingSkewedDefault(boolean onOff) {
+		selectivityEstimationIncludingSkewedDefault = onOff;
+	}
 	/**
 	 * Get the current next subquery number from this CompilerContext.
 	 *
@@ -1033,6 +1041,7 @@ public class CompilerContextImpl extends ContextImpl
 	private SchemaDescriptor	compilationSchema;
 	/* this is the number of tables taking into consideration the where Subqueries */
 	private int                 maximalPossibleTableCount;
+	private boolean             selectivityEstimationIncludingSkewedDefault = false;
 
 	/**
 	 * Saved execution time default schema, if we need to change it

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLCharTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLCharTest.java
@@ -182,4 +182,29 @@ public class SQLCharTest extends SQLDataValueDescriptorTest {
                 execRow2.getColumn(1).setSparkObject(row.get(0));
                 Assert.assertEquals("ExecRow Mismatch",execRow,execRow2);
         }
+
+        @Test
+        public void testSelectivityWithParameter() throws Exception {
+                /* let only the first 3 rows take different values, all remaining rows use the default value 'ZZZZ' */
+                SQLChar value1 = new SQLChar();
+                ItemStatistics stats = new ColumnStatisticsImpl(value1);
+                SQLChar sqlChar;
+                sqlChar = new SQLChar("aaaa");
+                stats.update(sqlChar);
+                sqlChar = new SQLChar("bbbb");
+                stats.update(sqlChar);
+                sqlChar = new SQLChar("cccc");
+                stats.update(sqlChar);
+                for (int i = 3; i < 81920; i++) {
+                     sqlChar = new SQLChar("ZZZZ");
+                     stats.update(sqlChar);
+                }
+                stats = serde(stats);
+
+                /* selectivityExcludingValueIfSkewed() is the function used to compute the electivity of equality
+                   predicate with parameterized value
+                 */
+                double range = stats.selectivityExcludingValueIfSkewed(sqlChar);
+                Assert.assertTrue(range + " did not match expected value of 1.0d", (range == 1.0d));
+        }
 }

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLDoubleTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLDoubleTest.java
@@ -165,4 +165,29 @@ public class SQLDoubleTest extends SQLDataValueDescriptorTest {
                 execRow2.getColumn(1).setSparkObject(row.get(0));
                 Assert.assertEquals("ExecRow Mismatch",execRow,execRow2);
         }
+
+        @Test
+        public void testSelectivityWithParameter() throws Exception {
+                /* let only the first 3 rows take different values, all remaining rows use a default value */
+                SQLDouble value1 = new SQLDouble();
+                ItemStatistics stats = new ColumnStatisticsImpl(value1);
+                SQLDouble sqlDouble;
+                sqlDouble = new SQLDouble(1.0d);
+                stats.update(sqlDouble);
+                sqlDouble = new SQLDouble(2.0d);
+                stats.update(sqlDouble);
+                sqlDouble = new SQLDouble(3.0d);
+                stats.update(sqlDouble);
+                for (int i = 3; i < 81920; i++) {
+                        sqlDouble = new SQLDouble(-1.0d);
+                        stats.update(sqlDouble);
+                }
+                stats = serde(stats);
+
+                /* selectivityExcludingValueIfSkewed() is the function used to compute the electivity of equality
+                   predicate with parameterized value
+                 */
+                double range = stats.selectivityExcludingValueIfSkewed(sqlDouble);
+                Assert.assertTrue(range + " did not match expected value of 1.0d", (range == 1.0d));
+        }
 }

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLIntegerTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLIntegerTest.java
@@ -178,4 +178,29 @@ public class SQLIntegerTest extends SQLDataValueDescriptorTest {
                 execRow2.getColumn(1).setSparkObject(row.get(0));
                 Assert.assertEquals("ExecRow Mismatch",execRow,execRow2);
         }
+
+        @Test
+        public void testSelectivityWithParameter() throws Exception {
+                /* let only the first 3 rows take different values, all remaining rows use a default value */
+                SQLInteger value1 = new SQLInteger();
+                ItemStatistics stats = new ColumnStatisticsImpl(value1);
+                SQLInteger sqlInteger;
+                sqlInteger = new SQLInteger(1);
+                stats.update(sqlInteger);
+                sqlInteger = new SQLInteger(2);
+                stats.update(sqlInteger);
+                sqlInteger = new SQLInteger(3);
+                stats.update(sqlInteger);
+                for (int i = 3; i < 81920; i++) {
+                        sqlInteger = new SQLInteger(-1);
+                        stats.update(sqlInteger);
+                }
+                stats = serde(stats);
+
+                /* selectivityExcludingValueIfSkewed() is the function used to compute the electivity of equality
+                   predicate with parameterized value
+                 */
+                double range = stats.selectivityExcludingValueIfSkewed(sqlInteger);
+                Assert.assertTrue(range + " did not match expected value of 1.0d", (range == 1.0d));
+        }
 }

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLLongIntTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLLongIntTest.java
@@ -162,4 +162,29 @@ public class SQLLongIntTest extends SQLDataValueDescriptorTest {
                 execRow2.getColumn(1).setSparkObject(row.get(0));
                 Assert.assertEquals("ExecRow Mismatch",execRow,execRow2);
         }
+
+        @Test
+        public void testSelectivityWithParameter() throws Exception {
+                /* let only the first 3 rows take different values, all remaining rows use a default value */
+                SQLLongint value1 = new SQLLongint();
+                ItemStatistics stats = new ColumnStatisticsImpl(value1);
+                SQLLongint sqlLongint;
+                sqlLongint = new SQLLongint(1L);
+                stats.update(sqlLongint);
+                sqlLongint = new SQLLongint(2L);
+                stats.update(sqlLongint);
+                sqlLongint = new SQLLongint(3L);
+                stats.update(sqlLongint);
+                for (int i = 3; i < 81920; i++) {
+                        sqlLongint = new SQLLongint(-1L);
+                        stats.update(sqlLongint);
+                }
+                stats = serde(stats);
+
+                /* selectivityExcludingValueIfSkewed() is the function used to compute the electivity of equality
+                   predicate with parameterized value
+                 */
+                double range = stats.selectivityExcludingValueIfSkewed(sqlLongint);
+                Assert.assertTrue(range + " did not match expected value of 1.0d", (range == 1.0d));
+        }
 }

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLVarcharTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLVarcharTest.java
@@ -143,4 +143,29 @@ public class SQLVarcharTest extends SQLDataValueDescriptorTest {
                 execRow2.getColumn(1).setSparkObject(row.get(0));
                 Assert.assertEquals("ExecRow Mismatch",execRow,execRow2);
         }
+
+        @Test
+        public void testSelectivityWithParameter() throws Exception {
+                /* let only the first 3 rows take different values, all remaining rows use the default value 'ZZZZ' */
+                SQLVarchar value1 = new SQLVarchar();
+                ItemStatistics stats = new ColumnStatisticsImpl(value1);
+                SQLVarchar sqlVarchar;
+                sqlVarchar = new SQLVarchar("aaaa");
+                stats.update(sqlVarchar);
+                sqlVarchar = new SQLVarchar("bbbb");
+                stats.update(sqlVarchar);
+                sqlVarchar = new SQLVarchar("cccc");
+                stats.update(sqlVarchar);
+                for (int i = 3; i < 81920; i++) {
+                        sqlVarchar = new SQLVarchar("ZZZZ");
+                        stats.update(sqlVarchar);
+                }
+                stats = serde(stats);
+
+                /* selectivityExcludingValueIfSkewed() is the function used to compute the electivity of equality
+                   predicate with parameterized value
+                 */
+                double range = stats.selectivityExcludingValueIfSkewed(sqlVarchar);
+                Assert.assertTrue(range + " did not match expected value of 1.0d", (range == 1.0d));
+        }
 }

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1205,4 +1205,7 @@ public interface Property {
 	 * When it is set to true, stats will be collected only on index columns.
 	 */
 	String COLLECT_INDEX_STATS_ONLY = "derby.database.collectIndexStatsOnly";
+
+	String SELECTIVITY_ESTIMATION_INCLUDING_SKEWED_DEFAULT =
+			"derby.database.selectivityEstimationIncludingSkewedDefault";
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/stats/StoreCostControllerImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/stats/StoreCostControllerImpl.java
@@ -375,4 +375,8 @@ public class StoreCostControllerImpl implements StoreCostController {
             throw StandardException.plainWrapException(ioe);
         }
     }
+
+    public double getSelectivityExcludingValueIfSkewed(int columnNumber, DataValueDescriptor value) {
+        return tableStatistics.selectivityExcludingValueIfSkewed(value, columnNumber-1);
+    }
 }


### PR DESCRIPTION
Please see [DB-6428](https://splicemachine.atlassian.net/browse/DB-6428) for description of the fix.