### PR TITLE
DB-6445 Upgrade joda-time to 2.8.2 (2.6)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,7 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.3</version>
+                <version>2.8.2</version>
             </dependency>
             <dependency>
                 <groupId>net.sf.ehcache</groupId>


### PR DESCRIPTION
Fixes importing from S3 in standalone environment.