### PR TITLE
DB-6284: add ignore txn cache (2.5)

### DIFF
--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/HBasePipelineEnvironment.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/HBasePipelineEnvironment.java
@@ -20,7 +20,6 @@ import java.net.URISyntaxException;
 import com.splicemachine.access.api.DistributedFileSystem;
 import com.splicemachine.access.api.PartitionFactory;
 import com.splicemachine.access.api.SConfiguration;
-import com.splicemachine.access.api.ServiceDiscovery;
 import com.splicemachine.access.api.SnowflakeFactory;
 import com.splicemachine.access.hbase.HBaseTableInfoFactory;
 import com.splicemachine.concurrent.Clock;
@@ -51,6 +50,7 @@ import com.splicemachine.si.api.txn.TxnSupplier;
 import com.splicemachine.si.data.hbase.coprocessor.HBaseSIEnvironment;
 import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.si.impl.driver.SIEnvironment;
+import com.splicemachine.si.impl.store.IgnoreTxnSupplier;
 import com.splicemachine.storage.DataFilterFactory;
 import com.splicemachine.storage.PartitionInfoCache;
 import com.splicemachine.timestamp.api.TimestampSource;
@@ -123,6 +123,7 @@ public class HBasePipelineEnvironment implements PipelineEnvironment{
     @Override public OperationStatusFactory statusFactory(){ return delegate.statusFactory(); }
     @Override public TimestampSource timestampSource(){ return delegate.timestampSource(); }
     @Override public TxnSupplier txnSupplier(){ return delegate.txnSupplier(); }
+    @Override public IgnoreTxnSupplier ignoreTxnSupplier(){ return delegate.ignoreTxnSupplier(); }
     @Override public RollForward rollForward(){ return delegate.rollForward(); }
     @Override public TxnOperationFactory operationFactory(){ return delegate.operationFactory(); }
     @Override public SIDriver getSIDriver(){ return delegate.getSIDriver(); }

--- a/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
+++ b/hbase_storage/hbase1.0.0.x/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
@@ -243,6 +243,17 @@ public class HBaseConnectionFactory{
         }
     }
 
+    public void createRestoreTable() {
+
+        try(Admin admin=connection.getAdmin()){
+            HTableDescriptor td=generateNonSITable(HConfiguration.IGNORE_TXN_TABLE_NAME);
+            admin.createTable(td);
+            SpliceLogUtils.info(LOG, HConfiguration.IGNORE_TXN_TABLE_NAME +" created");
+        }catch(Exception e) {
+            SpliceLogUtils.error(LOG, "Unable to create SPLICE_IGNORE_TXN Table", e);
+        }
+    }
+
     public static String escape(String first){
         // escape single quotes | compress multiple whitespace chars into one,
         // (replacing tab, newline, etc)

--- a/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
+++ b/hbase_storage/hbase1.0.0/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
@@ -245,6 +245,17 @@ public class HBaseConnectionFactory{
         }
     }
 
+    public void createRestoreTable() {
+
+        try(Admin admin=connection.getAdmin()){
+            HTableDescriptor td=generateNonSITable(HConfiguration.IGNORE_TXN_TABLE_NAME);
+            admin.createTable(td);
+            SpliceLogUtils.info(LOG, HConfiguration.IGNORE_TXN_TABLE_NAME +" created");
+        }catch(Exception e) {
+            SpliceLogUtils.error(LOG, "Unable to create SPLICE_IGNORE_TXN Table", e);
+        }
+    }
+
     public static String escape(String first){
         // escape single quotes | compress multiple whitespace chars into one,
         // (replacing tab, newline, etc)

--- a/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
+++ b/hbase_storage/hbase1.1.0/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
@@ -246,6 +246,17 @@ public class HBaseConnectionFactory{
         }
     }
 
+    public void createRestoreTable() {
+
+        try(Admin admin=connection.getAdmin()){
+            HTableDescriptor td=generateNonSITable(HConfiguration.IGNORE_TXN_TABLE_NAME);
+            admin.createTable(td);
+            SpliceLogUtils.info(LOG, HConfiguration.IGNORE_TXN_TABLE_NAME +" created");
+        }catch(Exception e) {
+            SpliceLogUtils.error(LOG, "Unable to create SPLICE_IGNORE_TXN Table", e);
+        }
+    }
+
     public static String escape(String first){
         // escape single quotes | compress multiple whitespace chars into one,
         // (replacing tab, newline, etc)

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
@@ -246,6 +246,17 @@ public class HBaseConnectionFactory{
         }
     }
 
+    public void createRestoreTable() {
+
+        try(Admin admin=connection.getAdmin()){
+            HTableDescriptor td=generateNonSITable(HConfiguration.IGNORE_TXN_TABLE_NAME);
+            admin.createTable(td);
+            SpliceLogUtils.info(LOG, HConfiguration.IGNORE_TXN_TABLE_NAME +" created");
+        }catch(Exception e) {
+            SpliceLogUtils.error(LOG, "Unable to create SPLICE_IGNORE_TXN Table", e);
+        }
+    }
+
     public static String escape(String first){
         // escape single quotes | compress multiple whitespace chars into one,
         // (replacing tab, newline, etc)

--- a/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
+++ b/hbase_storage/hbase1.1.2/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
@@ -245,6 +245,16 @@ public class HBaseConnectionFactory{
             return false;
         }
     }
+    public void createRestoreTable() {
+
+        try(Admin admin=connection.getAdmin()){
+            HTableDescriptor td=generateNonSITable(HConfiguration.IGNORE_TXN_TABLE_NAME);
+            admin.createTable(td);
+            SpliceLogUtils.info(LOG, HConfiguration.IGNORE_TXN_TABLE_NAME +" created");
+        }catch(Exception e) {
+            SpliceLogUtils.error(LOG, "Unable to create SPLICE_IGNORE_TXN Table", e);
+        }
+    }
 
     public static String escape(String first){
         // escape single quotes | compress multiple whitespace chars into one,

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
@@ -245,6 +245,17 @@ public class HBaseConnectionFactory{
         }
     }
 
+    public void createRestoreTable() {
+
+        try(Admin admin=connection.getAdmin()){
+            HTableDescriptor td=generateNonSITable(HConfiguration.IGNORE_TXN_TABLE_NAME);
+            admin.createTable(td);
+            SpliceLogUtils.info(LOG, HConfiguration.IGNORE_TXN_TABLE_NAME +" created");
+        }catch(Exception e) {
+            SpliceLogUtils.error(LOG, "Unable to create SPLICE_IGNORE_TXN Table", e);
+        }
+    }
+
     public static String escape(String first){
         // escape single quotes | compress multiple whitespace chars into one,
         // (replacing tab, newline, etc)

--- a/hbase_storage/src/main/java/com/splicemachine/access/hbase/H10PartitionAdmin.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/hbase/H10PartitionAdmin.java
@@ -114,7 +114,7 @@ public class H10PartitionAdmin implements PartitionAdmin{
             }
         }
         catch (Exception e) {
-            throw new IOException(e.getCause());
+            throw new IOException(e);
         }
     }
 
@@ -152,6 +152,8 @@ public class H10PartitionAdmin implements PartitionAdmin{
                     lastActivation.addWarning(warning);
                     return;
                 }
+                else
+                    throw e;
             }
         }
 
@@ -298,5 +300,12 @@ public class H10PartitionAdmin implements PartitionAdmin{
         String regionName = partition.getName();
         admin.assign(regionName.getBytes());
         HBaseFsckRepair.waitUntilAssigned(admin, ((RangedClientPartition)partition).getRegionInfo());
+
+    }
+
+    @Override
+    public boolean tableExists(String tableName) throws IOException
+    {
+        return admin.tableExists(tableInfoFactory.getTableInfo(tableName));
     }
 }

--- a/mem_pipeline/src/main/java/com/splicemachine/pipeline/MPipelineEnv.java
+++ b/mem_pipeline/src/main/java/com/splicemachine/pipeline/MPipelineEnv.java
@@ -42,6 +42,7 @@ import com.splicemachine.si.api.txn.TxnStore;
 import com.splicemachine.si.api.txn.TxnSupplier;
 import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.si.impl.driver.SIEnvironment;
+import com.splicemachine.si.impl.store.IgnoreTxnSupplier;
 import com.splicemachine.storage.DataFilterFactory;
 import com.splicemachine.storage.PartitionInfoCache;
 import com.splicemachine.timestamp.api.TimestampSource;
@@ -106,6 +107,11 @@ public class MPipelineEnv  implements PipelineEnvironment{
     @Override
     public TxnSupplier txnSupplier(){
         return siEnv.txnSupplier();
+    }
+
+    @Override
+    public IgnoreTxnSupplier ignoreTxnSupplier(){
+        return siEnv.ignoreTxnSupplier();
     }
 
     @Override

--- a/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MEnginePartitionAdmin.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MEnginePartitionAdmin.java
@@ -137,4 +137,10 @@ public class MEnginePartitionAdmin implements PartitionAdmin{
     {
         admin.assign(partition);
     }
+
+    @Override
+    public boolean tableExists(String tableName) throws IOException
+    {
+        return admin.tableExists(tableName);
+    }
 }

--- a/mem_storage/src/main/java/com/splicemachine/si/MemSIEnvironment.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/MemSIEnvironment.java
@@ -44,6 +44,7 @@ import com.splicemachine.si.impl.data.MExceptionFactory;
 import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.si.impl.driver.SIEnvironment;
 import com.splicemachine.si.impl.rollforward.NoopRollForward;
+import com.splicemachine.si.impl.store.IgnoreTxnSupplier;
 import com.splicemachine.storage.*;
 import com.splicemachine.timestamp.api.TimestampSource;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -121,6 +122,11 @@ public class MemSIEnvironment implements SIEnvironment{
     @Override
     public TxnSupplier txnSupplier(){
         return txnStore;
+    }
+
+    @Override
+    public IgnoreTxnSupplier ignoreTxnSupplier(){
+        return null;
     }
 
     @Override

--- a/mem_storage/src/main/java/com/splicemachine/storage/MPartitionFactory.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MPartitionFactory.java
@@ -189,5 +189,10 @@ public class MPartitionFactory implements PartitionFactory<Object>{
 
         @Override
         public void assign(Partition partition) throws IOException, InterruptedException {}
+
+        @Override
+        public boolean tableExists(String tableName) throws IOException {
+            return partitionMap.containsKey(tableName);
+        }
     }
 }

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/PartitionAdmin.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/PartitionAdmin.java
@@ -64,4 +64,6 @@ public interface PartitionAdmin extends AutoCloseable{
     void closeRegion(Partition partition) throws IOException, InterruptedException;
 
     void assign(Partition partition) throws IOException, InterruptedException;
+
+    boolean tableExists(String tableName) throws IOException;
 }

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/HBaseConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/HBaseConfiguration.java
@@ -167,6 +167,7 @@ public class HBaseConfiguration implements ConfigurationDefault {
     public static final String SYSSCHEMAS_CACHE = "SYSSCHEMAS_CACHE";
     public static final String SYSSCHEMAS_INDEX1_ID_CACHE = "SYSSCHEMAS_INDEX1_ID_CACHE";
     public static final String SEQUENCE_TABLE_NAME = "SPLICE_SEQUENCES";
+    public static final String IGNORE_TXN_TABLE_NAME = "SPLICE_IGNORE_TXN";
     @SuppressFBWarnings(value = "MS_MUTABLE_ARRAY",justification = "Intentional")
     public static final byte[] TRANSACTION_TABLE_BYTES = Bytes.toBytes(TRANSACTION_TABLE);
 

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyChildInterceptWriteHandler.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyChildInterceptWriteHandler.java
@@ -114,11 +114,25 @@ public class ForeignKeyChildInterceptWriteHandler implements WriteHandler{
             SimpleTxnFilter readUncommittedFilter;
             SimpleTxnFilter readCommittedFilter;
             if (ctx.getTxn() instanceof ActiveWriteTxn) {
-                readUncommittedFilter = new SimpleTxnFilter(Long.toString(referencedConglomerateNumber), ((ActiveWriteTxn) ctx.getTxn()).getReadUncommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
-                readCommittedFilter = new SimpleTxnFilter(Long.toString(referencedConglomerateNumber), ((ActiveWriteTxn) ctx.getTxn()).getReadCommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
+                readUncommittedFilter = new SimpleTxnFilter(Long.toString(referencedConglomerateNumber),
+                        ((ActiveWriteTxn) ctx.getTxn()).getReadUncommittedActiveTxn(),
+                        NoOpReadResolver.INSTANCE,
+                        SIDriver.driver().getTxnStore());
+
+                readCommittedFilter = new SimpleTxnFilter(Long.toString(referencedConglomerateNumber),
+                        ((ActiveWriteTxn) ctx.getTxn()).getReadCommittedActiveTxn(),
+                        NoOpReadResolver.INSTANCE,
+                        SIDriver.driver().getTxnStore());
             }else if (ctx.getTxn() instanceof WritableTxn) {
-                readUncommittedFilter = new SimpleTxnFilter(Long.toString(referencedConglomerateNumber), ((WritableTxn) ctx.getTxn()).getReadUncommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
-                readCommittedFilter = new SimpleTxnFilter(Long.toString(referencedConglomerateNumber), ((WritableTxn) ctx.getTxn()).getReadCommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
+                readUncommittedFilter = new SimpleTxnFilter(Long.toString(referencedConglomerateNumber),
+                        ((WritableTxn) ctx.getTxn()).getReadUncommittedActiveTxn(),
+                        NoOpReadResolver.INSTANCE,
+                        SIDriver.driver().getTxnStore());
+
+                readCommittedFilter = new SimpleTxnFilter(Long.toString(referencedConglomerateNumber),
+                        ((WritableTxn) ctx.getTxn()).getReadCommittedActiveTxn(),
+                        NoOpReadResolver.INSTANCE,
+                        SIDriver.driver().getTxnStore());
             }else
                 throw new IOException("invalidTxn");
 

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyParentInterceptWriteHandler.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyParentInterceptWriteHandler.java
@@ -151,13 +151,27 @@ public class ForeignKeyParentInterceptWriteHandler implements WriteHandler{
             SimpleTxnFilter readUncommittedFilter;
             SimpleTxnFilter readCommittedFilter;
             if (ctx.getTxn() instanceof ActiveWriteTxn) {
-                readCommittedFilter = new SimpleTxnFilter(Long.toString(indexConglomerateId), ((ActiveWriteTxn) ctx.getTxn()).getReadCommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
-                readUncommittedFilter = new SimpleTxnFilter(Long.toString(indexConglomerateId), ((ActiveWriteTxn) ctx.getTxn()).getReadUncommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
+                readCommittedFilter = new SimpleTxnFilter(Long.toString(indexConglomerateId),
+                        ((ActiveWriteTxn) ctx.getTxn()).getReadCommittedActiveTxn(),
+                        NoOpReadResolver.INSTANCE,
+                        SIDriver.driver().getTxnStore());
+
+                readUncommittedFilter = new SimpleTxnFilter(Long.toString(indexConglomerateId),
+                        ((ActiveWriteTxn) ctx.getTxn()).getReadUncommittedActiveTxn(),
+                        NoOpReadResolver.INSTANCE,
+                        SIDriver.driver().getTxnStore());
 
             }
             else if (ctx.getTxn() instanceof WritableTxn) {
-                readCommittedFilter = new SimpleTxnFilter(Long.toString(indexConglomerateId), ((WritableTxn) ctx.getTxn()).getReadCommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
-                readUncommittedFilter = new SimpleTxnFilter(Long.toString(indexConglomerateId), ((WritableTxn) ctx.getTxn()).getReadUncommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
+                readCommittedFilter = new SimpleTxnFilter(Long.toString(indexConglomerateId),
+                        ((WritableTxn) ctx.getTxn()).getReadCommittedActiveTxn(),
+                        NoOpReadResolver.INSTANCE,
+                        SIDriver.driver().getTxnStore());
+
+                readUncommittedFilter = new SimpleTxnFilter(Long.toString(indexConglomerateId),
+                        ((WritableTxn) ctx.getTxn()).getReadUncommittedActiveTxn(),
+                        NoOpReadResolver.INSTANCE,
+                        SIDriver.driver().getTxnStore());
             }
             else
                 throw new IOException("invalidTxn");

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/server/TransactionalRegionFactory.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/server/TransactionalRegionFactory.java
@@ -20,6 +20,7 @@ import com.splicemachine.si.api.readresolve.RollForward;
 import com.splicemachine.si.api.txn.TxnSupplier;
 import com.splicemachine.si.impl.TxnRegion;
 import com.splicemachine.si.impl.server.SITransactor;
+import com.splicemachine.si.impl.store.IgnoreTxnSupplier;
 import com.splicemachine.storage.Partition;
 
 /**

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/TxnRegion.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/TxnRegion.java
@@ -26,6 +26,7 @@ import com.splicemachine.si.api.txn.TxnSupplier;
 import com.splicemachine.si.api.txn.TxnView;
 import com.splicemachine.si.impl.filter.HRowAccumulator;
 import com.splicemachine.si.impl.filter.PackedTxnFilter;
+import com.splicemachine.si.impl.store.IgnoreTxnSupplier;
 import com.splicemachine.storage.*;
 import com.splicemachine.utils.ByteSlice;
 import org.spark_project.guava.collect.Iterators;

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIDriver.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIDriver.java
@@ -19,7 +19,6 @@ import com.splicemachine.access.api.PartitionFactory;
 import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.access.api.SnowflakeFactory;
 import com.splicemachine.concurrent.Clock;
-import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.si.api.data.ExceptionFactory;
 import com.splicemachine.si.api.data.OperationFactory;
 import com.splicemachine.si.api.data.OperationStatusFactory;
@@ -41,6 +40,7 @@ import com.splicemachine.si.impl.readresolve.NoOpReadResolver;
 import com.splicemachine.si.impl.rollforward.NoopRollForward;
 import com.splicemachine.si.impl.rollforward.RollForwardStatus;
 import com.splicemachine.si.impl.server.SITransactor;
+import com.splicemachine.si.impl.store.IgnoreTxnSupplier;
 import com.splicemachine.si.impl.txn.SITransactionReadController;
 import com.splicemachine.storage.DataFilterFactory;
 import com.splicemachine.storage.Partition;
@@ -82,6 +82,7 @@ public class SIDriver {
     private final OperationStatusFactory operationStatusFactory;
     private final TimestampSource timestampSource;
     private final TxnSupplier txnSupplier;
+    private final IgnoreTxnSupplier ignoreTxnSupplier;
     private final Transactor transactor;
     private final TxnOperationFactory txnOpFactory;
     private final RollForward rollForward;
@@ -109,7 +110,7 @@ public class SIDriver {
         this.clock = env.systemClock();
         this.partitionInfoCache = env.partitionInfoCache();
         this.snowflakeFactory = env.snowflakeFactory();
-
+        this.ignoreTxnSupplier = env.ignoreTxnSupplier();
         //noinspection unchecked
         this.transactor = new SITransactor(
                 this.txnSupplier,
@@ -159,7 +160,9 @@ public class SIDriver {
     public TxnSupplier getTxnSupplier(){
         return txnSupplier;
     }
-
+    public IgnoreTxnSupplier getIgnoreTxnSupplier(){
+        return ignoreTxnSupplier;
+    }
     public OperationStatusFactory getOperationStatusLib() {
         return operationStatusFactory;
     }

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIEnvironment.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIEnvironment.java
@@ -26,6 +26,7 @@ import com.splicemachine.si.api.server.ClusterHealth;
 import com.splicemachine.si.api.txn.KeepAliveScheduler;
 import com.splicemachine.si.api.txn.TxnStore;
 import com.splicemachine.si.api.txn.TxnSupplier;
+import com.splicemachine.si.impl.store.IgnoreTxnSupplier;
 import com.splicemachine.storage.DataFilterFactory;
 import com.splicemachine.storage.PartitionInfoCache;
 import com.splicemachine.timestamp.api.TimestampSource;
@@ -51,6 +52,8 @@ public interface SIEnvironment{
     TimestampSource timestampSource();
 
     TxnSupplier txnSupplier();
+
+    IgnoreTxnSupplier ignoreTxnSupplier();
 
     RollForward rollForward();
 

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/server/SITransactor.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/server/SITransactor.java
@@ -34,6 +34,7 @@ import com.splicemachine.si.constants.SIConstants;
 import com.splicemachine.si.impl.ConflictResults;
 import com.splicemachine.si.impl.SimpleTxnFilter;
 import com.splicemachine.si.impl.readresolve.NoOpReadResolver;
+import com.splicemachine.si.impl.store.IgnoreTxnSupplier;
 import com.splicemachine.storage.*;
 import com.splicemachine.utils.ByteSlice;
 import com.splicemachine.utils.Pair;
@@ -61,7 +62,6 @@ public class SITransactor implements Transactor{
 
     private final TxnOperationFactory txnOperationFactory;
     private final TxnSupplier txnSupplier;
-
     public SITransactor(TxnSupplier txnSupplier,
                         TxnOperationFactory txnOperationFactory,
                         OperationFactory opFactory,

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/store/IgnoreTxnSupplier.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/store/IgnoreTxnSupplier.java
@@ -1,0 +1,114 @@
+
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.si.impl.store;
+
+import com.splicemachine.access.api.PartitionAdmin;
+import com.splicemachine.access.api.PartitionFactory;
+import com.splicemachine.access.configuration.HBaseConfiguration;
+import com.splicemachine.encoding.MultiFieldDecoder;
+import com.splicemachine.si.api.data.TxnOperationFactory;
+import com.splicemachine.storage.*;
+import com.splicemachine.utils.SpliceLogUtils;
+import org.apache.hadoop.hbase.util.Pair;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Created by jyuan on 10/30/17.
+ */
+public class IgnoreTxnSupplier {
+    private Set<Pair<Long, Long>> cache;
+    private EntryDecoder entryDecoder;
+    final private PartitionFactory partitionFactory;
+    final private TxnOperationFactory txnOperationFactory;
+    private boolean ignoreTxnTableExists;
+    private volatile boolean initialized = false;
+
+    public IgnoreTxnSupplier(PartitionFactory partitionFactory, TxnOperationFactory txnOperationFactory) {
+        this.partitionFactory = partitionFactory;
+        this.txnOperationFactory = txnOperationFactory;
+        cache = new HashSet<>();
+    }
+
+    public boolean shouldIgnore(Long txnId) throws IOException{
+
+        boolean ignore = false;
+
+        init();
+        
+        if (!cache.isEmpty()) {
+            for (Pair<Long, Long> range : cache) {
+                if (txnId > range.getFirst() && txnId < range.getSecond()) {
+                    ignore = true;
+                    break;
+                }
+            }
+        }
+
+        return ignore;
+    }
+
+
+    private void populateIgnoreTxnCache() throws IOException {
+
+        PartitionAdmin admin = partitionFactory.getAdmin();
+        ignoreTxnTableExists = admin.tableExists(HBaseConfiguration.IGNORE_TXN_TABLE_NAME);
+        if (ignoreTxnTableExists) {
+            if (entryDecoder == null)
+                entryDecoder = new EntryDecoder();
+            DataResultScanner scanner = null;
+            try {
+                scanner = openScanner();
+                DataResult r = null;
+                while ((r = scanner.next()) != null) {
+                    DataCell cell = r.userData();
+                    byte[] buffer = cell.valueArray();
+                    int offset = cell.valueOffset();
+                    int length = cell.valueLength();
+                    entryDecoder.set(buffer, offset, length);
+                    MultiFieldDecoder decoder = entryDecoder.getEntryDecoder();
+                    long startTxnId = decoder.decodeNextLong();
+                    long endTxnId = decoder.decodeNextLong();
+                    cache.add(new Pair<Long, Long>(startTxnId, endTxnId));
+                }
+            } finally {
+                if (scanner != null)
+                    scanner.close();
+            }
+        }
+    }
+
+    private DataResultScanner openScanner() throws IOException {
+        Partition table = partitionFactory.getTable(HBaseConfiguration.IGNORE_TXN_TABLE_NAME);
+        DataScan scan = txnOperationFactory.newDataScan(null);
+        return table.openResultScanner(scan);
+    }
+
+    private void init() throws IOException {
+        if (!initialized) {
+            synchronized (this) {
+                if (!initialized) {
+                    populateIgnoreTxnCache();
+                    initialized = true;
+                }
+            }
+        }
+    }
+}

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/SITransactionReadController.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/SITransactionReadController.java
@@ -23,6 +23,7 @@ import com.splicemachine.si.impl.DDLFilter;
 import com.splicemachine.si.impl.SimpleTxnFilter;
 import com.splicemachine.si.impl.filter.HRowAccumulator;
 import com.splicemachine.si.impl.filter.PackedTxnFilter;
+import com.splicemachine.si.impl.store.IgnoreTxnSupplier;
 import com.splicemachine.storage.DataGet;
 import com.splicemachine.storage.DataScan;
 import com.splicemachine.storage.EntryDecoder;


### PR DESCRIPTION
Add an ignore txn cache to filter out txns that are committed during backup. The ignore txn cache entry is a pair of long [backup begin txnId, backup end TxnId]