### PR TITLE
SPLICE-1983 OOM in Spark executors while running TPCH1 repeatedly

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMRecordReaderImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMRecordReaderImpl.java
@@ -184,7 +184,7 @@ public class SMRecordReaderImpl extends RecordReader<RowLocation, ExecRow> imple
 				}
 			}
 			if (activationHolder != null) {
-				//activationHolder.close();
+				activationHolder.close();
 			}
 
 			for (AutoCloseable c : closeables) {

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMRecordReaderImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMRecordReaderImpl.java
@@ -21,7 +21,6 @@ import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.RowLocation;
 import com.splicemachine.derby.impl.sql.execute.operations.scanner.SITableScanner;
 import com.splicemachine.derby.impl.sql.execute.operations.scanner.TableScannerBuilder;
-import com.splicemachine.derby.stream.spark.SparkOperationContext;
 import com.splicemachine.metrics.Metrics;
 import com.splicemachine.mrio.MRConstants;
 import com.splicemachine.primitives.Bytes;
@@ -31,8 +30,6 @@ import com.splicemachine.si.api.txn.TxnView;
 import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.storage.*;
 import com.splicemachine.utils.SpliceLogUtils;
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.lang.SerializationUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.Table;
@@ -87,17 +84,12 @@ public class SMRecordReaderImpl extends RecordReader<RowLocation, ExecRow> imple
 			SpliceLogUtils.debug(LOG, "init");
 		TaskContext.get().addTaskFailureListener(this);
 		String tableScannerAsString = config.get(MRConstants.SPLICE_SCAN_INFO);
-		String operationContextAsString = config.get(MRConstants.SPLICE_OPERATION_CONTEXT);
         if (tableScannerAsString == null)
 			throw new IOException("splice scan info was not serialized to task, failing");
 		byte[] scanStartKey = null;
 		byte[] scanStopKey = null;
 		try {
 			builder = TableScannerBuilder.getTableScannerBuilderFromBase64String(tableScannerAsString);
-			SparkOperationContext operationContext = null;
-			if (operationContextAsString != null) {
-				operationContext = (SparkOperationContext) SerializationUtils.deserialize(Base64.decodeBase64(operationContextAsString));
-			}
 			if (LOG.isTraceEnabled())
 				SpliceLogUtils.trace(LOG, "config loaded builder=%s", builder);
 			TableSplit tSplit = ((SMSplit) split).getSplit();

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
@@ -169,6 +169,7 @@ public class ActivationHolder implements Externalizable {
         } finally {
             if (prepared) {
                 impl.close();
+                prepared = false;
             }
         }
     }
@@ -200,6 +201,8 @@ public class ActivationHolder implements Externalizable {
         TxnView txnView = otherTxn!=null ? otherTxn : this.txn;
         initialized = true;
         try {
+            close();
+
             impl = new SpliceTransactionResourceImpl();
             prepared =  impl.marshallTransaction(txnView);
             activation = soi.getActivation(this, impl.getLcc());


### PR DESCRIPTION
SMRecordReaderImpl not closing activationHolder was causing the memory leak.
However, closing it created more problems that it solved - triggers wouldn't work in Spark for one thing (this is likely the reason why it was commented out). It appears removing ActivationHolder altogether is a better solution as there is now another scope of ActivationHolder handling in ResultStreamer (probably not a perfect solution either).
Another memory leak was caused by ActivationHolder.reinitialize() not closing the currently opened SpliceTransactionResourceImpl when called repeatedly (this may not be an immediate issue any more after removing this call from SMRecordReaderImpl).