### PR TITLE
The startup script kills 'tail -f zoo.log' too.

### DIFF
--- a/start-splice-cluster
+++ b/start-splice-cluster
@@ -23,7 +23,7 @@ _kill_em_all () {
    P=$(ps -ef | awk '/spliceYarn|CoarseGrainedScheduler|ExecutorLauncher/ && !/awk/ {print $2}')
    [[ -n $P ]] && echo "Found Yarn. Stopping it." && for pid in $P; do kill -$SIG `echo $pid`; done
 
-   P=$(ps -ef | awk '/zoo/ && !/awk/ {print $2}')
+   P=$(ps -ef | awk '/zookeeper/ && !/awk/ {print $2}')
    [[ -n $P ]] && echo "Found Zoo. Stopping it." && for pid in $P; do kill -$SIG `echo $pid`; done
 
    P=$(ps -ef | awk '/TestKafkaCluster/ && !/awk/ {print $2}')


### PR DESCRIPTION
I would like to be able to continue to watch zookeeper when I run the startup script. The script looks for "zoo" and kills associated processes. I think that looking for "zookeeper" is a more specific termination directive.