### PR TITLE
SPLICE-1974 Splice derby timestamp format not compliant with Hadoop

### DIFF
--- a/hbase_sql/src/main/resources/hbase-log4j.properties
+++ b/hbase_sql/src/main/resources/hbase-log4j.properties
@@ -20,13 +20,13 @@
 log4j.rootLogger=TRACE, Console1
 
 log4j.appender.Console1=org.apache.log4j.ConsoleAppender
-log4j.appender.Console1.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.Console1.layout.ConversionPattern=%d{HH:mm:ss,SSS} (%t) %-5p [%c{1.}] - %m%n
+log4j.appender.Console1.layout=org.apache.log4j.PatternLayout
+log4j.appender.Console1.layout.ConversionPattern=%d{ISO8601} (%t) %-5p [%c{1.}] - %m%n
 
 log4j.appender.spliceDerby=org.apache.log4j.FileAppender
 log4j.appender.spliceDerby.File=splice-derby.log
-log4j.appender.spliceDerby.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.spliceDerby.layout.ConversionPattern=%d{EEE MMM d HH:mm:ss,SSS} Thread[%t] %m%n
+log4j.appender.spliceDerby.layout=org.apache.log4j.PatternLayout
+log4j.appender.spliceDerby.layout.ConversionPattern=%d%d{ISO8601} Thread[%t] %m%n
 
 log4j.logger.splice-derby=INFO, spliceDerby
 log4j.additivity.splice-derby=false

--- a/hbase_sql/src/main/resources/hbase-log4j.properties
+++ b/hbase_sql/src/main/resources/hbase-log4j.properties
@@ -26,7 +26,7 @@ log4j.appender.Console1.layout.ConversionPattern=%d{ISO8601} (%t) %-5p [%c{1.}] 
 log4j.appender.spliceDerby=org.apache.log4j.FileAppender
 log4j.appender.spliceDerby.File=splice-derby.log
 log4j.appender.spliceDerby.layout=org.apache.log4j.PatternLayout
-log4j.appender.spliceDerby.layout.ConversionPattern=%d%d{ISO8601} Thread[%t] %m%n
+log4j.appender.spliceDerby.layout.ConversionPattern=%d{ISO8601} Thread[%t] %m%n
 
 log4j.logger.splice-derby=INFO, spliceDerby
 log4j.additivity.splice-derby=false

--- a/hbase_sql/src/main/resources/info-log4j.properties
+++ b/hbase_sql/src/main/resources/info-log4j.properties
@@ -20,18 +20,18 @@
 log4j.rootLogger=INFO, Console1
 
 log4j.appender.Console1=org.apache.log4j.ConsoleAppender
-log4j.appender.Console1.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.Console1.layout.ConversionPattern=%d{HH:mm:ss,SSS} (%t) %-5p [%c{1.}] - %m%n
+log4j.appender.Console1.layout=org.apache.log4j.PatternLayout
+log4j.appender.Console1.layout.ConversionPattern=%d{ISO8601} (%t) %-5p [%c{1.}] - %m%n
 
 log4j.appender.spliceDerby=org.apache.log4j.FileAppender
 log4j.appender.spliceDerby.File=splice-derby.log
-log4j.appender.spliceDerby.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.spliceDerby.layout.ConversionPattern=%d{EEE MMM d HH:mm:ss,SSS} Thread[%t] %m%n
+log4j.appender.spliceDerby.layout=org.apache.log4j.PatternLayout
+log4j.appender.spliceDerby.layout.ConversionPattern=%d{ISO8601} Thread[%t] %m%n
 
 log4j.appender.spliceStatement=org.apache.log4j.FileAppender
 log4j.appender.spliceStatement.File=splice-statement.log
-log4j.appender.spliceStatement.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.spliceStatement.layout.ConversionPattern=%d{EEE MMM d HH:mm:ss,SSS} Thread[%t] %m%n
+log4j.appender.spliceStatement.layout=org.apache.log4j.PatternLayout
+log4j.appender.spliceStatement.layout.ConversionPattern=%d{ISO8601} Thread[%t] %m%n
 
 log4j.logger.splice-derby=INFO, spliceDerby
 log4j.additivity.splice-derby=false

--- a/hbase_sql/src/main/resources/log4j.properties
+++ b/hbase_sql/src/main/resources/log4j.properties
@@ -15,14 +15,14 @@
 log4j.rootLogger=INFO, Console
 
 log4j.appender.Console=org.apache.log4j.ConsoleAppender
-log4j.appender.Console.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.Console.layout.ConversionPattern=%d{HH:mm:ss,SSS} (%t) %-5p [%c{1.}] - %m%n
+log4j.appender.Console.layout=org.apache.log4j.PatternLayout
+log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} (%t) %-5p [%c{1.}] - %m%n
 
 
 log4j.appender.spliceDerby=org.apache.log4j.FileAppender
 log4j.appender.spliceDerby.File=splice-derby.log
-log4j.appender.spliceDerby.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.spliceDerby.layout.ConversionPattern=%d{EEE MMM d HH:mm:ss,SSS} Thread[%t] %m%n
+log4j.appender.spliceDerby.layout=org.apache.log4j.PatternLayout
+log4j.appender.spliceDerby.layout.ConversionPattern=%d{ISO8601} Thread[%t] %m%n
 
 log4j.logger.splice-derby=INFO, spliceDerby
 log4j.additivity.splice-derby=false

--- a/hbase_sql/src/main/resources/trace-log4j.properties
+++ b/hbase_sql/src/main/resources/trace-log4j.properties
@@ -20,13 +20,13 @@
 log4j.rootLogger=TRACE, Console1
 
 log4j.appender.Console1=org.apache.log4j.ConsoleAppender
-log4j.appender.Console1.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.Console1.layout.ConversionPattern=%d{HH:mm:ss,SSS} (%t) %-5p [%c{1.}] - %m%n
+log4j.appender.Console1.layout=org.apache.log4j.PatternLayout
+log4j.appender.Console1.layout.ConversionPattern=%d{ISO8601} (%t) %-5p [%c{1.}] - %m%n
 
 log4j.appender.spliceDerby=org.apache.log4j.FileAppender
 log4j.appender.spliceDerby.File=splice-derby.log
-log4j.appender.spliceDerby.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.spliceDerby.layout.ConversionPattern=%d{EEE MMM d HH:mm:ss,SSS} Thread[%t] %m%n
+log4j.appender.spliceDerby.layout=org.apache.log4j.PatternLayout
+log4j.appender.spliceDerby.layout.ConversionPattern=%d{ISO8601} Thread[%t] %m%n
 
 log4j.logger.splice-derby=INFO, spliceDerby
 log4j.additivity.splice-derby=false

--- a/hbase_sql/src/test/resources/log4j.properties
+++ b/hbase_sql/src/test/resources/log4j.properties
@@ -16,8 +16,8 @@ log4j.rootLogger=TRACE,Console1
 log4j.additivity.rootLogger=false
 
 log4j.appender.Console1=org.apache.log4j.ConsoleAppender
-log4j.appender.Console1.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.Console1.layout.ConversionPattern=%d{HH:mm:ss,SSS} (%t) %-5p [%c{1.}] - %m%n
+log4j.appender.Console1.layout=org.apache.log4j.PatternLayout
+log4j.appender.Console1.layout.ConversionPattern=%d{ISO8601} (%t) %-5p [%c{1.}] - %m%n
 
 #log4j.logger.com=WARN, Console1
 #log4j.additivity.com=false

--- a/hbase_storage/src/test/resources/log4j.properties
+++ b/hbase_storage/src/test/resources/log4j.properties
@@ -14,6 +14,6 @@
 
 log4j.appender.Console1=org.apache.log4j.ConsoleAppender
 log4j.appender.Console1.layout=org.apache.log4j.PatternLayout
-log4j.appender.Console1.layout.ConversionPattern=%d{HH:mm:ss,SSS} (%t) %-5p [%c] - %m%n
+log4j.appender.Console1.layout.ConversionPattern=%d{ISO8601} (%t) %-5p [%c] - %m%n
 
 log4j.rootLogger=INFO, Console1

--- a/mem_sql/src/main/resources/log4j.properties
+++ b/mem_sql/src/main/resources/log4j.properties
@@ -16,7 +16,8 @@ log4j.rootLogger=INFO, Console1
 
 log4j.appender.Console1=org.apache.log4j.ConsoleAppender
 log4j.appender.Console1.layout=org.apache.log4j.PatternLayout
-log4j.appender.Console1.layout.ConversionPattern=%d{HH:mm:ss,SSS} (%t) %-5p [%c] - %m%n
+log4j.appender.Console1.layout.ConversionPattern=%d{ISO8601} (%t) %-5p [%c] - %m%n
+
 
 #log4j.logger.com.splicemachine.db.impl.ast.JsonTreeBuilderVisitor=TRACE
 #log4j.logger.com.splicemachine.derby.utils=INFO

--- a/mem_sql/src/main/resources/log4j.properties
+++ b/mem_sql/src/main/resources/log4j.properties
@@ -18,7 +18,6 @@ log4j.appender.Console1=org.apache.log4j.ConsoleAppender
 log4j.appender.Console1.layout=org.apache.log4j.PatternLayout
 log4j.appender.Console1.layout.ConversionPattern=%d{ISO8601} (%t) %-5p [%c] - %m%n
 
-
 #log4j.logger.com.splicemachine.db.impl.ast.JsonTreeBuilderVisitor=TRACE
 #log4j.logger.com.splicemachine.derby.utils=INFO
 #log4j.logger.com.splicemachine.si.impl=INFO

--- a/splice_machine/src/test/resources/log4j.properties
+++ b/splice_machine/src/test/resources/log4j.properties
@@ -16,8 +16,8 @@ log4j.rootLogger=TRACE,Console1
 log4j.additivity.rootLogger=false
 
 log4j.appender.Console1=org.apache.log4j.ConsoleAppender
-log4j.appender.Console1.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.Console1.layout.ConversionPattern=%d{HH:mm:ss,SSS} (%t) %-5p [%c{1.}] - %m%n
+log4j.appender.Console1.layout=org.apache.log4j.PatternLayout
+log4j.appender.Console1.layout.ConversionPattern=%d{ISO8601} (%t) %-5p [%c{1.}] - %m%n
 
 #log4j.logger.com=WARN, Console1
 #log4j.additivity.com=false

--- a/splice_si_api/src/test/resources/log4j.properties
+++ b/splice_si_api/src/test/resources/log4j.properties
@@ -14,6 +14,6 @@
 
 log4j.appender.Console1=org.apache.log4j.ConsoleAppender
 log4j.appender.Console1.layout=org.apache.log4j.PatternLayout
-log4j.appender.Console1.layout.ConversionPattern=%d{HH:mm:ss,SSS} (%t) %-5p [%c] - %m%n
+log4j.appender.Console1.layout.ConversionPattern=%d{ISO8601} (%t) %-5p [%c] - %m%n
 
 log4j.rootLogger=INFO, Console1

--- a/splice_spark/src/test/resources/log4j.properties
+++ b/splice_spark/src/test/resources/log4j.properties
@@ -18,6 +18,6 @@
 log4j.rootLogger = WARN, out
 log4j.appender.out = org.apache.log4j.ConsoleAppender
 log4j.appender.out.layout = org.apache.log4j.PatternLayout
-log4j.appender.out.layout.ConversionPattern = %d{HH:mm:ss.SSS} [%p - %t] (%F:%L) %m%n
+log4j.appender.out.layout.ConversionPattern = %d{ISO8601} [%p - %t] (%F:%L) %m%n
 
 log4j.logger.com.splicemachine = INFO

--- a/utilities/src/test/resources/log4j.properties
+++ b/utilities/src/test/resources/log4j.properties
@@ -24,4 +24,4 @@ log4j.rootLogger=INFO, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
Modified the log4j default timestamp format for standalone version. The cluster version, the timestamp format of log file could be set in Cloudera Manager (CDH), Ambari (HDP) and file /opt/mapr/hbase/hbase-1.1.1/conf/log4j.properties (MapR in default). 