### PR TITLE
DB-6463 Add JDBC timeout support (2.5)

### DIFF
--- a/db-client/src/main/java/com/splicemachine/db/client/am/Statement.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Statement.java
@@ -787,7 +787,6 @@ public class Statement implements java.sql.Statement, StatementCallbackInterface
                 }
                 if (seconds != timeout_) {
                     timeout_ = seconds;
-                    connection_.setQueryTimeout(timeout_);
                     doWriteTimeout = true;
                 }
             }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ResultSet.java
@@ -363,4 +363,11 @@ public interface ResultSet
 		this result set. The warnings are cleared once this call returns.
 	*/
 	public SQLWarning getWarnings();
+
+	/**
+	 Find out if the ResultSet is timed out or not.
+
+	 @return true if the ResultSet has timed out.
+	 */
+    boolean isTimedout();
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/StatementContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/StatementContext.java
@@ -35,6 +35,7 @@ import com.splicemachine.db.iapi.services.context.Context;
 
 import com.splicemachine.db.iapi.error.StandardException;
 
+import com.splicemachine.db.iapi.sql.execute.Expirable;
 import com.splicemachine.db.iapi.sql.execute.NoPutResultSet;
 
 import com.splicemachine.db.iapi.sql.Activation;
@@ -296,4 +297,6 @@ public interface StatementContext extends Context {
     public void setXPlainTableOrProcedure(boolean val);
 
     public boolean hasXPlainTableOrProcedure();
+
+    void registerExpirable(Expirable expirable, Thread thread);
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/Expirable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/Expirable.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.db.iapi.sql.execute;
+
+import com.splicemachine.db.iapi.error.StandardException;
+
+import java.io.IOException;
+
+public interface Expirable {
+
+    /**
+     * Cancel operation and mark it as timed out
+     * @throws StandardException
+     */
+    void timeout() throws StandardException;
+}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedResultSet.java
@@ -4352,6 +4352,9 @@ public abstract class EmbedResultSet extends ConnectionChild
 			if (theResults.isKilled()) {
 				throw newSQLException(SQLState.LANG_CANCELLATION_EXCEPTION);
 			}
+			if (theResults.isTimedout()) {
+				throw newSQLException(SQLState.LANG_STATEMENT_CANCELLED_OR_TIMED_OUT);
+			}
 			throw newSQLException(SQLState.LANG_RESULT_SET_NOT_OPEN,operation);
 		}
 	}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericStatementContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericStatementContext.java
@@ -49,6 +49,7 @@ import com.splicemachine.db.iapi.sql.conn.SQLSessionContext;
 import com.splicemachine.db.iapi.sql.depend.Dependency;
 import com.splicemachine.db.iapi.sql.depend.DependencyManager;
 
+import com.splicemachine.db.iapi.sql.execute.Expirable;
 import com.splicemachine.db.iapi.sql.execute.NoPutResultSet;
 
 import com.splicemachine.db.iapi.sql.Activation;
@@ -59,6 +60,8 @@ import com.splicemachine.db.iapi.services.context.ContextImpl;
 
 import com.splicemachine.db.iapi.error.ExceptionSeverity;
 import com.splicemachine.db.iapi.reference.SQLState;
+import org.apache.log4j.Logger;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Timer;
@@ -73,6 +76,8 @@ import java.util.TimerTask;
 final class GenericStatementContext 
 	extends ContextImpl implements StatementContext
 {
+	private static final Logger LOG = Logger.getLogger(GenericStatementContext.class);
+	
 	private boolean		setSavePoint;
 	private String		internalSavePointName;
 	private ResultSet	topResultSet;
@@ -93,7 +98,7 @@ final class GenericStatementContext
 
     // Reference to the TimerTask that will time out this statement.
     // Needed for stopping the task when execution completes before timeout.
-    private CancelQueryTask cancelTask = null;
+    private volatile CancelQueryTask cancelTask = null;
         
     private	boolean		parentInTrigger;	// whetherparent started with a trigger on stack
     private	boolean		isForReadOnly = false;	
@@ -158,8 +163,10 @@ final class GenericStatementContext
          * which might time out.
          */
         private StatementContext statementContext;
+		private Expirable expirable;
+		private Thread thread;
 
-        /**
+		/**
          * Initializes a new task for timing out a statement's execution.
          * This does not schedule it for execution, the caller is
          * responsible for calling Timer.schedule() with this object
@@ -183,8 +190,18 @@ final class GenericStatementContext
                 if (statementContext != null) {
                     statementContext.cancel();
                 }
+                if (expirable != null) {
+					try {
+						expirable.timeout();
+					} catch (StandardException e) {
+						// ignore
+						LOG.error("Ignoring exception raised during cancellation due to a timeout", e);
+					}
+					thread.interrupt();
+				}
             }
-        }
+
+		}
 
         /**
          * Stops this task and prevents it from cancelling a statement.
@@ -196,10 +213,21 @@ final class GenericStatementContext
         public void forgetContext() {
             synchronized (this) {
                 statementContext = null;
+                expirable = null;
+                thread = null;
             }
             cancel();
         }
-    }
+
+		public void registerExpirable(Expirable expirable, Thread thread) {
+        	synchronized (this) {
+        		if (this.expirable == null) {
+					this.expirable = expirable;
+					this.thread = thread;
+				}
+			}
+		}
+	}
 
 	// StatementContext Interface
 
@@ -816,7 +844,14 @@ final class GenericStatementContext
         return hasXPlainTableOrProcedure;
     }
 
-    @Override
+	@Override
+	public void registerExpirable(Expirable expirable, Thread thread) {
+		if (cancelTask != null) {
+			cancelTask.registerExpirable(expirable, thread);
+		}
+	}
+
+	@Override
     public void setXPlainTableOrProcedure(boolean val) {
         this.hasXPlainTableOrProcedure = val;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BasicNoPutResultSetImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BasicNoPutResultSetImpl.java
@@ -606,6 +606,11 @@ implements NoPutResultSet
 		return false;
 	}
 
+	@Override
+	public boolean isTimedout() {
+		return false;
+	}
+
 	public void	finish() throws StandardException
 	{
 		finishAndRTS();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IteratorNoPutResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IteratorNoPutResultSet.java
@@ -185,6 +185,11 @@ public class IteratorNoPutResultSet implements NoPutResultSet {
 		return false;
 	}
 
+	@Override
+	public boolean isTimedout() {
+		return false;
+	}
+
 	@Override public void finish() throws StandardException { close(); }
 
 		@Override public long getExecuteTime() { return 0; }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TemporaryRowHolderResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TemporaryRowHolderResultSet.java
@@ -890,6 +890,11 @@ class TemporaryRowHolderResultSet implements CursorResultSet, NoPutResultSet, Cl
         return false;
     }
 
+    @Override
+    public boolean isTimedout() {
+        return false;
+    }
+
     /**
      * Tells the system that there will be no more access
      * to any database information via this result set;

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
@@ -606,11 +606,6 @@ public class SparkDataSet<V> implements DataSet<V> {
     }
 
     @Override
-    public Iterator<V> iterator() {
-        return toLocalIterator();
-    }
-
-    @Override
     public void setAttribute(String name, String value) {
         if (attributes == null)
             attributes = new HashMap<>();

--- a/hbase_sql/src/main/java/com/splicemachine/stream/StreamListener.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/StreamListener.java
@@ -272,6 +272,9 @@ public class StreamListener<T> extends ChannelInboundHandlerAdapter implements I
         PartitionState ps = new PartitionState(currentQueue, 0);
         ps.messages.add(SENTINEL);
         partitionStateMap.putIfAbsent(currentQueue, ps);
+        ps = partitionStateMap.get(currentQueue);
+        if (ps != null)
+            ps.messages.add(FAILURE); // just in case we are blocked in advance()
         close();
     }
 

--- a/hbase_sql/src/main/java/com/splicemachine/stream/StreamableRDD.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/StreamableRDD.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.stream;
 
+import com.splicemachine.derby.iapi.sql.olap.OlapStatus;
 import com.splicemachine.derby.impl.SpliceSpark;
 import com.splicemachine.derby.stream.iapi.OperationContext;
 import org.apache.log4j.Logger;
@@ -46,6 +47,7 @@ public class StreamableRDD<T> {
     private final int clientBatches;
     private final UUID uuid;
     private final OperationContext<?> context;
+    private OlapStatus jobStatus;
 
 
     StreamableRDD(JavaRDD<T> rdd, UUID uuid, String clientHost, int clientPort) {
@@ -88,9 +90,16 @@ public class StreamableRDD<T> {
             int received = 0;
             int submitted = 2;
             while (received < partitionBatches && error == null) {
+                if (jobStatus != null && !jobStatus.isRunning()) {
+                    throw new CancellationException("The olap job is no longer running, cancelling Spark job");
+                }
                 Future<Object> resultFuture = null;
                 try {
-                    resultFuture = completionService.take();
+                    resultFuture = completionService.poll(10, TimeUnit.SECONDS);
+                    if (resultFuture == null) {
+                        // retry loop checking job status
+                        continue;
+                    }
                     Object result = resultFuture.get();
                     received++;
                     if ("STOP".equals(result)) {
@@ -140,4 +149,7 @@ public class StreamableRDD<T> {
         });
     }
 
+    public void setJobStatus(OlapStatus jobStatus) {
+        this.jobStatus = jobStatus;
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/SingleRowCursorResultSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/SingleRowCursorResultSet.java
@@ -148,6 +148,11 @@ public class SingleRowCursorResultSet implements CursorResultSet {
     }
 
     @Override
+    public boolean isTimedout() {
+        return false;
+    }
+
+    @Override
     public void finish() throws StandardException {
 
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/SpliceOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/SpliceOperation.java
@@ -15,8 +15,10 @@
 package com.splicemachine.derby.iapi.sql.execute;
 
 import com.splicemachine.db.iapi.sql.execute.CursorResultSet;
-import com.splicemachine.db.iapi.sql.execute.NoPutResultSet;
 import com.splicemachine.db.iapi.sql.execute.ExecIndexRow;
+import com.splicemachine.db.iapi.sql.execute.ExecRow;
+import com.splicemachine.db.iapi.sql.execute.Expirable;
+import com.splicemachine.db.iapi.sql.execute.NoPutResultSet;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -27,7 +29,6 @@ import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.Activation;
-import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.RowLocation;
 import com.splicemachine.derby.stream.iapi.OperationContext;
 import com.splicemachine.si.api.txn.TxnView;
@@ -35,7 +36,7 @@ import com.splicemachine.si.api.txn.TxnView;
 /**
  * Interface for Parallel Operations in the Splice Machine.
  */
-public interface SpliceOperation extends StandardCloseable, NoPutResultSet, ConvertedResultSet, CursorResultSet {
+public interface SpliceOperation extends StandardCloseable, NoPutResultSet, ConvertedResultSet, CursorResultSet, Expirable {
     /**
      *
      * Retrieve the current Row Location (Cursor Concept) on the operation.
@@ -373,19 +374,19 @@ public interface SpliceOperation extends StandardCloseable, NoPutResultSet, Conv
     ExecIndexRow getStartPosition() throws StandardException;
 
     /**
+     * Forcefully close operation and mark it as killed
+     * @throws StandardException
+     * @throws IOException
+     */
+    void kill() throws StandardException;
+    
+    /**
      *
      * Return the VTI file name for this operation.
      *
      * @return
      */
     String getVTIFileName();
-
-    /**
-     * Forcefully close operation and mark it as killed
-     * @throws StandardException
-     * @throws IOException
-     */
-    void kill() throws StandardException;
 
     boolean accessExternalTable();
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperation.java
@@ -823,7 +823,7 @@ public class CreateIndexConstantOperation extends IndexConstantOperation impleme
                 td.getHeapConglomerateId(), indexConglomId, td, indexDescriptor, defaultValue);
         if (preSplit && !sampling) {
             splitIndex(indexDescriptor, splitKeyPath, columnDelimiter, characterDelimiter,
-                    timestampFormat, dateFormat, timeFormat, ddlChange.getTentativeIndex(), td);
+                    timestampFormat, dateFormat, timeFormat, ddlChange.getTentativeIndex(), td, activation);
         }
         String changeId = DDLUtils.notifyMetadataChange(ddlChange);
         tc.prepareDataDictionaryChange(changeId);
@@ -836,7 +836,7 @@ public class CreateIndexConstantOperation extends IndexConstantOperation impleme
 
     private void splitIndex(IndexDescriptor indexDescriptor, String splitKeyPath, String columnDelimiter,
                             String characterDelimiter, String timestampFormat, String dateTimeFormat, String timeFormat,
-                            DDLMessage.TentativeIndex tentativeIndex, TableDescriptor td) throws IOException, StandardException {
+                            DDLMessage.TentativeIndex tentativeIndex, TableDescriptor td, Activation activation) throws IOException, StandardException {
 
         List<Integer> indexCols = tentativeIndex.getIndex().getIndexColsToMainColMapList();
         List<Integer> allFormatIds = tentativeIndex.getTable().getFormatIdsList();
@@ -846,7 +846,7 @@ public class CreateIndexConstantOperation extends IndexConstantOperation impleme
         }
         DataSetProcessor dsp = EngineDriver.driver().processorFactory().localProcessor(null,null);
         DataSet<String> text = dsp.readTextFile(splitKeyPath);
-        OperationContext operationContext = dsp.createOperationContext((Activation)null);
+        OperationContext operationContext = dsp.createOperationContext(activation);
         ExecRow execRow = WriteReadUtils.getExecRowFromTypeFormatIds(indexFormatIds);
         DataSet<ExecRow> dataSet = text.flatMap(new FileFunction(characterDelimiter, columnDelimiter, execRow,
                 null, timeFormat, dateTimeFormat, timestampFormat, operationContext), true);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowReader.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowReader.java
@@ -14,6 +14,10 @@
 
 package com.splicemachine.derby.impl.sql.execute.operations;
 
+import com.splicemachine.EngineDriver;
+import com.splicemachine.derby.stream.function.IteratorUtils;
+import org.apache.spark.InterruptibleIterator;
+import org.apache.spark.TaskContext;
 import org.spark_project.guava.collect.Lists;
 import com.splicemachine.access.api.PartitionFactory;
 import com.splicemachine.db.iapi.error.StandardException;
@@ -29,6 +33,7 @@ import com.splicemachine.storage.*;
 import com.splicemachine.storage.util.MapAttributes;
 import com.splicemachine.utils.Pair;
 import org.apache.log4j.Logger;
+import scala.collection.JavaConverters;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
@@ -231,7 +236,7 @@ public class IndexRowReader implements Iterator<ExecRow>, Iterable<ExecRow>{
 
     @Override
     public Iterator<ExecRow> iterator(){
-        return this;
+        return IteratorUtils.asInterruptibleIterator(this);
     }
 
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
@@ -99,6 +99,7 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
     protected boolean returnedRows = false;
     private volatile UUID uuid = null;
     private volatile boolean isKilled = false;
+    private volatile boolean isTimedout = false;
 
     public SpliceBaseOperation(){
         super();
@@ -210,7 +211,7 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
             if(LOG_CLOSE.isTraceEnabled())
                 LOG_CLOSE.trace(String.format("closing operation %s",this));
             if (remoteQueryClient != null) {
-                if (!isKilled) {
+                if (!isKilled && !isTimedout) {
                     // wait for completion, it should be quick
                     try {
                         remoteQueryClient.waitForCompletion(1, TimeUnit.MINUTES);
@@ -437,6 +438,10 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
             LOG.warn("Exception ignored because operation was explicitly killed", e);
             throw StandardException.newException(SQLState.LANG_CANCELLATION_EXCEPTION);
         }
+        if (isTimedout) {
+            LOG.warn("Exception ignored because operation was timed out", e);
+            throw StandardException.newException(SQLState.LANG_STATEMENT_CANCELLED_OR_TIMED_OUT);
+        }
         // otherwise deal with it normally
     }
 
@@ -456,6 +461,7 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
         try {
             uuid = EngineDriver.driver().getOperationManager().registerOperation(this, Thread.currentThread());
             DataSetProcessor dsp = EngineDriver.driver().processorFactory().chooseProcessor(activation, this);
+            activation.getLanguageConnectionContext().getStatementContext().registerExpirable(this, Thread.currentThread());
             if (dsp.getType() == DataSetProcessor.Type.SPARK && !isOlapServer() && !SpliceClient.isClient) {
                 remoteQueryClient = EngineDriver.driver().processorFactory().getRemoteQueryClient(this);
                 remoteQueryClient.submit();
@@ -604,6 +610,8 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
             SpliceLogUtils.trace(LOG,"getNextRow");
         if(isKilled)
             throw StandardException.newException(SQLState.LANG_CANCELLATION_EXCEPTION);
+        if(isTimedout)
+            throw StandardException.newException(SQLState.LANG_STATEMENT_CANCELLED_OR_TIMED_OUT);
         if(!isOpen)
             throw StandardException.newException(SQLState.LANG_RESULT_SET_NOT_OPEN,NEXT);
         attachStatementContext();
@@ -648,6 +656,11 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
     @Override
     public boolean isKilled() {
         return isKilled;
+    }
+
+    @Override
+    public boolean isTimedout() {
+        return isTimedout;
     }
 
     @Override
@@ -881,8 +894,29 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
     @Override
     public void kill() throws StandardException {
         this.isKilled = true;
-        close();
+        // The cancel flag is checked during Control execution
+        getActivation().getLanguageConnectionContext().getStatementContext().cancel();
+        if (remoteQueryClient != null) {
+            try {
+                remoteQueryClient.close();
+            } catch (Exception e) {
+                throw Exceptions.parseException(e);
+            }
+        }
     }
+
+    @Override
+    public void timeout() throws StandardException {
+        this.isTimedout = true;
+        if (remoteQueryClient != null) {
+            try {
+                remoteQueryClient.close();
+            } catch (Exception e) {
+                throw Exceptions.parseException(e);
+            }
+        }
+    }
+
 
     @Override
     public boolean accessExternalTable() {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TemporaryRowHolderOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TemporaryRowHolderOperation.java
@@ -875,6 +875,11 @@ public class TemporaryRowHolderOperation implements CursorResultSet, NoPutResult
         return false;
     }
 
+    @Override
+    public boolean isTimedout() {
+        return false;
+    }
+
     /**
      * Tells the system that there will be no more access
      * to any database information via this result set;

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
@@ -46,7 +46,6 @@ import com.splicemachine.primitives.Bytes;
 import com.splicemachine.si.impl.driver.SIDriver;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.collections.IteratorUtils;
-import org.apache.commons.collections.iterators.IteratorChain;
 import org.spark_project.guava.base.Function;
 import org.spark_project.guava.base.Predicate;
 import org.spark_project.guava.collect.Iterators;
@@ -54,7 +53,6 @@ import org.spark_project.guava.collect.Multimaps;
 import org.spark_project.guava.collect.Sets;
 import org.spark_project.guava.io.Closeables;
 import org.spark_project.guava.util.concurrent.Futures;
-import org.spark_project.guava.util.concurrent.ThreadFactoryBuilder;
 import scala.Tuple2;
 
 import javax.annotation.Nullable;
@@ -72,13 +70,10 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 import static com.splicemachine.derby.stream.control.ControlUtils.entryToTuple;
 import static com.splicemachine.derby.stream.control.ControlUtils.limit;
+import static com.splicemachine.derby.stream.control.ControlUtils.checkCancellation;
 
 /**
  *
@@ -93,7 +88,7 @@ public class ControlDataSet<V> implements DataSet<V> {
     public ControlDataSet(Iterator<V> iterator) {
         this.iterator = iterator;
     }
-
+    
     @Override
     public int partitions() {
         return 1;
@@ -112,7 +107,7 @@ public class ControlDataSet<V> implements DataSet<V> {
     @Override
     public <Op extends SpliceOperation, U> DataSet<U> mapPartitions(SpliceFlatMapFunction<Op,Iterator<V>, U> f) {
         try {
-            return new ControlDataSet<>(f.call(iterator));
+            return new ControlDataSet<>(f.call(checkCancellation(iterator, f)));
         } catch (Exception e) {
             throw Exceptions.getRuntimeException(e);
         }
@@ -147,7 +142,7 @@ public class ControlDataSet<V> implements DataSet<V> {
 
     @Override
     public DataSet<V> distinct(OperationContext context) {
-        return new ControlDataSet<>(newHashSet(iterator, context).iterator());
+        return new ControlDataSet<>(newHashSet(ControlUtils.checkCancellation(iterator, context), context).iterator());
     }
 
     @Override
@@ -156,7 +151,7 @@ public class ControlDataSet<V> implements DataSet<V> {
     }
 
     public <Op extends SpliceOperation, K,U>PairDataSet<K, U> index(final SplicePairFunction<Op,V,K,U> function) {
-        return new ControlPairDataSet<>(Iterators.transform(iterator,new Function<V, Tuple2<K, U>>() {
+        return new ControlPairDataSet<>(Iterators.transform(checkCancellation(iterator, function),new Function<V, Tuple2<K, U>>() {
             @Nullable
             @Override
             public Tuple2<K, U> apply(@Nullable V v) {
@@ -181,7 +176,7 @@ public class ControlDataSet<V> implements DataSet<V> {
 
     @Override
     public <Op extends SpliceOperation, U> DataSet<U> map(SpliceFunction<Op,V,U> function) {
-        return new ControlDataSet<U>(Iterators.transform(iterator, function));
+        return new ControlDataSet<U>(Iterators.transform(checkCancellation(iterator, function), function));
     }
 
     @Override
@@ -201,7 +196,7 @@ public class ControlDataSet<V> implements DataSet<V> {
 
     @Override
     public <Op extends SpliceOperation, K> PairDataSet<K, V> keyBy(final SpliceFunction<Op, V, K> function) {
-        return new ControlPairDataSet<>(entryToTuple(Multimaps.index(limit(iterator, function.operationContext),function).entries()));
+        return new ControlPairDataSet<>(entryToTuple(Multimaps.index(limit(checkCancellation(iterator, function), function.operationContext),function).entries()));
     }
 
     @Override
@@ -257,7 +252,7 @@ public class ControlDataSet<V> implements DataSet<V> {
 
     @Override
     public <Op extends SpliceOperation> DataSet< V> filter(SplicePredicateFunction<Op, V> f) {
-        return new ControlDataSet<>(Iterators.filter(iterator,f));
+        return new ControlDataSet<>(Iterators.filter(checkCancellation(iterator, f),f));
     }
 
     @Override
@@ -273,8 +268,8 @@ public class ControlDataSet<V> implements DataSet<V> {
 
     @Override
     public DataSet< V> intersect(DataSet<V> dataSet, OperationContext context) {
-        Set<V> left=newHashSet(iterator, context);
-        Set<V> right=newHashSet(((ControlDataSet<V>)dataSet).iterator, context);
+        Set<V> left=newHashSet(ControlUtils.checkCancellation(iterator, context), context);
+        Set<V> right=newHashSet(ControlUtils.checkCancellation(((ControlDataSet<V>)dataSet).iterator, context), context);
         Sets.SetView<V> intersection=Sets.intersection(left,right);
         return new ControlDataSet<>(intersection.iterator());
     }
@@ -288,8 +283,8 @@ public class ControlDataSet<V> implements DataSet<V> {
 
     @Override
     public DataSet< V> subtract(DataSet<V> dataSet, OperationContext context) {
-        Set<V> left=newHashSet(iterator, context);
-        Set<V> right=newHashSet(((ControlDataSet<V>)dataSet).iterator, context);
+        Set<V> left=newHashSet(ControlUtils.checkCancellation(iterator, context), context);
+        Set<V> right=newHashSet(ControlUtils.checkCancellation(((ControlDataSet<V>)dataSet).iterator, context), context);
         return new ControlDataSet<>(Sets.difference(left,right).iterator());
     }
 
@@ -300,7 +295,7 @@ public class ControlDataSet<V> implements DataSet<V> {
 
     @Override
     public <Op extends SpliceOperation,U> DataSet<U> flatMap(SpliceFlatMapFunction<Op, V, U> f) {
-        return new ControlDataSet(Iterators.concat(Iterators.transform(iterator,f)));
+        return new ControlDataSet(Iterators.concat(Iterators.transform(checkCancellation(iterator, f),f)));
     }
 
     @Override
@@ -321,7 +316,7 @@ public class ControlDataSet<V> implements DataSet<V> {
     @Override
     public <Op extends SpliceOperation> DataSet<V> take(TakeFunction<Op,V> f) {
         try {
-            return new ControlDataSet<>(f.call(iterator));
+            return new ControlDataSet<>(f.call(checkCancellation(iterator, f)));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -409,11 +404,6 @@ public class ControlDataSet<V> implements DataSet<V> {
     @Override
     public void persist() {
         // no op
-    }
-
-    @Override
-    public Iterator<V> iterator() {
-        return this.toLocalIterator();
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
@@ -171,7 +171,7 @@ public class ControlDataSetProcessor implements DataSetProcessor{
 
     @Override
     public <Op extends SpliceOperation> OperationContext<Op> createOperationContext(Activation activation){
-        return new ControlOperationContext<>(null);
+        return new ControlOperationContext<>(activation);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlOperationContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlOperationContext.java
@@ -69,21 +69,25 @@ public class ControlOperationContext<Op extends SpliceOperation> implements Oper
     public ControlOperationContext() {
         }
 
-        protected ControlOperationContext(Op spliceOperation) {
-            this.op = spliceOperation;
-            if (op !=null) {
-                this.activation = op.getActivation();
-                try {
-                    this.txn = spliceOperation.getCurrentTransaction();
-                } catch (StandardException se) {
-                    throw new RuntimeException(se);
-                }
+    protected ControlOperationContext(Op spliceOperation) {
+        this.op = spliceOperation;
+        if (op !=null) {
+            this.activation = op.getActivation();
+            try {
+                this.txn = spliceOperation.getCurrentTransaction();
+            } catch (StandardException se) {
+                throw new RuntimeException(se);
             }
-            rowsRead = 0;
-            rowsFiltered=0;
-            rowsWritten = 0;
-            badRecords =new ArrayList<>();
         }
+        rowsRead = 0;
+        rowsFiltered=0;
+        rowsWritten = 0;
+        badRecords =new ArrayList<>();
+    }
+    protected ControlOperationContext(Activation activation) {
+        this((Op) null);
+        this.activation = activation;
+    }
 
         public void readExternalInContext(ObjectInput in) throws IOException, ClassNotFoundException
         {}
@@ -140,7 +144,7 @@ public class ControlOperationContext<Op extends SpliceOperation> implements Oper
 
     @Override
     public Activation getActivation() {
-        return op.getActivation();
+        return activation;
     }
 
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlPairDataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlPairDataSet.java
@@ -14,11 +14,9 @@
 
 package com.splicemachine.derby.stream.control;
 
-import com.splicemachine.db.iapi.sql.conn.ControlExecutionLimiter;
 import com.splicemachine.derby.impl.sql.execute.operations.JoinOperation;
 import org.spark_project.guava.base.Function;
 import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.stream.function.*;
 import com.splicemachine.derby.stream.iapi.DataSet;
@@ -26,17 +24,9 @@ import com.splicemachine.derby.stream.iapi.OperationContext;
 import com.splicemachine.derby.stream.iapi.PairDataSet;
 import com.splicemachine.derby.stream.output.DataSetWriter;
 import com.splicemachine.derby.stream.output.DataSetWriterBuilder;
-import com.splicemachine.derby.stream.output.InsertDataSetWriterBuilder;
-import com.splicemachine.derby.stream.output.UpdateDataSetWriterBuilder;
-import com.splicemachine.derby.stream.output.delete.DeletePipelineWriter;
-import com.splicemachine.derby.stream.output.delete.DeleteTableWriterBuilder;
 import com.splicemachine.derby.stream.output.direct.DirectDataSetWriter;
 import com.splicemachine.derby.stream.output.direct.DirectPipelineWriter;
 import com.splicemachine.derby.stream.output.direct.DirectTableWriterBuilder;
-import com.splicemachine.derby.stream.output.insert.InsertPipelineWriter;
-import com.splicemachine.derby.stream.output.insert.InsertTableWriterBuilder;
-import com.splicemachine.derby.stream.output.update.UpdatePipelineWriter;
-import com.splicemachine.derby.stream.output.update.UpdateTableWriterBuilder;
 import com.splicemachine.kvpair.KVPair;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.spark_project.guava.base.Predicate;
@@ -47,8 +37,9 @@ import java.util.*;
 
 import static com.splicemachine.derby.stream.control.ControlUtils.entryToTuple;
 import static com.splicemachine.derby.stream.control.ControlUtils.limit;
+import static com.splicemachine.derby.stream.control.ControlUtils.checkCancellation;
 import static com.splicemachine.derby.stream.control.ControlUtils.multimapFromIterator;
-import static org.spark_project.guava.collect.Maps.*;
+import static org.spark_project.guava.collect.Maps.transformValues;
 
 /**
  *
@@ -63,6 +54,7 @@ public class ControlPairDataSet<K,V> implements PairDataSet<K,V> {
     public ControlPairDataSet(Iterator<Tuple2<K,V>> source) {
         this.source = source;
     }
+
 
     @Override
     public DataSet<V> values() {
@@ -98,7 +90,7 @@ public class ControlPairDataSet<K,V> implements PairDataSet<K,V> {
 
     @Override
     public <Op extends SpliceOperation> PairDataSet<K, V> reduceByKey(final SpliceFunction2<Op,V, V, V> function2) {
-        Multimap<K,V> newMap = multimapFromIterator(limit(source, function2.operationContext));
+        Multimap<K,V> newMap = multimapFromIterator(limit(checkCancellation(source,function2), function2.operationContext));
         return new ControlPairDataSet<>(entryToTuple(Multimaps.<K,V>forMap(transformValues(newMap.asMap(),
                 new Function<Collection<V>, V>() {
             @Override
@@ -123,7 +115,7 @@ public class ControlPairDataSet<K,V> implements PairDataSet<K,V> {
     
     @Override
     public <Op extends SpliceOperation, U> DataSet<U> map(final SpliceFunction<Op,Tuple2<K, V>, U> function) {
-        return new ControlDataSet<U>(Iterators.transform(source,function));
+        return new ControlDataSet<U>(Iterators.transform(checkCancellation(source,function),function));
     }
 
     @Override
@@ -139,7 +131,7 @@ public class ControlPairDataSet<K,V> implements PairDataSet<K,V> {
             public int compare(Tuple2<K, V> o1, Tuple2<K, V> o2) {
                 return comparator.compare(o1._1(), o2._1());
             }
-        }).immutableSortedCopy(() -> limit(source, operationContext)).iterator());
+        }).immutableSortedCopy(() -> limit(ControlUtils.checkCancellation(source,operationContext), operationContext)).iterator());
     }
 
     @Override
@@ -156,7 +148,7 @@ public class ControlPairDataSet<K,V> implements PairDataSet<K,V> {
 
     @Override
     public PairDataSet<K, Iterable<V>> groupByKey(OperationContext context) {
-        Multimap<K,V> newMap = multimapFromIterator(limit(source, context));
+        Multimap<K,V> newMap = multimapFromIterator(limit(ControlUtils.checkCancellation(source,context), context));
         return new ControlPairDataSet<>(FluentIterable.from(newMap.asMap().entrySet()).transform(new Function<Map.Entry<K, Collection<V>>, Tuple2<K, Iterable<V>>>() {
             @Nullable
             @Override
@@ -175,8 +167,8 @@ public class ControlPairDataSet<K,V> implements PairDataSet<K,V> {
     @Override
     public <W> PairDataSet< K, Tuple2<V, W>> hashJoin(PairDataSet<K, W> rightDataSet, OperationContext operationContext) {
         // Materializes the right side
-        final Multimap<K,W> rightSide = multimapFromIterator(limit(((ControlPairDataSet<K,W>) rightDataSet).source, operationContext));
-        return new ControlPairDataSet(Iterators.concat(Iterators.transform(source,new Function<Tuple2<K, V>, Iterator<Tuple2<K, Tuple2<V, W>>>>() {
+        final Multimap<K,W> rightSide = multimapFromIterator(limit(ControlUtils.checkCancellation(((ControlPairDataSet<K,W>) rightDataSet).source,operationContext), operationContext));
+        return new ControlPairDataSet(Iterators.concat(Iterators.transform(ControlUtils.checkCancellation(source,operationContext),new Function<Tuple2<K, V>, Iterator<Tuple2<K, Tuple2<V, W>>>>() {
             @Nullable
             @Override
             public Iterator<Tuple2<K, Tuple2<V, W>>> apply(@Nullable Tuple2<K, V> t) {
@@ -201,8 +193,8 @@ public class ControlPairDataSet<K,V> implements PairDataSet<K,V> {
     @Override
     public <W> PairDataSet< K, V> subtractByKey(PairDataSet<K, W> rightDataSet, OperationContext operationContext) {
         // Materializes the right side
-        final Multimap<K,W> rightSide = multimapFromIterator(limit(((ControlPairDataSet<K,W>) rightDataSet).source, operationContext));
-        return new ControlPairDataSet<>(Iterators.filter(source, new Predicate<Tuple2<K, V>>() {
+        final Multimap<K,W> rightSide = multimapFromIterator(limit(ControlUtils.checkCancellation(((ControlPairDataSet<K,W>) rightDataSet).source,operationContext), operationContext));
+        return new ControlPairDataSet<>(Iterators.filter(ControlUtils.checkCancellation(source,operationContext), new Predicate<Tuple2<K, V>>() {
             @Override
             public boolean apply(@Nullable Tuple2<K, V> t) {
                 assert t!=null: "T cannot be null";
@@ -228,7 +220,7 @@ public class ControlPairDataSet<K,V> implements PairDataSet<K,V> {
     @Override
     public <Op extends SpliceOperation, U> DataSet<U> mapPartitions(SpliceFlatMapFunction<Op, Iterator<Tuple2<K, V>>, U> f) {
         try {
-            return new ControlDataSet<>(f.call(source));
+            return new ControlDataSet<>(f.call(checkCancellation(source,f)));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -237,6 +229,7 @@ public class ControlPairDataSet<K,V> implements PairDataSet<K,V> {
     @Override
     public <Op extends SpliceOperation, U> DataSet<U> flatmap(SpliceFlatMapFunction<Op, Tuple2<K,V>, U> function) {
         try {
+            Iterator<Tuple2<K, V>> source = checkCancellation(this.source,function);
             Iterator<U> iterator = Iterators.emptyIterator();
             List<Iterator<U>> l = Lists.newArrayList();
 
@@ -261,8 +254,8 @@ public class ControlPairDataSet<K,V> implements PairDataSet<K,V> {
     
     @Override
     public <W> PairDataSet<K, Tuple2<Iterable<V>, Iterable<W>>> cogroup(PairDataSet<K, W> rightDataSet, OperationContext operationContext) {
-        Multimap<K, V> left = multimapFromIterator(limit(source, operationContext));
-        Multimap<K, W> right = multimapFromIterator(limit(((ControlPairDataSet<K, W>) rightDataSet).source, operationContext));
+        Multimap<K, V> left = multimapFromIterator(limit(ControlUtils.checkCancellation(source,operationContext), operationContext));
+        Multimap<K, W> right = multimapFromIterator(limit(ControlUtils.checkCancellation(((ControlPairDataSet<K, W>) rightDataSet).source, operationContext), operationContext));
 
         List<Tuple2<K, Tuple2<Iterable<V>, Iterable<W>>>> result = new ArrayList<>();
         for (K key: Sets.union(left.keySet(),right.keySet())){

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/IteratorUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/IteratorUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.derby.stream.function;
+
+import com.splicemachine.db.iapi.sql.execute.ExecRow;
+import org.apache.spark.InterruptibleIterator;
+import org.apache.spark.TaskContext;
+import scala.collection.JavaConverters;
+
+import java.util.Iterator;
+
+public class IteratorUtils {
+    public static <E> Iterator<E> asInterruptibleIterator(Iterator<E> it) {
+        TaskContext context = TaskContext.get();
+        if (context != null) {
+            return (Iterator<E>) JavaConverters.asJavaIteratorConverter(new InterruptibleIterator(context, JavaConverters.asScalaIteratorConverter(it).asScala())).asJava();
+        } else
+            return it;
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeWindowFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeWindowFunction.java
@@ -21,7 +21,10 @@ import com.splicemachine.derby.impl.sql.execute.operations.window.WindowContext;
 import com.splicemachine.derby.stream.iapi.OperationContext;
 import com.splicemachine.derby.stream.window.BaseFrameBuffer;
 import com.splicemachine.derby.stream.window.WindowFrameBuffer;
+import org.apache.spark.InterruptibleIterator;
+import org.apache.spark.TaskContext;
 import scala.Tuple2;
+import scala.collection.JavaConverters;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -65,7 +68,9 @@ public class MergeWindowFunction<Op extends WindowOperation> extends SpliceFlatM
                 operationContext.getOperation().getExecRowDefinition().getClone());
 
         return new ExecRowToLocatedRowIterable(new Iterable<ExecRow>() {
-            @Override public Iterator<ExecRow> iterator() { return frameBuffer; }
+            @Override public Iterator<ExecRow> iterator() {
+                return IteratorUtils.asInterruptibleIterator(frameBuffer);
+            }
         });
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/broadcast/BroadcastJoinFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/broadcast/BroadcastJoinFlatMapFunction.java
@@ -14,6 +14,9 @@
 
 package com.splicemachine.derby.stream.function.broadcast;
 
+import com.splicemachine.derby.stream.function.IteratorUtils;
+import org.apache.spark.InterruptibleIterator;
+import org.apache.spark.TaskContext;
 import org.spark_project.guava.base.Function;
 import org.spark_project.guava.collect.FluentIterable;
 import org.spark_project.guava.collect.Iterables;
@@ -21,6 +24,7 @@ import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.derby.impl.sql.JoinTable;
 import com.splicemachine.derby.stream.iapi.OperationContext;
 import scala.Tuple2;
+import scala.collection.JavaConverters;
 
 import javax.annotation.Nullable;
 import java.util.Iterator;
@@ -53,7 +57,7 @@ public class BroadcastJoinFlatMapFunction extends AbstractBroadcastJoinFlatMapFu
                             @Override
                             public Iterator<ExecRow> iterator(){
                                 try{
-                                    return joinTable.fetchInner(left);
+                                    return IteratorUtils.asInterruptibleIterator(joinTable.fetchInner(left));
                                 }catch(Exception e){
                                     throw new RuntimeException(e);
                                 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/broadcast/CogroupBroadcastJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/broadcast/CogroupBroadcastJoinFunction.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.derby.stream.function.broadcast;
 
+import com.splicemachine.derby.stream.function.IteratorUtils;
 import org.spark_project.guava.base.Function;
 import org.spark_project.guava.collect.FluentIterable;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
@@ -51,7 +52,7 @@ public class CogroupBroadcastJoinFunction extends AbstractBroadcastJoinFlatMapFu
                             @Override
                             public Iterator<ExecRow> iterator(){
                                 try{
-                                    return joinTable.fetchInner(left);
+                                    return IteratorUtils.asInterruptibleIterator(joinTable.fetchInner(left));
                                 }catch(Exception e){
                                     throw new RuntimeException(e);
                                 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
@@ -29,7 +29,8 @@ import java.util.concurrent.Future;
 /**
  * Stream of data acting on an iterable set of values.
  */
-public interface DataSet<V> extends Iterable<V>, Serializable {
+public interface DataSet<V> extends //Iterable<V>,
+        Serializable {
 
     int partitions();
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/NestedLoopJoinIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/NestedLoopJoinIterator.java
@@ -18,6 +18,7 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.JoinUtils;
+import com.splicemachine.derby.stream.function.IteratorUtils;
 import com.splicemachine.derby.stream.iapi.IterableJoinFunction;
 import com.splicemachine.derby.stream.utils.StreamLogUtils;
 import com.splicemachine.utils.SpliceLogUtils;
@@ -68,6 +69,6 @@ public class NestedLoopJoinIterator<Op extends SpliceOperation> implements Itera
     }
     @Override
     public Iterator<ExecRow> iterator() {
-        return this;
+        return IteratorUtils.asInterruptibleIterator(this);
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/TableScannerIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/TableScannerIterator.java
@@ -23,6 +23,7 @@ import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.ScanOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.scanner.SITableScanner;
 import com.splicemachine.derby.impl.sql.execute.operations.scanner.TableScannerBuilder;
+import com.splicemachine.derby.stream.function.IteratorUtils;
 import com.splicemachine.derby.stream.utils.StreamLogUtils;
 import com.splicemachine.derby.utils.Scans;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -59,7 +60,7 @@ public class TableScannerIterator implements Iterable<ExecRow>, Iterator<ExecRow
 
     @Override
     public Iterator<ExecRow> iterator() {
-        return this;
+        return IteratorUtils.asInterruptibleIterator(this);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/ResultSetIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/ResultSetIterator.java
@@ -15,6 +15,7 @@
 package com.splicemachine.derby.vti;
 
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
+import com.splicemachine.derby.stream.function.IteratorUtils;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.Closeable;
@@ -59,7 +60,7 @@ public class ResultSetIterator implements Iterable<ExecRow>, Iterator<ExecRow>, 
 
     @Override
     public Iterator<ExecRow> iterator() {
-        return this;
+        return IteratorUtils.asInterruptibleIterator(this);
     }
 
     @Override

--- a/splice_machine/src/test/java/com/splicemachine/derby/transactions/QueryTimeoutIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/transactions/QueryTimeoutIT.java
@@ -266,7 +266,7 @@ public class QueryTimeoutIT extends SpliceUnitTest {
 
             if (expectTimeout) {
                 // We timed out and caught an exception. Make sure we get the correct exception
-                Assert.assertEquals("Expected a query timeout.", "08006", e.getSQLState());
+                Assert.assertEquals("Expected a query timeout.", "XCL52", e.getSQLState());
 
                 // Make sure the update txn got rolled back
                 rs = classWatcher.executeQuery(sqlText);

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/StatisticsAdminIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/StatisticsAdminIT.java
@@ -255,6 +255,8 @@ public class StatisticsAdminIT{
                 Assert.assertEquals("Not enough rows returned!",0,countDown);
             }
         }
+        conn.rollback();
+        conn.reset();
     }
 
     @Test
@@ -565,6 +567,8 @@ public class StatisticsAdminIT{
             conn.rollback();
         }
 
+        conn.rollback();
+        conn.reset();
     }
 
     @Test

--- a/splice_machine/src/test/java/com/splicemachine/jdbc/JdbcApiIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/jdbc/JdbcApiIT.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.jdbc;
+
+import com.splicemachine.derby.test.framework.SpliceDataWatcher;
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceTableWatcher;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.derby.test.framework.TestConnection;
+import com.splicemachine.homeless.TestUtils;
+import com.splicemachine.util.StatementUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.junit.runner.Description;
+import org.spark_project.guava.collect.Lists;
+import org.spark_project.guava.collect.Ordering;
+import org.spark_project.guava.collect.Sets;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLTimeoutException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static com.splicemachine.derby.test.framework.SpliceUnitTest.resultSetSize;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JdbcApiIT {
+
+    private static final String CLASS_NAME = JdbcApiIT.class.getSimpleName().toUpperCase();
+    private static final SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);
+    private static final SpliceSchemaWatcher schemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
+    protected static final SpliceTableWatcher A_TABLE = new SpliceTableWatcher("A",schemaWatcher.schemaName,
+            "(a1 int)");
+
+    @ClassRule
+    public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
+            .around(schemaWatcher)
+            .around(A_TABLE)
+            .around(new SpliceDataWatcher() {
+                @Override
+                protected void starting(Description description) {
+                    try {
+                        spliceClassWatcher.execute("insert into a values 1,2");
+                        try (PreparedStatement ps = spliceClassWatcher.prepareStatement("insert into a select a1 + (select count(*) from a) from a")) {
+                            for (int i = 0; i < 10; i++) {
+                                ps.execute();
+                            }
+                        }
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    } finally {
+                        spliceClassWatcher.closeAll();
+                    }
+                }
+            });
+
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher(CLASS_NAME);
+
+    private TestConnection conn;
+
+    @Before
+    public void setUp() throws Exception{
+        conn = methodWatcher.getOrCreateConnection();
+        conn.setAutoCommit(false);
+    }
+
+    @After
+    public void tearDown() throws Exception{
+        conn.rollback();
+        conn.reset();
+    }
+
+    @Rule
+    public Timeout globalTimeout= new Timeout(15, TimeUnit.SECONDS);
+
+
+    @Test(expected = SQLTimeoutException.class)
+    public void testTimeoutSpark() throws Exception {
+        String sql = "select count(*) from a --splice-properties useSpark=true \n" +
+                "natural join a a1 natural join a a2 natural join a a3";
+        try(Statement s = conn.createStatement()){
+            s.setQueryTimeout(2);
+            ResultSet rs = s.executeQuery(sql);
+        }
+    }
+
+    @Test(expected = SQLTimeoutException.class)
+    public void testTimeoutControl() throws Exception {
+        String sql = "select count(*) from a --splice-properties useSpark=false \n" +
+                "natural join a a1 natural join a a2 natural join a a3";
+        try(Statement s = conn.createStatement()){
+            s.setQueryTimeout(2);
+            ResultSet rs = s.executeQuery(sql);
+        }
+    }
+
+}


### PR DESCRIPTION
Fix non-terminating queries when they time out or are killed. Clear
resources in Spark after query has been killed/times out.