### PR TITLE
DB-6558: cache more database properties

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/property/PropertyUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/property/PropertyUtil.java
@@ -76,27 +76,28 @@ import java.util.Enumeration;
 public class PropertyUtil {
 
 	// List of properties that are stored in the service.properties file
-	public static final String[] servicePropertyList = {
-		EngineType.PROPERTY,
-		Property.NO_AUTO_BOOT,
-		Property.STORAGE_TEMP_DIRECTORY,
-        Attribute.CRYPTO_PROVIDER,
-        Attribute.CRYPTO_ALGORITHM,
-		Attribute.RESTORE_FROM,
-		Attribute.LOG_DEVICE,
-		Property.LOG_ARCHIVE_MODE,
-		// Additional Derby properties that Splice considers as "service" properties.
-		Property.PROPERTIES_CONGLOM_ID,
-		Property.ROW_LOCKING,
-		"derby.language.logStatementText",
-		"derby.language.logQueryPlan",
-		Property.LOCKS_ESCALATION_THRESHOLD,
-		Property.DATABASE_PROPERTIES_ONLY,
-		Property.DEFAULT_CONNECTION_MODE_PROPERTY,
-		Property.AUTHENTICATION_BUILTIN_ALGORITHM
-	};
+    public static final String[] servicePropertyList = {
+            EngineType.PROPERTY,
+            Property.NO_AUTO_BOOT,
+            Property.STORAGE_TEMP_DIRECTORY,
+            Attribute.CRYPTO_PROVIDER,
+            Attribute.CRYPTO_ALGORITHM,
+            Attribute.RESTORE_FROM,
+            Attribute.LOG_DEVICE,
+            Property.LOG_ARCHIVE_MODE,
+            // Additional Derby properties that Splice considers as "service" properties.
+            Property.PROPERTIES_CONGLOM_ID,
+            Property.ROW_LOCKING,
+            "derby.language.logStatementText",
+            "derby.language.logQueryPlan",
+            Property.LOCKS_ESCALATION_THRESHOLD,
+            Property.DATABASE_PROPERTIES_ONLY,
+            Property.DEFAULT_CONNECTION_MODE_PROPERTY,
+            Property.AUTHENTICATION_BUILTIN_ALGORITHM,
+            Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED
+    };
 
-	/**
+    /**
 		Property is set in JVM set
 	*/
 	public static final int SET_IN_JVM = 0;	

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -425,7 +425,7 @@ public class GenericStatement implements Statement{
 
             /* get the selectivity estimation property so that we know what strategy to use to estimate selectivity */
             String selectivityEstimationString = PropertyUtil.getServiceProperty(lcc.getTransactionCompile(),
-                    Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED_DEFAULT);
+                    Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED);
             Boolean selectivityEstimationIncludingSkewedDefault = Boolean.valueOf(selectivityEstimationString);
 
             cc.setSelectivityEstimationIncludingSkewedDefault(selectivityEstimationIncludingSkewedDefault);

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1205,6 +1205,6 @@ public interface Property {
 	 */
 	String COLLECT_INDEX_STATS_ONLY = "derby.database.collectIndexStatsOnly";
 
-	String SELECTIVITY_ESTIMATION_INCLUDING_SKEWED_DEFAULT =
+	String SELECTIVITY_ESTIMATION_INCLUDING_SKEWED =
 			"derby.database.selectivityEstimationIncludingSkewedDefault";
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/PropertyConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/PropertyConglomerate.java
@@ -105,7 +105,8 @@ public class PropertyConglomerate {
 			serviceProperties.put(Property.DATABASE_PROPERTIES_ONLY, "false");
 			serviceProperties.put(Property.DEFAULT_CONNECTION_MODE_PROPERTY, "fullAccess");
 			serviceProperties.put(Property.AUTHENTICATION_BUILTIN_ALGORITHM, Property.AUTHENTICATION_BUILTIN_ALGORITHM_DEFAULT);
-			for (Object key: serviceProperties.keySet()) {
+			serviceProperties.put(Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED, "false");
+            for (Object key: serviceProperties.keySet()) {
 				propertyManager.addProperty((String)key,serviceProperties.getProperty((String)key));
 			}
 		}


### PR DESCRIPTION
I have tested on the cluster. The # of read requests for splice:16 does not increase if I keep running SQL queries