### PR TITLE
SPLICE-2006 TPC-C run fails to complete, Region Servers die (2.6)

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
@@ -191,8 +191,6 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
 
     @Override
     public void close() throws StandardException {
-        if (isClosed())
-            return;
         if (uuid != null) {
             EngineDriver.driver().getOperationManager().unregisterOperation(uuid);
             logExecutionEnd();


### PR DESCRIPTION
Removing checking if already closed fixes memory leak.
This fix has already been integrated in master.