### PR TITLE
DB-6511. Fixed Discrepancy between internal and external Nexus repos (2.6)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,35 +106,6 @@
         <maven>3.3.0</maven>
     </prerequisites>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   distributionManagement -
-
-  Where 'mvn deploy' uploads files to.
-   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-    <distributionManagement>
-        <!--
-          TODO: public nexus required for open src
-          everything is in place, but still a little opaque:
-          - we do a separate set of deployments for "core" to splicemachine-public in Jenkins
-          - we use Maven opts (-DaltReleaseDeploymentRepository/-DaltSnapshotDeploymentRepository)
-        -->
-        <repository>
-            <id>splicemachine</id>
-            <name>Splice Machine Releases</name>
-            <url>http://nexus.splicemachine.com/nexus/content/repositories/releases</url>
-            <uniqueVersion>false</uniqueVersion>
-        </repository>
-        <snapshotRepository>
-            <id>splicemachine</id>
-            <name>Splice Machine Snapshots</name>
-            <url>http://nexus.splicemachine.com/nexus/content/repositories/snapshots</url>
-            <uniqueVersion>false</uniqueVersion>
-        </snapshotRepository>
-        <site>
-            <id>SpliceMachine</id>
-            <url>file://${basedir}/target/site</url>
-        </site>
-    </distributionManagement>
-    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  dependencies - should be a very minimal set of dependencies here as it is difficult to
  predict what all inhering projects will want/need and they can't exclude things
  inherited from the parent pom.
@@ -698,6 +669,49 @@
         </plugins>
     </build>
     <profiles>
+        <profile>
+            <id>splicemachine-internal</id>
+            <distributionManagement>
+               <repository>
+                   <id>splicemachine</id>
+                   <name>Splice Machine Releases</name>
+                   <url>http://nexus.splicemachine.com/nexus/content/repositories/releases</url>
+                   <uniqueVersion>false</uniqueVersion>
+               </repository>
+               <snapshotRepository>
+                   <id>splicemachine</id>
+                   <name>Splice Machine Snapshots</name>
+                   <url>http://nexus.splicemachine.com/nexus/content/repositories/snapshots</url>
+                   <uniqueVersion>false</uniqueVersion>
+               </snapshotRepository>
+               <site>
+                   <id>SpliceMachine</id>
+                   <url>file://${basedir}/target/site</url>
+               </site>
+           </distributionManagement>
+        </profile>
+        <profile>
+            <id>splicemachine-external</id>
+            <distributionManagement>
+               <repository>
+                   <id>splicemachine</id>
+                   <name>Splice Machine Releases</name>
+                   <url>http://repository.splicemachine.com/nexus/content/repositories/releases</url>
+                   <uniqueVersion>false</uniqueVersion>
+               </repository>
+               <snapshotRepository>
+                   <id>splicemachine</id>
+                   <name>Splice Machine Snapshots</name>
+                   <url>http://repository.splicemachine.com/nexus/content/repositories/snapshots</url>
+                   <uniqueVersion>false</uniqueVersion>
+               </snapshotRepository>
+               <site>
+                   <id>SpliceMachine</id>
+                   <url>file://${basedir}/target/site</url>
+               </site>
+           </distributionManagement>
+        </profile>
+
         <profile>
             <id>core</id>
             <activation>


### PR DESCRIPTION
… Open source builds will be published to external and internal nexus. In pom.xml, added profiles for distributionManagement. Added two IDs splicemachine-internal and splicemachine-external. The Jenkins projects configurations need to be changed after code is merged.

In Jenkins:

Build -> Invoke top-level Maven targets, replace "-P ${platform},ee" with
-P ${platform},ee,installer,splicemachine-internal,splicemachine-external

Remove lines below
-DaltReleaseDeploymentRepository=splicemachine-public::default::http://repository.splicemachine.com/nexus/content/repositories/releases/
-DaltSnapshotDeploymentRepository=splicemachine-public::default::http://repository.splicemachine.com/nexus/content/repositories/snapshots/