### PR TITLE
DB-6537: fix upsert index(2.6)

### DIFF
--- a/splice_machine/src/test/java/com/splicemachine/derby/test/TPCHIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/TPCHIT.java
@@ -277,7 +277,7 @@ public class TPCHIT extends SpliceUnitTest {
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
-    private static String getResource(String name) {
+    public static String getResource(String name) {
         return SpliceUnitTest.getResourceDirectory() + "tcph/data/" + name;
     }
 


### PR DESCRIPTION
Fix to DB-4165 missed a corner case when a tombstone is added to write buffer, the buffer gets flushed immediately, so the next insert cannot replace it. Here is a description of the original problem 
/*
                 * DB-4165: When we do an update to the base table, that translates to a delete
                 * and then an insert in the index. For situations where we update the indexed fields
                 * to different values, this is fine because the delete will go to one HBase row, and the
                 * insert to another. However, if you update an indexed field by setting it to the same value
                 * (i.e. update foo set bar = bar), then the insert and the delete will end up going to the same
                 * location, and the result is an insert and a delete on the same row with the same transaction.
                 * The SI module treats this as a delete (because there is no anti-tombstone record at that location),
                 * and thus the row goes missing from the index; the end result is a corrupted index.
                 *
                 * To avoid this scenario, we check for whether the insert and the delete have the same row key. If
                 * they do, then we hijack the previous KVPair(the deleteMutation), and change it into an update mutation
                 * instead. That way, we still get the WWConflict detection, but we don't have an insert and a delete
                 * competing for the row results.
                 */

The fix is to not add tombstone to write buffer before checking rowkey with insert row.