### PR TITLE
DB-6603: prevent incremental backup from losing changes(2.5)

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceHFileCleaner.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceHFileCleaner.java
@@ -45,10 +45,10 @@ public class SpliceHFileCleaner extends BaseHFileCleanerDelegate {
             Path rootDir = FSUtils.getRootDir(conf);
             FileSystem fs = FSUtils.getCurrentFileSystem(conf);
             /**An archived HFile is reserved for an incremental backup if
-             * 1) There exists a successful full/incremental backup for the database
+             * 1) There exists a successful full/incremental backup for the database or a backup is running
              * 2) An empty file with the same name exists in backup directory.
             */
-            if (BackupUtils.existsDatabaseBackup(fs, rootDir)) {
+            if (BackupUtils.backupInProgress() || BackupUtils.existsDatabaseBackup(fs, rootDir)) {
                 String p = BackupUtils.getBackupFilePath(fStat.getPath().toString());
                 if (fs.exists(new Path(p))) {
                     if (LOG.isDebugEnabled()) {

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupRestoreConstants.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupRestoreConstants.java
@@ -21,7 +21,8 @@ import org.apache.hadoop.hbase.util.Bytes;
 
 public class BackupRestoreConstants {
 
-    public static String BACKUP_DIR = "backup";
+    public static final String BACKUP_DIR = "backup";
+    public static final String BACKUP_DATA_DIR = "data";
     public static final String BACKUP_RECORD_FILE_NAME = "SYSBACKUP";
     public static final String REGION_FILE_NAME = ".regioninfo";
     public static final String ARCHIVE_DIR = "archive";


### PR DESCRIPTION
During the first full backup, some incremental changes were produced right after a region finishes backup. SpliceHFileCleaner should keep incremental changes either it finds there was successful backup in the system, or there is an ongoing backup.