### PR TITLE
DB-6541 User defined function does not work on spark

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextService.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextService.java
@@ -362,8 +362,11 @@ public final class ContextService{
             }
         }
 
-        if(cm.activeCount!=-1){
-            if(--cm.activeCount<=0){
+        ContextManager current = getCurrentContextManager();
+        if (current == null) return;
+
+        if(current.activeCount!=-1){
+            if(current == cm && --cm.activeCount<=0){
                 cm.activeThread=null;
 
                 // If the ContextManager is empty
@@ -383,7 +386,10 @@ public final class ContextService{
 
         java.util.Stack stack=(java.util.Stack)tcl.get();
 
-        Object oldCM=stack.pop();
+        int idx = stack.lastIndexOf(cm);
+        if (idx >= 0) {
+            stack.remove(idx);
+        }
 
         ContextManager nextCM=(ContextManager)stack.peek();
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
@@ -59,7 +59,8 @@ public class ActivationHolder implements Externalizable {
     private Activation activation;
     private SpliceObserverInstructions soi;
     private TxnView txn;
-    private boolean initialized=false;
+    private boolean initialized = false;
+    private int reinitCount = 0;
     private SpliceTransactionResourceImpl impl;
     private boolean prepared = false;
 
@@ -152,7 +153,7 @@ public class ActivationHolder implements Externalizable {
     }
 
     public synchronized void init(TxnView txn){
-        if(initialized)
+        if (initialized)
             return;
         initialized = true;
         try {
@@ -197,11 +198,15 @@ public class ActivationHolder implements Externalizable {
         reinitialize(otherTxn, true);
     }
 
-    public void reinitialize(TxnView otherTxn, boolean reinit) {
+    public synchronized void reinitialize(TxnView otherTxn, boolean reinit) {
         TxnView txnView = otherTxn!=null ? otherTxn : this.txn;
         initialized = true;
+        reinitCount += 1;
         try {
-            close();
+            if (prepared) {
+                impl.close();
+                prepared = false;
+            }
 
             impl = new SpliceTransactionResourceImpl();
             prepared =  impl.marshallTransaction(txnView);
@@ -222,10 +227,12 @@ public class ActivationHolder implements Externalizable {
         }
     }
 
-    public void close() {
-        if (prepared) {
-            impl.close();
-            prepared = false;
+    public synchronized void close() {
+        if (--reinitCount == 0) {
+            if (prepared) {
+                impl.close();
+                prepared = false;
+            }
         }
     }
 }


### PR DESCRIPTION
SPLICE-1983 is undone to restore UDF functionality. ActivationHolder.close() is uncommented in SMRecordReaderImpl to avoid memory leaks. Trigger ITs are fixed by guarding against out-of-order  activationHolder.close() called from SMRecordReaderImpl and SMRecordWriter (violated nesting or push/pop semantics) whether sharing the same activationHolder or using different instances.