### PR TITLE
DB-6516: disable dependency manager for spark(2.5)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -2114,4 +2114,6 @@ public interface DataDictionary{
     void addSnapshot(TupleDescriptor descriptor, TransactionController tc) throws StandardException;
 
     void deleteSnapshot(String snapshotName, long conglomeratenumber, TransactionController tc) throws StandardException;
+
+    boolean canUseDependencyManager();
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicDependencyManager.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicDependencyManager.java
@@ -135,7 +135,9 @@ public class BasicDependencyManager implements DependencyManager {
 		@exception StandardException thrown if something goes wrong
 	 */
 	public void addDependency(Dependent d, Provider p, ContextManager cm) throws StandardException {
-		addDependency(d, p, cm, null);
+        if (dd.canUseDependencyManager()) {
+			addDependency(d, p, cm, null);
+		}
 	}
 
     /**

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -918,6 +918,11 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
     }
 
     @Override
+    public boolean canUseDependencyManager() {
+        return !SpliceClient.isClient;
+    }
+
+    @Override
     public ColPermsDescriptor getColumnPermissions(UUID colPermsUUID) throws StandardException {
         Manager manager = EngineDriver.driver().manager();
             return manager.isEnabled()?manager.getColPermsManager().getColumnPermissions(this,colPermsUUID):null;


### PR DESCRIPTION
Disable dependency manager for splice adapter because it caused memory leak