### PR TITLE
DB-6685 invalidate dictionary cache after update schema owner

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
@@ -45,9 +45,7 @@ import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.store.access.conglomerate.Conglomerate;
 import com.splicemachine.db.impl.sql.GenericStatement;
 import com.splicemachine.db.impl.sql.GenericStorablePreparedStatement;
-import com.splicemachine.utils.Pair;
 import org.apache.log4j.Logger;
-import org.spark_project.guava.cache.Cache;
 import org.spark_project.guava.cache.CacheBuilder;
 import org.spark_project.guava.cache.RemovalListener;
 import org.spark_project.guava.cache.RemovalNotification;
@@ -185,6 +183,11 @@ public class DataDictionaryCache {
         return td;
     }
 
+    public void clearOidTdCache() throws StandardException {
+        if (LOG.isDebugEnabled())
+            LOG.debug("clearOidTdCache ");
+        oidTdCache.invalidateAll();
+    }
 
     public List<PartitionStatisticsDescriptor> partitionStatisticsCacheFind(Long conglomID) throws StandardException {
         if (!dd.canReadCache(null))
@@ -222,6 +225,13 @@ public class DataDictionaryCache {
         if (LOG.isDebugEnabled())
             LOG.debug("permissionCacheRemove " + desc);
         permissionsCache.invalidate(desc);
+    }
+
+    public void clearPermissionCache() throws StandardException {
+        if (LOG.isDebugEnabled())
+            LOG.debug("clearPermissionsCache ");
+        permissionsCache.invalidateAll();
+
     }
 
     public PermissionsDescriptor permissionCacheFind(PermissionsDescriptor desc) throws StandardException {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
@@ -156,6 +156,12 @@ public class DataDictionaryCache {
         return td;
     }
 
+    public void clearNameTdCache() throws StandardException {
+        if (LOG.isDebugEnabled())
+            LOG.debug("clearNameTdCache ");
+        nameTdCache.invalidateAll();
+    }
+
     public TableDescriptor oidTdCacheFind(UUID tableID) throws StandardException {
         if (!dd.canReadCache(null))
             return null;

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLUtils.java
@@ -385,6 +385,7 @@ public class DDLUtils {
         dd.getDataDictionaryCache().clearPermissionCache();
         // clear  TableDescriptor cache as it may reference the schema with an out-of-date authorization id
         dd.getDataDictionaryCache().clearOidTdCache();
+        dd.getDataDictionaryCache().clearNameTdCache();
     }
 
     public static void preCreateIndex(DDLMessage.DDLChange change, DataDictionary dd, DependencyManager dm) throws StandardException {

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLUtils.java
@@ -14,27 +14,16 @@
 
 package com.splicemachine.derby.ddl;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
 import com.carrotsearch.hppc.BitSet;
-import com.splicemachine.db.iapi.services.loader.ClassFactory;
-import com.splicemachine.db.iapi.sql.dictionary.*;
-import org.apache.log4j.Logger;
-
 import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.concurrent.Clock;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
+import com.splicemachine.db.iapi.services.loader.ClassFactory;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.depend.DependencyManager;
+import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.impl.services.uuid.BasicUUID;
 import com.splicemachine.db.impl.sql.compile.ColumnDefinitionNode;
@@ -59,6 +48,12 @@ import com.splicemachine.storage.DataScan;
 import com.splicemachine.stream.Stream;
 import com.splicemachine.stream.StreamException;
 import com.splicemachine.utils.SpliceLogUtils;
+import org.apache.log4j.Logger;
+
+import java.io.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Created by jleach on 11/12/15.
@@ -380,6 +375,16 @@ public class DDLUtils {
         if (LOG.isDebugEnabled())
             SpliceLogUtils.debug(LOG,"preDropSchema with change=%s",change);
         dd.getDataDictionaryCache().schemaCacheRemove(change.getDropSchema().getSchemaName());
+    }
+
+    public static void preUpdateSchemaOwner(DDLMessage.DDLChange change, DataDictionary dd, DependencyManager dm) throws StandardException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG,"preUpdateSchemaOwner with change=%s",change);
+        dd.getDataDictionaryCache().schemaCacheRemove(change.getUpdateSchemaOwner().getSchemaName());
+        // clear permission cache as it has out-of-date permission info for the schema
+        dd.getDataDictionaryCache().clearPermissionCache();
+        // clear  TableDescriptor cache as it may reference the schema with an out-of-date authorization id
+        dd.getDataDictionaryCache().clearOidTdCache();
     }
 
     public static void preCreateIndex(DDLMessage.DDLChange change, DataDictionary dd, DependencyManager dm) throws StandardException {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
@@ -359,6 +359,9 @@ public class SpliceDatabase extends BasicDatabase{
                     case DROP_SCHEMA:
                         DDLUtils.preDropSchema(change,dataDictionary,dependencyManager);
                         break;
+                    case UPDATE_SCHEMA_OWNER:
+                        DDLUtils.preUpdateSchemaOwner(change,dataDictionary,dependencyManager);
+                        break;
                     case DROP_ROLE:
                         DDLUtils.preDropRole(change,dataDictionary,dependencyManager);
                         break;

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
@@ -1081,7 +1081,7 @@ public class SpliceAdmin extends BaseAdminProcedures{
                 throw StandardException.newException(String.format("User '%s' does not exist.", ownerName));
             }
             ((DataDictionaryImpl)dd).updateSchemaAuth(schemaName, ownerName, tc);
-            DDLMessage.DDLChange ddlChange = ProtoUtil.createDropSchema(tc.getActiveStateTxn().getTxnId(), schemaName);
+            DDLMessage.DDLChange ddlChange = ProtoUtil.createUpdateSchemaOwner(tc.getActiveStateTxn().getTxnId(), schemaName, ownerName);
             tc.prepareDataDictionaryChange(DDLUtils.notifyMetadataChange(ddlChange));
         } catch (StandardException se) {
             throw PublicAPI.wrapStandardException(se);

--- a/splice_machine/src/main/java/com/splicemachine/protobuf/ProtoUtil.java
+++ b/splice_machine/src/main/java/com/splicemachine/protobuf/ProtoUtil.java
@@ -69,6 +69,16 @@ public class ProtoUtil {
                 .build();
     }
 
+    public static DDLChange createUpdateSchemaOwner(long txnId, String schemaName, String ownerName) {
+        return DDLChange.newBuilder().setTxnId(txnId).setUpdateSchemaOwner(UpdateSchemaOwner.newBuilder()
+                .setSchemaName(schemaName)
+                .setOwnerName(ownerName)
+                .build())
+                .setDdlChangeType(DDLChangeType.UPDATE_SCHEMA_OWNER)
+                .build();
+    }
+
+
     public static DDLChange createRefreshEnterpriseFeatures(long txnId) {
         return DDLChange.newBuilder().setTxnId(txnId).setRefreshEnterpriseFeatures(RefreshEnterpriseFeatures.newBuilder().build())
                 .setDdlChangeType(DDLChangeType.REFRESH_ENTRPRISE_FEATURES)

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
@@ -14,20 +14,19 @@
 
 package com.splicemachine.derby.test.framework;
 
-import com.splicemachine.derby.utils.ConglomerateUtils;
-import org.spark_project.guava.collect.Lists;
 import org.apache.log4j.Logger;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.junit.runners.model.MultipleFailureException;
+import org.spark_project.guava.collect.Lists;
 
 import java.sql.*;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import static org.spark_project.guava.base.Strings.isNullOrEmpty;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.spark_project.guava.base.Strings.isNullOrEmpty;
 
 /**
  * A TestWatcher that provides Connections, Statements, and ResultSets and then closes them when finished() is called.
@@ -94,6 +93,15 @@ public class SpliceWatcher extends TestWatcher {
      */
     public TestConnection createConnection(String userName, String password) throws Exception {
         currentConnection = new TestConnection(SpliceNetConnection.getConnectionAs(userName, password));
+        connections.add(currentConnection);
+        if (!isNullOrEmpty(defaultSchema)) {
+            setSchema(defaultSchema);
+        }
+        return currentConnection;
+    }
+
+    public TestConnection createConnection(String providedURL, String userName, String password) throws Exception {
+        currentConnection = new TestConnection(SpliceNetConnection.getConnectionAs(providedURL, userName, password));
         connections.add(currentConnection);
         if (!isNullOrEmpty(defaultSchema)) {
             setSchema(defaultSchema);

--- a/splice_protocol/src/main/protobuf/DDL.proto
+++ b/splice_protocol/src/main/protobuf/DDL.proto
@@ -169,6 +169,11 @@ message RevokePrivilege {
         optional RevokeSchemaPrivilege  revokeSchemaPrivilege = 6;
 }
 
+message UpdateSchemaOwner {
+        required string schemaName = 1;
+        required string ownerName = 2;
+}
+
 message TentativeFK {
         optional int64 baseConglomerate = 1;
         optional int64 conglomerate = 2;
@@ -320,6 +325,7 @@ enum DDLChangeType {
     NOTIFY_MODIFY_CLASSPATH = 35;
     REFRESH_ENTRPRISE_FEATURES = 36;
     CREATE_ROLE = 37;
+    UPDATE_SCHEMA_OWNER=38;
 }
 
 message DDLChange {
@@ -357,4 +363,5 @@ message DDLChange {
     optional NotifyModifyClasspath notifyModifyClasspath = 32;
     optional RefreshEnterpriseFeatures refreshEnterpriseFeatures = 33;
     optional CreateRole createRole = 34;
+    optional UpdateSchemaOwner updateSchemaOwner = 35;
 }


### PR DESCRIPTION
Please see problem description and solution in [DB-6685](https://splicemachine.atlassian.net/browse/DB-6685?focusedCommentId=53176&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-53176)