### PR TITLE
DB-6722 Fixing Log4j inclusion in hbase_sql jar

### DIFF
--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -559,6 +559,7 @@
                         <exclude>**/com/splicemachine/backup/*</exclude>
                         <exclude>**/core-site.xml</exclude>
                         <exclude>**/yarn-site.xml</exclude>
+                        <exclude>**/*log4j.properties</exclude>
                     </excludes>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Fixes log4h inclusion which causes issues for log files on the cluster.