### PR TITLE
SPLICE-2066: Duplicate create connection in Splicemachinecontext(2.5)

### DIFF
--- a/splice_spark/src/main/spark2.2/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
+++ b/splice_spark/src/main/spark2.2/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
@@ -65,7 +65,6 @@ class SplicemachineContext(url: String) extends Serializable {
     val maker = new EmbedConnectionMaker
     val dbProperties = new Properties
     dbProperties.put("useSpark", "true")
-    maker.createNew(dbProperties)
     dbProperties.put(EmbedConnection.INTERNAL_CONNECTION, "true")
     maker.createNew(dbProperties)
   }


### PR DESCRIPTION
@jleach4 This was missed in spark2.2 in the recent merge.