### PR TITLE
DB-6754 Add build number for hdp2.6.3

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -583,7 +583,8 @@
                                     <name>splicemachine</name>
                                     <targetOS>linux</targetOS>
                                     <classifier>splicemachine</classifier>
-                                    <version>${envClassifier}_${project.version}.${parcel.patch}</version>
+                                    <version>${envClassifier}_${project.version}</version>
+				    <release>${parcel.patch}</release>
                                     <group>Applications/Internet</group>
                                     <licence>Copyright © 2018 Splice Machine Inc. Licensed under the Apache License, Version 2.0.</licence>
                                     <requires>
@@ -610,7 +611,8 @@
                                     <targetOS>linux</targetOS>
                                     <classifier>splicemachine_ambari_service</classifier>
                                     <name>splicemachine_ambari_service</name>
-                                    <version>${envClassifier}_${project.version}.${parcel.patch}</version>
+                                    <version>${envClassifier}_${project.version}</version>
+				    <release>${parcel.patch}</release>
                                     <group>Applications/Internet</group>
                                     <licence>Copyright © 2018 Splice Machine Inc. Licensed under the Apache License, Version 2.0.</licence>
                                     <requires>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -583,8 +583,7 @@
                                     <name>splicemachine</name>
                                     <targetOS>linux</targetOS>
                                     <classifier>splicemachine</classifier>
-                                    <version>${envClassifier}_${project.version}</version>
-				    <release>${parcel.patch}</release>
+                                    <version>${envClassifier}.${project.version}.${parcel.patch}</version>
                                     <group>Applications/Internet</group>
                                     <licence>Copyright © 2018 Splice Machine Inc. Licensed under the Apache License, Version 2.0.</licence>
                                     <requires>
@@ -611,8 +610,7 @@
                                     <targetOS>linux</targetOS>
                                     <classifier>splicemachine_ambari_service</classifier>
                                     <name>splicemachine_ambari_service</name>
-                                    <version>${envClassifier}_${project.version}</version>
-				    <release>${parcel.patch}</release>
+                                    <version>${envClassifier}.${project.version}.${parcel.patch}</version>
                                     <group>Applications/Internet</group>
                                     <licence>Copyright © 2018 Splice Machine Inc. Licensed under the Apache License, Version 2.0.</licence>
                                     <requires>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -583,7 +583,7 @@
                                     <name>splicemachine</name>
                                     <targetOS>linux</targetOS>
                                     <classifier>splicemachine</classifier>
-                                    <version>${envClassifier}_${project.version}</version>
+                                    <version>${envClassifier}_${project.version}.${parcel.patch}</version>
                                     <group>Applications/Internet</group>
                                     <licence>Copyright © 2018 Splice Machine Inc. Licensed under the Apache License, Version 2.0.</licence>
                                     <requires>
@@ -610,7 +610,7 @@
                                     <targetOS>linux</targetOS>
                                     <classifier>splicemachine_ambari_service</classifier>
                                     <name>splicemachine_ambari_service</name>
-                                    <version>${envClassifier}_${project.version}</version>
+                                    <version>${envClassifier}_${project.version}.${parcel.patch}</version>
                                     <group>Applications/Internet</group>
                                     <licence>Copyright © 2018 Splice Machine Inc. Licensed under the Apache License, Version 2.0.</licence>
                                     <requires>


### PR DESCRIPTION
The hdp2.6.3 rpm package names do not match our naming conventions. It places "1" at end of the name for release build, places timestamps at the end of the name for SNAPSHOT build. The release scripts cannot find the packages and upload to S3 bucket. Added build number at the end of package name.