### PR TITLE
SPLICE-137 allow default roles to be set automatically in a session

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -31,30 +31,33 @@
 
 package com.splicemachine.db.iapi.sql.conn;
 
+import com.splicemachine.db.catalog.UUID;
+import com.splicemachine.db.iapi.db.Database;
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.ContextId;
 import com.splicemachine.db.iapi.services.context.Context;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
-import com.splicemachine.db.iapi.db.Database;
-import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.iapi.sql.compile.CompilerContext;
-import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
-import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
-import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
-import com.splicemachine.db.iapi.sql.compile.OptimizerFactory;
-import com.splicemachine.db.iapi.types.DataValueFactory;
+import com.splicemachine.db.iapi.sql.Activation;
+import com.splicemachine.db.iapi.sql.LanguageFactory;
+import com.splicemachine.db.iapi.sql.ParameterValueSet;
+import com.splicemachine.db.iapi.sql.PreparedStatement;
 import com.splicemachine.db.iapi.sql.compile.ASTVisitor;
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
+import com.splicemachine.db.iapi.sql.compile.OptimizerFactory;
 import com.splicemachine.db.iapi.sql.depend.Provider;
+import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
+import com.splicemachine.db.iapi.sql.dictionary.RoleGrantDescriptor;
+import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
+import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.sql.execute.ConstantAction;
 import com.splicemachine.db.iapi.sql.execute.CursorActivation;
 import com.splicemachine.db.iapi.sql.execute.ExecutionStmtValidator;
-import com.splicemachine.db.iapi.sql.Activation;
-import com.splicemachine.db.iapi.sql.LanguageFactory;
-import com.splicemachine.db.iapi.sql.PreparedStatement;
-import com.splicemachine.db.iapi.sql.ParameterValueSet;
 import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.db.iapi.types.DataValueFactory;
 import com.splicemachine.db.impl.sql.execute.TriggerExecutionContext;
-import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.impl.sql.execute.TriggerExecutionStack;
+
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -1109,14 +1112,21 @@ public interface LanguageConnectionContext extends Context {
 	void setCurrentRole(Activation a, String role);
 
 	/**
-	 * Get the current role authorization identifier of the dynamic
+	 * Set the current role
+	 *
+	 * @param a activation of set role statement
+	 * @param roles  the list of roles to be set to current
+	 */
+	public void setCurrentRoles(Activation a, List<String> roles);
+
+	/**
+	 * Get the current set of roles of the dynamic
 	 * call context associated with this activation.
 	 *
 	 * @param a activation of statement needing current role
-	 * @return String	the role id
+	 * @return List of roleids
 	 */
-	String getCurrentRoleId(Activation a);
-
+	List<String> getCurrentRoles(Activation a);
 	/**
 	 * Get the current role authorization identifier in external delimited form
 	 * (not case normal form) of the dynamic call context associated with this
@@ -1144,6 +1154,22 @@ public interface LanguageConnectionContext extends Context {
 	 */
 	boolean roleIsSettable(Activation a, String role)
             throws StandardException;
+
+	/**
+	 *
+	 * @param a activation
+	 * @param roleName role name for the role to remove from session's current role list.
+	 * @throws StandardException
+	 */
+	public void removeRole(Activation a, String roleName);
+
+	/**
+	 *
+	 * @param a activation
+	 * @param rolesToRemove a list of roles to remove from session's current role list.
+	 * @throws StandardException
+	 */
+	public void removeRoles(Activation a, List<String> rolesToRemove);
 
 	/**
 	 * Create a new SQL session context for the current activation on the basis

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/SQLSessionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/SQLSessionContext.java
@@ -31,8 +31,9 @@
 
 package com.splicemachine.db.iapi.sql.conn;
 
-import java.lang.String;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
+
+import java.util.List;
 
 /**
  * An implementation of this interface encapsulates some of the SQL
@@ -84,11 +85,6 @@ public interface SQLSessionContext {
     void setRole(String role);
 
     /**
-     * Get the SQL role of this SQL connection context
-     */
-    String getRole();
-
-    /**
      * Set the SQL current user of this SQL connection context
      */
     void setUser(String user);
@@ -107,4 +103,13 @@ public interface SQLSessionContext {
      * Get the schema of this SQL connection context
      */
     SchemaDescriptor getDefaultSchema();
+
+    /**
+     * Get the SQL roles of this SQL connection context
+     */
+    List<String> getRoles();
+
+    void setRoles(List<String> roles);
+
+    void removeRole(String roleName);
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDescriptorGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDescriptorGenerator.java
@@ -593,13 +593,16 @@ public class DataDescriptorGenerator
 	 *        this descriptor
      * @param isDef if true, this descriptor represents a role
      *              definition, otherwise it represents a grant.
+	 * @param isDefaultRole if true, the role is a default role of the
+	 *                      user granted the role
      */
     public RoleGrantDescriptor newRoleGrantDescriptor(UUID uuid,
 													  String roleName,
 													  String grantee,
 													  String grantor,
 													  boolean withadminoption,
-													  boolean isDef)
+													  boolean isDef,
+													  boolean isDefaultRole)
         throws StandardException
     {
         return new RoleGrantDescriptor(dataDictionary,
@@ -608,7 +611,8 @@ public class DataDescriptorGenerator
 									   grantee,
 									   grantor,
 									   withadminoption,
-									   isDef);
+									   isDef,
+				                       isDefaultRole);
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -2121,4 +2121,13 @@ public interface DataDictionary{
     void deleteSnapshot(String snapshotName, long conglomeratenumber, TransactionController tc) throws StandardException;
 
     boolean canUseDependencyManager();
+
+    /**
+     * Get default roles granted to a user
+     *
+     * @param username      the name of the user we want to find the default roles granted
+     * @param tc            the transaction to use for dropping
+     * @throws StandardException
+     */
+    List<String> getDefaultRoles(String username, TransactionController tc) throws StandardException;
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/RoleGrantDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/RoleGrantDescriptor.java
@@ -66,6 +66,7 @@ public class RoleGrantDescriptor extends TupleDescriptor
     private boolean withAdminOption;
     private final boolean isDef; // if true, represents a role
                                  // definition, else a grant
+    private boolean isDefaultRole; // if true, it is a default role of the user granted this role
 
     /**
      * Constructor
@@ -78,6 +79,7 @@ public class RoleGrantDescriptor extends TupleDescriptor
      * @param grantor
      * @param withAdminOption
      * @param isDef
+     * @param isDefaultRole
      *
      */
     public RoleGrantDescriptor(DataDictionary dd,
@@ -86,7 +88,8 @@ public class RoleGrantDescriptor extends TupleDescriptor
                                String grantee,
                                String grantor,
                                boolean withAdminOption,
-                               boolean isDef) {
+                               boolean isDef,
+                               boolean isDefaultRole) {
         super(dd);
         this.uuid = uuid;
         this.roleName = roleName;
@@ -94,6 +97,7 @@ public class RoleGrantDescriptor extends TupleDescriptor
         this.grantor = grantor;
         this.withAdminOption = withAdminOption;
         this.isDef = isDef;
+        this.isDefaultRole = isDefaultRole;
     }
 
     public UUID getUUID() {
@@ -112,6 +116,13 @@ public class RoleGrantDescriptor extends TupleDescriptor
         return isDef;
     }
 
+    public boolean isDefaultRole() {
+        return isDefaultRole;
+    }
+
+    public void setDefaultRole(boolean isDefault) {
+        isDefaultRole = isDefault;
+    }
     public String getRoleName() {
         return roleName;
     }
@@ -131,7 +142,8 @@ public class RoleGrantDescriptor extends TupleDescriptor
                 "grantor: " + grantor + "\n" +
                 "grantee: " + grantee + "\n" +
                 "withadminoption: " + withAdminOption + "\n" +
-                "isDef: " + isDef + "\n";
+                "isDef: " + isDef + "\n" +
+                "defaultRole: " + isDefaultRole + "\n";
         } else {
             return "";
         }
@@ -197,6 +209,7 @@ public class RoleGrantDescriptor extends TupleDescriptor
     {
         return ((isDef ? "CREATE ROLE: " : "GRANT ROLE: ") + roleName +
                 " GRANT TO: " + grantee +
+                (isDefaultRole? " AS DEFAULT": "") +
                 " GRANTED BY: " + grantor +
                 (withAdminOption? " WITH ADMIN OPTION" : ""));
     }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementColumnPermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementColumnPermission.java
@@ -31,16 +31,19 @@
 
 package com.splicemachine.db.iapi.sql.dictionary;
 
-import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.catalog.UUID;
-import com.splicemachine.db.iapi.sql.conn.Authorizer;
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
-import com.splicemachine.db.iapi.services.io.FormatableBitSet;
-import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
-import com.splicemachine.db.iapi.sql.Activation;
-import com.splicemachine.db.iapi.sql.execute.ExecPreparedStatement;
-import com.splicemachine.db.iapi.sql.depend.DependencyManager;
 import com.splicemachine.db.iapi.services.context.ContextManager;
+import com.splicemachine.db.iapi.services.io.FormatableBitSet;
+import com.splicemachine.db.iapi.sql.Activation;
+import com.splicemachine.db.iapi.sql.conn.Authorizer;
+import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
+import com.splicemachine.db.iapi.sql.depend.DependencyManager;
+import com.splicemachine.db.iapi.sql.execute.ExecPreparedStatement;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This class describes a column permission used (required) by a statement.
@@ -160,16 +163,16 @@ public class StatementColumnPermission extends StatementTablePermission
 
 		// If columns are still unauthorized, look to role closure for
 		// resolution.
-		String role = lcc.getCurrentRoleId(activation);
-		RoleGrantDescriptor rd = null;
-
-		if (role != null) {
+		List<String> currentRoles = lcc.getCurrentRoles(activation);
+		List<String> rolesToRemove = new ArrayList<>();
+		String lastRole = null;
+		for (String role : currentRoles) {
 			// Check that role is still granted to current user or
 			// to PUBLIC: A revoked role which is current for this
 			// session, is lazily set to none when it is attempted
 			// used.
 			String dbo = dd.getAuthorizationDatabaseOwner();
-            rd = dd.getRoleGrantDescriptor(role, currentUserId, dbo);
+			RoleGrantDescriptor rd = dd.getRoleGrantDescriptor(role, currentUserId, dbo);
 
 			if (rd == null) {
 				rd = dd.getRoleGrantDescriptor
@@ -181,8 +184,9 @@ public class StatementColumnPermission extends StatementTablePermission
 			if (rd == null) {
 				// we have lost the right to set this role, so we can't
 				// make use of any permission granted to it or its ancestors.
-				lcc.setCurrentRole(activation, null);
+				rolesToRemove.add(role);
 			} else {
+				lastRole = role;
 				// The current role is OK, so we can make use of
 				// any permission granted to it.
 				//
@@ -235,8 +239,13 @@ public class StatementColumnPermission extends StatementTablePermission
 						}
 					}
 				}
+				//if we get the permission we want, we don't need to look further
+				if (unresolvedColumns.anySetBit() < 0)
+					break;
 			}
 		}
+		lcc.removeRoles(activation, rolesToRemove);
+
 		TableDescriptor td = getTableDescriptor(dd);
 		//if we are still here, then that means that we didn't find any select
 		//privilege on the table or any column in the table
@@ -269,22 +278,30 @@ public class StatementColumnPermission extends StatementTablePermission
 					td.getName());
 			}
 		} else {
-			// We found and successfully applied a role to resolve the
+			// We found and successfully applied a (set of) role to resolve the
 			// (remaining) required permissions.
 			//
-			// Also add a dependency on the role (qua provider), so
-			// that if role is no longer available to the current
+			// Also add a dependency on the roles (qua provider), so
+			// that if the roles are no longer available to the current
 			// user (e.g. grant is revoked, role is dropped,
 			// another role has been set), we are able to
 			// invalidate the ps or activation (the latter is used
 			// if the current role changes).
 			DependencyManager dm = dd.getDependencyManager();
-			RoleGrantDescriptor rgd =
-				dd.getRoleDefinitionDescriptor(role);
 			ContextManager cm = lcc.getContextManager();
-
-			dm.addDependency(ps, rgd, cm);
-			dm.addDependency(activation, rgd, cm);
+			// get the currentRoles again, as some may have been removed
+			// during the loop above due to the loss of the right to set this role
+			// we need to set dependency for all roles checked so far, as the privileges of columns
+			// may come from multiple roles
+			currentRoles = lcc.getCurrentRoles(activation);
+			for (String role: currentRoles) {
+				RoleGrantDescriptor rgd =
+						dd.getRoleDefinitionDescriptor(role);
+				dm.addDependency(ps, rgd, cm);
+				dm.addDependency(activation, rgd, cm);
+				if (role.equals(lastRole))
+					break;
+			}
 		}
 
 	} // end of check

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/RoleClosureIteratorImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/RoleClosureIteratorImpl.java
@@ -31,12 +31,12 @@
 
 package com.splicemachine.db.impl.sql.catalog;
 
-import java.util.*;
-
-import com.splicemachine.db.iapi.sql.dictionary.RoleGrantDescriptor;
-import com.splicemachine.db.iapi.sql.dictionary.RoleClosureIterator;
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.dictionary.RoleClosureIterator;
+import com.splicemachine.db.iapi.sql.dictionary.RoleGrantDescriptor;
 import com.splicemachine.db.iapi.store.access.TransactionController;
+
+import java.util.*;
 
 /**
  * Allows iterator over the role grant closure defined by the relation
@@ -136,6 +136,7 @@ public class RoleClosureIteratorImpl implements RoleClosureIterator
              inverse ? root : null,
              inverse ? null : root,
              null,
+             false,
              false,
              false);
         List dummyList = new ArrayList();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSBACKUPITEMSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSBACKUPITEMSRowFactory.java
@@ -68,7 +68,7 @@ public class SYSBACKUPITEMSRowFactory extends CatalogRowFactory {
             "a0527143-4f6e-42df-98ab-b1dff6bea7db",
             "a0527143-4f6c-42df-98ab-b1dff6bea7db",
             "a0527143-4f6d-42df-98ab-b1dff6bea7db",
-            "a0527143-4f6e-42df-98ab-b1dff6bea7db"
+            "a0527143-4f6b-42df-98ab-b1dff6bea7db"
     };
 
     public SYSBACKUPITEMSRowFactory(UUIDFactory uuidf, ExecutionFactory ef, DataValueFactory dvf) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSROLESRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSROLESRowFactory.java
@@ -32,6 +32,7 @@
 package com.splicemachine.db.impl.sql.catalog;
 
 import com.splicemachine.db.catalog.UUID;
+import com.splicemachine.db.client.am.Types;
 import com.splicemachine.db.iapi.types.SQLChar;
 import com.splicemachine.db.iapi.types.SQLVarchar;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
@@ -54,9 +55,9 @@ import com.splicemachine.db.iapi.services.sanity.SanityManager;
 
 public class SYSROLESRowFactory extends CatalogRowFactory
 {
-    private static final String TABLENAME_STRING = "SYSROLES";
+    public static final String TABLENAME_STRING = "SYSROLES";
 
-    private static final int SYSROLES_COLUMN_COUNT = 6;
+    private static final int SYSROLES_COLUMN_COUNT = 7;
     /* Column #s for sysinfo (1 based) */
     private static final int SYSROLES_ROLE_UUID = 1;
     private static final int SYSROLES_ROLEID = 2;
@@ -64,12 +65,14 @@ public class SYSROLESRowFactory extends CatalogRowFactory
     private static final int SYSROLES_GRANTOR = 4;
     private static final int SYSROLES_WITHADMINOPTION = 5;
     static final int SYSROLES_ISDEF = 6;
+    static final int SYSROLES_DEFAULT_ROLE = 7;
 
     private static final int[][] indexColumnPositions =
     {
         {SYSROLES_ROLEID, SYSROLES_GRANTEE, SYSROLES_GRANTOR},
         {SYSROLES_ROLEID, SYSROLES_ISDEF},
-        {SYSROLES_ROLE_UUID}
+        {SYSROLES_ROLE_UUID},
+        {SYSROLES_GRANTEE}
     };
 
     static final int SYSROLES_ROLEID_COLPOS_IN_INDEX_ID_EE_OR = 1;
@@ -81,18 +84,22 @@ public class SYSROLESRowFactory extends CatalogRowFactory
     static final int SYSROLES_INDEX_ID_DEF_IDX = 1;
     // UUID
     static final int SYSROLES_INDEX_UUID_IDX = 2;
+    // (grant)EE_DEFAULT(role)
+    public static final int SYSROLES_INDEX_EE_DEFAULT_IDX = 3;
 
     private static  final   boolean[]   uniqueness = {
         true,
         false, // many rows have same roleid and is not a definition
-        true};
+        true,
+        false};
 
     private static final String[] uuids = {
         "e03f4017-0115-382c-08df-ffffe275b270", // catalog UUID
         "c851401a-0115-382c-08df-ffffe275b270", // heap UUID
         "c065801d-0115-382c-08df-ffffe275b270", // SYSROLES_INDEX_ID_EE_OR
         "787c0020-0115-382c-08df-ffffe275b270", // SYSROLES_INDEX_ID_DEF
-        "629f8094-0116-d8f9-5f97-ffffe275b270"  // SYSROLES_INDEX_UUID
+        "629f8094-0116-d8f9-5f97-ffffe275b270", // SYSROLES_INDEX_UUID
+        "629f8098-0116-d8f9-5f97-ffffe275b270"  // SYSROLES_INDEX_EE_DEFAULT
     };
 
     /**
@@ -131,7 +138,8 @@ public class SYSROLESRowFactory extends CatalogRowFactory
         String                  grantee = null;
         String                  grantor = null;
         boolean                 wao = false;
-        boolean                 isdef = false;
+        boolean                 isdef = false;   // is role definition or not
+        boolean                 isDefaultRole = false; // is default role of a user or not
 
         if (td != null)
         {
@@ -144,6 +152,7 @@ public class SYSROLESRowFactory extends CatalogRowFactory
             isdef = rgd.isDef();
             UUID oid = rgd.getUUID();
             oid_string = oid.toString();
+            isDefaultRole = rgd.isDefaultRole();
         }
 
         /* Build the row to insert */
@@ -166,6 +175,9 @@ public class SYSROLESRowFactory extends CatalogRowFactory
 
         /* 6th column is ISDEF */
         row.setColumn(6, new SQLChar(isdef ? "Y" : "N"));
+
+        /* 7th column is DefaultRole */
+        row.setColumn(7, new SQLChar(isDefaultRole? "Y" : "N"));
 
         return row;
     }
@@ -201,7 +213,8 @@ public class SYSROLESRowFactory extends CatalogRowFactory
         String                      grantee;
         String                      grantor;
         String                      wao;
-        String                      isdef;
+        boolean                      isdef;
+        boolean                      isDefaultRole;
         DataDescriptorGenerator     ddg = dd.getDataDescriptorGenerator();
 
         if (SanityManager.DEBUG)
@@ -232,15 +245,26 @@ public class SYSROLESRowFactory extends CatalogRowFactory
 
         // sixth column is isdef (char(1))
         col = row.getColumn(6);
-        isdef = col.getString();
+        isdef = col.getString().equals("Y");
 
+        // seventh column is defaultRole (char(1))
+        col = row.getColumn(7);
+        if (col == null || col.isNull()) {
+            // whether this is a role definition
+            if (!isdef)
+                isDefaultRole = true;
+            else
+                isDefaultRole = false;
+        } else
+            isDefaultRole = col.getString().equals("Y");
         descriptor = ddg.newRoleGrantDescriptor
             (getUUIDFactory().recreateUUID(oid_string),
              roleid,
              grantee,
              grantor,
-                    wao.equals("Y"),
-                    isdef.equals("Y"));
+             wao.equals("Y"),
+             isdef,
+             isDefaultRole);
 
         return descriptor;
     }
@@ -261,6 +285,7 @@ public class SYSROLESRowFactory extends CatalogRowFactory
             SystemColumnImpl.getIdentifierColumn("GRANTOR", false),
             SystemColumnImpl.getIndicatorColumn("WITHADMINOPTION"),
             SystemColumnImpl.getIndicatorColumn("ISDEF"),
+            SystemColumnImpl.getColumn("DEFAULTROLE", Types.CHAR, true, 1)
         };
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GrantRoleNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GrantRoleNode.java
@@ -45,6 +45,7 @@ public class GrantRoleNode extends DDLStatementNode
 {
     private List roles;
     private List grantees;
+    private boolean isDefaultRole;
 
     /**
      * Initialize a GrantRoleNode.
@@ -53,12 +54,14 @@ public class GrantRoleNode extends DDLStatementNode
      * @param grantees list of strings containing grantee names
      */
     public void init(Object roles,
-					 Object grantees)
+					 Object grantees,
+                     Object isDefaultRole)
         throws StandardException
     {
         initAndCheck(null);
         this.roles = (List) roles;
         this.grantees = (List) grantees;
+        this.isDefaultRole = (Boolean)isDefaultRole;
     }
 
 
@@ -70,7 +73,7 @@ public class GrantRoleNode extends DDLStatementNode
     public ConstantAction makeConstantAction() throws StandardException
     {
         return getGenericConstantActionFactory().
-            getGrantRoleConstantAction( roles, grantees);
+            getGrantRoleConstantAction( roles, grantees, isDefaultRole);
     }
 
 
@@ -102,7 +105,7 @@ public class GrantRoleNode extends DDLStatementNode
                 return (super.toString() +
                         sb1.toString() +
                         " TO: " +
-                        sb2.toString() +
+                        sb2.toString() + (isDefaultRole?" AS DEFAULT": "") +
                         "\n");
 		} else {
 			return "";

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -15954,17 +15954,19 @@ roleGrantStatement() throws StandardException :
 {
 	List rolesGranted;
 	List grantees;
+	boolean isDefaultRole = true;
 }
 {
 	/*
 	 * GRANT <rolename> {, <rolename>}* TO <authentication identifier>
-	 *									{, <authentication identifier>}*
+	 *									{, <authentication identifier>}* {AS DEFAULT | NOT AS DEFAULT}
 	 *
 	 * not implemented: WITH ADMIN OPTION, GRANTED BY clauses
 	 */
 	rolesGranted = roleList()
 	<TO>
 	grantees = granteeList()
+	[isDefaultRole = asDefault()]
 	{
 		checkSqlStandardAccess("GRANT <role>");
 		checkVersion( DataDictionary.DD_VERSION_DERBY_10_5, "ROLES");
@@ -15973,10 +15975,24 @@ roleGrantStatement() throws StandardException :
 			(C_NodeTypes.GRANT_ROLE_NODE,
 			 rolesGranted,
 			 grantees,
+			 isDefaultRole,
 			 getContextManager());
 	}
 }
 
+boolean asDefault() throws StandardException :
+{
+}
+{
+   <AS> <_DEFAULT>
+   {
+       return true;
+   }
+   | <NOT> <AS> <_DEFAULT>
+   {
+       return false;
+   }
+}
 
 /*
  * <A NAME="roleList">roleList</A>

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/SQLSessionContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/SQLSessionContextImpl.java
@@ -31,28 +31,59 @@
 
 package com.splicemachine.db.impl.sql.conn;
 
-import java.lang.String;
 import com.splicemachine.db.iapi.sql.conn.SQLSessionContext;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class SQLSessionContextImpl implements SQLSessionContext {
 
     private String currentUser;
-    private String currentRole;
+    private ArrayList<String> currentRoles = new ArrayList<>();
     private SchemaDescriptor currentDefaultSchema;
 
-    public SQLSessionContextImpl (SchemaDescriptor sd, String currentUser) {
-        currentRole = null;
+    public SQLSessionContextImpl (SchemaDescriptor sd, String currentUser, List<String> roles) {
+        if (roles != null)
+            currentRoles.addAll(roles);
         currentDefaultSchema = sd;
         this.currentUser = currentUser;
     }
 
     public void setRole(String role) {
-        currentRole = role;
+        if (role == null) {
+            currentRoles.clear();
+        } else {
+            // check if it already exists
+            for (String aRole : currentRoles) {
+                if (aRole.equals(role))
+                    return;
+            }
+            currentRoles.add(role);
+        }
     }
 
-    public String getRole() {
-        return currentRole;
+    public void removeRole(String roleName) {
+        int i;
+        for (i=0; i< currentRoles.size(); i++) {
+            String aRole = currentRoles.get(i);
+            if (aRole.equals(roleName)) {
+                break;
+            }
+        }
+        if (i < currentRoles.size())
+            currentRoles.remove(i);
+        return;
+    }
+
+    public List<String> getRoles() {
+        return currentRoles;
+    }
+
+    public void setRoles(List<String> roles) {
+        currentRoles.clear();
+        if (roles != null)
+            currentRoles.addAll(roles);
     }
 
     public void setUser(String user) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericConstantActionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericConstantActionFactory.java
@@ -31,27 +31,23 @@
 
 package com.splicemachine.db.impl.sql.execute;
 
-import java.sql.Timestamp;
-import java.util.List;
-import java.util.Properties;
-
 import com.splicemachine.db.catalog.AliasInfo;
 import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.sql.ResultDescription;
 import com.splicemachine.db.iapi.sql.depend.ProviderInfo;
-import com.splicemachine.db.iapi.sql.dictionary.ConstraintDescriptorList;
-import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
-import com.splicemachine.db.iapi.sql.dictionary.IndexRowGenerator;
-import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
-import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
+import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ConstantAction;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.store.access.StaticCompiledOpenConglomInfo;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.RowLocation;
 import com.splicemachine.db.impl.sql.compile.TableName;
+
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Properties;
 
 /**
  * Factory for creating ConstantActions.
@@ -882,7 +878,7 @@ public abstract class GenericConstantActionFactory {
 	 * @param grantees  list of authentication ids (user or roles) to
 	 *                  which roles(s) are to be granted
 	 */
-	public abstract ConstantAction getGrantRoleConstantAction(List roleNames, List grantees);
+	public abstract ConstantAction getGrantRoleConstantAction(List roleNames, List grantees, boolean isDefaultRole);
 
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexChanger.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexChanger.java
@@ -31,8 +31,6 @@
 
 package com.splicemachine.db.impl.sql.execute;
 
-import java.util.Properties;
-
 import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
@@ -43,11 +41,7 @@ import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.ResultDescription;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
-import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
-import com.splicemachine.db.iapi.sql.dictionary.ConstraintDescriptor;
-import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
-import com.splicemachine.db.iapi.sql.dictionary.IndexRowGenerator;
-import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
+import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.CursorResultSet;
 import com.splicemachine.db.iapi.sql.execute.ExecIndexRow;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
@@ -55,6 +49,8 @@ import com.splicemachine.db.iapi.sql.execute.ScanQualifier;
 import com.splicemachine.db.iapi.store.access.*;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.types.RowLocation;
+
+import java.util.Properties;
 
 /**
   Perform Index maintenace associated with DML operations for a single index.
@@ -272,6 +268,7 @@ public class IndexChanger
               ScanQualifier qualifier = new GenericScanQualifier();
               qualifier.setQualifier(dvdPos,ourRowDvds[dvdPos],DataValueDescriptor.ORDER_OP_EQUALS,false,false,false);
               qualifiers[0][qualPos] = qualifier;
+              qualPos ++;
           }
       }
 		/* Get the SC from the activation if re-using */

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/SpliceIndexObserver.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/SpliceIndexObserver.java
@@ -14,8 +14,6 @@
 
 package com.splicemachine.derby.hbase;
 
-import com.splicemachine.si.data.hbase.coprocessor.CoprocessorUtils;
-import org.spark_project.guava.base.Function;
 import com.splicemachine.access.HConfiguration;
 import com.splicemachine.access.api.ServerControl;
 import com.splicemachine.concurrent.SystemClock;
@@ -35,6 +33,7 @@ import com.splicemachine.si.api.data.TxnOperationFactory;
 import com.splicemachine.si.api.server.TransactionalRegion;
 import com.splicemachine.si.api.txn.TxnView;
 import com.splicemachine.si.constants.SIConstants;
+import com.splicemachine.si.data.hbase.coprocessor.CoprocessorUtils;
 import com.splicemachine.si.data.hbase.coprocessor.TableType;
 import com.splicemachine.si.impl.HWriteConflict;
 import com.splicemachine.si.impl.driver.SIDriver;
@@ -47,14 +46,14 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.RegionCoprocessorHost;
 import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
-import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.log4j.Logger;
+import org.spark_project.guava.base.Function;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.util.List;
 
 /**
@@ -162,11 +161,21 @@ public class SpliceIndexObserver extends BaseRegionObserver {
             if(conglomId>0){
                 if(put.getAttribute(SIConstants.SUPPRESS_INDEXING_ATTRIBUTE_NAME)!=null) return;
                 if(factoryLoader==null){
+                    /** the below awaitStartup() call is commented out since we don't think there will be
+                     * rows inserted into a user index during startup, this code will cause a deadlock
+                     * when we add a new system index during system upgrade *
                     try{
                         DatabaseLifecycleManager.manager().awaitStartup();
                     }catch(InterruptedException e1){
                         throw new InterruptedIOException();
                     }
+                    */
+                    /* In the case that a new system index is added during a system upgrade, its conglomId will be
+                       bigger than 0, but it should still go through the path for system index instead of the regular
+                       user table index
+                     */
+                    super.prePut(e, put, edit, durability);
+                    return;
                 }
                 //we can't update an index if the conglomerate id isn't positive--it's probably a temp table or something
                 byte[] row = put.getRow();

--- a/hbase_storage/src/main/java/com/splicemachine/constants/EnvUtils.java
+++ b/hbase_storage/src/main/java/com/splicemachine/constants/EnvUtils.java
@@ -27,7 +27,7 @@ public class EnvUtils {
 	private static Logger LOG = Logger.getLogger(EnvUtils.class);
     // NOTE: JC - this constant is also defined in DataDictionary. When adding a new sys table, this
     // number will need to be increased in BOTH places.
-	private static final long FIRST_USER_TABLE_NUMBER = 1458;
+	private static final long FIRST_USER_TABLE_NUMBER = 1568;
 
     public static TableType getTableType(SConfiguration config,RegionCoprocessorEnvironment e) {
         return EnvUtils.getTableType(config,e.getRegion().getTableDesc().getTableName());

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLUtils.java
@@ -1002,4 +1002,10 @@ public class DDLUtils {
             dm.invalidateFor(privilegedSQLObject, invalidationType, lcc);
         }
     }
+
+    public static void preGrantRevokeRole(DDLMessage.DDLChange change, DataDictionary dd, DependencyManager dm) throws StandardException {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG,"preGrantRevokeRole with change=%s",change);
+        dd.getDataDictionaryCache().defaultRoleCacheRemove(change.getGrantRevokeRole().getGranteeName());
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
@@ -390,6 +390,9 @@ public class SpliceDatabase extends BasicDatabase{
                     case REFRESH_ENTRPRISE_FEATURES:
                         EngineDriver.driver().refreshEnterpriseFeatures();
                         break;
+                    case GRANT_REVOKE_ROLE:
+                        DDLUtils.preGrantRevokeRole(change, dataDictionary, dependencyManager);
+                        break;
                 }
                 final List<DDLAction> ddlActions = new ArrayList<>();
                 ddlActions.add(new AddIndexToPipeline());

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -62,6 +62,7 @@ public class SpliceCatalogUpgradeScripts{
         scripts.put(new Splice_DD_Version(sdd,1,1,1),new LassenUpgradeScript(sdd,tc));
         scripts.put(new Splice_DD_Version(sdd,2,6,0),new UpgradeScriptFor260(sdd,tc));
         scripts.put(new Splice_DD_Version(sdd,2,7,1), new UpgradeScriptForModifySchemaPermission(sdd,tc));
+        scripts.put(new Splice_DD_Version(sdd,2,7,1), new UpgradeScriptForAddDefaultRole(sdd,tc));
     }
 
     public void run() throws StandardException{

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForAddDefaultRole.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForAddDefaultRole.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.splicemachine.derby.impl.sql.catalog.upgrade;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.derby.impl.sql.catalog.SpliceDataDictionary;
+
+/**
+ * Created by yxia on 3/8/18.
+ */
+public class UpgradeScriptForAddDefaultRole extends UpgradeScriptBase {
+    public UpgradeScriptForAddDefaultRole(SpliceDataDictionary sdd, TransactionController tc) {
+        super(sdd, tc);
+    }
+
+    @Override
+    protected void upgradeSystemTables() throws StandardException {
+        sdd.upgradeSysRolesWithDefaultRoleColumn(tc);
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericConstantActionFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericConstantActionFactory.java
@@ -478,9 +478,9 @@ public abstract class SpliceGenericConstantActionFactory extends GenericConstant
     }
 
     @Override
-    public ConstantAction getGrantRoleConstantAction(List roleNames,List grantees){
-        SpliceLogUtils.trace(LOG,"getGrantRoleConstantAction for roles {%s} and grantees {%s}",roleNames,grantees);
-        return new GrantRoleConstantOperation(roleNames,grantees);
+    public ConstantAction getGrantRoleConstantAction(List roleNames,List grantees, boolean isDefaultRole){
+        SpliceLogUtils.trace(LOG,"getGrantRoleConstantAction for %s roles {%s} and grantees {%s}",(isDefaultRole?"default":"non-default"), roleNames,grantees);
+        return new GrantRoleConstantOperation(roleNames,grantees,isDefaultRole);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateRoleConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateRoleConstantOperation.java
@@ -110,7 +110,8 @@ public class CreateRoleConstantOperation extends DDLConstantOperation {
             currentAuthId,// grantee
             Authorizer.SYSTEM_AUTHORIZATION_ID,// grantor
             true,         // with admin option
-            true);        // is definition
+            true,
+            false);        // is definition
 
         dd.addDescriptor(rdDef,
                          null,  // parent

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/btree/IndexController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/btree/IndexController.java
@@ -15,7 +15,8 @@
 
 package com.splicemachine.derby.impl.store.access.btree;
 
-import com.splicemachine.access.api.PartitionFactory;import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.access.api.PartitionFactory;
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.store.access.ConglomerateController;

--- a/splice_machine/src/main/java/com/splicemachine/protobuf/ProtoUtil.java
+++ b/splice_machine/src/main/java/com/splicemachine/protobuf/ProtoUtil.java
@@ -78,6 +78,15 @@ public class ProtoUtil {
                 .build();
     }
 
+    public static DDLChange createGrantRevokeRole(long txnId, String roleName, String granteeName, boolean isGrant) {
+        return DDLChange.newBuilder().setTxnId(txnId).setGrantRevokeRole(GrantRevokeRole.newBuilder()
+                .setType(isGrant?GrantRevokeRole.Type.GRANT_OP:GrantRevokeRole.Type.REVOKE_OP)
+                .setRoleName(roleName)
+                .setGranteeName(granteeName)
+                .build())
+                .setDdlChangeType(DDLChangeType.GRANT_REVOKE_ROLE)
+                .build();
+    }
 
     public static DDLChange createRefreshEnterpriseFeatures(long txnId) {
         return DDLChange.newBuilder().setTxnId(txnId).setRefreshEnterpriseFeatures(RefreshEnterpriseFeatures.newBuilder().build())

--- a/splice_machine/src/test/java/com/splicemachine/derby/security/DefaultRoleIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/security/DefaultRoleIT.java
@@ -1,0 +1,446 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.splicemachine.derby.security;
+
+import com.splicemachine.db.shared.common.reference.SQLState;
+import com.splicemachine.derby.test.framework.*;
+import com.splicemachine.homeless.TestUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static com.splicemachine.db.shared.common.reference.SQLState.LANG_ROLE_NOT_REVOKED;
+import static com.splicemachine.derby.test.framework.SpliceUnitTest.assertFailed;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by yxia on 3/8/18.
+ */
+public class DefaultRoleIT {
+    private static final String SCHEMA1 = "TEST1";
+    private static final String SCHEMA2 = "TEST2";
+    private static final String SCHEMA3 = "TEST3";
+    private static final String SCHEMA4 = "TEST4";
+    private static final String SCHEMA5 = "TEST5";
+    private static final String SCHEMA = "XIAYI";
+
+
+    private static final String TABLE1 = "T1";
+    private static final String TABLE2 = "T2";
+    private static final String TABLE3 = "T3";
+    private static final String TABLE4 = "T4";
+    private static final String TABLE5 = "T5";
+
+    protected static final String ROLE1 = "ADMIN1";
+    protected static final String ROLE2 = "ADMIN2";
+    protected static final String ROLE3 = "ADMIN3";
+    protected static final String ROLE4 = "ADMIN4";
+    protected static final String ROLE5 = "ADMIN5";
+
+
+    protected static final String USER1 = "XIAYI";
+    protected static final String PASSWORD1 = "xiayi";
+    protected static final String PUBLIC = "PUBLIC";
+
+    private static SpliceWatcher spliceClassWatcherAdmin = new SpliceWatcher();
+    private static SpliceSchemaWatcher spliceSchemaWatcher1 = new SpliceSchemaWatcher(SCHEMA1);
+    private static SpliceSchemaWatcher spliceSchemaWatcher2 = new SpliceSchemaWatcher(SCHEMA2);
+    private static SpliceSchemaWatcher spliceSchemaWatcher3 = new SpliceSchemaWatcher(SCHEMA3);
+    private static SpliceSchemaWatcher spliceSchemaWatcher4 = new SpliceSchemaWatcher(SCHEMA4);
+    private static SpliceSchemaWatcher spliceSchemaWatcher5 = new SpliceSchemaWatcher(SCHEMA5);
+    private static SpliceSchemaWatcher  spliceSchemaWatcherUser1 = new SpliceSchemaWatcher(SCHEMA,USER1);
+    private static SpliceUserWatcher spliceUserWatcher1 = new SpliceUserWatcher(USER1, PASSWORD1);
+    private static SpliceRoleWatcher spliceRoleWatcher1 = new SpliceRoleWatcher(ROLE1);
+    private static SpliceRoleWatcher spliceRoleWatcher2 = new SpliceRoleWatcher(ROLE2);
+    private static SpliceRoleWatcher spliceRoleWatcher3 = new SpliceRoleWatcher(ROLE3);
+    private static SpliceRoleWatcher spliceRoleWatcher4 = new SpliceRoleWatcher(ROLE4);
+    private static SpliceRoleWatcher spliceRoleWatcher5 = new SpliceRoleWatcher(ROLE5);
+    private static SpliceTableWatcher tableWatcher1 = new SpliceTableWatcher(TABLE1, SCHEMA1,"(a1 int, b1 int, c1 int)" );
+    private static SpliceTableWatcher tableWatcher2 = new SpliceTableWatcher(TABLE2, SCHEMA2,"(a2 int, b2 int, c2 int)" );
+    private static SpliceTableWatcher tableWatcher3 = new SpliceTableWatcher(TABLE3, SCHEMA3,"(a3 int, b3 int, c3 int)" );
+    private static SpliceTableWatcher tableWatcher4 = new SpliceTableWatcher(TABLE4, SCHEMA4,"(a4 int, b4 int, c4 int)" );
+    private static SpliceTableWatcher tableWatcher5 = new SpliceTableWatcher(TABLE5, SCHEMA5,"(a5 int, b5 int, c5 int)" );
+
+    @Rule
+    public TestRule chain =
+            RuleChain.outerRule(spliceClassWatcherAdmin)
+                    .around(spliceSchemaWatcher1)
+                    .around(spliceSchemaWatcher2)
+                    .around(spliceSchemaWatcher3)
+                    .around(spliceSchemaWatcher4)
+                    .around(spliceSchemaWatcher5)
+                    .around(spliceSchemaWatcherUser1)
+                    .around(spliceUserWatcher1)
+                    .around(spliceRoleWatcher1)
+                    .around(spliceRoleWatcher2)
+                    .around(spliceRoleWatcher3)
+                    .around(spliceRoleWatcher4)
+                    .around(spliceRoleWatcher5)
+                    .around(spliceSchemaWatcher1)
+                    .around(tableWatcher1)
+                    .around(tableWatcher2)
+                    .around(tableWatcher3)
+                    .around(tableWatcher4)
+                    .around(tableWatcher5);
+
+    protected static TestConnection adminConn;
+    protected static TestConnection user1Conn;
+    protected static TestConnection user1Conn2;
+
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher();
+
+    // explicit syntax to grant role as default
+    String grantRoleToUserAsDefault1 = "grant %s to %s AS DEFAULT";
+    // implicit syntax to grant role as default
+    String grantRoleToUserAsDefault = "grant %s to %s";
+    // syntax NOT to grant role as default
+    String grantRoleToUserNotAsDefault = "grant %s to %s NOT AS DEFAULT";
+
+    String revokeRoleFromUser = "revoke %s from %s";
+
+    private String selectQuery1      = format("select a1 from %s.%s", SCHEMA1, TABLE1);
+    private String selectQuery2      = format("select a2 from %s.%s", SCHEMA2, TABLE2);
+    private String selectQuery3      = format("select a3 from %s.%s", SCHEMA3, TABLE3);
+    private String selectQuery4      = format("select a4 from %s.%s", SCHEMA4, TABLE4);
+    private String selectQuery5      = format("select a5 from %s.%s", SCHEMA5, TABLE5);
+    String localURLTemplate = "jdbc:splice://localhost:1527/splicedb;create=true;user=%s;password=%s";
+    String remoteURLTemplate = "jdbc:splice://localhost:1528/splicedb;create=true;user=%s;password=%s";
+
+    @Before
+    public  void setUpClass() throws Exception {
+        String grantPrivilegeTemplate = "grant all privileges on schema %s to %s";
+
+        adminConn = spliceClassWatcherAdmin.createConnection();
+        adminConn.execute( format("insert into %s.%s values ( 1,1,1)", SCHEMA1, TABLE1 ) );
+        adminConn.execute( format("insert into %s.%s values ( 2,2,2)", SCHEMA2, TABLE2 ) );
+        adminConn.execute( format("insert into %s.%s values ( 3,3,3)", SCHEMA3, TABLE3 ) );
+        adminConn.execute( format("insert into %s.%s values ( 4,4,4)", SCHEMA4, TABLE4 ) );
+        adminConn.execute( format("insert into %s.%s values ( 5,5,5)", SCHEMA5, TABLE5 ) );
+        adminConn.execute(format(grantPrivilegeTemplate, SCHEMA1, ROLE1));
+        adminConn.execute(format(grantPrivilegeTemplate, SCHEMA2, ROLE2));
+        adminConn.execute(format(grantPrivilegeTemplate, SCHEMA3, ROLE3));
+        adminConn.execute(format(grantPrivilegeTemplate, SCHEMA4, ROLE4));
+        adminConn.execute(format(grantPrivilegeTemplate, SCHEMA5, ROLE5));
+    }
+
+    @Test
+    public void testSetRoleAsDefault() throws Exception {
+        clearAllRolesOnUsers();
+
+        // 1: grant role as default implicitly
+        adminConn.execute(format(grantRoleToUserAsDefault, ROLE1, PUBLIC));
+        adminConn.execute(format(grantRoleToUserAsDefault, ROLE2, USER1));
+        // grant ROLE3 as default explicitly
+        adminConn.execute(format(grantRoleToUserAsDefault1, ROLE3, USER1));
+        adminConn.execute(format(grantRoleToUserNotAsDefault, ROLE4, USER1));
+
+        // 2: check the role definition table
+        String expected = "ROLEID | GRANTEE | GRANTOR | ISDEF | DEFAULTROLE |\n" +
+                "--------------------------------------------------\n" +
+                "ADMIN1 | PUBLIC  | SPLICE  |   N   |      Y      |\n" +
+                "ADMIN2 |  XIAYI  | SPLICE  |   N   |      Y      |\n" +
+                "ADMIN3 |  XIAYI  | SPLICE  |   N   |      Y      |\n" +
+                "ADMIN4 |  XIAYI  | SPLICE  |   N   |      N      |";
+        PreparedStatement ps = adminConn.prepareStatement(format("select ROLEID, GRANTEE, GRANTOR, ISDEF, DEFAULTROLE from sys.sysroles where grantee = '%s' or grantee = 'PUBLIC'", USER1));
+        ResultSet rs = ps.executeQuery();
+        assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+        // 3: check current_role(local) and privilege/permission
+        expected = "1              |\n" +
+                "------------------------------\n" +
+                "\"ADMIN2\", \"ADMIN3\", \"ADMIN1\" |";
+        user1Conn = spliceClassWatcherAdmin.createConnection(USER1, PASSWORD1);
+        ps = user1Conn.prepareStatement("values current_role");
+        rs = ps.executeQuery();
+        assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+        // we should be able to select from schema1, schema2, schema3, but not schema4 and schema5
+        testPrivileges(user1Conn, new boolean[] {false, false, false, true, true});
+
+        // 4. check current_role(remote) and privilege/permisssion
+        user1Conn2 = spliceClassWatcherAdmin.createConnection(remoteURLTemplate, USER1, PASSWORD1);
+        ps = user1Conn2.prepareStatement("values current_role");
+        rs = ps.executeQuery();
+        assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+        testPrivileges(user1Conn2, new boolean[] {false, false, false, true, true});
+    }
+
+    @Test
+    public void testSetRoleNotAsDefault() throws Exception {
+        clearAllRolesOnUsers();
+
+        // 1: grant role as default
+        adminConn.execute(format(grantRoleToUserAsDefault1, ROLE1, PUBLIC));
+        adminConn.execute(format(grantRoleToUserAsDefault1, ROLE2, USER1));
+        adminConn.execute(format(grantRoleToUserAsDefault, ROLE3, USER1));
+        adminConn.execute(format(grantRoleToUserNotAsDefault, ROLE4, USER1));
+
+        // 2: grant role NOT as default for ROLE2 and ROLE3
+        adminConn.execute(format(grantRoleToUserNotAsDefault, ROLE2, USER1));
+        adminConn.execute(format(grantRoleToUserNotAsDefault, ROLE3, USER1));
+
+        // 3: check the role definition table
+        String expected = "ROLEID | GRANTEE | GRANTOR | ISDEF | DEFAULTROLE |\n" +
+                "--------------------------------------------------\n" +
+                "ADMIN1 | PUBLIC  | SPLICE  |   N   |      Y      |\n" +
+                "ADMIN2 |  XIAYI  | SPLICE  |   N   |      N      |\n" +
+                "ADMIN3 |  XIAYI  | SPLICE  |   N   |      N      |\n" +
+                "ADMIN4 |  XIAYI  | SPLICE  |   N   |      N      |";
+        PreparedStatement ps = adminConn.prepareStatement(format("select ROLEID, GRANTEE, GRANTOR, ISDEF, DEFAULTROLE from sys.sysroles where grantee = '%s' or grantee = 'PUBLIC'", USER1));
+        ResultSet rs = ps.executeQuery();
+        assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+        // 4: check current_role(local) and privilege/permission
+        expected = "1    |\n" +
+                "----------\n" +
+                "\"ADMIN1\" |";
+        user1Conn = spliceClassWatcherAdmin.createConnection(USER1, PASSWORD1);
+        ps = user1Conn.prepareStatement("values current_role");
+        rs = ps.executeQuery();
+        assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+        // we should be able to select from schema1 but not schema2, schema3, schema4 and schema5
+        testPrivileges(user1Conn, new boolean[] {false, true, true, true, true});
+
+        // 4. check current_role(remote) and privilege/permisssion
+        user1Conn2 = spliceClassWatcherAdmin.createConnection(remoteURLTemplate, USER1, PASSWORD1);
+        ps = user1Conn2.prepareStatement("values current_role");
+        rs = ps.executeQuery();
+        assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+        testPrivileges(user1Conn2, new boolean[] {false, true, true, true, true});
+    }
+
+    @Test
+    public void testRevokeRole() throws Exception {
+        clearAllRolesOnUsers();
+
+        // 1: grant role as default
+        adminConn.execute(format(grantRoleToUserAsDefault, ROLE1, PUBLIC));
+        adminConn.execute(format(grantRoleToUserAsDefault, ROLE2, USER1));
+        adminConn.execute(format(grantRoleToUserAsDefault, ROLE3, USER1));
+        adminConn.execute(format(grantRoleToUserNotAsDefault, ROLE4, USER1));
+
+        // 2: check current_role(local) and privilege/permission
+        String expected = "1              |\n" +
+                "------------------------------\n" +
+                "\"ADMIN2\", \"ADMIN3\", \"ADMIN1\" |";
+        user1Conn = spliceClassWatcherAdmin.createConnection(USER1, PASSWORD1);
+        PreparedStatement ps = user1Conn.prepareStatement("values current_role");
+        ResultSet rs = ps.executeQuery();
+        assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+        // we should be able to select from schema1, schema2, schema3, but not schema4 and schema5
+        testPrivileges(user1Conn, new boolean[] {false, false, false, true, true});
+
+        // 3: revoke role2 from user1
+        adminConn.execute(format(revokeRoleFromUser, ROLE2, USER1));
+
+        // we loss privilege on schema2
+        testPrivileges(user1Conn, new boolean[] {false, true, false, true, true});
+
+        // also admin2 will be removed from current_role
+        expected = "1         |\n" +
+                "--------------------\n" +
+                "\"ADMIN3\", \"ADMIN1\" |";
+        ps = user1Conn.prepareStatement("values current_role");
+        rs = ps.executeQuery();
+        assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+        // 4. check current_role(remote) and privilege/permisssion
+        user1Conn2 = spliceClassWatcherAdmin.createConnection(remoteURLTemplate, USER1, PASSWORD1);
+        ps = user1Conn2.prepareStatement("values current_role");
+        rs = ps.executeQuery();
+        assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+        testPrivileges(user1Conn2, new boolean[] {false, true, false, true, true});
+    }
+
+    @Test
+    public void testReGrantANonDefaultRoleAsDefault() throws Exception {
+        clearAllRolesOnUsers();
+
+        // 1: grant role as default
+        adminConn.execute(format(grantRoleToUserAsDefault, ROLE1, PUBLIC));
+        adminConn.execute(format(grantRoleToUserAsDefault, ROLE2, USER1));
+        adminConn.execute(format(grantRoleToUserAsDefault, ROLE3, USER1));
+        adminConn.execute(format(grantRoleToUserNotAsDefault, ROLE4, USER1));
+
+        // 2: check current_role(local) and privilege/permission
+        String expected = "1              |\n" +
+                "------------------------------\n" +
+                "\"ADMIN2\", \"ADMIN3\", \"ADMIN1\" |";
+        user1Conn = spliceClassWatcherAdmin.createConnection(USER1, PASSWORD1);
+        PreparedStatement ps = user1Conn.prepareStatement("values current_role");
+        ResultSet rs = ps.executeQuery();
+        assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+        // we should be able to select from schema1, schema2, schema3, but not schema4 and schema5
+        testPrivileges(user1Conn, new boolean[] {false, false, false, true, true});
+
+        // 3: re-grant role4 to user1 as default, and role2 as non-default
+        adminConn.execute(format(grantRoleToUserAsDefault, ROLE4, USER1));
+        adminConn.execute(format(grantRoleToUserNotAsDefault, ROLE2, USER1));
+
+        // 4. In new connection, we should see role4 in current_role, also role2 will be removed from current_role
+        user1Conn = spliceClassWatcherAdmin.createConnection(USER1, PASSWORD1);
+
+        expected = "1              |\n" +
+                "------------------------------\n" +
+                "\"ADMIN3\", \"ADMIN4\", \"ADMIN1\" |";
+        ps = user1Conn.prepareStatement("values current_role");
+        rs = ps.executeQuery();
+        assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+        testPrivileges(user1Conn, new boolean[] {false, true, false, false, true});
+
+        // 4. check current_role(remote) and privilege/permisssion
+        user1Conn2 = spliceClassWatcherAdmin.createConnection(remoteURLTemplate, USER1, PASSWORD1);
+        ps = user1Conn2.prepareStatement("values current_role");
+        rs = ps.executeQuery();
+        assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+        testPrivileges(user1Conn2, new boolean[] {false, true, false, false, true});
+    }
+
+    @Test
+    public void testSetRole() throws Exception {
+        clearAllRolesOnUsers();
+
+        // 1: grant role as default
+        adminConn.execute(format(grantRoleToUserAsDefault, ROLE1, PUBLIC));
+        adminConn.execute(format(grantRoleToUserAsDefault, ROLE2, USER1));
+        adminConn.execute(format(grantRoleToUserAsDefault, ROLE3, USER1));
+        adminConn.execute(format(grantRoleToUserNotAsDefault, ROLE4, USER1));
+
+        // 2: check current_role(local) and privilege/permission
+        String expected = "1              |\n" +
+                "------------------------------\n" +
+                "\"ADMIN2\", \"ADMIN3\", \"ADMIN1\" |";
+        user1Conn = spliceClassWatcherAdmin.createConnection(USER1, PASSWORD1);
+        PreparedStatement ps = user1Conn.prepareStatement("values current_role");
+        ResultSet rs = ps.executeQuery();
+        assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+        // we should be able to select from schema1, schema2, schema3, but not schema4 and schema5
+        testPrivileges(user1Conn, new boolean[] {false, false, false, true, true});
+
+        // 3: set another role admin4
+        user1Conn.execute(format("set role %s", ROLE4));
+
+        // current_role should include admin4 now
+        String expected2 = "1                   |\n" +
+                "----------------------------------------\n" +
+                "\"ADMIN2\", \"ADMIN3\", \"ADMIN1\", \"ADMIN4\" |";
+        ps = user1Conn.prepareStatement("values current_role");
+        rs = ps.executeQuery();
+        assertEquals(expected2, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+        // we should be able to select from admin4 too
+        testPrivileges(user1Conn, new boolean[] {false, false, false, false, true});
+
+        // unset all role
+        user1Conn.execute("set role NONE");
+        expected2 = "1  |\n" +
+                "------\n" +
+                "NULL |";
+        ps = user1Conn.prepareStatement("values current_role");
+        rs = ps.executeQuery();
+        assertEquals(expected2, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+        // we are not able to select from any schema
+        testPrivileges(user1Conn, new boolean[] {true, true, true, true, true});
+
+        // 4: remote connection current_role is not change
+        user1Conn2 = spliceClassWatcherAdmin.createConnection(remoteURLTemplate, USER1, PASSWORD1);
+        ps = user1Conn2.prepareStatement("values current_role");
+        rs = ps.executeQuery();
+        assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+        testPrivileges(user1Conn2, new boolean[] {false, false, false, true, true});
+
+    }
+    private void clearAllRolesOnUsers() throws Exception {
+        try {
+            adminConn.execute(format(revokeRoleFromUser, ROLE1, PUBLIC));
+            adminConn.execute(format(revokeRoleFromUser, ROLE2, PUBLIC));
+            adminConn.execute(format(revokeRoleFromUser, ROLE3, PUBLIC));
+            adminConn.execute(format(revokeRoleFromUser, ROLE4, PUBLIC));
+            adminConn.execute(format(revokeRoleFromUser, ROLE1, USER1));
+            adminConn.execute(format(revokeRoleFromUser, ROLE2, USER1));
+            adminConn.execute(format(revokeRoleFromUser, ROLE3, USER1));
+            adminConn.execute(format(revokeRoleFromUser, ROLE4, USER1));
+        } catch (SQLException se) {
+            assertTrue("Incorrect error state: " + se.getSQLState() + ", expected: " + LANG_ROLE_NOT_REVOKED,  se.getSQLState().startsWith(LANG_ROLE_NOT_REVOKED));
+        }
+    }
+
+    private void testPrivileges(TestConnection conn, boolean[] shouldFail) throws Exception {
+
+        String expected[] = {
+                "A1 |\n" +
+                "----\n" +
+                " 1 |",
+                "A2 |\n" +
+                "----\n" +
+                " 2 |",
+                "A3 |\n" +
+                "----\n" +
+                " 3 |",
+                "A4 |\n" +
+                "----\n" +
+                " 4 |",
+                "A5 |\n" +
+                "----\n" +
+                " 5 |"
+        };
+        String sql[] = {selectQuery1, selectQuery2, selectQuery3, selectQuery4, selectQuery5};
+        for (int i=0; i<5; i++) {
+            if (!shouldFail[i]) {
+                PreparedStatement ps = conn.prepareStatement(sql[i]);
+                ResultSet rs = ps.executeQuery();
+                assertEquals(expected[i], TestUtils.FormattedResult.ResultFactory.toString(rs));
+                rs.close();
+            } else {
+                assertFailed(conn, sql[i], SQLState.AUTH_NO_COLUMN_PERMISSION);
+            }
+        }
+    }
+}

--- a/splice_protocol/src/main/protobuf/DDL.proto
+++ b/splice_protocol/src/main/protobuf/DDL.proto
@@ -174,6 +174,15 @@ message UpdateSchemaOwner {
         required string ownerName = 2;
 }
 
+message GrantRevokeRole {
+        enum Type {
+            GRANT_OP = 0;
+            REVOKE_OP = 1;
+        }
+        required Type type = 1;
+        required string roleName = 2;
+        required string granteeName = 3;
+}
 message TentativeFK {
         optional int64 baseConglomerate = 1;
         optional int64 conglomerate = 2;
@@ -326,6 +335,7 @@ enum DDLChangeType {
     REFRESH_ENTRPRISE_FEATURES = 36;
     CREATE_ROLE = 37;
     UPDATE_SCHEMA_OWNER=38;
+    GRANT_REVOKE_ROLE = 39;
 }
 
 message DDLChange {
@@ -364,4 +374,5 @@ message DDLChange {
     optional RefreshEnterpriseFeatures refreshEnterpriseFeatures = 33;
     optional CreateRole createRole = 34;
     optional UpdateSchemaOwner updateSchemaOwner = 35;
+    optional GrantRevokeRole grantRevokeRole = 36;
 }


### PR DESCRIPTION
This is a port of SPLICE-137-2.5-1 to master. Some minor changes are made to resolve conflicts:
1. In the function insertIndexRowListImpl(), use batchInsert() to insert index rows instead of individual rows one by one.
2. In DataDictionaryCache(), replace canUseCache() with canReadCache() or canWriteCache() based on whether it is a read or write operation.
