### PR TITLE
DB-6431: Fix imported rows count and bad records count for IMPORT_DATA and HFILE_BULK_LOAD

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/HFileGenerationFunction.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/HFileGenerationFunction.java
@@ -90,10 +90,20 @@ public abstract class HFileGenerationFunction implements MapPartitionsFunction<R
     public Iterator<String> call(Iterator<Row> mainAndIndexRows) throws Exception {
 
         try {
+            String lastKey = null;
             while (mainAndIndexRows.hasNext()) {
                 Row row = mainAndIndexRows.next();
                 Long conglomerateId = row.getAs("conglomerateId");
-                byte[] key = Bytes.fromHex(row.getAs("key"));
+                String keyStr = row.getAs("key");
+                if (lastKey != null && lastKey.equals(keyStr)) {
+                    if (operationContext != null) {
+                        operationContext.recordBadRecord("Primary key duplicate, row: "
+                            + row.toString(), null);
+                    }
+                    continue;
+                }
+                lastKey = keyStr;
+                byte[] key = Bytes.fromHex(keyStr);
                 byte[] value = row.getAs("value");
                 if (LOG.isDebugEnabled()) {
                     SpliceLogUtils.error(LOG, "conglomerateId:%d, key:%s, value:%s",

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BulkInsertDataSetWriter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BulkInsertDataSetWriter.java
@@ -212,6 +212,7 @@ public class BulkInsertDataSetWriter extends BulkDataSetWriter implements DataSe
 
                 // dump cut points to file system for reference
                 dumpCutPoints(cutPoints, bulkImportDirectory);
+                operationContext.reset();
             }
             if (!samplingOnly && !outputKeysOnly) {
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkOperationContext.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkOperationContext.java
@@ -62,7 +62,6 @@ public class SparkOperationContext<Op extends SpliceOperation> implements Operat
     public LongAccumulator retryAttempts;
     public LongAccumulator regionTooBusyExceptions;
 
-    public LongAccumulator pipelineRowsWritten;
     public LongAccumulator thrownErrorsRows;
     public LongAccumulator retriedRows;
     public LongAccumulator partialRows;
@@ -115,7 +114,6 @@ public class SparkOperationContext<Op extends SpliceOperation> implements Operat
     private void initWritePipeline() {
         this.retryAttempts =SpliceSpark.getContext().sc().longAccumulator("(WritePipeline) retry attempts");
         this.regionTooBusyExceptions =SpliceSpark.getContext().sc().longAccumulator("(WritePipeline) region too busy exceptions");
-        this.pipelineRowsWritten=SpliceSpark.getContext().sc().longAccumulator("(WritePipeline) rows written");
         this.thrownErrorsRows=SpliceSpark.getContext().sc().longAccumulator("(WritePipeline) rows thrown errors");
         this.retriedRows=SpliceSpark.getContext().sc().longAccumulator("(WritePipeline) rows retried");
         this.partialRows=SpliceSpark.getContext().sc().longAccumulator("(WritePipeline) total rows partial error");
@@ -167,7 +165,6 @@ public class SparkOperationContext<Op extends SpliceOperation> implements Operat
         out.writeObject(ignoredRows);
         out.writeObject(catchThrownRows);
         out.writeObject(catchRetriedRows);
-        out.writeObject(pipelineRowsWritten);
     }
 
     @Override
@@ -209,7 +206,6 @@ public class SparkOperationContext<Op extends SpliceOperation> implements Operat
         ignoredRows=(LongAccumulator)in.readObject();
         catchThrownRows=(LongAccumulator)in.readObject();
         catchRetriedRows=(LongAccumulator)in.readObject();
-        pipelineRowsWritten=(LongAccumulator)in.readObject();
     }
 
     @Override
@@ -260,7 +256,7 @@ public class SparkOperationContext<Op extends SpliceOperation> implements Operat
 
     @Override
     public void recordPipelineWrites(long w) {
-        pipelineRowsWritten.add(w);
+        rowsWritten.add(w);
     }
 
     @Override

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkOperationContext.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkOperationContext.java
@@ -220,14 +220,16 @@ public class SparkOperationContext<Op extends SpliceOperation> implements Operat
     @Override
     public void reset(){
 //        impl.resetContextManager();
-        BadRecordsRecorder oldRecorder = this.badRecordsAccumulator.value();
-        BadRecordsRecorder badRecordsRecorder = new BadRecordsRecorder(
-                oldRecorder.getStatusDirectory(),
-                importFileName,
-                badRecordThreshold);
-        this.badRecordsAccumulator=SpliceSpark.getContext().accumulable(badRecordsRecorder,
-                badRecordsRecorder.getUniqueName(),
-                new BadRecordsAccumulator());
+        if (this.permissive) {
+            BadRecordsRecorder oldRecorder = this.badRecordsAccumulator.value();
+            BadRecordsRecorder badRecordsRecorder = new BadRecordsRecorder(
+                    oldRecorder.getStatusDirectory(),
+                    importFileName,
+                    badRecordThreshold);
+            this.badRecordsAccumulator = SpliceSpark.getContext().accumulable(badRecordsRecorder,
+                    badRecordsRecorder.getUniqueName(),
+                    new BadRecordsAccumulator());
+        }
         badRecordsSeen = 0;
         String baseName="";
         if (op != null) {

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/client/BulkWriteAction.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/client/BulkWriteAction.java
@@ -322,7 +322,9 @@ public class BulkWriteAction implements Callable<WriteStats>{
                                     ctx.refreshCache=ctx.refreshCache || isFailure;
                                     ctx.sleep=true; //always sleep
                                 }
-                                writtenCounter.add(currentBulkWrite.getSize() - writes.size());
+                                writtenCounter.add(currentBulkWrite.getSize() -
+                                        bulkWriteResult.getNotRunRows().size() -
+                                        bulkWriteResult.getFailedRows().size());
                                 partialRetriedRows.add(writes.size());
                                 break;
                             case IGNORE:

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetWriter.java
@@ -67,12 +67,11 @@ public class ControlDataSetWriter<K> implements DataSetWriter{
             operation.fireBeforeStatementTriggers();
             pipelineWriter.open(operation.getTriggerHandler(),operation);
             pipelineWriter.write(dataSet.toLocalIterator());
-
-            long recordsWritten = operationContext.getRecordsWritten();
-            operationContext.getActivation().getLanguageConnectionContext().setRecordsImported(operationContext.getRecordsWritten());
             txn.commit(); // Commit before closing pipeline so triggers see our writes
             if(pipelineWriter!=null)
                 pipelineWriter.close();
+            long recordsWritten = operationContext.getRecordsWritten();
+            operationContext.getActivation().getLanguageConnectionContext().setRecordsImported(operationContext.getRecordsWritten());
             long badRecords = 0;
             if(operation instanceof InsertOperation){
                 InsertOperation insertOperation = (InsertOperation)operation;

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/delete/DeletePipelineWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/delete/DeletePipelineWriter.java
@@ -95,7 +95,6 @@ public class DeletePipelineWriter extends AbstractPipelineWriter<ExecRow>{
             rowsDeleted++;
             writeBuffer.add(encode);
             TriggerHandler.fireAfterRowTriggers(triggerHandler, execRow, flushCallback);
-            operationContext.recordWrite();
         } catch (Exception e) {
             throw Exceptions.parseException(e);
         }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/insert/InsertPipelineWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/insert/InsertPipelineWriter.java
@@ -119,8 +119,6 @@ public class InsertPipelineWriter extends AbstractPipelineWriter<ExecRow>{
             KVPair encode = encoder.encode(execRow);
             writeBuffer.add(encode);
             TriggerHandler.fireAfterRowTriggers(triggerHandler, execRow, flushCallback);
-            if (operationContext!=null)
-                operationContext.recordWrite();
         } catch (Exception e) {
             if (operationContext!=null && operationContext.isPermissive()) {
                     operationContext.recordBadRecord(e.getLocalizedMessage() + execRow.toString(), e);

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/update/UpdatePipelineWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/update/UpdatePipelineWriter.java
@@ -218,7 +218,6 @@ public class UpdatePipelineWriter extends AbstractPipelineWriter<ExecRow>{
             assert encode.getRowKey()!=null && encode.getRowKey().length>0:"Tried to buffer incorrect row key";
             writeBuffer.add(encode);
             TriggerHandler.fireAfterRowTriggers(triggerHandler,execRow,flushCallback);
-            operationContext.recordWrite();
         }catch(Exception e){
             throw Exceptions.parseException(e);
         }

--- a/splice_machine/src/test/test-data/rows_count.csv
+++ b/splice_machine/src/test/test-data/rows_count.csv
@@ -1,0 +1,3 @@
+"abc","efg"
+"abc","def"
+"abd",null


### PR DESCRIPTION
This is the first patch to fix one of the bugs in DB-6431.

`AbstractPipelineWriter` already write the rows count to `operationContext` based on `writeStats`. But there are some problems:

1. The `writeStats` returned from `BulkWriteAction` is not correct.
2. `SparkOperationContext` record the written rows to `pipelineRowsWritten`, which seems to be not used in anywhere.
3. Because of 2, `AbstractPipelineWriter` didn't write the row count into `rowsWritten`. Thus some pipeline writer re-add these counters. And when they add these counters, the data is still in buffer which may fail in later writes.

This patch fix these issues.