### PR TITLE
SPLICE-2104: Dictionary Scans Should Use HBase Small Scans vs. the network heavy regular scan (2.7)

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceScan.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceScan.java
@@ -143,6 +143,7 @@ public class SpliceScan implements ScanManager, LazyScan{
                     ((SpliceConglomerate)this.spliceConglomerate.getConglomerate()).columnOrdering,
                     ((SpliceConglomerate)this.spliceConglomerate.getConglomerate()).columnOrdering,
                     trans.getDataValueFactory(),"1.0",false);
+            scan.setSmall(true); // Removes extra rpc calls for dictionary scans (smallish)
         }catch(Exception e){
             LOG.error("Exception creating start key");
             throw new RuntimeException(e);


### PR DESCRIPTION
already merged in branch-2.5 but missing in master/2.7 branch