### PR TITLE
SPLICE-2112 Configure org.xerial.snappy.Snappy to avoid extracting its native library to /tmp

### DIFF
--- a/db-drda/pom.xml
+++ b/db-drda/pom.xml
@@ -49,11 +49,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
-            <version>1.1.2.4</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>2.6.0-cdh5.6.0</version>

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DDMWriter.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DDMWriter.java
@@ -52,8 +52,8 @@ import com.splicemachine.db.iapi.services.property.PropertyUtil;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.services.io.DynamicByteArrayOutputStream;
 import com.splicemachine.db.iapi.types.RowLocation;
+import com.splicemachine.compression.SpliceSnappy;
 import org.apache.log4j.Logger;
-import org.xerial.snappy.Snappy;
 
 /**
 	The DDMWriter is used to write DRDA protocol.   The DRDA Protocol is
@@ -1506,10 +1506,10 @@ class DDMWriter
 		{
 			// use snappy compression
 			final int uncompressedSize = totalSize - 6;
-			byte[] compressedBuffer = new byte[uncompressedSize];
+			byte[] compressedBuffer = new byte[SpliceSnappy.maxCompressedLength(uncompressedSize)];
 			int compressedSize = 0;
 			try {
-			    compressedSize = Snappy.compress(buffer.array(), dssLengthLocation + 6, 
+			    compressedSize = SpliceSnappy.compress(buffer.array(), dssLengthLocation + 6,
 			        uncompressedSize, compressedBuffer, 0);
 			} catch (IOException e) {
 				LOG.warn("COMPRESS Snappy compression exception:  " + e.getMessage());

--- a/hbase_pipeline/src/main/java/com/splicemachine/pipeline/SnappyPipelineCompressor.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/pipeline/SnappyPipelineCompressor.java
@@ -16,10 +16,9 @@ package com.splicemachine.pipeline;
 
 import java.io.IOException;
 import org.apache.log4j.Logger;
-import org.xerial.snappy.Snappy;
 
 import com.splicemachine.pipeline.utils.PipelineCompressor;
-import com.splicemachine.utils.SpliceLogUtils;
+import com.splicemachine.compression.SpliceSnappy;
 
 /**
  * @author Scott Fines
@@ -27,20 +26,6 @@ import com.splicemachine.utils.SpliceLogUtils;
  */
 public class SnappyPipelineCompressor implements PipelineCompressor{
     private static final Logger LOG=Logger.getLogger(SnappyPipelineCompressor.class);
-    private static final boolean supportsNative;
-
-    static {
-        boolean installed = false;
-        try {
-            String version = Snappy.getNativeLibraryVersion();
-            SpliceLogUtils.info(LOG, "Snappy Installed (" + version + "): Splice Machine's Write Pipeline will compress data over the wire.");
-            installed = true;
-        }
-        catch (Exception ex) {
-            SpliceLogUtils.error(LOG,"No Native Snappy Installed: Splice Machine's Write Pipeline will not compress data over the wire.");
-        }
-        supportsNative = installed;
-    }
 
     private final PipelineCompressor delegate;
 
@@ -51,18 +36,13 @@ public class SnappyPipelineCompressor implements PipelineCompressor{
     @Override
     public byte[] compress(Object o) throws IOException {
         byte[] d = delegate.compress(o);
-        if (supportsNative) {
-            d = Snappy.compress(d);
-        }
+        d = SpliceSnappy.compress(d);
         return d;
     }
 
     @Override
     public <T> T decompress(byte[] bytes,Class<T> clazz) throws IOException {
-        byte[] d = bytes;
-        if (supportsNative) {
-            d = Snappy.uncompress(bytes);
-        }
+        byte[] d = SpliceSnappy.uncompress(bytes);
         return delegate.decompress(d, clazz);
     }
 }

--- a/utilities/pom.xml
+++ b/utilities/pom.xml
@@ -48,5 +48,11 @@
             <artifactId>log4j</artifactId>
             <version>1.2.17</version>
         </dependency>
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>1.0.4.1</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/utilities/src/main/java/com/splicemachine/compression/SpliceSnappy.java
+++ b/utilities/src/main/java/com/splicemachine/compression/SpliceSnappy.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.compression;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.log4j.Logger;
+import org.xerial.snappy.Snappy;
+
+public class SpliceSnappy {
+    private static final Logger LOG = Logger.getLogger(SpliceSnappy.class);
+    private static boolean installed = false;
+
+    static {
+        String tempDir = System.getProperty("org.xerial.snappy.tempdir");
+        if (tempDir == null) {
+            String userDir = System.getProperty("user.dir");
+            if (userDir != null && new File(userDir).exists()) {
+                System.setProperty("org.xerial.snappy.tempdir", userDir);
+            }
+        }
+
+        try {
+            Snappy.compress(new byte[16]);
+            String version = Snappy.getNativeLibraryVersion();
+            LOG.info("Snappy Installed (" + version + "): data will be compressed over the wire.");
+            installed = true;
+        }
+        catch (Throwable t) {
+            LOG.error("No Native Snappy Installed: data will not be compressed over the wire.", t);
+        }
+    }
+
+    public static int maxCompressedLength(int byteSize) {
+        return installed ? Snappy.maxCompressedLength(byteSize) : byteSize;
+    }
+
+    public static byte[] compress(byte[] bytes) throws IOException {
+        if (installed) {
+            bytes = Snappy.compress(bytes);
+        }
+        return bytes;
+    }
+
+    public static int compress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset) throws IOException {
+        if (installed) {
+            return Snappy.compress(input, inputOffset, inputLength, output, outputOffset);
+        }
+        System.arraycopy(input, inputOffset, output, outputOffset, inputLength);
+        return inputLength;
+    }
+
+    public static byte[] uncompress(byte[] bytes) throws IOException {
+        if (installed) {
+            bytes = Snappy.uncompress(bytes);
+        }
+        return bytes;
+    }
+}


### PR DESCRIPTION
A wrapper, SpliceSnappy, is introduced. It sets "org.xerial.snappy.tempdir" to control Snappy native library extraction and provides robustness in case Snappy is not loaded.
Snappy version is downgraded to 1.0.4.1 to match the one provided in cluster environment.