### PR TITLE
SPLICE-1348 remove dependency on db-engine from db-tools-ij

### DIFF
--- a/db-tools-ij/pom.xml
+++ b/db-tools-ij/pom.xml
@@ -45,7 +45,7 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>db-engine</artifactId>
+            <artifactId>db-shared</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/db-tools-ij/src/main/grammar/ij.jj
+++ b/db-tools-ij/src/main/grammar/ij.jj
@@ -40,8 +40,6 @@ import com.splicemachine.db.tools.JDBCDisplayUtil;
 import com.splicemachine.db.iapi.tools.i18n.LocalizedInput;
 import com.splicemachine.db.iapi.tools.i18n.LocalizedResource;
 
-import com.splicemachine.db.iapi.services.info.JVMInfo;
-
 import java.lang.reflect.*;
 import java.security.AccessController;
 import java.security.PrivilegedAction;

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/utilMain.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/utilMain.java
@@ -31,7 +31,6 @@
 
 package com.splicemachine.db.impl.tools.ij;
                 
-import com.splicemachine.db.jdbc.AutoloadedDriver;
 import com.splicemachine.db.tools.JDBCDisplayUtil;
 import com.splicemachine.db.iapi.tools.i18n.*;
 
@@ -434,22 +433,22 @@ public class utilMain implements java.security.PrivilegedAction {
 		/*
 			If an exit was requested, then we will be shutting down.
 		 */
-		if (ijParser.exit || (initialFileInput && !mtUse)) {
-        if(!AutoloadedDriver.isBooted()) return; //no reason to try booting the db if we are just going to shut it down
-			Driver d = null;
-			try {
-			    d = DriverManager.getDriver("jdbc:splice:");
-			} catch (Throwable e) {
-				d = null;
-			}
-			if (d!=null) { // do we have a driver running? shutdown on exit.
-				try {
-					DriverManager.getConnection("jdbc:splice:;shutdown=true");
-				} catch (SQLException e) {
-					// ignore the errors, they are expected.
-				}
-			}
-		}
+//		if (ijParser.exit || (initialFileInput && !mtUse)) {
+//        	if(!AutoloadedDriver.isBooted()) return; //no reason to try booting the db if we are just going to shut it down
+//			Driver d = null;
+//			try {
+//			    d = DriverManager.getDriver("jdbc:splice:");
+//			} catch (Throwable e) {
+//				d = null;
+//			}
+//			if (d!=null) { // do we have a driver running? shutdown on exit.
+//				try {
+//					DriverManager.getConnection("jdbc:splice:;shutdown=true");
+//				} catch (SQLException e) {
+//					// ignore the errors, they are expected.
+//				}
+//			}
+//		}
   	}
 
 	private void displayResult(LocalizedOutput out, ijResult result, Connection conn) throws SQLException {


### PR DESCRIPTION
Switched to db-shared, removed what I believe was unused code.