### PR TITLE
SPLICE-2120 update SYS.SYSROUTINEPERMS when upgrading system procedures (2.5)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -2125,4 +2125,14 @@ public interface DataDictionary{
      * @throws StandardException
      */
     List<String> getDefaultRoles(String username, TransactionController tc) throws StandardException;
+
+    /**
+     * Get permissions for a routine (function or procedure).
+     *
+     * @param routineUUID     the uuid of the routing permissions to fetch
+     * @param permsList       list of routine permissions related to routineUUID to be populated
+     * @return The first found descriptor of the users permissions for the routine.
+     * @throws StandardException
+     */
+    RoutinePermsDescriptor getRoutinePermissions(UUID routineUUID, List<RoutinePermsDescriptor> permsList) throws StandardException;
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/RoutinePermsDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/RoutinePermsDescriptor.java
@@ -59,8 +59,11 @@ public class RoutinePermsDescriptor extends PermissionsDescriptor
         this.hasExecutePermission = hasExecutePermission;
         //routineUUID can be null only if the constructor with routineePermsUUID
         //has been invoked.
-        if (routineUUID != null)
-        	routineName = dd.getAliasDescriptor(routineUUID).getObjectName();
+        if (routineUUID != null) {
+        	AliasDescriptor ad = dd.getAliasDescriptor(routineUUID);
+        	if (ad != null)
+        		routineName = ad.getObjectName();
+		}
 	}
 	
 	public RoutinePermsDescriptor( DataDictionary dd,
@@ -173,5 +176,9 @@ public class RoutinePermsDescriptor extends PermissionsDescriptor
 	{
         return getDependableFinder(
                 StoredFormatIds.ROUTINE_PERMISSION_FINDER_V01_ID);
+	}
+
+	public String getRoutineName() {
+		return routineName;
 	}
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -8155,7 +8155,9 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
         RoutinePermsDescriptor routinePermDesc=
                 new RoutinePermsDescriptor(this,"PUBLIC",authorizationID,routineUUID);
 
-        addDescriptor(routinePermDesc,null,DataDictionary.SYSROUTINEPERMS_CATALOG_NUM,false,tc);
+        // add if this permission has not been granted before
+        if (getUncachedRoutinePermsDescriptor(routinePermDesc) == null)
+            addDescriptor(routinePermDesc,null,DataDictionary.SYSROUTINEPERMS_CATALOG_NUM,false,tc);
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -9316,6 +9316,15 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
         return getUncachedRoutinePermsDescriptor(key);
     }
 
+    @Override
+    public RoutinePermsDescriptor getRoutinePermissions(UUID routineUUID,
+                                                 List<RoutinePermsDescriptor> permsList) throws StandardException{
+        RoutinePermsDescriptor key=new RoutinePermsDescriptor(this,null,null,routineUUID);
+        TabInfoImpl ti=getNonCoreTI(SYSROUTINEPERMS_CATALOG_NUM);
+        PermissionsCatalogRowFactory rowFactory=(PermissionsCatalogRowFactory)ti.getCatalogRowFactory();
+        ExecIndexRow keyRow=rowFactory.buildIndexKeyRow(SYSROUTINEPERMSRowFactory.ALIASID_INDEX_NUM,key);
+        return (RoutinePermsDescriptor)getDescriptorViaIndex(SYSROUTINEPERMSRowFactory.ALIASID_INDEX_NUM,keyRow,null,ti,null,permsList,false);
+    } // end of getRoutinePermissions
     /**
      * Add or remove a permission to/from the permission database.
      *
@@ -9514,7 +9523,6 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
         ExecIndexRow keyRow=rowFactory.buildIndexKeyRow(indexNumber,key);
         return getDescriptorViaIndex(indexNumber,keyRow,null,ti,null,null,false);
     } // end of getUncachedPermissionsDescriptor
-
     /**
      * Get a routine permissions descriptor from the system tables, without going through the cache.
      * This method is called to fill the permissions cache.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DefaultSystemProcedureGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DefaultSystemProcedureGenerator.java
@@ -31,16 +31,6 @@
 
 package com.splicemachine.db.impl.sql.catalog;
 
-import java.sql.Types;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-
 import com.splicemachine.db.catalog.AliasInfo;
 import com.splicemachine.db.catalog.TypeDescriptor;
 import com.splicemachine.db.catalog.UUID;
@@ -52,9 +42,13 @@ import com.splicemachine.db.iapi.services.monitor.ModuleControl;
 import com.splicemachine.db.iapi.services.monitor.Monitor;
 import com.splicemachine.db.iapi.sql.dictionary.AliasDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
+import com.splicemachine.db.iapi.sql.dictionary.RoutinePermsDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+
+import java.sql.Types;
+import java.util.*;
 
 /**
  * @author Scott Fines
@@ -103,7 +97,7 @@ public class DefaultSystemProcedureGenerator implements SystemProcedureGenerator
                 //free null check plus cast protection
                 if(n instanceof Procedure){
                     Procedure procedure = (Procedure)n;
-                    newlyCreatedRoutines.add(procedure.createSystemProcedure(uuid,dictionary,tc));
+                    newlyCreatedRoutines.add(procedure.createSystemProcedure(uuid,dictionary,tc).getAliasInfo());
                 }
             }
         }
@@ -145,7 +139,7 @@ public class DefaultSystemProcedureGenerator implements SystemProcedureGenerator
     	if (procedure == null) {
     		throw StandardException.newException(SQLState.LANG_OBJECT_NOT_FOUND_DURING_EXECUTION, "PROCEDURE", (schemaName + "." + procName));
     	} else {
-    		newlyCreatedRoutines.add(procedure.createSystemProcedure(schemaId, dictionary, tc));
+    		newlyCreatedRoutines.add(procedure.createSystemProcedure(schemaId, dictionary, tc).getAliasInfo());
     	}
     }
 
@@ -223,7 +217,12 @@ public class DefaultSystemProcedureGenerator implements SystemProcedureGenerator
     		// If not found check for existing function
         	ad = dictionary.getAliasDescriptor(schemaIdStr, procName, AliasInfo.ALIAS_NAME_SPACE_FUNCTION_AS_CHAR);
     	}
-    	if (ad != null) {  // Drop the procedure if it already exists.
+
+		List<RoutinePermsDescriptor> permsList = new ArrayList<> ();
+
+    	if (ad != null) {
+			dictionary.getRoutinePermissions(ad.getUUID(), permsList);
+    		// Drop the procedure if it already exists.
     		dictionary.dropAliasDescriptor(ad, tc);
     	}
 
@@ -232,7 +231,18 @@ public class DefaultSystemProcedureGenerator implements SystemProcedureGenerator
     	if (procedure == null) {
     		throw StandardException.newException(SQLState.LANG_OBJECT_NOT_FOUND_DURING_EXECUTION, "PROCEDURE", (schemaName + "." + procName));
     	} else {
-    		newlyCreatedRoutines.add(procedure.createSystemProcedure(schemaId, dictionary, tc));
+    		AliasDescriptor newAliasDescriptor = procedure.createSystemProcedure(schemaId, dictionary, tc);
+    		newlyCreatedRoutines.add(newAliasDescriptor.getAliasInfo());
+
+    		// drop permission with old aliasInfo and re-populate with the new AliasInfo
+			for (RoutinePermsDescriptor perm : permsList) {
+				//remove perm from SYS.SYSROUTINEPERMS
+				dictionary.addRemovePermissionsDescriptor(false, perm, perm.getGrantee(), tc);
+				//update perm with new routineUUID
+				RoutinePermsDescriptor newPerm = new RoutinePermsDescriptor(dictionary, perm.getGrantee(), perm.getGrantor(), newAliasDescriptor.getUUID(), perm.getHasExecutePermission());
+				// add a new perm row with updated UUID of the system procedure
+				dictionary.addRemovePermissionsDescriptor(true, newPerm, newPerm.getGrantee(), tc);
+			}
     	}
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DefaultSystemProcedureGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DefaultSystemProcedureGenerator.java
@@ -97,7 +97,7 @@ public class DefaultSystemProcedureGenerator implements SystemProcedureGenerator
                 //free null check plus cast protection
                 if(n instanceof Procedure){
                     Procedure procedure = (Procedure)n;
-                    newlyCreatedRoutines.add(procedure.createSystemProcedure(uuid,dictionary,tc).getAliasInfo());
+                    newlyCreatedRoutines.add(procedure.createSystemProcedure(uuid,dictionary,tc).getAliasInfo().getMethodName());
                 }
             }
         }
@@ -139,7 +139,7 @@ public class DefaultSystemProcedureGenerator implements SystemProcedureGenerator
     	if (procedure == null) {
     		throw StandardException.newException(SQLState.LANG_OBJECT_NOT_FOUND_DURING_EXECUTION, "PROCEDURE", (schemaName + "." + procName));
     	} else {
-    		newlyCreatedRoutines.add(procedure.createSystemProcedure(schemaId, dictionary, tc).getAliasInfo());
+    		newlyCreatedRoutines.add(procedure.createSystemProcedure(schemaId, dictionary, tc).getAliasInfo().getMethodName());
     	}
     }
 
@@ -232,7 +232,7 @@ public class DefaultSystemProcedureGenerator implements SystemProcedureGenerator
     		throw StandardException.newException(SQLState.LANG_OBJECT_NOT_FOUND_DURING_EXECUTION, "PROCEDURE", (schemaName + "." + procName));
     	} else {
     		AliasDescriptor newAliasDescriptor = procedure.createSystemProcedure(schemaId, dictionary, tc);
-    		newlyCreatedRoutines.add(newAliasDescriptor.getAliasInfo());
+    		newlyCreatedRoutines.add(newAliasDescriptor.getAliasInfo().getMethodName());
 
     		// drop permission with old aliasInfo and re-populate with the new AliasInfo
 			for (RoutinePermsDescriptor perm : permsList) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/Procedure.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/Procedure.java
@@ -100,7 +100,7 @@ public class Procedure {
         return name.hashCode();
     }
 
-    public RoutineAliasInfo createSystemProcedure(UUID schemaId,
+    public AliasDescriptor createSystemProcedure(UUID schemaId,
                                                   DataDictionary dataDictionary,
                                                   TransactionController tc) throws StandardException {
         int numArgs = args.length;
@@ -139,7 +139,7 @@ public class Procedure {
                 null);
         dataDictionary.addDescriptor(ads,null,DataDictionary.SYSALIASES_CATALOG_NUM,false,tc);
 
-        return rai;
+        return ads;
     }
 
     public static class Builder{

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSROUTINEPERMSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSROUTINEPERMSRowFactory.java
@@ -59,10 +59,10 @@ public class SYSROUTINEPERMSRowFactory extends PermissionsCatalogRowFactory
 	static final String TABLENAME_STRING = "SYSROUTINEPERMS";
 
     // Column numbers for the SYSROUTINEPERMS table. 1 based
-    private static final int ROUTINEPERMSID_COL_NUM = 1;
+    public static final int ROUTINEPERMSID_COL_NUM = 1;
     private static final int GRANTEE_COL_NUM = 2;
     private static final int GRANTOR_COL_NUM = 3;
-    private static final int ALIASID_COL_NUM = 4;
+    public static final int ALIASID_COL_NUM = 4;
     private static final int GRANTOPTION_COL_NUM = 5;
     private static final int COLUMN_COUNT = 5;
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -502,6 +502,7 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
     public void createOrUpdateAllSystemProcedures(TransactionController tc) throws StandardException{
         tc.elevate("dictionary");
         super.createOrUpdateAllSystemProcedures(tc);
+        SpliceLogUtils.info(LOG, "System procedures created or updated");
     }
 
     /*Table fetchers for Statistics tables*/
@@ -552,13 +553,9 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
             tc.setProperty(SPLICE_DATA_DICTIONARY_VERSION,spliceSoftwareVersion,true);
             tc.commit();
         }
-        // TODO - include the following in an upgrade script
-        if (spliceSoftwareVersion.toLong() >= 2005000) {
-            upgradeSystables(tc);
-        }
     }
 
-    private void upgradeSystables(TransactionController tc) throws StandardException {
+    public void upgradeSystables(TransactionController tc) throws StandardException {
         addNewColumToSystables(tc);
         SchemaDescriptor sd = getSystemSchemaDescriptor();
         TableDescriptor td = getTableDescriptor(SYSSNAPSHOTSRowFactory.TABLENAME_STRING, sd, tc);
@@ -570,8 +567,6 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
         }
 
         upgradeSysStatsTable(tc);
-
-        createOrUpdateAllSystemProcedures(tc);
 
         updateSysTableStatsView1(tc);
     }
@@ -783,8 +778,8 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
         }
 
         // Compare software version and catalog version
-        if(catalogVersion.toLong()<=spliceSoftwareVersion.toLong()){
-            LOG.info("Upgrade needed since catalog version <= software version");
+        if(catalogVersion.toLong()<spliceSoftwareVersion.toLong()){
+            LOG.info("Upgrade needed since catalog version < software version");
             return true;
         }
         return false;
@@ -1082,5 +1077,50 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
         // 3 indexes is not fully populated. This TI should not be reused for future operations
         clearNoncoreTable(SYSROLES_CATALOG_NUM-NUM_CORE);
         SpliceLogUtils.info(LOG, "SYS.SYSROLES upgraded: added columns: DEFAULTROLE; added index on (GRANTEE, DEFAULTROLE)");
+    }
+
+    // remove rows in sysroutineperms whose aliasid are no longer valid
+    public void cleanSysRoutinePerms(TransactionController tc) throws StandardException {
+        // scan the sysroutineperms table
+        TabInfoImpl ti = getNonCoreTIByNumber(SYSROUTINEPERMS_CATALOG_NUM);
+        SYSROUTINEPERMSRowFactory rf=(SYSROUTINEPERMSRowFactory)ti.getCatalogRowFactory();
+        ExecRow outRow = rf.makeEmptyRow();
+        ScanController scanController=tc.openScan(
+                ti.getHeapConglomerate(),      // conglomerate to open
+                false,                          // don't hold open across commit
+                0,                              // for read
+                TransactionController.MODE_TABLE,
+                TransactionController.ISOLATION_REPEATABLE_READ,
+                null,               // all fields as objects
+                null, // start position - first row
+                0,                          // startSearchOperation - none
+                null,              // scanQualifier,
+                null, // stop position -through last row
+                0);                          // stopSearchOperation - none
+
+        List<RoutinePermsDescriptor> listToDelete = new ArrayList<>();
+
+        try{
+            while(scanController.fetchNext(outRow.getRowArray())){
+                String aliasUUIDString = outRow.getColumn(SYSROUTINEPERMSRowFactory.ALIASID_COL_NUM).getString();
+                UUID aliasUUID = getUUIDFactory().recreateUUID(aliasUUIDString);
+                RoutinePermsDescriptor permsDescriptor = (RoutinePermsDescriptor)rf.buildDescriptor(outRow, null, this);
+                // we have looked up the sysaliases table when building the permsDescriptor above,
+                // if the aliasid does not exist, routineName is null
+                String ad = permsDescriptor.getRoutineName();
+                if (ad == null) {
+                    listToDelete.add(permsDescriptor);
+                }
+            }
+        }finally{
+            scanController.close();
+        }
+
+        // delete the obselete rows
+        for (RoutinePermsDescriptor permsDescriptor: listToDelete) {
+            addRemovePermissionsDescriptor(false, permsDescriptor, permsDescriptor.getGrantee(), tc);
+        }
+        
+        SpliceLogUtils.info(LOG, "SYS.SYSROUTINEPERMS upgraded: obsolete rows deleted");
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -1082,7 +1082,7 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
     // remove rows in sysroutineperms whose aliasid are no longer valid
     public void cleanSysRoutinePerms(TransactionController tc) throws StandardException {
         // scan the sysroutineperms table
-        TabInfoImpl ti = getNonCoreTIByNumber(SYSROUTINEPERMS_CATALOG_NUM);
+        TabInfoImpl ti = getNonCoreTI(SYSROUTINEPERMS_CATALOG_NUM);
         SYSROUTINEPERMSRowFactory rf=(SYSROUTINEPERMSRowFactory)ti.getCatalogRowFactory();
         ExecRow outRow = rf.makeEmptyRow();
         ScanController scanController=tc.openScan(

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -61,8 +61,9 @@ public class SpliceCatalogUpgradeScripts{
         scripts.put(new Splice_DD_Version(sdd,1,0,0),new UpgradeScriptForFuji(sdd,tc));
         scripts.put(new Splice_DD_Version(sdd,1,1,1),new LassenUpgradeScript(sdd,tc));
         scripts.put(new Splice_DD_Version(sdd,2,5,0),new K2UpgradeScript(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,2,5,1), new UpgradeScriptForModifySchemaPermission(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,2,5,1), new UpgradeScriptForAddDefaultRole(sdd,tc));
+        scripts.put(new Splice_DD_Version(sdd,2,5,1), new UpgradeScriptForModifySchemaPermissionAndDefaultRole(sdd,tc));
+        scripts.put(new Splice_DD_Version(sdd,2,5,0, 1750), new UpgradeScriptForSysTables(sdd,tc));
+        scripts.put(new Splice_DD_Version(sdd,2,5,0, 1812), new UpgradeScriptToCleanSysRoutinePerms(sdd,tc));
     }
 
     public void run() throws StandardException{

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForModifySchemaPermissionAndDefaultRole.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForModifySchemaPermissionAndDefaultRole.java
@@ -20,13 +20,14 @@ import com.splicemachine.derby.impl.sql.catalog.SpliceDataDictionary;
 /**
  * Created by yxia on 2/14/18.
  */
-public class UpgradeScriptForModifySchemaPermission extends UpgradeScriptBase {
-    public UpgradeScriptForModifySchemaPermission(SpliceDataDictionary sdd, TransactionController tc) {
+public class UpgradeScriptForModifySchemaPermissionAndDefaultRole extends UpgradeScriptBase {
+    public UpgradeScriptForModifySchemaPermissionAndDefaultRole(SpliceDataDictionary sdd, TransactionController tc) {
         super(sdd, tc);
     }
 
     @Override
     protected void upgradeSystemTables() throws StandardException {
         sdd.upgradeSysSchemaPermsForModifySchemaPrivilege(tc);
+        sdd.upgradeSysRolesWithDefaultRoleColumn(tc);
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForSysTables.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForSysTables.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.splicemachine.derby.impl.sql.catalog.upgrade;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.derby.impl.sql.catalog.SpliceDataDictionary;
+
+/**
+ * Created by yxia on 3/21/18.
+ */
+public class UpgradeScriptForSysTables extends UpgradeScriptBase {
+    public UpgradeScriptForSysTables(SpliceDataDictionary sdd, TransactionController tc) {
+        super(sdd, tc);
+    }
+
+    @Override
+    protected void upgradeSystemTables() throws StandardException {
+        sdd.upgradeSystables(tc);
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptToCleanSysRoutinePerms.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptToCleanSysRoutinePerms.java
@@ -11,6 +11,7 @@
  * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
  * If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.splicemachine.derby.impl.sql.catalog.upgrade;
 
 import com.splicemachine.db.iapi.error.StandardException;
@@ -18,15 +19,15 @@ import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.derby.impl.sql.catalog.SpliceDataDictionary;
 
 /**
- * Created by yxia on 3/8/18.
+ * Created by yxia on 3/21/18.
  */
-public class UpgradeScriptForAddDefaultRole extends UpgradeScriptBase {
-    public UpgradeScriptForAddDefaultRole(SpliceDataDictionary sdd, TransactionController tc) {
+public class UpgradeScriptToCleanSysRoutinePerms extends UpgradeScriptBase {
+    public UpgradeScriptToCleanSysRoutinePerms(SpliceDataDictionary sdd, TransactionController tc) {
         super(sdd, tc);
     }
 
     @Override
     protected void upgradeSystemTables() throws StandardException {
-        sdd.upgradeSysRolesWithDefaultRoleColumn(tc);
+        sdd.cleanSysRoutinePerms(tc);
     }
 }


### PR DESCRIPTION
also clean obsolete rows in sysroutineperms if any

Please see [SPLICE-2120](https://splice.atlassian.net/browse/SPLICE-2120) for analysis and solution.
Since the fix is in the upgrade logic, no automatic test is added to IT. I've manually tested with the upgrade from 2.5.1810T to 2.5.1812, 2.5.1810 to 2.5.1812.