### PR TITLE
SPLICE-2125 Remove hadoop/hbase dependencies from core modules

### DIFF
--- a/db-drda/pom.xml
+++ b/db-drda/pom.xml
@@ -48,18 +48,6 @@
             <artifactId>db-tools-i18n</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <version>2.6.0-cdh5.6.0</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>asm</groupId>
-                    <artifactId>asm</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAConnThread.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAConnThread.java
@@ -73,7 +73,6 @@ import com.splicemachine.db.jdbc.InternalDriver;
 import com.splicemachine.db.iapi.jdbc.EnginePreparedStatement;
 import com.sun.security.auth.callback.TextCallbackHandler;
 import com.sun.security.jgss.GSSUtil;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSException;
@@ -202,7 +201,7 @@ class DRDAConnThread extends Thread {
 
 	// contexts for Kerberos authentication
 	private GSSContext gssContext;
-	private UserGroupInformation user;
+	private User user;
 
     // generated target seed to be used to generate the password substitute
     // as part of SECMEC_USRSSBPWD security mechanism
@@ -2010,9 +2009,7 @@ class DRDAConnThread extends Thread {
 
 
 								try {
-
-
-									user = UserGroupInformation.getCurrentUser();
+									user = UserManagerService.loadPropertyManager().getCurrentUser();
 
 									Exception exception = user.doAs(new PrivilegedAction<Exception>() {
 										@Override

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/RemoteUserKerberos.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/RemoteUserKerberos.java
@@ -17,7 +17,6 @@ package com.splicemachine.db.impl.drda;
 
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.sun.security.jgss.GSSUtil;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSName;
@@ -41,7 +40,7 @@ public class RemoteUserKerberos implements RemoteUser {
             GSSName clientName = clientCr.getName(); 
             Subject subject = GSSUtil.createSubject(clientName, clientCr);
             String databaseURL = String.format("jdbc:splice://%s/splicedb;principal=%s",hostname, clientName.toString());
-            return UserGroupInformation.getUGIFromSubject(subject).doAs(
+            return UserManagerService.loadPropertyManager().getUserFromSubject(subject).doAs(
                     (PrivilegedExceptionAction<Connection>) () -> DriverManager.getConnection(databaseURL));
         } catch (Exception e) {
             throw new SQLException(SQLState.AUTH_ERROR_KERBEROS_CLIENT,

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/User.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/User.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.db.impl.drda;
+
+import java.io.IOException;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedExceptionAction;
+import java.sql.Connection;
+
+public interface User {
+    <T> T doAs(PrivilegedAction<T> action);
+    String getUserName();
+
+    <T> T doAs(PrivilegedExceptionAction<T> action) throws IOException, InterruptedException;
+}

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/UserManager.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/UserManager.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.db.impl.drda;
+
+import javax.security.auth.Subject;
+import java.io.IOException;
+
+public interface UserManager {
+    User getCurrentUser() throws IOException;
+
+    User getUserFromSubject(Subject subject) throws IOException;
+}

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/UserManagerService.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/UserManagerService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.db.impl.drda;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+/**
+ * @author Scott Fines
+ *         Date: 1/11/16
+ */
+public class UserManagerService {
+    private static volatile UserManager userManager;
+
+    public static UserManager loadPropertyManager(){
+        UserManager pm = userManager;
+        if(pm==null){
+            pm = loadPropertyManagerSync();
+        }
+        return pm;
+    }
+
+    private static synchronized UserManager loadPropertyManagerSync(){
+        UserManager pm = userManager;
+        if(pm==null){
+            ServiceLoader<UserManager> load=ServiceLoader.load(UserManager.class);
+            Iterator<UserManager> iter=load.iterator();
+            if(!iter.hasNext())
+                throw new IllegalStateException("No UserManager service found, make sure Enterprise Edition is enabled!");
+            pm = userManager = iter.next();
+            if(iter.hasNext())
+                throw new IllegalStateException("Only one UserManager service is allowed!");
+        }
+        return pm;
+    }
+}

--- a/db-engine/pom.xml
+++ b/db-engine/pom.xml
@@ -39,30 +39,6 @@
     <artifactId>db-engine</artifactId>
     <dependencies>
         <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <version>2.6.0-cdh5.6.0</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>asm</groupId>
-                    <artifactId>asm</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hbase</groupId>
-            <artifactId>hbase-common</artifactId>
-            <version>1.0.0-cdh5.6.0</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.yahoo.datasketches</groupId>
             <artifactId>sketches-core</artifactId>
             <version>0.8.4</version>

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/StatsBoundaryDataValueDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/StatsBoundaryDataValueDescriptor.java
@@ -38,8 +38,6 @@ import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.types.DataValueFactoryImpl;
 import com.yahoo.sketches.quantiles.ItemsSketch;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -449,21 +447,6 @@ public class StatsBoundaryDataValueDescriptor implements DataValueDescriptor {
     @Override
     public void read(Row row, int ordinal) throws StandardException {
         dvd.read(row,ordinal);
-    }
-
-    @Override
-    public int encodedKeyLength() throws StandardException {
-        return dvd.encodedKeyLength();
-    }
-
-    @Override
-    public void encodeIntoKey(PositionedByteRange builder, Order order) throws StandardException {
-        dvd.encodeIntoKey(builder,order);
-    }
-
-    @Override
-    public void decodeFromKey(PositionedByteRange builder) throws StandardException {
-        dvd.decodeFromKey(builder);
     }
 
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueDescriptor.java
@@ -34,8 +34,6 @@ package com.splicemachine.db.iapi.types;
 import com.splicemachine.db.iapi.services.io.ArrayInputStream;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -1066,28 +1064,6 @@ public interface DataValueDescriptor extends Storable, Orderable, Comparator<Dat
 	 * @param ordinal
 	 */
 	void read(Row row, int ordinal) throws StandardException;
-
-
-	/**
-	*
-	* Length for generating buffer
-	*
-	*/
-	int encodedKeyLength() throws StandardException;
-
-	/**
-	*
-    * Encode Value into Key (PK,etc.).  This follows the current hbase ordering mechanism.
-	*
-	*/
-	void encodeIntoKey(PositionedByteRange builder, Order order) throws StandardException;
-
-	/**
-	*
-	* Decode value from key.  This follows the current hbase ordering mechanism.
-	*
-	*/
-	void decodeFromKey(PositionedByteRange builder) throws StandardException;
 
 	/**
 	 *

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/HBaseRowLocation.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/HBaseRowLocation.java
@@ -22,9 +22,6 @@ import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 import com.splicemachine.db.shared.common.sanity.SanityManager;
 import com.splicemachine.utils.ByteSlice;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -276,27 +273,6 @@ public class HBaseRowLocation extends DataType implements RowLocation {
             setToNull();
         else
             slice = ByteSlice.wrap((byte[]) row.get(ordinal));
-    }
-
-    @Override
-    public int encodedKeyLength() throws StandardException {
-        return isNull()?1:9;
-    }
-
-    @Override
-    public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-        if (isNull())
-            OrderedBytes.encodeNull(src, order);
-        else
-            OrderedBytes.encodeBlobVar(src, slice.getByteCopy(), order);
-    }
-
-    @Override
-    public void decodeFromKey(PositionedByteRange src) throws StandardException {
-        if (OrderedBytes.isNull(src))
-            setToNull();
-        else
-            slice = ByteSlice.wrap(OrderedBytes.decodeBlobVar(src));
     }
 
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLArray.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLArray.java
@@ -33,8 +33,6 @@ import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.types.DataValueFactoryImpl.Format;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -486,42 +484,6 @@ public class SQLArray extends DataType implements ArrayDataValue {
 		}
 	}
 
-	/**
-	 *
-	 * This calls the references encodedKeyLength method.
-	 *
-	 * @return
-	 * @throws StandardException
-     */
-	@Override
-	public int encodedKeyLength() throws StandardException {
-		throw new UnsupportedOperationException("Cannot index arrays");
-	}
-
-	/**
-	 *
-	 * This calls the references underlying encodeIntoKey
-	 *
-	 * @param src
-	 * @param order
-	 * @throws StandardException
-     */
-	@Override
-	public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-		throw new UnsupportedOperationException("Cannot index arrays");
-	}
-
-	/**
-	 *
-	 * This calls the references underlying decodeFromKey method.
-	 *
-	 * @param src
-	 * @throws StandardException
-     */
-	@Override
-	public void decodeFromKey(PositionedByteRange src) throws StandardException {
-		throw new UnsupportedOperationException("Cannot index arrays");
-	}
 
 	@Override
 	public StructField getStructField(String columnName) {

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLBinary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLBinary.java
@@ -47,9 +47,6 @@ import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.services.i18n.MessageService;
 import com.splicemachine.db.iapi.services.cache.ClassSize;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -1419,54 +1416,6 @@ abstract class SQLBinary
 	}
 
 
-
-	/**
-	 *
-	 * Gets the encoded key length
-	 *
-	 * @see OrderedBytes#blobVarEncodedLength(int)
-	 *
-	 * @throws StandardException
-	 */
-	@Override
-	public int encodedKeyLength() throws StandardException {
-		return isNull()?1:OrderedBytes.blobVarEncodedLength(dataValue.length);
-	}
-
-	/**
-	 *
-	 * Performs null check and then encodes
-	 *
-	 * @see OrderedBytes#decodeBlobVar(PositionedByteRange)
-	 *
-	 * @param src
-	 * @param order
-	 * @throws StandardException
-     */
-	@Override
-	public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-		if (isNull())
-			OrderedBytes.encodeNull(src, order);
-		else
-			OrderedBytes.encodeBlobVar(src, dataValue, order);
-	}
-
-	/**
-	 *
-	 * Performs null check and then decodes
-	 *
-	 * @see OrderedBytes#decodeBlobVar(PositionedByteRange)
-	 *
-	 * @param src
-	 * @throws StandardException
-     */
-	@Override
-	public void decodeFromKey(PositionedByteRange src) throws StandardException {
-		if (OrderedBytes.isNull(src))
-			setToNull();
-		else
-			dataValue = OrderedBytes.decodeBlobVar(src);
-	}
 
 	@Override
 	public StructField getStructField(String columnName) {

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLBoolean.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLBoolean.java
@@ -47,9 +47,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import com.splicemachine.db.iapi.types.DataValueFactoryImpl.Format;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -1143,54 +1140,6 @@ public final class SQLBoolean
 			isNull = false;
 			value = row.getBoolean(ordinal);
 		}
-	}
-
-
-	/**
-	 *
-	 * Gets the encoded key length.  1 if null else 2.
-	 *
-	 * @return
-	 * @throws StandardException
-     */
-	@Override
-	public int encodedKeyLength() throws StandardException {
-		return isNull()?1:2;
-	}
-
-	/**
-	 *
-	 * Performs null check and then encodes.
-	 *
-	 * @see OrderedBytes#encodeInt8(PositionedByteRange, byte, Order)
-	 *
-	 * @param src
-	 * @param order
-	 * @throws StandardException
-     */
-	@Override
-	public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-		if (isNull())
-			OrderedBytes.encodeNull(src,order);
-		else
-			OrderedBytes.encodeInt8(src, value ? T : F, order);
-	}
-
-	/**
-	 *
-	 * Performs null check and then decodes.
-	 *
-	 * @see OrderedBytes#decodeInt8(PositionedByteRange)
-	 *
-	 * @param src
-	 * @throws StandardException
-     */
-	@Override
-	public void decodeFromKey(PositionedByteRange src) throws StandardException {
-		if (OrderedBytes.isNull(src))
-			setToNull();
-		else
-			value = OrderedBytes.decodeInt8(src) == T;
 	}
 
 	@Override

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLChar.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLChar.java
@@ -47,10 +47,6 @@ import com.splicemachine.db.iapi.types.DataValueFactoryImpl.Format;
 import com.splicemachine.db.iapi.util.StringUtil;
 import com.splicemachine.db.iapi.util.UTF8Util;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.types.OrderedString;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -3386,50 +3382,6 @@ public class SQLChar
             isNull = false;
             value = row.getString(ordinal);
         }
-    }
-
-    /**
-    *
-    * Get the encodedLength of the string.
-    *
-    * @return
-    * @throws StandardException
-    */
-    @Override
-    public int encodedKeyLength() throws StandardException {
-        return OrderedString.ASCENDING.encodedLength(value); // Order Does Not Matter for Length
-    }
-
-    /**
-     *
-     * Performs null check and then encodes.
-     *
-     * @see OrderedBytes#encodeString(PositionedByteRange, String, Order)
-     *
-     * @param src
-     * @param order
-     * @throws StandardException
-     */
-    @Override
-    public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-        if (isNull())
-            OrderedBytes.encodeNull(src, order);
-        else
-            OrderedBytes.encodeString(src, value, order);
-    }
-
-    /**
-     *
-     * Performs null check and then decodes.
-     *
-     * @see OrderedBytes#decodeString(PositionedByteRange)
-     *
-     * @param src
-     * @throws StandardException
-     */
-    @Override
-    public void decodeFromKey(PositionedByteRange src) throws StandardException {
-        value = OrderedBytes.decodeString(src);
     }
 
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLDate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLDate.java
@@ -41,9 +41,6 @@ import com.splicemachine.db.iapi.services.cache.ClassSize;
 import com.splicemachine.db.iapi.services.i18n.LocaleFinder;
 import com.splicemachine.db.iapi.util.StringUtil;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -1382,56 +1379,6 @@ public final class SQLDate extends DataType
 			isNull = false;
 		}
 	}
-
-
-
-	/**
-	 *
-	 * Get the encoded key length.  1 if null else 5.
-	 *
-	 * @return
-	 * @throws StandardException
-     */
-	@Override
-	public int encodedKeyLength() throws StandardException {
-		return isNull()?1:5;
-	}
-
-	/**
-	 *
-	 * Encode into a key
-	 *
-	 * @see OrderedBytes#encodeInt32(PositionedByteRange, int, Order)
-	 *
-	 * @param src
-	 * @param order
-	 * @throws StandardException
-     */
-	@Override
-	public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-		if (isNull())
-			OrderedBytes.encodeNull(src, order);
-		else
-			OrderedBytes.encodeInt32(src, encodedDate, order);
-		}
-
-	/**
-	 *
-	 * Decode from a key
-	 *
-	 * @see OrderedBytes#decodeInt32(PositionedByteRange)
-	 *
- 	 * @param src
-	 * @throws StandardException
-     */
-	@Override
-	public void decodeFromKey(PositionedByteRange src) throws StandardException {
-		if (OrderedBytes.isNull(src))
-			setToNull();
-		else
-			encodedDate = OrderedBytes.decodeInt32(src);
-			setIsNull(false);
-		}
 
 	@Override
 	public StructField getStructField(String columnName) {

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLDecimal.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLDecimal.java
@@ -48,9 +48,6 @@ import java.sql.*;
 
 import com.splicemachine.db.iapi.types.DataValueFactoryImpl.Format;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -1236,54 +1233,6 @@ public final class SQLDecimal extends NumberDataType implements VariableSizeData
 			isNull = false;
 			value = unsafeRow.getDecimal(ordinal, precision, scale).toJavaBigDecimal();
 		}
-	}
-
-	/**
-	 *
-	 * TODO JL: This is not accurate...
-	 *
-	 * @return
-	 * @throws StandardException
-     */
-	@Override
-	public int encodedKeyLength() throws StandardException {
-//		throw new RuntimeException("not implemented correctly");
-		return 33;
-	}
-
-	/**
-	 *
-	 * Encode into Key
-	 *
-	 * @see OrderedBytes#encodeNumeric(PositionedByteRange, BigDecimal, Order)
-	 *
-	 * @param src
-	 * @param order
-	 * @throws StandardException
-     */
-	@Override
-	public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-		if (isNull())
-				OrderedBytes.encodeNull(src, order);
-		else
-			OrderedBytes.encodeNumeric(src, value, order);
-	}
-
-	/**
-	 *
-	 * Decode from Key
-	 *
-	 * @see OrderedBytes#decodeNumericAsBigDecimal(PositionedByteRange)
-	 *
-	 * @param src
-	 * @throws StandardException
-     */
-	@Override
-	public void decodeFromKey(PositionedByteRange src) throws StandardException {
-		if (OrderedBytes.isNull(src))
-				setToNull();
-		else
-			value = OrderedBytes.decodeNumericAsBigDecimal(src);
 	}
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLDouble.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLDouble.java
@@ -46,9 +46,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import com.splicemachine.db.iapi.types.DataValueFactoryImpl.Format;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -987,54 +984,6 @@ public final class SQLDouble extends NumberDataType
 			isNull = false;
 			value = row.getDouble(ordinal);
 		}
-	}
-
-
-	/**
-	 *
-	 * Get Encoded Key Length.
-	 *
-	 * @return
-	 * @throws StandardException
-     */
-	@Override
-	public int encodedKeyLength() throws StandardException {
-		return isNull()?1:9;
-	}
-
-	/**
-	 *
-	 * Encode into Key.
-	 *
-	 * @see OrderedBytes#encodeFloat64(PositionedByteRange, double, Order)
-	 *
-	 * @param src
-	 * @param order
-	 * @throws StandardException
-     */
-	@Override
-	public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-		if (isNull())
-				OrderedBytes.encodeNull(src, order);
-		else
-			OrderedBytes.encodeFloat64(src, value, order);
-	}
-
-	/**
-	 *
-	 * Decode from Key.
-	 *
-	 * @see OrderedBytes#decodeFloat64(PositionedByteRange)
-	 *
- 	 * @param src
-	 * @throws StandardException
-     */
-	@Override
-	public void decodeFromKey(PositionedByteRange src) throws StandardException {
-		if (OrderedBytes.isNull(src))
-				setToNull();
-		else
-			value = OrderedBytes.decodeFloat64(src);
 	}
 
 	@Override

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLInteger.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLInteger.java
@@ -52,9 +52,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import com.splicemachine.db.iapi.types.DataValueFactoryImpl.Format;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -794,53 +791,6 @@ public final class SQLInteger
 			isNull =false;
 			value = row.getInt(ordinal);
 		}
-	}
-
-	/**
-	 *
-	 * Get encoded key length.  if null then 1 else 5.
-	 *
-	 * @return
-	 * @throws StandardException
-     */
-	@Override
-	public int encodedKeyLength() throws StandardException {
-		return isNull()?1:5;
-	}
-
-	/**
-	 *
-	 * Encode Into Key.
-	 *
-	 * @see OrderedBytes#encodeInt32(PositionedByteRange, int, Order)
-	 *
-	 * @param src
-	 * @param order
-	 * @throws StandardException
-     */
-	@Override
-	public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-		if (isNull())
-				OrderedBytes.encodeNull(src,order);
-		else
-			OrderedBytes.encodeInt32(src, value, order);
-	}
-
-	/**
-	 *
-	 * Decode from Key.
-	 *
-	 * @see OrderedBytes#decodeInt32(PositionedByteRange)
-	 *
-	 * @param src
-	 * @throws StandardException
-     */
-	@Override
-	public void decodeFromKey(PositionedByteRange src) throws StandardException {
-		if (OrderedBytes.isNull(src))
-				setToNull();
-		else
-			value = OrderedBytes.decodeInt32(src);
 	}
 
 	@Override

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLLongint.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLLongint.java
@@ -53,9 +53,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import com.splicemachine.db.iapi.types.DataValueFactoryImpl.Format;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -969,28 +966,6 @@ public final class SQLLongint extends NumberDataType {
 			isNull = false;
 			value = row.getLong(ordinal);
 		}
-	}
-
-
-	@Override
-	public int encodedKeyLength() throws StandardException {
-		return isNull()?1:9;
-	}
-
-	@Override
-	public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-		if (isNull())
-			OrderedBytes.encodeNull(src,order);
-		else
-			OrderedBytes.encodeInt64(src, value, order);
-	}
-
-			@Override
-	public void decodeFromKey(PositionedByteRange src) throws StandardException {
-		if (OrderedBytes.isNull(src))
-				setToNull();
-		else
-			value = OrderedBytes.decodeInt64(src);
 	}
 
 	@Override

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLReal.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLReal.java
@@ -54,9 +54,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import com.splicemachine.db.iapi.types.DataValueFactoryImpl.Format;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -978,53 +975,6 @@ public final class SQLReal
 			isNull = false;
 			value = row.getFloat(ordinal);
 		}
-	}
-
-	/**
-	 *
-	 * Get Encoded Key Length.  if null then 1 else 5.
-	 *
-	 * @return
-	 * @throws StandardException
-     */
-	@Override
-	public int encodedKeyLength() throws StandardException {
-		return isNull()?1:5;
-	}
-
-	/**
-	 *
-	 * Encode into Key.
-	 *
-	 * @see OrderedBytes#encodeFloat32(PositionedByteRange, float, Order)
-	 *
-	 * @param src
-	 * @param order
-	 * @throws StandardException
-     */
-	@Override
-	public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-		if (isNull())
-				OrderedBytes.encodeNull(src, order);
-		else
-			OrderedBytes.encodeFloat32(src, value, order);
-	}
-
-	/**
-	 *
-	 * Decode from Key.
-	 *
-	 * @see OrderedBytes#decodeFloat32(PositionedByteRange)
-	 *
-	 * @param src
-	 * @throws StandardException
-     */
-	@Override
-	public void decodeFromKey(PositionedByteRange src) throws StandardException {
-		if (OrderedBytes.isNull(src))
-				setToNull();
-		else
-			value = OrderedBytes.decodeFloat32(src);
 	}
 
 	@Override

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLRef.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLRef.java
@@ -45,9 +45,6 @@ import java.sql.PreparedStatement;
 import java.sql.RowId;
 import com.splicemachine.db.iapi.types.DataValueFactoryImpl.Format;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -363,50 +360,6 @@ public class SQLRef extends DataType implements RefDataValue {
 		value.read(row,ordinal);
 	}
 
-	/**
-	 *
-	 * This calls the references encodedKeyLength method.
-	 *
-	 * @return
-	 * @throws StandardException
-     */
-	@Override
-	public int encodedKeyLength() throws StandardException {
-		return isNull()?1:value.encodedKeyLength(); // Order Does Not Matter for Length
-	}
-
-	/**
-	 *
-	 * This calls the references underlying encodeIntoKey
-	 *
-	 * @param src
-	 * @param order
-	 * @throws StandardException
-     */
-	@Override
-	public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-		if (isNull())
-				OrderedBytes.encodeNull(src, order);
-		else
-			value.encodeIntoKey(src,order);
-	}
-
-	/**
-	 *
-	 * This calls the references underlying decodeFromKey method.
-	 *
-	 * @param src
-	 * @throws StandardException
-     */
-	@Override
-	public void decodeFromKey(PositionedByteRange src) throws StandardException {
-		if (OrderedBytes.isNull(src))
-				setToNull();
-		else
-		if (value==null)
-				value = new SQLRowId();
-		value.decodeFromKey(src);
-	}
 
 	@Override
 	public StructField getStructField(String columnName) {

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLRowId.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLRowId.java
@@ -37,9 +37,6 @@ import com.splicemachine.db.iapi.services.io.ArrayInputStream;
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -341,53 +338,6 @@ public class SQLRowId extends DataType implements RowLocation, RowId{
             bytes = (byte[]) row.get(ordinal);
         }
     }
-
-    /**
-     *
-     * Get Encoded Key Length
-     *
-     * @return
-     * @throws StandardException
-     */
-    @Override
-    public int encodedKeyLength() throws StandardException {
-        return isNull()?1:OrderedBytes.blobVarEncodedLength(bytes.length);
-    }
-
-    /**
-     *
-     * Encode into Key.
-     *
-     * @see OrderedBytes#encodeBlobVar(PositionedByteRange, byte[], Order)
-     *
-     * @param src
-     * @param order
-     * @throws StandardException
-     */
-    @Override
-    public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-        if (isNull())
-                OrderedBytes.encodeNull(src, order);
-        else
-            OrderedBytes.encodeBlobVar(src, bytes, order);
-     }
-
-    /**
-     *
-     * Encode from Key.
-     *
-     * @see OrderedBytes#decodeBlobVar(PositionedByteRange)
-     *
-     * @param src
-     * @throws StandardException
-     */
-    @Override
-    public void decodeFromKey(PositionedByteRange src) throws StandardException {
-        if (OrderedBytes.isNull(src))
-                setToNull();
-        else
-            bytes = OrderedBytes.decodeBlobVar(src);
-     }
 
     @Override
     public StructField getStructField(String columnName) {

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLSmallint.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLSmallint.java
@@ -46,9 +46,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import com.splicemachine.db.iapi.types.DataValueFactoryImpl.Format;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -840,53 +837,6 @@ public final class SQLSmallint
 			isNull = false;
 			value = row.getShort(ordinal);
 		}
-	}
-
-	/**
-	 *
-	 * Encoded Key length. if null 1 else 3.
-	 *
-	 * @return
-	 * @throws StandardException
-     */
-	@Override
-	public int encodedKeyLength() throws StandardException {
-		return isNull()?1:3;
-	}
-
-	/**
-	 *
-	 * Encode into Key.
-	 *
-	 * @see OrderedBytes#encodeInt16(PositionedByteRange, short, Order)
-	 *
-	 * @param src
-	 * @param order
-	 * @throws StandardException
-     */
-	@Override
-	public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-		if (isNull())
-				OrderedBytes.encodeNull(src, order);
-		else
-			OrderedBytes.encodeInt16(src, value, order);
-	}
-
-	/**
-	 *
-	 * Decode from Key.
-	 *
-	 * @see OrderedBytes#decodeInt16(PositionedByteRange)
-	 *
-	 * @param src
-	 * @throws StandardException
-     */
-	@Override
-	public void decodeFromKey(PositionedByteRange src) throws StandardException {
-		if (OrderedBytes.isNull(src))
-				setToNull();
-		else
-			value = OrderedBytes.decodeInt16(src);
 	}
 
 	@Override

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTime.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTime.java
@@ -54,9 +54,6 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import com.splicemachine.db.iapi.types.DataValueFactoryImpl.Format;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -1217,54 +1214,6 @@ public final class SQLTime extends DataType
 			isNull = false;
 			encodedTime = computeEncodedTime(row.getTimestamp(ordinal));
 			encodedTimeFraction = 0;
-		}
-	}
-
-	/**
-	 *
-	 * Get Encoded Key Length.  if null then 1 else 10.
-	 *
-	 * @return
-	 * @throws StandardException
-     */
-	@Override
-	public int encodedKeyLength() throws StandardException {
-		return isNull()?1:10;
-	}
-
-	/**
-	 *
-	 * Encode into key two int32s.
-	 *
-	 * @param src
-	 * @param order
-	 * @throws StandardException
-     */
-	@Override
-	public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-		if (isNull())
-			OrderedBytes.encodeNull(src, order);
-		else {
-			OrderedBytes.encodeInt32(src, encodedTime, order);
-			OrderedBytes.encodeInt32(src, encodedTimeFraction, order);
-		}
-	}
-
-	/**
-	 *
-	 * Decode from key two int32s.
-	 *
-	 * @param src
-	 * @throws StandardException
-     */
-	@Override
-	public void decodeFromKey(PositionedByteRange src) throws StandardException {
-		if (OrderedBytes.isNull(src))
-			setToNull();
-		else {
-			encodedTime = OrderedBytes.decodeInt32(src);
-			encodedTimeFraction = OrderedBytes.decodeInt32(src);
-			setIsNull(false);
 		}
 	}
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTimestamp.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTimestamp.java
@@ -43,9 +43,6 @@ import com.splicemachine.db.iapi.services.cache.ClassSize;
 import com.splicemachine.db.iapi.util.StringUtil;
 import com.splicemachine.db.iapi.util.ReuseFactory;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -1668,54 +1665,6 @@ public final class SQLTimestamp extends DataType
 		}
 	}
 
-	/**
-	 *
-	 * Get Encoded Key Length.  if null then 1 else 15.
-	 * @return
-	 * @throws StandardException
-     */
-		@Override
-	    public int encodedKeyLength() throws StandardException {
-	        return isNull()?1:15;
-	    }
-
-	/**
-	 *
-	 * Encode into key 3 int32s.
-	 *
-	 * @param src
-	 * @param order
-	 * @throws StandardException
-     */
-		@Override
-	    public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-	        if (isNull())
-				OrderedBytes.encodeNull(src, order);
-	        else {
-				OrderedBytes.encodeInt32(src, encodedDate, order);
-				OrderedBytes.encodeInt32(src, encodedTime, order);
-				OrderedBytes.encodeInt32(src, nanos, order);
-			}
-	    }
-
-	/**
-	 *
-	 * Decode from key 3 int32's
-	 *
-	 * @param src
-	 * @throws StandardException
-     */
-	    @Override
-	    public void decodeFromKey(PositionedByteRange src) throws StandardException {
-	        if (OrderedBytes.isNull(src))
-				setToNull();
-	        else {
-				encodedDate = OrderedBytes.decodeInt32(src);
-				encodedTime = OrderedBytes.decodeInt32(src);
-				nanos = OrderedBytes.decodeInt32(src);
-				setIsNull(false);
-			}
-	    }
 	@Override
 	public StructField getStructField(String columnName) {
 		return DataTypes.createStructField(columnName, DataTypes.TimestampType, true);

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTinyint.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTinyint.java
@@ -46,9 +46,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import com.splicemachine.db.iapi.types.DataValueFactoryImpl.Format;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -839,52 +836,6 @@ public final class SQLTinyint
 			value = row.getByte(ordinal);
 		}
 	}
-	/**
-	 *
-	 * Get Encoded Key length.  if null then 1 else 2.
-	 *
- 	 * @return
-	 * @throws StandardException
-     */
-		@Override
-	    public int encodedKeyLength() throws StandardException {
-	        return isNull()?1:2;
-	    }
-
-	/**
-	 *
-	 * Encode into Key.
-	 *
-	 * @see OrderedBytes#encodeInt8(PositionedByteRange, byte, Order)
-	 *
-	 * @param src
-	 * @param order
-	 * @throws StandardException
-     */
-		@Override
-	    public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-	        if (isNull())
-		            OrderedBytes.encodeNull(src, order);
-	        else
-	            OrderedBytes.encodeInt8(src, value, order);
-		}
-
-	/**
-	 *
-	 * Decode from Key.
-	 *
-	 * @see OrderedBytes#decodeInt8(PositionedByteRange)
-	 *
-	 * @param src
-	 * @throws StandardException
-     */
-		@Override
-	    public void decodeFromKey(PositionedByteRange src) throws StandardException {
-	        if (OrderedBytes.isNull(src))
-		            setToNull();
-	        else
-	            value = OrderedBytes.decodeInt8(src);
-	    }
 
 	@Override
 	public StructField getStructField(String columnName) {

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/UserType.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/UserType.java
@@ -51,9 +51,6 @@ import java.util.Calendar;
 import com.splicemachine.db.iapi.types.DataValueFactoryImpl.Format;
 import com.yahoo.sketches.theta.UpdateSketch;
 import org.apache.commons.lang.SerializationUtils;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -703,53 +700,6 @@ public class UserType extends DataType
 			isNull = false;
 			value = row.get(ordinal);
 		}
-	}
-
-	/**
-	 *
-	 * Get Key length.  TODO JL.
-	 *
-	 * @return
-	 * @throws StandardException
-     */
-	@Override
-	public int encodedKeyLength() throws StandardException {
-		return isNull()?1:SerializationUtils.serialize((Serializable)value).length;
-	}
-
-	/**
-	 *
-	 * Encode into Key
-	 *
-	 * @see OrderedBytes#encodeBlobVar(PositionedByteRange, byte[], Order)
-	 *
-	 * @param src
-	 * @param order
-	 * @throws StandardException
-     */
-	@Override
-	public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-		if (isNull())
-			OrderedBytes.encodeNull(src, order);
-		else
-			OrderedBytes.encodeBlobVar(src, SerializationUtils.serialize((Serializable)value), order);
-	}
-
-	/**
-	 *
-	 * Decode from Key
-	 *
-	 * @see OrderedBytes#decodeBlobVar(PositionedByteRange)
-	 *
-	 * @param src
-	 * @throws StandardException
-     */
-	@Override
-	public void decodeFromKey(PositionedByteRange src) throws StandardException {
-		if (OrderedBytes.isNull(src))
-			setToNull();
-		else
-			value = SerializationUtils.deserialize(OrderedBytes.decodeBlobVar(src));
 	}
 
 	@Override

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/XML.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/XML.java
@@ -50,9 +50,6 @@ import java.lang.reflect.Method;
 import java.util.List;
 import com.splicemachine.db.iapi.types.DataValueFactoryImpl.Format;
 import com.yahoo.sketches.theta.UpdateSketch;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.OrderedBytes;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -1170,51 +1167,6 @@ public class XML
             setToNull();
         else
             xmlStringValue = new SQLChar(row.getString(ordinal));
-    }
-
-    /**
-     *
-     * Get encoded key length.
-     *
-     * @return
-     * @throws StandardException
-     */
-    @Override
-    public int encodedKeyLength() throws StandardException {
-        return isNull()?1:xmlStringValue.encodedKeyLength(); // Order Does Not Matter for Length
-    }
-
-    /**
-     *
-     * Encode into key.
-     *
-     * @param src
-     * @param order
-     * @throws StandardException
-     */
-    @Override
-    public void encodeIntoKey(PositionedByteRange src, Order order) throws StandardException {
-        if (isNull())
-                OrderedBytes.encodeNull(src, order);
-        else
-            xmlStringValue.encodeIntoKey(src,order);
-    }
-
-    /**
-     *
-     * Decode from key
-     *
-     * @param src
-     * @throws StandardException
-     */
-    @Override
-    public void decodeFromKey(PositionedByteRange src) throws StandardException {
-        if (OrderedBytes.isNull(src))
-                setToNull();
-        else
-            if (xmlStringValue==null)
-                    xmlStringValue = new SQLChar();
-        xmlStringValue.decodeFromKey(src);
     }
 
     @Override

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLArrayTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLArrayTest.java
@@ -14,9 +14,6 @@
  */
 package com.splicemachine.db.iapi.types;
 
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
-import org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder;
 import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter;
@@ -43,12 +40,5 @@ public class SQLArrayTest extends SQLDataValueDescriptorTest {
                 value.read(row, 0);
                 Assert.assertTrue("SerdeIncorrect", valueA.isNull());
         }
-    
-        @Test (expected = Exception.class)
-        public void serdeKeyData() throws Exception {
-                SQLArray value = new SQLArray();
-                value.setValue(new DataValueDescriptor[] {new SQLInteger(23),new SQLInteger(48), new SQLInteger(10)});
-                PositionedByteRange range1 = new SimplePositionedMutableByteRange(value.encodedKeyLength());
-                value.encodeIntoKey(range1, Order.ASCENDING);
-        }
+
 }

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLBlobTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLBlobTest.java
@@ -32,7 +32,6 @@ package com.splicemachine.db.iapi.types;
 
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
-import org.apache.hadoop.hbase.util.*;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder;
@@ -58,7 +57,7 @@ public class SQLBlobTest extends SQLDataValueDescriptorTest {
                 writer.reset();
                 value.write(writer, 0);
                 valueA.read(row,0);
-                Assert.assertTrue("SerdeIncorrect",Bytes.equals("1".getBytes(),valueA.getBytes()));
+                Assert.assertTrue("SerdeIncorrect",Arrays.equals("1".getBytes(),valueA.getBytes()));
         }
 
         @Test
@@ -71,25 +70,6 @@ public class SQLBlobTest extends SQLDataValueDescriptorTest {
                 Assert.assertTrue("SerdeIncorrect", row.isNullAt(0));
                 value.read(row, 0);
                 Assert.assertTrue("SerdeIncorrect", valueA.isNull());
-        }
-    
-        @Test
-        public void serdeKeyData() throws Exception {
-                SQLBlob value1 = new SQLBlob("1".getBytes());
-                SQLBlob value2 = new SQLBlob("2".getBytes());
-                SQLBlob value1a = new SQLBlob();
-                SQLBlob value2a = new SQLBlob();
-                PositionedByteRange range1 = new SimplePositionedMutableByteRange(value1.encodedKeyLength());
-                PositionedByteRange range2 = new SimplePositionedMutableByteRange(value2.encodedKeyLength());
-                value1.encodeIntoKey(range1, Order.ASCENDING);
-                value2.encodeIntoKey(range2, Order.ASCENDING);
-                Assert.assertTrue("Positioning is Incorrect", Bytes.compareTo(range1.getBytes(), 0, 9, range2.getBytes(), 0, 9) < 0);
-                range1.setPosition(0);
-                range2.setPosition(0);
-                value1a.decodeFromKey(range1);
-                value2a.decodeFromKey(range2);
-                Assert.assertTrue("1 incorrect",Bytes.equals(value1.getBytes(),value1a.getBytes()));
-                Assert.assertTrue("2 incorrect",Bytes.equals(value2.getBytes(),value2a.getBytes()));
         }
 
         @Test

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLBooleanTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLBooleanTest.java
@@ -35,10 +35,6 @@ import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.stats.ColumnStatisticsImpl;
 import com.splicemachine.db.iapi.stats.ItemStatistics;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
-import org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -79,25 +75,6 @@ public class SQLBooleanTest extends SQLDataValueDescriptorTest {
                 value.read(row, 0);
                 Assert.assertTrue("SerdeIncorrect", valueA.isNull());
             }
-
-        @Test
-        public void serdeKeyData() throws Exception {
-                SQLBoolean value1 = new SQLBoolean(false);
-                SQLBoolean value2 = new SQLBoolean(true);
-                SQLBoolean value1a = new SQLBoolean();
-                SQLBoolean value2a = new SQLBoolean();
-                PositionedByteRange range1 = new SimplePositionedMutableByteRange(value1.encodedKeyLength());
-                PositionedByteRange range2 = new SimplePositionedMutableByteRange(value2.encodedKeyLength());
-                value1.encodeIntoKey(range1, Order.ASCENDING);
-                value2.encodeIntoKey(range2, Order.ASCENDING);
-                Assert.assertTrue("Positioning is Incorrect", Bytes.compareTo(range1.getBytes(), 0, 9, range2.getBytes(), 0, 9) < 0);
-                range1.setPosition(0);
-                range2.setPosition(0);
-                value1a.decodeFromKey(range1);
-                value2a.decodeFromKey(range2);
-                Assert.assertEquals("1 incorrect",value1.getBoolean(),value1a.getBoolean());
-                Assert.assertEquals("2 incorrect",value2.getBoolean(),value2a.getBoolean());
-        }
 
         @Test
         public void rowValueToDVDValue() throws Exception {

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLCharTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLCharTest.java
@@ -35,10 +35,6 @@ import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.stats.ColumnStatisticsImpl;
 import com.splicemachine.db.iapi.stats.ItemStatistics;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
-import org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -84,25 +80,6 @@ public class SQLCharTest extends SQLDataValueDescriptorTest {
                 value.read(row, 0);
                 Assert.assertTrue("SerdeIncorrect", valueA.isNull());
             }
-    
-        @Test
-        public void serdeKeyData() throws Exception {
-                SQLChar value1 = new SQLChar("Splice Machine");
-                SQLChar value2 = new SQLChar("Xplice Machine");
-                SQLChar value1a = new SQLChar();
-                SQLChar value2a = new SQLChar();
-                PositionedByteRange range1 = new SimplePositionedMutableByteRange(value1.encodedKeyLength());
-                PositionedByteRange range2 = new SimplePositionedMutableByteRange(value2.encodedKeyLength());
-                value1.encodeIntoKey(range1, Order.ASCENDING);
-                value2.encodeIntoKey(range2, Order.ASCENDING);
-                Assert.assertTrue("Positioning is Incorrect", Bytes.compareTo(range1.getBytes(), 0, 9, range2.getBytes(), 0, 9) < 0);
-                range1.setPosition(0);
-                range2.setPosition(0);
-                value1a.decodeFromKey(range1);
-                value2a.decodeFromKey(range2);
-                Assert.assertEquals("1 incorrect",value1.getString(),value1a.getString());
-                Assert.assertEquals("2 incorrect",value2.getString(),value2a.getString());
-        }
 
         @Test
         public void rowValueToDVDValue() throws Exception {

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLDateTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLDateTest.java
@@ -32,10 +32,6 @@ package com.splicemachine.db.iapi.types;
 
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
-import org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder;
@@ -79,27 +75,6 @@ public class SQLDateTest extends SQLDataValueDescriptorTest {
                 value.read(row, 0);
                 Assert.assertTrue("SerdeIncorrect", valueA.isNull());
             }
-    
-        @Test
-        public void serdeKeyData() throws Exception {
-                GregorianCalendar gc = new GregorianCalendar();
-                SQLDate value1 = new SQLDate(new Date(97,9,7));
-                SQLDate value2 = new SQLDate(new Date(97,10,7));
-                SQLDate value1a = new SQLDate();
-                SQLDate value2a = new SQLDate();
-                PositionedByteRange range1 = new SimplePositionedMutableByteRange(value1.encodedKeyLength());
-                PositionedByteRange range2 = new SimplePositionedMutableByteRange(value2.encodedKeyLength());
-                value1.encodeIntoKey(range1, Order.ASCENDING);
-                value2.encodeIntoKey(range2, Order.ASCENDING);
-                Assert.assertTrue("Positioning is Incorrect", Bytes.compareTo(range1.getBytes(), 0, 9, range2.getBytes(), 0, 9) < 0);
-                range1.setPosition(0);
-                range2.setPosition(0);
-                value1a.decodeFromKey(range1);
-                value2a.decodeFromKey(range2);
-                Assert.assertEquals("1 incorrect",value1.getDate(gc),value1a.getDate(gc));
-                Assert.assertEquals("2 incorrect",value2.getDate(gc),value2a.getDate(gc));
-        }
-
 
         @Test
         public void testArray() throws Exception {

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLDecimalTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLDecimalTest.java
@@ -34,10 +34,6 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.stats.ColumnStatisticsImpl;
 import com.splicemachine.db.iapi.stats.ItemStatistics;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
-import org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder;
@@ -97,30 +93,7 @@ public class SQLDecimalTest extends SQLDataValueDescriptorTest {
                 value.read(row, 0);
                 Assert.assertTrue("SerdeIncorrect", valueA.isNull());
             }
-        // TODO
-        @Test
-        @Ignore
-        public void serdeKeyData() throws Exception {
-                SQLDecimal value1 = new SQLDecimal(new BigDecimal(100.0d));
-                SQLDecimal value2 = new SQLDecimal(new BigDecimal(200.0d));
-                SQLDecimal value1a = new SQLDecimal();
-                value1a.setPrecision(value1.getPrecision());
-                value1a.setScale(value1.getScale());
-                SQLDecimal value2a = new SQLDecimal();
-                value2a.setPrecision(value2.getPrecision());
-                value2a.setScale(value2.getScale());
-                PositionedByteRange range1 = new SimplePositionedMutableByteRange(value1.encodedKeyLength());
-                PositionedByteRange range2 = new SimplePositionedMutableByteRange(value2.encodedKeyLength());
-                value1.encodeIntoKey(range1, Order.ASCENDING);
-                value2.encodeIntoKey(range2, Order.ASCENDING);
-                Assert.assertTrue("Positioning is Incorrect", Bytes.compareTo(range1.getBytes(), 0, 9, range2.getBytes(), 0, 9) < 0);
-                range1.setPosition(0);
-                range2.setPosition(0);
-                value1a.decodeFromKey(range1);
-                value2a.decodeFromKey(range2);
-                Assert.assertEquals("1 incorrect",value1.getBigDecimal().doubleValue(),value1a.getBigDecimal().doubleValue(),0.1d);
-                Assert.assertEquals("2 incorrect",value2.getBigDecimal().doubleValue(),value2a.getBigDecimal().doubleValue(),0.1d);
-        }
+
 
         @Test
         public void testColumnStatistics() throws Exception {

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLDoubleTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLDoubleTest.java
@@ -34,10 +34,6 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.stats.ItemStatistics;
 import com.splicemachine.db.iapi.stats.ColumnStatisticsImpl;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
-import org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder;
@@ -108,25 +104,7 @@ public class SQLDoubleTest extends SQLDataValueDescriptorTest {
                 value.read(row, 0);
                 Assert.assertTrue("SerdeIncorrect", valueA.isNull());
             }
-    
-                @Test
-        public void serdeKeyData() throws Exception {
-                SQLDouble value1 = new SQLDouble(100.0d);
-                SQLDouble value2 = new SQLDouble(200.0d);
-                SQLDouble value1a = new SQLDouble();
-                SQLDouble value2a = new SQLDouble();
-                PositionedByteRange range1 = new SimplePositionedMutableByteRange(value1.encodedKeyLength());
-                PositionedByteRange range2 = new SimplePositionedMutableByteRange(value2.encodedKeyLength());
-                value1.encodeIntoKey(range1, Order.ASCENDING);
-                value2.encodeIntoKey(range2, Order.ASCENDING);
-                Assert.assertTrue("Positioning is Incorrect", Bytes.compareTo(range1.getBytes(), 0, 9, range2.getBytes(), 0, 9) < 0);
-                range1.setPosition(0);
-                range2.setPosition(0);
-                value1a.decodeFromKey(range1);
-                value2a.decodeFromKey(range2);
-                Assert.assertEquals("1 incorrect",value1.getDouble(),value1a.getDouble(),0.0d);
-                Assert.assertEquals("2 incorrect",value2.getDouble(),value2a.getDouble(),0.0d);
-            }
+
         @Test
         public void testColumnStatistics() throws Exception {
                 SQLDouble value1 = new SQLDouble();

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLIntegerTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLIntegerTest.java
@@ -35,10 +35,6 @@ import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.db.iapi.stats.ColumnStatisticsImpl;
 import com.splicemachine.db.iapi.stats.ItemStatistics;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
-import org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
@@ -106,25 +102,6 @@ public class SQLIntegerTest extends SQLDataValueDescriptorTest {
                 value.read(row, 0);
                 Assert.assertTrue("SerdeIncorrect", valueA.isNull());
             }
-    
-        @Test
-        public void serdeKeyData() throws Exception {
-                SQLInteger value1 = new SQLInteger(100);
-                SQLInteger value2 = new SQLInteger(200);
-                SQLInteger value1a = new SQLInteger();
-                SQLInteger value2a = new SQLInteger();
-                PositionedByteRange range1 = new SimplePositionedMutableByteRange(value1.encodedKeyLength());
-                PositionedByteRange range2 = new SimplePositionedMutableByteRange(value2.encodedKeyLength());
-                value1.encodeIntoKey(range1, Order.ASCENDING);
-                value2.encodeIntoKey(range2, Order.ASCENDING);
-                Assert.assertTrue("Positioning is Incorrect", Bytes.compareTo(range1.getBytes(), 0, 9, range2.getBytes(), 0, 9) < 0);
-                range1.setPosition(0);
-                range2.setPosition(0);
-                value1a.decodeFromKey(range1);
-                value2a.decodeFromKey(range2);
-                Assert.assertEquals("1 incorrect",value1.getInt(),value1a.getInt(),0);
-                Assert.assertEquals("2 incorrect",value2.getInt(),value2a.getInt(),0);
-        }
 
         @Test
         public void rowValueToDVDValue() throws Exception {

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLLongIntTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLLongIntTest.java
@@ -34,10 +34,6 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.stats.ColumnStatisticsImpl;
 import com.splicemachine.db.iapi.stats.ItemStatistics;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
-import org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder;
@@ -104,25 +100,6 @@ public class SQLLongIntTest extends SQLDataValueDescriptorTest {
                 value.read(row, 0);
                 Assert.assertTrue("SerdeIncorrect", valueA.isNull());
             }
-    
-        @Test
-        public void serdeKeyData() throws Exception {
-                SQLLongint value1 = new SQLLongint(100l);
-                SQLLongint value2 = new SQLLongint(200l);
-                SQLLongint value1a = new SQLLongint();
-                SQLLongint value2a = new SQLLongint();
-                PositionedByteRange range1 = new SimplePositionedMutableByteRange(value1.encodedKeyLength());
-                PositionedByteRange range2 = new SimplePositionedMutableByteRange(value2.encodedKeyLength());
-                value1.encodeIntoKey(range1, Order.ASCENDING);
-                value2.encodeIntoKey(range2, Order.ASCENDING);
-                Assert.assertTrue("Positioning is Incorrect", Bytes.compareTo(range1.getBytes(), 0, 9, range2.getBytes(), 0, 9) < 0);
-                range1.setPosition(0);
-                range2.setPosition(0);
-                value1a.decodeFromKey(range1);
-                value2a.decodeFromKey(range2);
-                Assert.assertEquals("1 incorrect",value1.getLong(),value1a.getLong(),0l);
-                Assert.assertEquals("2 incorrect",value2.getLong(),value2a.getLong(),0l);
-        }
 
         @Test
         public void testColumnStatistics() throws Exception {

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLRealTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLRealTest.java
@@ -34,10 +34,6 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.stats.ColumnStatisticsImpl;
 import com.splicemachine.db.iapi.stats.ItemStatistics;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
-import org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder;
@@ -104,25 +100,6 @@ public class SQLRealTest extends SQLDataValueDescriptorTest {
                 Assert.assertTrue("SerdeIncorrect", row.isNullAt(0));
                 value.read(row, 0);
                 Assert.assertTrue("SerdeIncorrect", valueA.isNull());
-            }
-    
-        @Test
-        public void serdeKeyData() throws Exception {
-                SQLReal value1 = new SQLReal(100.0f);
-                SQLReal value2 = new SQLReal(200.0f);
-                SQLReal value1a = new SQLReal();
-                SQLReal value2a = new SQLReal();
-                PositionedByteRange range1 = new SimplePositionedMutableByteRange(value1.encodedKeyLength());
-                PositionedByteRange range2 = new SimplePositionedMutableByteRange(value2.encodedKeyLength());
-                value1.encodeIntoKey(range1, Order.ASCENDING);
-                value2.encodeIntoKey(range2, Order.ASCENDING);
-                Assert.assertTrue("Positioning is Incorrect", Bytes.compareTo(range1.getBytes(), 0, 9, range2.getBytes(), 0, 9) < 0);
-                range1.setPosition(0);
-                range2.setPosition(0);
-                value1a.decodeFromKey(range1);
-                value2a.decodeFromKey(range2);
-                Assert.assertEquals("1 incorrect",value1.getFloat(),value1a.getFloat(),0.0f);
-                Assert.assertEquals("2 incorrect",value2.getFloat(),value2a.getFloat(),0.0f);
             }
 
         @Test

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLRefTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLRefTest.java
@@ -30,7 +30,6 @@
  */
 package com.splicemachine.db.iapi.types;
 
-import org.apache.hadoop.hbase.util.*;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder;
 import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter;
@@ -80,25 +79,6 @@ public class SQLRefTest extends SQLDataValueDescriptorTest {
                 Assert.assertTrue("SerdeIncorrect", row.isNullAt(0));
                 value.read(row, 0);
                 Assert.assertTrue("SerdeIncorrect", valueA.isNull());
-        }
-    
-        @Test
-        public void serdeKeyData() throws Exception {
-                SQLRef value1 = new SQLRef(new SQLRowId("1".getBytes()));
-                SQLRef value2 = new SQLRef(new SQLRowId("2".getBytes()));
-                SQLRef value1a = new SQLRef();
-                SQLRef value2a = new SQLRef();
-                PositionedByteRange range1 = new SimplePositionedMutableByteRange(value1.encodedKeyLength());
-                PositionedByteRange range2 = new SimplePositionedMutableByteRange(value2.encodedKeyLength());
-                value1.encodeIntoKey(range1, Order.ASCENDING);
-                value2.encodeIntoKey(range2, Order.ASCENDING);
-                Assert.assertTrue("Positioning is Incorrect", Bytes.compareTo(range1.getBytes(), 0, 9, range2.getBytes(), 0, 9) < 0);
-                range1.setPosition(0);
-                range2.setPosition(0);
-                value1a.decodeFromKey(range1);
-                value2a.decodeFromKey(range2);
-                Assert.assertEquals("1 incorrect",value1.getObject(),value1a.getObject());
-                Assert.assertEquals("2 incorrect",value2.getObject(),value2a.getObject());
         }
 
         @Test

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLSmallIntTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLSmallIntTest.java
@@ -34,10 +34,6 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.stats.ColumnStatisticsImpl;
 import com.splicemachine.db.iapi.stats.ItemStatistics;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
-import org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder;
@@ -104,25 +100,6 @@ public class SQLSmallIntTest extends SQLDataValueDescriptorTest {
                 value.read(row, 0);
                 Assert.assertTrue("SerdeIncorrect", valueA.isNull());
             }
-    
-        @Test
-        public void serdeKeyData() throws Exception {
-                SQLSmallint value1 = new SQLSmallint(100);
-                SQLSmallint value2 = new SQLSmallint(200);
-                SQLSmallint value1a = new SQLSmallint();
-                SQLSmallint value2a = new SQLSmallint();
-                PositionedByteRange range1 = new SimplePositionedMutableByteRange(value1.encodedKeyLength());
-                PositionedByteRange range2 = new SimplePositionedMutableByteRange(value2.encodedKeyLength());
-                value1.encodeIntoKey(range1, Order.ASCENDING);
-                value2.encodeIntoKey(range2, Order.ASCENDING);
-                Assert.assertTrue("Positioning is Incorrect", Bytes.compareTo(range1.getBytes(), 0, 9, range2.getBytes(), 0, 9) < 0);
-                range1.setPosition(0);
-                range2.setPosition(0);
-                value1a.decodeFromKey(range1);
-                value2a.decodeFromKey(range2);
-                Assert.assertEquals("1 incorrect",value1.getInt(),value1a.getInt(),0);
-                Assert.assertEquals("2 incorrect",value2.getInt(),value2a.getInt(),0);
-        }
 
         @Test
         public void testColumnStatistics() throws Exception {

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLTimeTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLTimeTest.java
@@ -32,9 +32,6 @@ package com.splicemachine.db.iapi.types;
 
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
-import org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder;
@@ -77,26 +74,6 @@ public class SQLTimeTest extends SQLDataValueDescriptorTest {
                 value.write(writer, 0);
                 Assert.assertTrue("SerdeIncorrect", valueA.isNull());
             }
-    
-        @Test
-        public void serdeKeyData() throws Exception {
-                GregorianCalendar gc = new GregorianCalendar();
-                long currentTimeMillis = System.currentTimeMillis();
-                SQLTime value1 = new SQLTime(new Time(currentTimeMillis));
-                SQLTime value2 = new SQLTime(new Time(currentTimeMillis+200));
-                SQLTime value1a = new SQLTime();
-                SQLTime value2a = new SQLTime();
-                PositionedByteRange range1 = new SimplePositionedMutableByteRange(value1.encodedKeyLength());
-                PositionedByteRange range2 = new SimplePositionedMutableByteRange(value2.encodedKeyLength());
-                value1.encodeIntoKey(range1, Order.ASCENDING);
-                value2.encodeIntoKey(range2, Order.ASCENDING);
-                range1.setPosition(0);
-                range2.setPosition(0);
-                value1a.decodeFromKey(range1);
-                value2a.decodeFromKey(range2);
-                Assert.assertEquals("1 incorrect",value1.getTime(gc),value1a.getTime(gc));
-                Assert.assertEquals("2 incorrect",value2.getTime(gc),value2a.getTime(gc));
-        }
 
         @Test
         public void testArray() throws Exception {

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLTimestampTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLTimestampTest.java
@@ -36,9 +36,6 @@ import com.splicemachine.db.iapi.stats.ItemStatistics;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.yahoo.sketches.quantiles.ItemsSketch;
 import com.yahoo.sketches.quantiles.ItemsUnion;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
-import org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder;
@@ -80,26 +77,6 @@ public class SQLTimestampTest extends SQLDataValueDescriptorTest {
                 value.write(writer, 0);
                 Assert.assertTrue("SerdeIncorrect", valueA.isNull());
             }
-    
-        @Test
-        public void serdeKeyData() throws Exception {
-                GregorianCalendar gc = new GregorianCalendar();
-                long currentTimeMillis = System.currentTimeMillis();
-                SQLTimestamp value1 = new SQLTimestamp(new Timestamp(currentTimeMillis));
-                SQLTimestamp value2 = new SQLTimestamp(new Timestamp(currentTimeMillis+200));
-                SQLTimestamp value1a = new SQLTimestamp();
-                SQLTimestamp value2a = new SQLTimestamp();
-                PositionedByteRange range1 = new SimplePositionedMutableByteRange(value1.encodedKeyLength());
-                PositionedByteRange range2 = new SimplePositionedMutableByteRange(value2.encodedKeyLength());
-                value1.encodeIntoKey(range1, Order.ASCENDING);
-                value2.encodeIntoKey(range2, Order.ASCENDING);
-                range1.setPosition(0);
-                range2.setPosition(0);
-                value1a.decodeFromKey(range1);
-                value2a.decodeFromKey(range2);
-                Assert.assertEquals("1 incorrect",value1.getTimestamp(gc),value1a.getTimestamp(gc));
-                Assert.assertEquals("2 incorrect",value2.getTimestamp(gc),value2a.getTimestamp(gc));
-        }
 
         @Test
         public void testColumnStatistics() throws Exception {

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLTinyIntTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLTinyIntTest.java
@@ -34,10 +34,6 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.stats.ColumnStatisticsImpl;
 import com.splicemachine.db.iapi.stats.ItemStatistics;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
-import org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder;
@@ -77,25 +73,6 @@ public class SQLTinyIntTest extends SQLDataValueDescriptorTest {
                 value.read(row, 0);
                 Assert.assertTrue("SerdeIncorrect", valueA.isNull());
             }
-    
-        @Test
-        public void serdeKeyData() throws Exception {
-                SQLTinyint value1 = new SQLTinyint(Byte.valueOf("1"));
-                SQLTinyint value2 = new SQLTinyint(Byte.valueOf("2"));
-                SQLTinyint value1a = new SQLTinyint();
-                SQLTinyint value2a = new SQLTinyint();
-                PositionedByteRange range1 = new SimplePositionedMutableByteRange(value1.encodedKeyLength());
-                PositionedByteRange range2 = new SimplePositionedMutableByteRange(value2.encodedKeyLength());
-                value1.encodeIntoKey(range1, Order.ASCENDING);
-                value2.encodeIntoKey(range2, Order.ASCENDING);
-                Assert.assertTrue("Positioning is Incorrect", Bytes.compareTo(range1.getBytes(), 0, 9, range2.getBytes(), 0, 9) < 0);
-                range1.setPosition(0);
-                range2.setPosition(0);
-                value1a.decodeFromKey(range1);
-                value2a.decodeFromKey(range2);
-                Assert.assertEquals("1 incorrect",value1.getByte(),value1a.getByte());
-                Assert.assertEquals("2 incorrect",value2.getByte(),value2a.getByte());
-        }
 
         @Test
         public void testColumnStatistics() throws Exception {

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLVarcharTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLVarcharTest.java
@@ -34,10 +34,6 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.stats.ColumnStatisticsImpl;
 import com.splicemachine.db.iapi.stats.ItemStatistics;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
-import org.apache.hadoop.hbase.util.SimplePositionedMutableByteRange;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder;
@@ -79,25 +75,6 @@ public class SQLVarcharTest extends SQLDataValueDescriptorTest {
                 value.read(row, 0);
                 Assert.assertTrue("SerdeIncorrect", valueA.isNull());
             }
-    
-        @Test
-        public void serdeKeyData() throws Exception {
-                SQLChar value1 = new SQLChar("Splice Machine");
-                SQLChar value2 = new SQLChar("Xplice Machine");
-                SQLChar value1a = new SQLChar();
-                SQLChar value2a = new SQLChar();
-                PositionedByteRange range1 = new SimplePositionedMutableByteRange(value1.encodedKeyLength());
-                PositionedByteRange range2 = new SimplePositionedMutableByteRange(value2.encodedKeyLength());
-                value1.encodeIntoKey(range1, Order.ASCENDING);
-                value2.encodeIntoKey(range2, Order.ASCENDING);
-                Assert.assertTrue("Positioning is Incorrect", Bytes.compareTo(range1.getBytes(), 0, 9, range2.getBytes(), 0, 9) < 0);
-                range1.setPosition(0);
-                range2.setPosition(0);
-                value1a.decodeFromKey(range1);
-                value2a.decodeFromKey(range2);
-                Assert.assertEquals("1 incorrect",value1.getString(),value1a.getString());
-                Assert.assertEquals("2 incorrect",value2.getString(),value2a.getString());
-        }
 
         @Test
         public void testColumnStatistics() throws Exception {

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/UGIUser.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/UGIUser.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.derby.impl;
+
+import com.splicemachine.db.impl.drda.User;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import java.io.IOException;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedExceptionAction;
+
+public class UGIUser implements User {
+
+    private final UserGroupInformation ugi;
+
+    public UGIUser(UserGroupInformation ugi) {
+        this.ugi = ugi;
+    }
+
+    @Override
+    public <T> T doAs(PrivilegedAction<T> action) {
+        return ugi.doAs(action);
+    }
+
+    @Override
+    public String getUserName() {
+        return ugi.getUserName();
+    }
+
+    @Override
+    public <T> T doAs(PrivilegedExceptionAction<T> action) throws IOException, InterruptedException {
+        return ugi.doAs(action);
+    }
+}

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/UGIUserManager.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/UGIUserManager.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.derby.impl;
+
+import com.splicemachine.db.impl.drda.User;
+import com.splicemachine.db.impl.drda.UserManager;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import javax.security.auth.Subject;
+import java.io.IOException;
+
+public class UGIUserManager implements UserManager {
+    @Override
+    public User getCurrentUser() throws IOException {
+        return new UGIUser(UserGroupInformation.getCurrentUser());
+    }
+
+    @Override
+    public User getUserFromSubject(Subject subject) throws IOException {
+        return new UGIUser(UserGroupInformation.getUGIFromSubject(subject));
+    }
+}

--- a/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.db.impl.drda.UserManager
+++ b/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.db.impl.drda.UserManager
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+#
+# This file is part of Splice Machine.
+# Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+# GNU Affero General Public License as published by the Free Software Foundation, either
+# version 3, or (at your option) any later version.
+# Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+com.splicemachine.derby.impl.UGIUserManager

--- a/splice_machine/pom.xml
+++ b/splice_machine/pom.xml
@@ -105,18 +105,6 @@
             <artifactId>commons-cli</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.hbase</groupId>
-            <artifactId>hbase-common</artifactId>
-            <version>1.0.0-cdh5.6.0</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>commons-dbutils</groupId>
             <artifactId>commons-dbutils</artifactId>
             <scope>test</scope>

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupRestoreConstants.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupRestoreConstants.java
@@ -17,17 +17,19 @@ package com.splicemachine.backup;
 /**
  * Created by jyuan on 8/8/16.
  */
-import org.apache.hadoop.hbase.util.Bytes;
+
+import java.nio.charset.Charset;
 
 public class BackupRestoreConstants {
+    private static Charset UTF8_CHARSET = Charset.forName("UTF-8");
 
     public static final String BACKUP_DIR = "backup";
     public static final String BACKUP_DATA_DIR = "data";
     public static final String BACKUP_RECORD_FILE_NAME = "SYSBACKUP";
     public static final String REGION_FILE_NAME = ".regioninfo";
     public static final String ARCHIVE_DIR = "archive";
-    public static final byte[] BACKUP_TYPE_FULL_BYTES = Bytes.toBytes("FULL");
-    public static final byte[] BACKUP_TYPE_INCR_BYTES = Bytes.toBytes("INCR");
+    public static final byte[] BACKUP_TYPE_FULL_BYTES = "FULL".getBytes(UTF8_CHARSET);
+    public static final byte[] BACKUP_TYPE_INCR_BYTES = "INCR".getBytes(UTF8_CHARSET);
     public static final String BACKUP_JOB_GROUP = "Backup";
     public static final String RESTORE_JOB_GROUP = "Restore";
     public static final long BACKUP_JOB_TIMEOUT = 30000;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperation.java
@@ -52,6 +52,7 @@ import com.splicemachine.derby.utils.marshall.DataHash;
 import com.splicemachine.derby.utils.marshall.dvd.DescriptorSerializer;
 import com.splicemachine.derby.utils.marshall.dvd.VersionedSerializers;
 import com.splicemachine.pipeline.Exceptions;
+import com.splicemachine.primitives.Bytes;
 import com.splicemachine.protobuf.ProtoUtil;
 import com.splicemachine.si.api.txn.Txn;
 import com.splicemachine.si.api.txn.TxnLifecycleManager;
@@ -863,7 +864,7 @@ public class CreateIndexConstantOperation extends IndexConstantOperation impleme
             byte[] splitKey = encoder.encode();
             if (LOG.isDebugEnabled()) {
                 SpliceLogUtils.debug(LOG, "execRow = %s, splitKey = %s", execRow,
-                        org.apache.hadoop.hbase.util.Bytes.toStringBinary(splitKey));
+                        Bytes.toStringBinary(splitKey));
             }
             admin.splitTable(new Long(conglomId).toString(), splitKey);
         }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
@@ -47,6 +47,7 @@ import com.splicemachine.derby.utils.marshall.DataHash;
 import com.splicemachine.derby.utils.marshall.KeyHashDecoder;
 import com.splicemachine.derby.utils.marshall.dvd.DescriptorSerializer;
 import com.splicemachine.derby.utils.marshall.dvd.VersionedSerializers;
+import com.splicemachine.primitives.Bytes;
 import com.splicemachine.si.api.data.TxnOperationFactory;
 import com.splicemachine.si.api.txn.TxnView;
 import com.splicemachine.si.constants.SIConstants;
@@ -61,8 +62,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.HConstants;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
 import org.spark_project.guava.collect.Lists;
@@ -81,6 +80,7 @@ import java.util.*;
 public class SpliceRegionAdmin {
 
     private static final Logger LOG=Logger.getLogger(SpliceRegionAdmin.class);
+    public static final String HBASE_DIR = "hbase.rootdir";
 
 
     /**
@@ -891,7 +891,7 @@ public class SpliceRegionAdmin {
 
     }
     private static Path getRegionPath(Configuration conf, String conglomId, String encodedName) throws IOException {
-        Path p = new Path(conf.get(HConstants.HBASE_DIR));
+        Path p = new Path(conf.get(HBASE_DIR));
         FileSystem fs = p.getFileSystem(conf);
         p =  p.makeQualified(fs);
         Path data = new Path(p, "data");
@@ -904,7 +904,7 @@ public class SpliceRegionAdmin {
     private static Path getTmpPath(Configuration conf,
                                              String conglomId,
                                              String encodedName) throws IOException {
-        Path p = new Path(conf.get(HConstants.HBASE_DIR));
+        Path p = new Path(conf.get(HBASE_DIR));
         FileSystem fs = p.getFileSystem(conf);
         p =  p.makeQualified(fs);
         Path tmp = new Path(p, ".tmp");

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/TableSplit.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/TableSplit.java
@@ -16,6 +16,7 @@ package com.splicemachine.derby.impl.storage;
 
 import java.io.*;
 import java.net.URI;
+import java.nio.file.StandardOpenOption;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -23,6 +24,8 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.splicemachine.access.api.DistributedFileSystem;
+import com.splicemachine.access.configuration.HBaseConfiguration;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.sql.Activation;
@@ -30,12 +33,11 @@ import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.impl.jdbc.EmbedConnection;
 import com.splicemachine.derby.utils.SpliceAdmin;
 import com.splicemachine.pipeline.ErrorState;
+import com.splicemachine.primitives.Bytes;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.HBaseConfiguration;
-import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.log4j.Logger;
 import org.spark_project.guava.base.Splitter;
 
@@ -106,10 +108,9 @@ public class TableSplit{
         ps.executeQuery();
         ps.close();
 
-        Configuration conf = HBaseConfiguration.create();
-        FileSystem fs = FileSystem.get(URI.create(tempDir), conf);
+        DistributedFileSystem fs = SIDriver.driver().getFileSystem(tempDir);
         Path filePath = new Path(tempDir, conglomId + "/keys");
-        FSDataInputStream in = fs.open(filePath);
+        InputStream in = fs.newInputStream(filePath.toString(), StandardOpenOption.READ);
         BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
         String splitKey = null;
         while((splitKey = br.readLine()) != null) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceConglomerate.java
@@ -31,8 +31,6 @@ import com.splicemachine.derby.impl.store.access.SpliceTransaction;
 import com.splicemachine.si.api.data.TxnOperationFactory;
 import com.yahoo.sketches.theta.UpdateSketch;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.apache.hadoop.hbase.util.Order;
-import org.apache.hadoop.hbase.util.PositionedByteRange;
 import org.apache.log4j.Logger;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
@@ -237,21 +235,6 @@ public abstract class SpliceConglomerate extends GenericConglomerate implements 
 
     @Override
     public void read(Row unsafeRow, int ordinal) throws StandardException {
-        throw new UnsupportedOperationException("Not Implemented");
-    }
-
-    @Override
-    public int encodedKeyLength() throws StandardException {
-        throw new UnsupportedOperationException("Not Implemented");
-    }
-
-    @Override
-    public void encodeIntoKey(PositionedByteRange builder, Order order) throws StandardException {
-        throw new UnsupportedOperationException("Not Implemented");
-    }
-
-    @Override
-    public void decodeFromKey(PositionedByteRange builder) throws StandardException {
         throw new UnsupportedOperationException("Not Implemented");
     }
 

--- a/utilities/src/main/java/com/splicemachine/primitives/Bytes.java
+++ b/utilities/src/main/java/com/splicemachine/primitives/Bytes.java
@@ -905,4 +905,12 @@ public class Bytes {
         return b[offset] != (byte) 0;
     }
 
+    /**
+     * @param left left operand
+     * @param right right operand
+     * @return 0 if equal, &lt; 0 if left is less than right, etc.
+     */
+    public static int compareTo(byte[] left, byte[] right) {
+        return compareBytes(false, left, right);
+    }
 }


### PR DESCRIPTION
Changes summary:

1. Removed unused code from Datatypes
  1.1 encodedKeyLength() 
  1.2 encodeIntoKey(PositionedByteRange builder, Order order)  
  1.3 decodeFromKey(PositionedByteRange builder)
2. Wrapped UserGroupInformation in DRDAConnThread into a dynamically loaded object implemented in the hbase_sql module
3. Removed usages of org.apache.hadoop.hbase.util.Bytes from splice_machine module