### PR TITLE
SPLICE-2120 update SYS.SYSROUTINEPERMS when upgrading system procedures (2.7)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -2130,4 +2130,14 @@ public interface DataDictionary{
      * @throws StandardException
      */
     List<String> getDefaultRoles(String username, TransactionController tc) throws StandardException;
+
+    /**
+     * Get permissions for a routine (function or procedure).
+     *
+     * @param routineUUID     the uuid of the routing permissions to fetch
+     * @param permsList       list of routine permissions related to routineUUID to be populated
+     * @return The first found descriptor of the users permissions for the routine.
+     * @throws StandardException
+     */
+    RoutinePermsDescriptor getRoutinePermissions(UUID routineUUID, List<RoutinePermsDescriptor> permsList) throws StandardException;
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/RoutinePermsDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/RoutinePermsDescriptor.java
@@ -59,8 +59,11 @@ public class RoutinePermsDescriptor extends PermissionsDescriptor
         this.hasExecutePermission = hasExecutePermission;
         //routineUUID can be null only if the constructor with routineePermsUUID
         //has been invoked.
-        if (routineUUID != null)
-        	routineName = dd.getAliasDescriptor(routineUUID).getObjectName();
+        if (routineUUID != null) {
+        	AliasDescriptor ad = dd.getAliasDescriptor(routineUUID);
+        	if (ad != null)
+        		routineName = ad.getObjectName();
+		}
 	}
 	
 	public RoutinePermsDescriptor( DataDictionary dd,
@@ -170,5 +173,9 @@ public class RoutinePermsDescriptor extends PermissionsDescriptor
 	{
         return getDependableFinder(
                 StoredFormatIds.ROUTINE_PERMISSION_FINDER_V01_ID);
+	}
+
+	public String getRoutineName() {
+		return routineName;
 	}
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DefaultSystemProcedureGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DefaultSystemProcedureGenerator.java
@@ -31,16 +31,6 @@
 
 package com.splicemachine.db.impl.sql.catalog;
 
-import java.sql.Types;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-
 import com.splicemachine.db.catalog.AliasInfo;
 import com.splicemachine.db.catalog.TypeDescriptor;
 import com.splicemachine.db.catalog.UUID;
@@ -52,9 +42,13 @@ import com.splicemachine.db.iapi.services.monitor.ModuleControl;
 import com.splicemachine.db.iapi.services.monitor.Monitor;
 import com.splicemachine.db.iapi.sql.dictionary.AliasDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
+import com.splicemachine.db.iapi.sql.dictionary.RoutinePermsDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+
+import java.sql.Types;
+import java.util.*;
 
 /**
  * @author Scott Fines
@@ -100,7 +94,7 @@ public class DefaultSystemProcedureGenerator implements SystemProcedureGenerator
                 //free null check plus cast protection
                 if (n instanceof Procedure) {
                     Procedure procedure = (Procedure) n;
-                    newlyCreatedRoutines.add(procedure.createSystemProcedure(uuid, dictionary, tc).getMethodName());
+                    newlyCreatedRoutines.add(procedure.createSystemProcedure(uuid, dictionary, tc).getAliasInfo().getMethodName());
                 }
             }
         }
@@ -142,7 +136,7 @@ public class DefaultSystemProcedureGenerator implements SystemProcedureGenerator
     	if (procedure == null) {
     		throw StandardException.newException(SQLState.LANG_OBJECT_NOT_FOUND_DURING_EXECUTION, "PROCEDURE", (schemaName + "." + procName));
     	} else {
-    		newlyCreatedRoutines.add(procedure.createSystemProcedure(schemaId, dictionary, tc).getMethodName());
+    		newlyCreatedRoutines.add(procedure.createSystemProcedure(schemaId, dictionary, tc).getAliasInfo().getMethodName());
     	}
     }
 
@@ -220,7 +214,12 @@ public class DefaultSystemProcedureGenerator implements SystemProcedureGenerator
     		// If not found check for existing function
         	ad = dictionary.getAliasDescriptor(schemaIdStr, procName, AliasInfo.ALIAS_NAME_SPACE_FUNCTION_AS_CHAR);
     	}
-    	if (ad != null) {  // Drop the procedure if it already exists.
+
+		List<RoutinePermsDescriptor> permsList = new ArrayList<> ();
+
+    	if (ad != null) {
+			dictionary.getRoutinePermissions(ad.getUUID(), permsList);
+    		// Drop the procedure if it already exists.
     		dictionary.dropAliasDescriptor(ad, tc);
     	}
 
@@ -229,7 +228,18 @@ public class DefaultSystemProcedureGenerator implements SystemProcedureGenerator
     	if (procedure == null) {
     		throw StandardException.newException(SQLState.LANG_OBJECT_NOT_FOUND_DURING_EXECUTION, "PROCEDURE", (schemaName + "." + procName));
     	} else {
-    		newlyCreatedRoutines.add(procedure.createSystemProcedure(schemaId, dictionary, tc).getMethodName());
+    		AliasDescriptor newAliasDescriptor = procedure.createSystemProcedure(schemaId, dictionary, tc);
+    		newlyCreatedRoutines.add(newAliasDescriptor.getAliasInfo().getMethodName());
+
+    		// drop permission with old aliasInfo and re-populate with the new AliasInfo
+			for (RoutinePermsDescriptor perm : permsList) {
+				//remove perm from SYS.SYSROUTINEPERMS
+				dictionary.addRemovePermissionsDescriptor(false, perm, perm.getGrantee(), tc);
+				//update perm with new routineUUID
+				RoutinePermsDescriptor newPerm = new RoutinePermsDescriptor(dictionary, perm.getGrantee(), perm.getGrantor(), newAliasDescriptor.getUUID(), perm.getHasExecutePermission());
+				// add a new perm row with updated UUID of the system procedure
+				dictionary.addRemovePermissionsDescriptor(true, newPerm, newPerm.getGrantee(), tc);
+			}
     	}
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/Procedure.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/Procedure.java
@@ -99,7 +99,7 @@ public class Procedure {
         return name.hashCode();
     }
 
-    public RoutineAliasInfo createSystemProcedure(UUID schemaId,
+    public AliasDescriptor createSystemProcedure(UUID schemaId,
                                                   DataDictionary dataDictionary,
                                                   TransactionController tc) throws StandardException {
         int numArgs = args.length;
@@ -138,7 +138,7 @@ public class Procedure {
                 null);
         dataDictionary.addDescriptor(ads,null,DataDictionary.SYSALIASES_CATALOG_NUM,false,tc);
 
-        return rai;
+        return ads;
     }
 
     public static class Builder{

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSROUTINEPERMSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSROUTINEPERMSRowFactory.java
@@ -59,10 +59,10 @@ public class SYSROUTINEPERMSRowFactory extends PermissionsCatalogRowFactory
 	static final String TABLENAME_STRING = "SYSROUTINEPERMS";
 
     // Column numbers for the SYSROUTINEPERMS table. 1 based
-    private static final int ROUTINEPERMSID_COL_NUM = 1;
+    public static final int ROUTINEPERMSID_COL_NUM = 1;
     private static final int GRANTEE_COL_NUM = 2;
     private static final int GRANTOR_COL_NUM = 3;
-    private static final int ALIASID_COL_NUM = 4;
+    public static final int ALIASID_COL_NUM = 4;
     private static final int GRANTOPTION_COL_NUM = 5;
     private static final int COLUMN_COUNT = 5;
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -61,8 +61,8 @@ public class SpliceCatalogUpgradeScripts{
         scripts.put(new Splice_DD_Version(sdd,1,0,0),new UpgradeScriptForFuji(sdd,tc));
         scripts.put(new Splice_DD_Version(sdd,1,1,1),new LassenUpgradeScript(sdd,tc));
         scripts.put(new Splice_DD_Version(sdd,2,6,0),new UpgradeScriptFor260(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,2,7,1), new UpgradeScriptForModifySchemaPermission(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,2,7,1), new UpgradeScriptForAddDefaultRole(sdd,tc));
+        scripts.put(new Splice_DD_Version(sdd,2,7,1), new UpgradeScriptForModifySchemaPermissionAndDefaultRole(sdd,tc));
+        scripts.put(new Splice_DD_Version(sdd,2,7,0, 1812), new UpgradeScriptToCleanSysRoutinePerms(sdd,tc));
     }
 
     public void run() throws StandardException{

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForModifySchemaPermissionAndDefaultRole.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForModifySchemaPermissionAndDefaultRole.java
@@ -20,13 +20,14 @@ import com.splicemachine.derby.impl.sql.catalog.SpliceDataDictionary;
 /**
  * Created by yxia on 2/14/18.
  */
-public class UpgradeScriptForModifySchemaPermission extends UpgradeScriptBase {
-    public UpgradeScriptForModifySchemaPermission(SpliceDataDictionary sdd, TransactionController tc) {
+public class UpgradeScriptForModifySchemaPermissionAndDefaultRole extends UpgradeScriptBase {
+    public UpgradeScriptForModifySchemaPermissionAndDefaultRole(SpliceDataDictionary sdd, TransactionController tc) {
         super(sdd, tc);
     }
 
     @Override
     protected void upgradeSystemTables() throws StandardException {
         sdd.upgradeSysSchemaPermsForModifySchemaPrivilege(tc);
+        sdd.upgradeSysRolesWithDefaultRoleColumn(tc);
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptToCleanSysRoutinePerms.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptToCleanSysRoutinePerms.java
@@ -11,6 +11,7 @@
  * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
  * If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.splicemachine.derby.impl.sql.catalog.upgrade;
 
 import com.splicemachine.db.iapi.error.StandardException;
@@ -18,15 +19,15 @@ import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.derby.impl.sql.catalog.SpliceDataDictionary;
 
 /**
- * Created by yxia on 3/8/18.
+ * Created by yxia on 3/21/18.
  */
-public class UpgradeScriptForAddDefaultRole extends UpgradeScriptBase {
-    public UpgradeScriptForAddDefaultRole(SpliceDataDictionary sdd, TransactionController tc) {
+public class UpgradeScriptToCleanSysRoutinePerms extends UpgradeScriptBase {
+    public UpgradeScriptToCleanSysRoutinePerms(SpliceDataDictionary sdd, TransactionController tc) {
         super(sdd, tc);
     }
 
     @Override
     protected void upgradeSystemTables() throws StandardException {
-        sdd.upgradeSysRolesWithDefaultRoleColumn(tc);
+        sdd.cleanSysRoutinePerms(tc);
     }
 }


### PR DESCRIPTION
also clean obsolete rows in sysroutineperms if any

Port change to branch-2.7. a minor difference from 2.5 is that: there is no call of upgradeSystables() in SpliceDataDictionary.upgradeIfNecessary(), so no need to add a UpgradeScriptForSysTables.java.
