### PR TITLE
SPLICE-2064 Add logging on System.exit() calls

### DIFF
--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -708,7 +708,7 @@
                             <groups>com.splicemachine.test.SerialTest</groups>
                             <excludedGroups>${excluded.categories}</excludedGroups>
                             <argLine>-Xmx3g</argLine>
-                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
                             <dependenciesToScan>
                                 <dependency>com.splicemachine:splice_machine</dependency>
                             </dependenciesToScan>
@@ -735,7 +735,7 @@
                             <!-- -sf- single-threaded for now -->
                             <perCoreThreadCount>false</perCoreThreadCount>
                             <argLine>-Xmx5g</argLine>
-                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
                             <dependenciesToScan>
                                 <dependency>com.splicemachine:splice_machine</dependency>
                             </dependenciesToScan>
@@ -759,7 +759,7 @@
                         <configuration>
                             <groups>com.splicemachine.test.RestoreTest</groups>
                             <argLine>-Xmx3g</argLine>
-                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
                             <includes>
                                 <include>**/*RestoreIT.java</include>
                             </includes>

--- a/mem_sql/pom.xml
+++ b/mem_sql/pom.xml
@@ -211,7 +211,7 @@
                             <groups>com.splicemachine.test.SerialTest</groups>
                             <excludedGroups>com.splicemachine.test.HBaseTest, ${excluded.categories}</excludedGroups>
                             <argLine>-Xmx3g</argLine>
-                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
                             <dependenciesToScan>
                                 <dependency>com.splicemachine:splice_machine</dependency>
                             </dependenciesToScan>
@@ -237,7 +237,7 @@
                             <threadCount>4</threadCount>
                             <perCoreThreadCount>false</perCoreThreadCount>
                             <argLine>-Xmx3g</argLine>
-                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
                             <dependenciesToScan>
                                 <dependency>com.splicemachine:splice_machine</dependency>
                             </dependenciesToScan>

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
@@ -20,6 +20,7 @@ import org.junit.runner.Description;
 import org.junit.runners.model.MultipleFailureException;
 import org.spark_project.guava.collect.Lists;
 
+import java.security.Permission;
 import java.sql.*;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -34,6 +35,20 @@ import static org.spark_project.guava.base.Strings.isNullOrEmpty;
  * Not thread-safe, synchronize externally if using in a multi-threaded test case.
  */
 public class SpliceWatcher extends TestWatcher {
+    static {
+        System.setSecurityManager(new SecurityManager() {
+            @Override
+            public void checkPermission(Permission perm) {
+                if (perm instanceof RuntimePermission) {
+                    RuntimePermission rperm = (RuntimePermission) perm;
+                    if (rperm.getName().startsWith("exitVM")) {
+                        new RuntimeException().printStackTrace(System.out);
+                        System.out.println("exit called");
+                    }
+                }
+            }
+        });
+    }
 
     private static final Logger LOG = Logger.getLogger(SpliceWatcher.class);
 


### PR DESCRIPTION
This change adds logging to intercept System.exit() calls during the ITs execution, which could be the cause of the "VM crashed" messages on jenkins.

This will cause jenkins output to be less readable, we can switch back once the issue is fixed or if this doesn't help diagnose it.