### PR TITLE
SPLICE-2064 Upgrade surefire plugin

### DIFF
--- a/hbase_storage/pom.xml
+++ b/hbase_storage/pom.xml
@@ -292,7 +292,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
                 <configuration>
                     <dependenciesToScan>
                         <dependency>com.splicemachine:splice_si_api</dependency>

--- a/mem_pipeline/pom.xml
+++ b/mem_pipeline/pom.xml
@@ -71,7 +71,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
                 <configuration>
                     <dependenciesToScan>
                         <dependency>com.splicemachine:pipeline_api</dependency>

--- a/mem_sql/pom.xml
+++ b/mem_sql/pom.xml
@@ -127,7 +127,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
                 <configuration>
                     <dependenciesToScan>
                         <dependency>com.splicemachine:splice_machine</dependency>

--- a/mem_storage/pom.xml
+++ b/mem_storage/pom.xml
@@ -57,7 +57,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
                 <configuration>
                     <dependenciesToScan>
                         <dependency>com.splicemachine:splice_si_api</dependency>

--- a/pipeline_api/pom.xml
+++ b/pipeline_api/pom.xml
@@ -61,7 +61,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
                 <!--
                                 -sf- We skip the tests in this module because all of our tests require an architecture
                                 to run, and those architectures are contained further down the line. The poms for

--- a/pom.xml
+++ b/pom.xml
@@ -535,7 +535,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.19</version>
+                    <version>2.21.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -550,7 +550,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.19</version>
+                    <version>2.21.0</version>
                 </plugin>
                 <plugin>
                     <!-- TODO: will need to use splice open source github repo -->

--- a/splice_machine/pom.xml
+++ b/splice_machine/pom.xml
@@ -186,7 +186,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
                 <!--
                     -sf- We skip the tests in this module because all of our tests require an architecture
                     to run, and those architectures are contained further down the line. The poms for

--- a/splice_si_api/pom.xml
+++ b/splice_si_api/pom.xml
@@ -85,7 +85,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
                 <!--
                 -sf- We skip the tests in this module because all of our tests require an architecture
                 to run, and those architectures are contained further down the line. The poms for


### PR DESCRIPTION
The "VM crashed" failure might be related to https://issues.apache.org/jira/browse/SUREFIRE-1302

Upgrading to surefire 2.21.0 might solve it