### PR TITLE
DB-6833 Fixing Index creation errors which where meta handlers not ha…

### DIFF
--- a/pipeline_api/src/test/java/com/splicemachine/pipeline/PipelineDriverTest.java
+++ b/pipeline_api/src/test/java/com/splicemachine/pipeline/PipelineDriverTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.splicemachine.pipeline;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * Test for splitting pipeline amounts
+ *
+ */
+public class PipelineDriverTest {
+    @Test
+    public void determinePortionOfWriteThreads() {
+        Assert.assertEquals(4,PipelineDriver.determinePortionOfWriteThreads(10));
+        Assert.assertEquals(4,PipelineDriver.determinePortionOfWriteThreads(2));
+        Assert.assertEquals(4,PipelineDriver.determinePortionOfWriteThreads(11));
+        Assert.assertEquals(8,PipelineDriver.determinePortionOfWriteThreads(20));
+        Assert.assertEquals(80,PipelineDriver.determinePortionOfWriteThreads(200));
+    }
+}

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/PipelineConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/PipelineConfiguration.java
@@ -146,8 +146,8 @@ public class PipelineConfiguration implements ConfigurationDefault {
     public static final String MAX_DEPENDENT_WRITES = "splice.client.write.maxDependentWrites";
     public static final int DEFAULT_MAX_DEPENDENT_WRITES = 40000;
 
-    public static final String IPC_THREADS="hbase.regionserver.handler.count";
-    public static final int DEFAULT_IPC_THREADS = 200;
+    public static final String IPC_THREADS="hbase.regionserver.metahandler.count";
+    public static final int DEFAULT_IPC_THREADS = 10;
 
     public static final String PIPELINE_KRYO_POOL_SIZE= "splice.writer.kryoPoolSize";
     private static final int DEFAULT_PIPELINE_KRYO_POOL_SIZE=1024;


### PR DESCRIPTION
…ving resources to perform the scans

Makes sure the max threads for the write pipeline limiter are pointing to the correct configuration and also that 20% are reserved for meta scans.  For standard configuration (200), we should have 40 threads available.