### PR TITLE
DB-6833 Set Max Dependent and Independent write threads directly (2.5)

### DIFF
--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineDriver.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineDriver.java
@@ -88,11 +88,11 @@ public class PipelineDriver{
         this.pipelineMeter= meter;
         this.writePipelineFactory = writePipelineFactory;
 
-        int ipcThreads = config.getIpcThreads();
-        int maxIndependentWrites = config.getMaxIndependentWrites();
-        int maxDependentWrites = config.getMaxDependentWrites();
-
-        this.writeControl= new SynchronousWriteControl(ipcThreads/2,ipcThreads/2,maxDependentWrites,maxIndependentWrites);
+        this.writeControl= new SynchronousWriteControl(
+                config.getMaxDependentWriteThreads(),
+                config.getMaxIndependentWriteThreads(),
+                config.getMaxIndependentWrites(),
+                config.getMaxDependentWrites());
         this.pipelineWriter = new PipelineWriter(pef, writePipelineFactory,writeControl,pipelineMeter);
         channelFactory.setWriter(pipelineWriter);
         channelFactory.setPipeline(writePipelineFactory);

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
@@ -111,7 +111,9 @@ public interface SConfiguration {
     // PipelineConfiguration
     int getCoreWriterThreads();
 
-    int getIpcThreads();
+    int getMaxDependentWriteThreads();
+
+    int getMaxIndependentWriteThreads();
 
     int getMaxBufferEntries();
 

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
@@ -132,10 +132,11 @@ public class ConfigurationBuilder {
 
     // PipelineConfiguration
     public int coreWriterThreads;
-    public int ipcThreads;
     public int maxBufferEntries;
     public int maxDependentWrites;
     public int maxIndependentWrites;
+    public int maxDependentWriteThreads;
+    public int maxIndependentWriteThreads;
     public int maxRetries;
     public int maxWriterThreads;
     public int pipelineKryoPoolSize;

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/PipelineConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/PipelineConfiguration.java
@@ -146,8 +146,11 @@ public class PipelineConfiguration implements ConfigurationDefault {
     public static final String MAX_DEPENDENT_WRITES = "splice.client.write.maxDependentWrites";
     public static final int DEFAULT_MAX_DEPENDENT_WRITES = 40000;
 
-    public static final String IPC_THREADS="hbase.regionserver.handler.count";
-    public static final int DEFAULT_IPC_THREADS = 200;
+    public static final String MAX_INDEPENDENT_WRITE_THREADS="splice.independent.write.threads";
+    public static final int DEFAULT_MAX_INDEPENDENT_WRITE_THREADS = 50;
+
+    public static final String MAX_DEPENDENT_WRITE_THREADS="splice.dependent.write.threads";
+    public static final int DEFAULT_MAX_DEPENDENT_WRITE_THREADS = 50;
 
     public static final String PIPELINE_KRYO_POOL_SIZE= "splice.writer.kryoPoolSize";
     private static final int DEFAULT_PIPELINE_KRYO_POOL_SIZE=1024;
@@ -164,7 +167,9 @@ public class PipelineConfiguration implements ConfigurationDefault {
 
     @Override
     public void setDefaults(ConfigurationBuilder builder, ConfigurationSource configurationSource) {
-        builder.ipcThreads = configurationSource.getInt(IPC_THREADS, DEFAULT_IPC_THREADS);
+        builder.maxIndependentWriteThreads = configurationSource.getInt(MAX_INDEPENDENT_WRITE_THREADS, DEFAULT_MAX_INDEPENDENT_WRITE_THREADS);
+        builder.maxDependentWriteThreads = configurationSource.getInt(MAX_DEPENDENT_WRITE_THREADS, DEFAULT_MAX_DEPENDENT_WRITE_THREADS);
+
         builder.maxIndependentWrites = configurationSource.getInt(MAX_INDEPENDENT_WRITES, DEFAULT_MAX_INDEPENDENT_WRITES);
         builder.maxDependentWrites = configurationSource.getInt(MAX_DEPENDENT_WRITES, DEFAULT_MAX_DEPENDENT_WRITES);
         builder.coreWriterThreads = configurationSource.getInt(CORE_WRITER_THREADS, DEFAULT_WRITE_THREADS_CORE);

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
@@ -83,7 +83,8 @@ public final class SConfigurationImpl implements SConfiguration {
 
     // PipelineConfiguration
     private final  int coreWriterThreads;
-    private final  int ipcThreads;
+    private final  int maxDependentWriteThreads;
+    private final  int maxIndependentWriteThreads;
     private final  int maxBufferEntries;
     private final  int maxDependentWrites;
     private final  int maxIndependentWrites;
@@ -329,9 +330,14 @@ public final class SConfigurationImpl implements SConfiguration {
         return coreWriterThreads;
     }
     @Override
-    public int getIpcThreads() {
-        return ipcThreads;
+    public int getMaxDependentWriteThreads() {
+        return maxDependentWriteThreads;
     }
+    @Override
+    public int getMaxIndependentWriteThreads() {
+        return maxIndependentWriteThreads;
+    }
+
     @Override
     public int getMaxBufferEntries() {
         return maxBufferEntries;
@@ -749,7 +755,8 @@ public final class SConfigurationImpl implements SConfiguration {
         networkBindAddress = builder.networkBindAddress;
         upgradeForcedFrom = builder.upgradeForcedFrom;
         coreWriterThreads = builder.coreWriterThreads;
-        ipcThreads = builder.ipcThreads;
+        maxDependentWriteThreads = builder.maxDependentWriteThreads;
+        maxIndependentWriteThreads = builder.maxIndependentWriteThreads;
         maxBufferEntries = builder.maxBufferEntries;
         maxDependentWrites = builder.maxDependentWrites;
         maxIndependentWrites = builder.maxIndependentWrites;


### PR DESCRIPTION
Set the configuration manually since there are issues between different HBase versions.  This should leave 50% of the threads open based on our default implementation.