### PR TITLE
SPLICE-2136 SPLICE-2138 fix issues related to index excluding default keys (2.5)

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperation.java
@@ -590,7 +590,8 @@ public class CreateIndexConstantOperation extends IndexConstantOperation impleme
                     continue;
                 }
                 numSet++;
-                if (defaultValue == null && numSet==1) {
+                // check if the current column is the leading index column, then set the defaultValue
+                if (cd.getPosition() == baseColumnPositions[0]) {
                     defaultValue = cd.getDefaultValue();
                 }
                 DataValueDescriptor colDescriptor = dts.getNull();


### PR DESCRIPTION
This PR contains fixes for two tickets:
[SPLICE-2136](https://splice.atlassian.net/browse/SPLICE-2136) fix issue with index exclude default keys feature not correctly suppressing rows with default values if leading index column is in descending order

[SPLICE-2138](https://splice.atlassian.net/browse/SPLICE-2138) set the defaultValue for the leading column of an index excluding default key correctly


