### PR TITLE
DB-6728 Apache Ranger Integration (2.5)

### DIFF
--- a/assembly/hdp2.6.3/src/main/resources/common-services/SPLICEMACHINE/2.5.1/metainfo.xml
+++ b/assembly/hdp2.6.3/src/main/resources/common-services/SPLICEMACHINE/2.5.1/metainfo.xml
@@ -19,6 +19,18 @@
                         <scriptType>PYTHON</scriptType>
                         <timeout>600</timeout>
                     </commandScript>
+                    <configFiles>
+                        <configFile>
+                            <type>xml</type>
+                            <fileName>ranger-splicemachine-audit.xml</fileName>
+                            <dictionaryName>ranger-splicemachine-audit</dictionaryName>
+                        </configFile>
+                        <configFile>
+                            <type>env</type>
+                            <fileName>ranger-splicemachine-security.xml</fileName>
+                            <dictionaryName>ranger-splicemachine-security</dictionaryName>
+                        </configFile>
+                    </configFiles>
                     <customCommands>
                         <customCommand>
                             <name>CUSTOM_INSTALL</name>
@@ -51,6 +63,8 @@
                 <config-type>zeppelin-env</config-type>
                 <config-type>zoo.cfg</config-type>
                 <config-type>yarn-site</config-type>
+                <config-type>ranger-splicemachine-audit</config-type>
+                <config-type>ranger-splicemachine-security</config-type>
             </configuration-dependencies>
 
             <requiredServices>

--- a/assembly/hdp2.6.3/src/main/resources/common-services/SPLICEMACHINE/2.5.1/package/scripts/splice_install.py
+++ b/assembly/hdp2.6.3/src/main/resources/common-services/SPLICEMACHINE/2.5.1/package/scripts/splice_install.py
@@ -1,5 +1,8 @@
 import sys
 import sys
+from resource_management.libraries.script.script import Script
+from resource_management.core.resources import Directory
+from resource_management.libraries.resources import XmlConfig
 from resource_management import *
 
 reload(sys)
@@ -10,8 +13,10 @@ class SpliceInstall(Script):
     import params
     self.install_packages(env)
     env.set_params(params)
-    print(params)
+    print 'Before Print';
+    print(params.config)
     print 'Install the client';
+    self.configure(env)
 
 #    dir = '/var/lib/splicemachine'
 #    if os.path.exists(dir):
@@ -19,8 +24,40 @@ class SpliceInstall(Script):
 #    os.makedirs(dir)
 
   def configure(self, env):
+    import params
     print 'Configure the client';
-  def somethingcustom(self, env):
+    hbase_user = params.config['configurations']['hbase-env']['hbase_user']
+    user_group = params.config['configurations']['cluster-env']["user_group"]
+    splicemachine_conf_dir = '/etc/splicemachine/conf'
+
+    Directory( splicemachine_conf_dir,
+               owner = hbase_user,
+               group = user_group,
+               create_parents = True
+               )
+    Directory( splicemachine_conf_dir,
+               owner = hbase_user,
+               group = user_group,
+               create_parents = True
+               )
+
+
+    XmlConfig( "ranger-splicemachine-security.xml",
+               conf_dir = splicemachine_conf_dir,
+               configurations = params.config['configurations']['ranger-splicemachine-security'],
+               configuration_attributes=params.config['configuration_attributes']['ranger-splicemachine-security'],
+               owner = hbase_user,
+               group = user_group,
+               )
+    XmlConfig( "ranger-splicemachine-audit.xml",
+               conf_dir = splicemachine_conf_dir,
+               configurations = params.config['configurations']['ranger-splicemachine-audit'],
+               configuration_attributes=params.config['configuration_attributes']['ranger-splicemachine-audit'],
+               owner = hbase_user,
+               group = user_group,
+               )
+
+def somethingcustom(self, env):
     print 'Something custom';
 
 if __name__ == "__main__":

--- a/assembly/hdp2.6.3/src/main/resources/stacks/HDP/2.6/services/SPLICEMACHINE/configuration/ranger-servicedef-splicemachine.json
+++ b/assembly/hdp2.6.3/src/main/resources/stacks/HDP/2.6/services/SPLICEMACHINE/configuration/ranger-servicedef-splicemachine.json
@@ -1,0 +1,434 @@
+{
+  "id":3,
+  "name": "splicemachine",
+  "implClass": "com.splicemachine.ranger.services.RangerServiceSplicemachine",
+  "label": "Splice Machine",
+  "description": "Splice Machine RDBMS",
+  "guid": "3e1afb345-184a-4e82-9d9c-87a5cacc243c",
+  "resources":
+  [
+    {
+      "itemId": 1,
+      "name": "schema",
+      "type": "string",
+      "level": 10,
+      "parent": "",
+      "mandatory": true,
+      "lookupSupported": true,
+      "recursiveSupported": false,
+      "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard":true, "ignoreCase":true },
+      "validationRegEx":"",
+      "validationMessage": "",
+      "uiHint":"",
+      "label": "Schema",
+      "description": "Splicemachine Schema"
+    },
+
+    {
+      "itemId": 2,
+      "name": "table",
+      "type": "string",
+      "level": 20,
+      "parent": "schema",
+      "mandatory": true,
+      "lookupSupported": true,
+      "recursiveSupported": false,
+      "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard":true, "ignoreCase":true },
+      "validationRegEx":"",
+      "validationMessage": "",
+      "uiHint":"",
+      "label": "Table",
+      "description": "Splicemachine tables/views/synonyms"
+    },
+    {
+      "itemId": 3,
+      "name": "udt_type",
+      "type": "string",
+      "level": 20,
+      "parent": "schema",
+      "mandatory": true,
+      "lookupSupported": true,
+      "recursiveSupported": false,
+      "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard":true, "ignoreCase":true },
+      "validationRegEx":"",
+      "validationMessage": "",
+      "uiHint":"",
+      "label": "UDT Type",
+      "description": "Splicemachine UDT"
+    },
+
+    {
+      "itemId": 4,
+      "name": "routine",
+      "type": "string",
+      "level": 20,
+      "parent": "schema",
+      "mandatory": true,
+      "lookupSupported": true,
+      "recursiveSupported": false,
+      "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard":true, "ignoreCase":true },
+      "validationRegEx":"",
+      "validationMessage": "",
+      "uiHint":"",
+      "label": "Routine",
+      "description": "Splicemachine Routines"
+    },
+
+    {
+      "itemId": 5,
+      "name": "sequence",
+      "type": "string",
+      "level": 20,
+      "parent": "schema",
+      "mandatory": true,
+      "lookupSupported": true,
+      "recursiveSupported": false,
+      "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard":true, "ignoreCase":true },
+      "validationRegEx":"",
+      "validationMessage": "",
+      "uiHint":"",
+      "label": "Sequence",
+      "description": "Splicemachine Sequence"
+    },
+
+    {
+      "itemId": 6,
+      "name": "column",
+      "type": "string",
+      "level": 30,
+      "parent": "table",
+      "mandatory": true,
+      "lookupSupported": true,
+      "recursiveSupported": false,
+      "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard":true, "ignoreCase":true },
+      "validationRegEx":"",
+      "validationMessage": "",
+      "uiHint":"",
+      "label": "Column",
+      "description": "Column"
+    }
+  ],
+
+  "accessTypes":
+  [
+    {
+      "itemId": 1,
+      "name": "select",
+      "label": "Select"
+    },
+
+    {
+      "itemId": 2,
+      "name": "update",
+      "label": "Update"
+    },
+
+    {
+      "itemId": 3,
+      "name": "references",
+      "label": "References"
+    },
+
+    {
+      "itemId": 4,
+      "name": "insert",
+      "label": "Insert"
+    },
+
+    {
+      "itemId": 5,
+      "name": "delete",
+      "label": "Delete"
+    },
+
+    {
+      "itemId": 6,
+      "name": "trigger",
+      "label": "Trigger"
+    },
+
+    {
+      "itemId": 7,
+      "name": "execute",
+      "label": "Execute"
+    },
+
+    {
+      "itemId": 8,
+      "name": "usage",
+      "label": "Usage"
+    },
+
+    {
+      "itemId": 9,
+      "name": "create_schema",
+      "label": "Create Schema"
+    },
+
+    {
+      "itemId": 10,
+      "name": "modify_schema",
+      "label": "Modify Schema"
+    },
+
+    {
+      "itemId": 11,
+      "name": "drop_schema",
+      "label": "Drop Schema"
+    },
+
+    {
+      "itemId": 12,
+      "name": "all",
+      "label": "All",
+      "impliedGrants":
+      [
+        "select",
+        "update",
+        "references",
+        "insert",
+        "delete",
+        "trigger",
+        "execute",
+        "usage",
+        "create_schema",
+        "modify_schema",
+        "drop_schema"
+      ]
+    }
+  ],
+
+  "configs":
+  [
+    {
+      "itemId": 1,
+      "name": "username",
+      "type": "string",
+      "defaultValue": "splice",
+      "mandatory": true,
+      "validationRegEx":"",
+      "validationMessage": "",
+      "uiHint":"",
+      "label": "Username"
+    },
+
+    {
+      "itemId": 2,
+      "name": "password",
+      "type": "password",
+      "defaultValue": "admin",
+      "mandatory": true,
+      "validationRegEx":"",
+      "validationMessage": "",
+      "uiHint":"",
+      "label": "Password"
+    },
+
+    {
+      "itemId": 3,
+      "name": "authentication",
+      "type": "enum",
+      "subType": "authType",
+      "mandatory": true,
+      "validationRegEx": "",
+      "validationMessage": "",
+      "uiHint": "",
+      "label": "Splicemachine Authentication Type",
+      "defaultValue": "simple"
+    },
+
+    {
+      "itemId": 4,
+      "name": "principal",
+      "type": "string",
+      "mandatory": false,
+      "validationRegEx": "",
+      "validationMessage": "",
+      "uiHint": "",
+      "label": "Splicemachine Kerberos Service Name",
+      "defaultValue": ""
+    },
+
+    {
+      "itemId": 5,
+      "name": "hostname",
+      "type": "string",
+      "mandatory": true,
+      "validationRegEx": "",
+      "validationMessage": "",
+      "uiHint": "",
+      "label": "Splicemachine Hostname"
+    },
+
+    {
+      "itemId": 6,
+      "name": "port",
+      "type": "int",
+      "mandatory": true,
+      "validationRegEx": "",
+      "validationMessage": "",
+      "uiHint": "",
+      "label": "Splicemachine Port",
+      "defaultValue": 1527
+    }
+  ],
+
+  "enums":
+  [
+    {
+      "itemId": 1,
+      "name": "authType",
+      "elements":
+      [
+        {
+          "itemId": 1,
+          "name": "simple",
+          "label": "Simple"
+        },
+        {
+          "itemId": 2,
+          "name": "kerberos",
+          "label": "Kerberos"
+        }
+      ],
+      "defaultIndex": 0
+    }
+  ],
+
+  "contextEnrichers":
+  [
+  ],
+
+  "policyConditions":
+  [
+  ],
+  "dataMaskDef": {
+    "accessTypes": [
+      {
+        "name": "select"
+      }
+    ],
+    "resources": [
+      {
+        "name": "schema",
+        "matcherOptions": {
+          "wildCard": "false"
+        },
+        "lookupSupported": true,
+        "uiHint":"{ \"singleValue\":true }"
+      },
+      {
+        "name": "table",
+        "matcherOptions": {
+          "wildCard": "false"
+        },
+        "lookupSupported": true,
+        "uiHint":"{ \"singleValue\":true }"
+      },
+      {
+        "name": "column",
+        "matcherOptions": {
+          "wildCard": "false"
+        },
+        "lookupSupported": true,
+        "uiHint":"{ \"singleValue\":true }"
+      }
+    ],
+    "maskTypes": [
+      {
+        "itemId": 1,
+        "name": "MASK",
+        "label": "Redact",
+        "description": "Replace lowercase with 'x', uppercase with 'X', digits with '0'",
+        "transformer": "mask({col})",
+        "dataMaskOptions": {
+        }
+      },
+      {
+        "itemId": 2,
+        "name": "MASK_SHOW_LAST_4",
+        "label": "Partial mask: show last 4",
+        "description": "Show last 4 characters; replace rest with 'x'",
+        "transformer": "mask_show_last_n({col}, 4, 'x', 'x', 'x', -1, '1')"
+      },
+      {
+        "itemId": 3,
+        "name": "MASK_SHOW_FIRST_4",
+        "label": "Partial mask: show first 4",
+        "description": "Show first 4 characters; replace rest with 'x'",
+        "transformer": "mask_show_first_n({col}, 4, 'x', 'x', 'x', -1, '1')"
+      },
+      {
+        "itemId": 4,
+        "name": "MASK_HASH",
+        "label": "Hash",
+        "description": "Hash the value",
+        "transformer": "mask_hash({col})"
+      },
+      {
+        "itemId": 5,
+        "name": "MASK_NULL",
+        "label": "Nullify",
+        "description": "Replace with NULL"
+      },
+      {
+        "itemId": 6,
+        "name": "MASK_NONE",
+        "label": "Unmasked (retain original value)",
+        "description": "No masking"
+      },
+      {
+        "itemId": 12,
+        "name": "MASK_DATE_SHOW_YEAR",
+        "label": "Date: show only year",
+        "description": "Date: show only year",
+        "transformer": "mask({col}, 'x', 'x', 'x', -1, '1', 1, 0, -1)"
+      },
+      {
+        "itemId": 13,
+        "name": "CUSTOM",
+        "label": "Custom",
+        "description": "Custom"
+      }
+    ]
+  },
+  "rowFilterDef": {
+    "accessTypes": [
+      {
+        "name": "select"
+      }
+    ],
+    "resources": [
+      {
+        "name": "schema",
+        "matcherOptions": {
+          "wildCard": "false"
+        },
+        "lookupSupported": true,
+        "mandatory": true,
+        "uiHint": "{ \"singleValue\":true }"
+      },
+      {
+        "name": "table",
+        "matcherOptions": {
+          "wildCard": "false"
+        },
+        "lookupSupported": true,
+        "mandatory": true,
+        "uiHint": "{ \"singleValue\":true }"
+      }
+    ]
+  }
+}

--- a/assembly/hdp2.6.3/src/main/resources/stacks/HDP/2.6/services/SPLICEMACHINE/configuration/ranger-splicemachine-audit.xml
+++ b/assembly/hdp2.6.3/src/main/resources/stacks/HDP/2.6/services/SPLICEMACHINE/configuration/ranger-splicemachine-audit.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<configuration>
+
+  <property>
+    <name>ranger.plugin.splicemachine.ambari.cluster.name</name>
+    <value>splicemachine</value>
+    <description>Capture cluster name from where Ranger splicemachine plugin is enabled.</description>
+    <value-attributes>
+      <empty-value-valid>true</empty-value-valid>
+    </value-attributes>
+    <on-ambari-upgrade add="false"/>
+  </property>
+
+  <property>
+    <name>xasecure.audit.is.enabled</name>
+    <value>false</value>
+    <description>Is Audit enabled?</description>
+    <on-ambari-upgrade add="false"/>
+  </property>
+  <property>
+    <name>xasecure.audit.destination.hdfs</name>
+    <value>false</value>
+    <display-name>Audit to HDFS</display-name>
+    <description>Is Audit to HDFS enabled?</description>
+    <value-attributes>
+      <type>boolean</type>
+    </value-attributes>
+    <depends-on>
+      <property>
+        <type>ranger-env</type>
+        <name>xasecure.audit.destination.hdfs</name>
+      </property>
+    </depends-on>
+    <on-ambari-upgrade add="false"/>
+  </property>
+  <property>
+    <name>xasecure.audit.destination.hdfs.dir</name>
+    <value>hdfs://localhost:8020/ranger/audit</value>
+    <description>HDFS folder to write audit to, make sure the service user has requried permissions</description>
+    <depends-on>
+      <property>
+        <type>ranger-env</type>
+        <name>xasecure.audit.destination.hdfs.dir</name>
+      </property>
+    </depends-on>
+    <on-ambari-upgrade add="false"/>
+  </property>
+  <property>
+    <name>xasecure.audit.destination.hdfs.batch.filespool.dir</name>
+    <value>/var/log/splicemachine/audit/hdfs/spool</value>
+    <description>/var/log/splicemachine/audit/hdfs/spool</description>
+    <on-ambari-upgrade add="false"/>
+  </property>
+  <property>
+    <name>xasecure.audit.destination.solr</name>
+    <value>false</value>
+    <display-name>Audit to SOLR</display-name>
+    <description>Is Solr audit enabled?</description>
+    <value-attributes>
+      <type>boolean</type>
+    </value-attributes>
+    <depends-on>
+      <property>
+        <type>ranger-env</type>
+        <name>xasecure.audit.destination.solr</name>
+      </property>
+    </depends-on>
+    <on-ambari-upgrade add="false"/>
+  </property>
+  <property>
+    <name>xasecure.audit.destination.solr.urls</name>
+    <value/>
+    <description>Solr URL</description>
+    <value-attributes>
+      <empty-value-valid>true</empty-value-valid>
+    </value-attributes>
+    <depends-on>
+      <property>
+        <type>ranger-admin-site</type>
+        <name>ranger.audit.solr.urls</name>
+      </property>
+    </depends-on>
+    <on-ambari-upgrade add="false"/>
+  </property>
+  <property>
+    <name>xasecure.audit.destination.solr.zookeepers</name>
+    <value>NONE</value>
+    <description>Solr Zookeeper string</description>
+    <depends-on>
+      <property>
+        <type>ranger-admin-site</type>
+        <name>ranger.audit.solr.zookeepers</name>
+      </property>
+    </depends-on>
+    <on-ambari-upgrade add="false"/>
+  </property>
+  <property>
+    <name>xasecure.audit.destination.solr.batch.filespool.dir</name>
+    <value>/var/log/splicemachine/audit/solr/spool</value>
+    <description>/var/log/splicemachine/audit/solr/spool</description>
+    <on-ambari-upgrade add="false"/>
+  </property>
+  <property>
+    <name>xasecure.audit.provider.summary.enabled</name>
+    <value>true</value>
+    <display-name>Audit provider summary enabled</display-name>
+    <description>Enable Summary audit?</description>
+    <value-attributes>
+      <type>boolean</type>
+    </value-attributes>
+    <on-ambari-upgrade add="false"/>
+  </property>
+
+</configuration>

--- a/assembly/hdp2.6.3/src/main/resources/stacks/HDP/2.6/services/SPLICEMACHINE/configuration/ranger-splicemachine-security.xml
+++ b/assembly/hdp2.6.3/src/main/resources/stacks/HDP/2.6/services/SPLICEMACHINE/configuration/ranger-splicemachine-security.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+
+<configuration>
+
+    <property>
+        <name>ranger.plugin.splicemachine.service.name</name>
+        <value>splicemachine</value>
+        <description>Name of the Ranger service containing HBase policies</description>
+        <on-ambari-upgrade add="false"/>
+    </property>
+    <property>
+        <name>ranger.plugin.splicemachine.policy.source.impl</name>
+        <value>org.apache.ranger.admin.client.RangerAdminRESTClient</value>
+        <description>Class to retrieve policies from the source</description>
+        <on-ambari-upgrade add="false"/>
+    </property>
+    <property>
+        <name>ranger.plugin.splicemachine.policy.rest.url</name>
+        <value>http://localhost:6080</value>
+        <description>URL to Ranger Admin</description>
+        <on-ambari-upgrade add="false"/>
+        <depends-on>
+            <property>
+                <type>admin-properties</type>
+                <name>policymgr_external_url</name>
+            </property>
+        </depends-on>
+    </property>
+    <property>
+        <name>ranger.plugin.splicemachine.policy.rest.ssl.config.file</name>
+        <value>/etc/hbase/conf/ranger-policymgr-ssl.xml</value>
+        <description>Path to the file containing SSL details to contact Ranger Admin</description>
+        <on-ambari-upgrade add="false"/>
+    </property>
+    <property>
+        <name>ranger.plugin.splicemachine.policy.pollIntervalMs</name>
+        <value>30000</value>
+        <description>How often to poll for changes in policies?</description>
+        <on-ambari-upgrade add="false"/>
+    </property>
+    <property>
+        <name>ranger.plugin.splicemachine.policy.cache.dir</name>
+        <value>/etc/ranger/splicemachine/policycache</value>
+        <description>Directory where Ranger policies are cached after successful retrieval from the source</description>
+        <on-ambari-upgrade add="false"/>
+    </property>
+
+</configuration>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -514,6 +514,25 @@
                     <value>installer</value>
                 </property>
             </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.splicemachine</groupId>
+                    <artifactId>splice_ranger_service-${envClassifier}</artifactId>
+                    <version>2.5.0.1815-SNAPSHOT</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.splicemachine</groupId>
+                    <artifactId>splice_ranger_admin-${envClassifier}</artifactId>
+                    <version>2.5.0.1815-SNAPSHOT</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.splicemachine</groupId>
+                    <artifactId>splice_ranger_admin-${envClassifier}</artifactId>
+                    <version>2.5.0.1815-SNAPSHOT</version>
+                </dependency>
+
+
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -522,6 +541,7 @@
                         <version>2.10</version>
                         <executions>
                             <execution>
+
                                 <id>copy</id>
                                 <phase>package</phase>
                                 <goals>
@@ -560,7 +580,9 @@
                                         splice_encryption,
                                         akka-remote_${scala.binary.version},
                                         splicemachine-${envClassifier}-${spark.version}_${scala.binary.version},
-                                        super-csv
+                                        super-csv,
+                                        splice_ranger_admin-${envClassifier},
+                                        splice_ranger_service-${envClassifier}
                                     </includeArtifactIds>
                                 </configuration>
                             </execution>

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAConnThread.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAConnThread.java
@@ -1532,6 +1532,9 @@ class DRDAConnThread extends Thread {
 		}
             
 	 	try {
+			System.out.println("Remote --> " + ((InetSocketAddress)this.getSession().clientSocket.getRemoteSocketAddress()).getAddress().toString().replace("/",""));
+			System.out.println("Local --> " + ((InetSocketAddress)this.getSession().clientSocket.getLocalSocketAddress()).getAddress().toString().replace("/",""));
+
 			p.put(Property.IP_ADDRESS, ((InetSocketAddress)this.getSession().clientSocket.getRemoteSocketAddress()).getAddress().toString().replace("/",""));
 			database.makeConnection(p);
 	  	} catch (SQLException se) {

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAConnThread.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAConnThread.java
@@ -1532,9 +1532,6 @@ class DRDAConnThread extends Thread {
 		}
             
 	 	try {
-			System.out.println("Remote --> " + ((InetSocketAddress)this.getSession().clientSocket.getRemoteSocketAddress()).getAddress().toString().replace("/",""));
-			System.out.println("Local --> " + ((InetSocketAddress)this.getSession().clientSocket.getLocalSocketAddress()).getAddress().toString().replace("/",""));
-
 			p.put(Property.IP_ADDRESS, ((InetSocketAddress)this.getSession().clientSocket.getRemoteSocketAddress()).getAddress().toString().replace("/",""));
 			database.makeConnection(p);
 	  	} catch (SQLException se) {

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/authorization/AuthorizationFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/authorization/AuthorizationFactory.java
@@ -1,0 +1,17 @@
+package com.splicemachine.db.iapi.services.authorization;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.conn.Authorizer;
+import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
+
+/**
+ *
+ *
+ */
+public interface AuthorizationFactory {
+
+    Authorizer getAuthorizer(LanguageConnectionContext lcc)
+            throws StandardException;
+
+    int getPriority();
+}

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/authorization/AuthorizationFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/authorization/AuthorizationFactory.java
@@ -1,3 +1,33 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
 package com.splicemachine.db.iapi.services.authorization;
 
 import com.splicemachine.db.iapi.error.StandardException;
@@ -5,7 +35,8 @@ import com.splicemachine.db.iapi.sql.conn.Authorizer;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 
 /**
- *
+ * Factory for returning the authorizer depending on whether you want the in database authorization,
+ * Apache Ranger, or Apache Sentry.
  *
  */
 public interface AuthorizationFactory {

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/authorization/AuthorizationFactoryService.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/authorization/AuthorizationFactoryService.java
@@ -1,0 +1,22 @@
+package com.splicemachine.db.iapi.services.authorization;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+public class AuthorizationFactoryService {
+
+    public static AuthorizationFactory newAuthorizationFactory(){
+        ServiceLoader<AuthorizationFactory> factoryService = ServiceLoader.load(AuthorizationFactory.class);
+        Iterator<AuthorizationFactory> iter = factoryService.iterator();
+        if(!iter.hasNext())
+            throw new IllegalStateException("No AuthorizationFactory service found!");
+        AuthorizationFactory af = null;
+        AuthorizationFactory currentAF = null;
+        while (iter.hasNext()) {
+            currentAF = (AuthorizationFactory) iter.next();
+            if (af == null || af.getPriority() < currentAF.getPriority())
+                af = currentAF;
+        }
+        return af;
+    }
+}

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/authorization/GenericAuthorizationFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/authorization/GenericAuthorizationFactory.java
@@ -1,0 +1,21 @@
+package com.splicemachine.db.iapi.services.authorization;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.conn.Authorizer;
+import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
+import com.splicemachine.db.impl.sql.conn.GenericAuthorizer;
+
+/**
+ * Created by jleach on 3/19/18.
+ */
+public class GenericAuthorizationFactory implements AuthorizationFactory {
+    @Override
+    public Authorizer getAuthorizer(LanguageConnectionContext lcc) throws StandardException {
+        return new GenericAuthorizer(lcc);
+    }
+
+    @Override
+    public int getPriority() {
+        return 1;
+    }
+}

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -854,12 +854,12 @@ public interface LanguageConnectionContext extends Context {
 	/**
 	  * Get the readOnly status for the current connection. 
 	  */
-	public boolean isReadOnly();
+	public boolean isReadOnly() throws StandardException;
 
 	/**
 	 * Get an Authorizer for this connection.
 	 */
-	public Authorizer getAuthorizer(); 
+	public Authorizer getAuthorizer() throws StandardException;
 
 	/**
 	 *	Get the current StatementContext.

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionFactory.java
@@ -34,6 +34,7 @@ package com.splicemachine.db.iapi.sql.conn;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.db.Database;
 
+import com.splicemachine.db.iapi.services.authorization.AuthorizationFactory;
 import com.splicemachine.db.iapi.services.property.PropertyFactory;
 
 import com.splicemachine.db.iapi.sql.compile.OptimizerFactory;
@@ -151,6 +152,14 @@ public interface LanguageConnectionFactory {
 		Get the PropertyFactory to use with this language connection
 	 */
 	PropertyFactory	getPropertyFactory();
+
+	/**
+	 *
+	 * GetAuthorizationFactory
+	 *
+	 * @return
+     */
+	AuthorizationFactory getAuthorizationFactory();
 
 	/**
 		Get the OptimizerFactory to use with this language connection

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementColumnPermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementColumnPermission.java
@@ -268,6 +268,10 @@ public class StatementColumnPermission extends StatementTablePermission
 		TableDescriptor td = getTableDescriptor(dd);
 		//if we are still here, then that means that we didn't find any select
 		//privilege on the table or any column in the table
+		if (td.getTableType() == TableDescriptor.VIEW_TYPE) {
+			ViewDescriptor vd = dd.getViewDescriptor(td);
+			vd.getViewText();
+		}
 		if (privType == Authorizer.MIN_SELECT_PRIV)
 			throw StandardException.newException( forGrant ? SQLState.AUTH_NO_TABLE_PERMISSION_FOR_GRANT
 					  : SQLState.AUTH_NO_TABLE_PERMISSION,
@@ -513,5 +517,10 @@ public class StatementColumnPermission extends StatementTablePermission
 	{
 		return "StatementColumnPermission: " + getPrivName() + " " +
 			tableUUID + " columns: " + columns;
+	}
+
+	@Override
+	public Type getType() {
+		return Type.COLUMN;
 	}
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementGenericPermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementGenericPermission.java
@@ -119,4 +119,11 @@ public final class StatementGenericPermission extends StatementPermission
 	{
 		return "StatementGenericPermission( " + _objectID + ", " + _objectType + ", " + _privilege + " )";
 	}
+
+	@Override
+	public Type getType() {
+		return Type.GENERIC;
+	}
+
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementPermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementPermission.java
@@ -48,8 +48,17 @@ import java.util.List;
  * This class describes a permission require by a statement.
  */
 
-public abstract class StatementPermission
-{
+public abstract class StatementPermission {
+	public enum Type {
+		COLUMN,
+		TABLE,
+		GENERIC,
+		SCHEMA,
+		ROUTINE,
+		ROLE;
+	}
+
+
 	public static final int UNAUTHORIZED = 0;
 	public static final int AUTHORIZED = 1;
 	public static final int NONE = 2;
@@ -242,4 +251,6 @@ public abstract class StatementPermission
 
 	} // end of genericCheck
 
+
+	public abstract Type getType() ;
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementRolePermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementRolePermission.java
@@ -122,4 +122,10 @@ public class StatementRolePermission extends StatementPermission
     {
         return "StatementRolePermission: " + roleName + " " + getPrivName();
     }
+
+    @Override
+    public Type getType() {
+        return Type.ROLE;
+    }
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementRoutinePermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementRoutinePermission.java
@@ -107,4 +107,10 @@ public final class StatementRoutinePermission extends StatementPermission
 	{
 		return "StatementRoutinePermission: " + routineUUID;
 	}
+
+	@Override
+	public Type getType() {
+		return Type.ROUTINE;
+	}
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementSchemaPermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementSchemaPermission.java
@@ -308,8 +308,27 @@ public class StatementSchemaPermission extends StatementPermission
         }
     }
 
+	public UUID getSchemaUUID() {
+		return schemaUUID;
+	}
+
+	public int getPrivType() {
+		return privType;
+	}
+
+
 	public String toString() {
 		return "StatementSchemaPermission: " + schemaName + " owner:" +
 			aid + " " + getPrivName();
 	}
+
+	@Override
+	public Type getType() {
+		return Type.SCHEMA;
+	}
+
+	public String getSchemaName() {
+		return schemaName;
+	}
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementTablePermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementTablePermission.java
@@ -397,8 +397,18 @@ public class StatementTablePermission extends StatementSchemaPermission
 		return "?";
 	} // end of getPrivName
 
+	public UUID getSchemaUUID() {
+		return schemaUUID;
+	}
+
 	public String toString()
 	{
 		return "StatementTablePermission: " + getPrivName() + " " + tableUUID;
 	}
+
+	@Override
+	public Type getType() {
+		return Type.TABLE;
+	}
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection.java
@@ -1636,7 +1636,11 @@ public abstract class EmbedConnection implements EngineConnection
     public final boolean isReadOnly() throws SQLException
 	{
 		checkIfClosed();
-		return getLanguageConnection().isReadOnly();
+		try {
+			return getLanguageConnection().isReadOnly();
+		} catch (StandardException se) {
+			throw new SQLException(se);
+		}
 	}
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericAuthorizer.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericAuthorizer.java
@@ -48,9 +48,7 @@ import com.splicemachine.db.iapi.sql.dictionary.StatementPermission;
 import java.util.List;
 import java.util.Iterator;
 
-class GenericAuthorizer
-implements Authorizer
-{
+public class GenericAuthorizer implements Authorizer {
 	//
 	//Enumerations for user access levels.
 	private static final int NO_ACCESS = 0;
@@ -68,7 +66,7 @@ implements Authorizer
 
 	private final LanguageConnectionContext lcc;
 	
-    GenericAuthorizer(LanguageConnectionContext lcc)
+    public GenericAuthorizer(LanguageConnectionContext lcc)
 		 throws StandardException
 	{
 		this.lcc = lcc;
@@ -205,7 +203,7 @@ implements Authorizer
         }
     }
 
-	private static StandardException externalRoutineException(int operation, int sqlAllowed) {
+	public static StandardException externalRoutineException(int operation, int sqlAllowed) {
 
 		String sqlState;
 		if (sqlAllowed == RoutineAliasInfo.READS_SQL_DATA)

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -377,10 +377,6 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     public void initialize() throws StandardException{
         interruptedException=null;
         sessionUser=IdUtil.getUserAuthorizationId(userName);
-        //
-        //Creating the authorizer authorizes the connection.
-        authorizer=new GenericAuthorizer(this);
-
         /*
         ** Set the authorization id.  User shouldn't
         ** be null or else we are going to blow up trying
@@ -412,9 +408,6 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     public void initializeSplice(String sessionUser,SchemaDescriptor defaultSchemaDescriptor) throws StandardException{
         interruptedException=null;
         this.sessionUser=sessionUser;
-        //
-        //Creating the authorizer authorizes the connection.
-        authorizer=new GenericAuthorizer(this);
 
             /*
             ** Set the authorization id.  User shouldn't
@@ -3003,16 +2996,19 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     public void setReadOnly(boolean on) throws StandardException{
         if(!tran.isPristine())
             throw StandardException.newException(SQLState.AUTH_SET_CONNECTION_READ_ONLY_IN_ACTIVE_XACT);
-        authorizer.setReadOnlyConnection(on,true);
+        getAuthorizer().setReadOnlyConnection(on,true);
     }
 
     @Override
-    public boolean isReadOnly(){
-        return authorizer.isReadOnlyConnection();
+    public boolean isReadOnly() throws StandardException {
+        return getAuthorizer().isReadOnlyConnection();
     }
 
     @Override
-    public Authorizer getAuthorizer(){
+    public Authorizer getAuthorizer() throws StandardException {
+        if (authorizer == null) {
+            authorizer = getLanguageConnectionFactory().getAuthorizationFactory().getAuthorizer(this);
+        }
         return authorizer;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionFactory.java
@@ -34,6 +34,8 @@ package com.splicemachine.db.impl.sql.conn;
 import com.splicemachine.db.iapi.db.Database;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.*;
+import com.splicemachine.db.iapi.services.authorization.AuthorizationFactory;
+import com.splicemachine.db.iapi.services.authorization.AuthorizationFactoryService;
 import com.splicemachine.db.iapi.services.cache.CacheManager;
 import com.splicemachine.db.iapi.services.cache.Cacheable;
 import com.splicemachine.db.iapi.services.cache.CacheableFactory;
@@ -87,6 +89,7 @@ public class GenericLanguageConnectionFactory
 	private 	ClassFactory			classFactory;
 	private 	NodeFactory				nodeFactory;
 	private 	PropertyFactory			pf;
+	private AuthorizationFactory        authorizationFactory;
 
 	private		int						nextLCCInstanceNumber;
 
@@ -415,5 +418,13 @@ public class GenericLanguageConnectionFactory
 	protected synchronized int getNextLCCInstanceNumber()
 	{
 		return nextLCCInstanceNumber++;
+	}
+
+	@Override
+	public AuthorizationFactory getAuthorizationFactory() {
+		if (authorizationFactory==null) {
+			authorizationFactory = AuthorizationFactoryService.newAuthorizationFactory();
+		}
+		return authorizationFactory;
 	}
 }

--- a/db-engine/src/main/resources/META-INF/services/com.splicemachine.db.iapi.services.authorization.AuthorizationFactory
+++ b/db-engine/src/main/resources/META-INF/services/com.splicemachine.db.iapi.services.authorization.AuthorizationFactory
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+#
+# This file is part of Splice Machine.
+# Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+# GNU Affero General Public License as published by the Free Software Foundation, either
+# version 3, or (at your option) any later version.
+# Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+com.splicemachine.db.iapi.services.authorization.GenericAuthorizationFactory

--- a/db-engine/src/main/resources/META-INF/services/com.splicemachine.db.iapi.services.authorization.AuthorizationFactory
+++ b/db-engine/src/main/resources/META-INF/services/com.splicemachine.db.iapi.services.authorization.AuthorizationFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2018 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -2014,5 +2014,10 @@ public interface SQLState {
 
 	String OLAP_SERVER_CONNECTION                                   = "OS001";
 	String TIMESTAMP_SERVER_CONNECTION                              = "TSS01";
+	String NO_GRANT_PERMISSIONS_WITH_RANGER                                = "EXT35";
+	String NO_REVOKE_PERMISSIONS_WITH_RANGER                                = "EXT36";
+	String ACCESS_DENIED_SENTRY                                = "EXT37";
+	String ROLE_ALREADY_EXISTS_SENTRY                                = "EXT38";
+
 }
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -9198,6 +9198,30 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
                <name>TSS01</name>
 	       <text>Timestamp server connection exception, see next exception for more details.</text>
            </msg>
+
+           <msg>
+               <name>EXT35</name>
+               <text>Cannot grant permissions when Splice Machine is attached to Ranger.  Please use the Ranger UI.</text>
+           </msg>
+
+           <msg>
+               <name>EXT36</name>
+               <text>Cannot revoke permissions when Splice Machine is attached to Ranger.  Please use the Ranger UI.</text>
+           </msg>
+
+           <msg>
+               <name>EXT37</name>
+               <text>Access Denied for Sentry, user '{0}' does not have privileges to execute: {1}</text>
+               <arg>userName</arg>
+               <arg>execute</arg>
+           </msg>
+
+           <msg>
+               <name>EXT38</name>
+               <text>Role {0} already exists in Sentry.</text>
+               <arg>role</arg>
+           </msg>
+
        </family>
     </section>
 

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
@@ -145,6 +145,12 @@ public interface SConfiguration {
 
     double getBulkImportSampleFraction();
 
+    String getAuthorizationScheme();
+
+    String getRangerServiceName();
+
+    int getSentryPollingInterval();
+
     int getBulkImportTasksPerRegion();
 
     int getRegionToLoadPerTask();

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/AuthenticationConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/AuthenticationConfiguration.java
@@ -49,6 +49,16 @@ public class AuthenticationConfiguration implements ConfigurationDefault {
     public static final String AUTHENTICATION_NATIVE_ALGORITHM = "splice.authentication.native.algorithm";
     private static final String DEFAULT_AUTHENTICATION_NATIVE_ALGORITHM = "SHA-512";
 
+    public static final String AUTHORIZATION_SCHEME = "splice.authorization.scheme";
+    public static final String DEFAULT_AUTHORIZATION_SCHEME = "NATIVE";
+
+    public static final String RANGER_SERVICE_NAME = "splice.authorization.ranger.service.name";
+    public static final String DEFAULT_RANGER_SERVICE_NAME = "splicemachine";
+
+    public static final String SENTRY_POLLING_INTERVAL = "splice.authorization.sentry.polling.interval";
+    public static final int DEFAULT_SENTRY_POLLING_INTERVAL = 60;
+
+
     // Property to force the creation of the native credentials database.
     // Generally, this is only done at the time of the creation of the whole Splice/Derby database.
     // In this particular instance, there are Splice beta customers with AnA disabled and they want to
@@ -65,7 +75,12 @@ public class AuthenticationConfiguration implements ConfigurationDefault {
     @Override
     public void setDefaults(ConfigurationBuilder builder, ConfigurationSource configurationSource) {
         builder.authentication = configurationSource.getString(AUTHENTICATION, DEFAULT_AUTHENTICATION);
-
+        builder.rangerServiceName = configurationSource.getString(RANGER_SERVICE_NAME,DEFAULT_RANGER_SERVICE_NAME);
+        builder.sentryPollingInterval = configurationSource.getInt(SENTRY_POLLING_INTERVAL,DEFAULT_SENTRY_POLLING_INTERVAL);
+        if (System.getProperty(AUTHORIZATION_SCHEME) != null)
+            builder.authorizationScheme = System.getProperty(AUTHORIZATION_SCHEME);
+        else
+            builder.authorizationScheme = configurationSource.getString(AUTHORIZATION_SCHEME, DEFAULT_AUTHORIZATION_SCHEME);
         if (builder.authentication.equals(Property.AUTHENTICATION_PROVIDER_LDAP)) {
             builder.authenticationLdapServer = configurationSource.getString(AUTHENTICATION_LDAP_SERVER, DEFAULT_AUTHENTICATION_LDAP_SERVER);
             builder.authenticationLdapSearchauthdn = configurationSource.getString(AUTHENTICATION_LDAP_SEARCHAUTHDN, DEFAULT_AUTHENTICATION_LDAP_SEARCHAUTHDN);

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
@@ -60,6 +60,11 @@ public class ConfigurationBuilder {
     public String authenticationLdapMapGroupAttr;
     public String authenticationNativeAlgorithm;
 
+    // Authorization Configuration
+    public String authorizationScheme;
+    public String rangerServiceName;
+    public int sentryPollingInterval;
+
     // StatsConfiguration
     public double fallbackNullFraction;
     public double optimizerExtraQualifierMultiplier;

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
@@ -57,6 +57,12 @@ public final class SConfigurationImpl implements SConfiguration {
     private final  String authenticationLdapMapGroupAttr;
     private final  String authenticationNativeAlgorithm;
 
+    // Authorization Configuration
+    private final String authorizationScheme;
+    private final String rangerServiceName;
+    private final int sentryPollingInterval;
+
+
     // DDLConfiguration
     private final  long ddlDrainingInitialWait;
     private final  long ddlDrainingMaximumWait;
@@ -458,6 +464,20 @@ public final class SConfigurationImpl implements SConfiguration {
         return olapServerSubmitAttempts;
     }
     @Override
+    public String getAuthorizationScheme() {
+        return authorizationScheme;
+    }
+    @Override
+    public String getRangerServiceName() {
+        return rangerServiceName;
+    }
+    @Override
+    public int getSentryPollingInterval() {
+        return sentryPollingInterval;
+    }
+
+
+    @Override
     public int getOlapServerMemory() {
         return olapServerMemory;
     }
@@ -707,6 +727,9 @@ public final class SConfigurationImpl implements SConfiguration {
         authenticationLdapServer = builder.authenticationLdapServer;
         authenticationLdapMapGroupAttr = builder.authenticationLdapMapGroupAttr;
         authenticationNativeAlgorithm = builder.authenticationNativeAlgorithm;
+        authorizationScheme = builder.authorizationScheme;
+        rangerServiceName = builder.rangerServiceName;
+        sentryPollingInterval = builder.sentryPollingInterval;
         fallbackNullFraction = builder.fallbackNullFraction;
         optimizerExtraQualifierMultiplier = builder.optimizerExtraQualifierMultiplier;
         cardinalityPrecision = builder.cardinalityPrecision;

--- a/splice_machine/src/main/java/com/splicemachine/EngineDriver.java
+++ b/splice_machine/src/main/java/com/splicemachine/EngineDriver.java
@@ -22,6 +22,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.splicemachine.access.api.DatabaseVersion;
 import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.access.api.ServiceDiscovery;
+import com.splicemachine.db.iapi.services.authorization.AuthorizationFactory;
+import com.splicemachine.db.iapi.services.authorization.AuthorizationFactoryService;
 import com.splicemachine.derby.iapi.sql.PartitionLoadWatcher;
 import com.splicemachine.derby.iapi.sql.PropertyManager;
 import com.splicemachine.derby.iapi.sql.execute.DataSetProcessorFactory;
@@ -97,6 +99,7 @@ public class EngineDriver{
                     }
                 }).build();
         this.serviceDiscovery = environment.serviceDiscovery();
+
     }
 
     public DatabaseAdministrator dbAdministrator(){
@@ -156,5 +159,6 @@ public class EngineDriver{
     public ServiceDiscovery getServiceDiscovery() {
         return serviceDiscovery;
     }
+
 
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
@@ -96,6 +96,9 @@ public class SpliceDatabase extends BasicDatabase{
 
         configureAuthentication();
 
+        // setup authorization
+
+
         create=Boolean.TRUE.equals(EngineLifecycleService.isCreate.get()); //written like this to avoid autoboxing
 
         if(create){
@@ -173,6 +176,12 @@ public class SpliceDatabase extends BasicDatabase{
     public void checkpoint() throws SQLException{
         throw new SQLException("Unsupported Exception");
     }
+/*
+    protected void configureAuthorization() {
+        SConfiguration configuration = SIDriver.driver().getConfiguration();
+        System.setProperty("splice.authorization.scheme",configuration.getAuthorizationScheme());
+    }
+*/
 
     protected void configureAuthentication(){
         SConfiguration configuration =SIDriver.driver().getConfiguration();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
@@ -176,12 +176,6 @@ public class SpliceDatabase extends BasicDatabase{
     public void checkpoint() throws SQLException{
         throw new SQLException("Unsupported Exception");
     }
-/*
-    protected void configureAuthorization() {
-        SConfiguration configuration = SIDriver.driver().getConfiguration();
-        System.setProperty("splice.authorization.scheme",configuration.getAuthorizationScheme());
-    }
-*/
 
     protected void configureAuthentication(){
         SConfiguration configuration =SIDriver.driver().getConfiguration();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateRoleConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateRoleConstantOperation.java
@@ -59,6 +59,7 @@ public class CreateRoleConstantOperation extends DDLConstantOperation {
      */
     public void executeConstantAction(Activation activation) throws StandardException {
     	SpliceLogUtils.trace(LOG, "executeConstantAction with activation {%s}",activation);
+        checkAuthorizationScheme(SQLState.NO_GRANT_PERMISSIONS_WITH_RANGER);
         LanguageConnectionContext lcc = activation.getLanguageConnectionContext();
         DataDictionary dd = lcc.getDataDictionary();
         TransactionController tc = lcc.getTransactionExecute();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DDLConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DDLConstantOperation.java
@@ -42,6 +42,7 @@ import com.splicemachine.derby.stream.iapi.ScopeNamed;
 import com.splicemachine.primitives.Bytes;
 import com.splicemachine.si.api.txn.Txn;
 import com.splicemachine.si.api.txn.TxnView;
+import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.stream.Stream;
 import com.splicemachine.stream.StreamException;
 import com.splicemachine.utils.SpliceLogUtils;
@@ -956,6 +957,15 @@ public abstract class DDLConstantOperation implements ConstantAction, ScopeNamed
 			StringUtils.splitByCharacterTypeCamelCase(
 				this.getClass().getSimpleName().
 					replace("ConstantOperation", "")), ' ');
+	}
+
+	public static void checkAuthorizationScheme(String exceptionCode) throws StandardException {
+		if (SIDriver.driver().getConfiguration().getAuthorizationScheme().equals("RANGER")) {
+			throw StandardException.
+					newException(exceptionCode);
+		}
+
+
 	}
 }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropRoleConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropRoleConstantOperation.java
@@ -56,6 +56,7 @@ public class DropRoleConstantOperation extends DDLConstantOperation {
      * @see com.splicemachine.db.iapi.sql.execute.ConstantAction#executeConstantAction
      */
     public void executeConstantAction( Activation activation ) throws StandardException {
+        checkAuthorizationScheme(SQLState.NO_REVOKE_PERMISSIONS_WITH_RANGER);
         LanguageConnectionContext lcc = activation.getLanguageConnectionContext();
         DataDictionary dd = lcc.getDataDictionary();
         TransactionController tc = lcc.getTransactionExecute();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/GrantRevokeConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/GrantRevokeConstantOperation.java
@@ -57,6 +57,7 @@ public class GrantRevokeConstantOperation implements ConstantAction {
 	 * @exception StandardException		Thrown on failure
 	 */
 	public void executeConstantAction( Activation activation ) throws StandardException {
+        DDLConstantOperation.checkAuthorizationScheme(grant?SQLState.NO_GRANT_PERMISSIONS_WITH_RANGER:SQLState.NO_REVOKE_PERMISSIONS_WITH_RANGER);
         LanguageConnectionContext lcc = activation.getLanguageConnectionContext();
         TransactionController tc = lcc.getTransactionExecute();
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/GrantRoleConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/GrantRoleConstantOperation.java
@@ -30,6 +30,7 @@ import com.splicemachine.ddl.DDLMessage;
 import com.splicemachine.derby.ddl.DDLUtils;
 import com.splicemachine.derby.impl.store.access.SpliceTransactionManager;
 import com.splicemachine.protobuf.ProtoUtil;
+import com.splicemachine.si.impl.driver.SIDriver;
 
 import java.util.Iterator;
 import java.util.List;
@@ -60,7 +61,8 @@ public class GrantRoleConstantOperation extends DDLConstantOperation {
      * @exception StandardException     Thrown on failure
      */
     public void executeConstantAction(Activation activation) throws StandardException {
-        LanguageConnectionContext lcc = activation.getLanguageConnectionContext();
+        checkAuthorizationScheme(SQLState.NO_GRANT_PERMISSIONS_WITH_RANGER);
+       LanguageConnectionContext lcc = activation.getLanguageConnectionContext();
         DataDictionary dd = lcc.getDataDictionary();
         TransactionController tc = lcc.getTransactionExecute();
         DataDescriptorGenerator ddg = dd.getDataDescriptorGenerator();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/RevokeRoleConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/RevokeRoleConstantOperation.java
@@ -29,6 +29,7 @@ import com.splicemachine.ddl.DDLMessage;
 import com.splicemachine.derby.ddl.DDLUtils;
 import com.splicemachine.derby.impl.store.access.SpliceTransactionManager;
 import com.splicemachine.protobuf.ProtoUtil;
+import com.splicemachine.si.impl.driver.SIDriver;
 
 import java.util.Iterator;
 import java.util.List;
@@ -63,6 +64,7 @@ public class RevokeRoleConstantOperation extends DDLConstantOperation {
      * @see com.splicemachine.db.iapi.sql.execute.ConstantAction#executeConstantAction
      */
     public void executeConstantAction(Activation activation) throws StandardException {
+        checkAuthorizationScheme(SQLState.NO_REVOKE_PERMISSIONS_WITH_RANGER);
         LanguageConnectionContext lcc = activation.getLanguageConnectionContext();
         DataDictionary dd = lcc.getDataDictionary();
         TransactionController tc = lcc.getTransactionExecute();


### PR DESCRIPTION
This is the public side of the ranger implementation.  

Key Concepts:

AuthorizationProvider is now a factory vs. a singleton.
Splice Ambari Service now has its own config files for ranger if someone wants to configure it.
HDP 2.6.3 assembly now requires the ranger service and ranger plugin from the enterprise repo.