### PR TITLE
SPLICE-2108 Can't disable logging statements

### DIFF
--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SQLConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SQLConfiguration.java
@@ -93,7 +93,7 @@ public class SQLConfiguration implements ConfigurationDefault {
      * For logging sql statements.  This is off by default. Turning on will hurt you in the case of an OLTP workload.
      */
     public static final String DEBUG_LOG_STATEMENT_CONTEXT = "splice.debug.logStatementContext";
-    private static final boolean DEFAULT_LOG_STATEMENT_CONTEXT=false;
+    private static final boolean DEFAULT_LOG_STATEMENT_CONTEXT=true;
 
     /**
      * Threshold in megabytes for the broadcast join region size.

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
@@ -89,13 +89,9 @@ public class SpliceDatabase extends BasicDatabase{
         //  System.setProperty("derby.language.logQueryPlan", Boolean.toString(true));
         String logStatementText = System.getProperty("derby.language.logStatementText");
         if (logStatementText == null) {
-            if (config.debugLogStatementContext()) {
-                System.setProperty("com.splicemachine.enableLegacyAsserts", Boolean.TRUE.toString());
-                startParams.put("derby.language.logStatementText", Boolean.TRUE.toString());
-            } else {
-                startParams.put("derby.language.logStatementText", Boolean.FALSE.toString());
-            }
+            startParams.put("derby.language.logStatementText", Boolean.toString(config.debugLogStatementContext()));
         }
+
         if (config.debugDumpClassFile()) {
             System.setProperty("com.splicemachine.enableLegacyAsserts",Boolean.TRUE.toString());
             SanityManager.DEBUG_SET("DumpClassFile");

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
@@ -77,23 +77,34 @@ public class SpliceDatabase extends BasicDatabase{
     public void boot(boolean create,Properties startParams) throws StandardException{
         Configuration.setConfiguration(null);
         SConfiguration config = SIDriver.driver().getConfiguration();
+
+        if (startParams == null) {
+            startParams = new Properties();
+        }
+
         // Set 60 Second Default if Missing from startup parameters
         if (System.getProperty("derby.drda.timeSlice") == null)
             System.setProperty("derby.drda.timeSlice","60000");
 
         //  System.setProperty("derby.language.logQueryPlan", Boolean.toString(true));
-        if(config.debugLogStatementContext()) {
-            System.setProperty("com.splicemachine.enableLegacyAsserts",Boolean.TRUE.toString());
-            System.setProperty("derby.language.logStatementText",Boolean.toString(true));
+        String logStatementText = System.getProperty("derby.language.logStatementText");
+        if (logStatementText == null) {
+            if (config.debugLogStatementContext()) {
+                System.setProperty("com.splicemachine.enableLegacyAsserts", Boolean.TRUE.toString());
+                startParams.put("derby.language.logStatementText", Boolean.TRUE.toString());
+            } else {
+                startParams.put("derby.language.logStatementText", Boolean.FALSE.toString());
+            }
         }
-        if(config.debugDumpClassFile()) {
+        if (config.debugDumpClassFile()) {
             System.setProperty("com.splicemachine.enableLegacyAsserts",Boolean.TRUE.toString());
             SanityManager.DEBUG_SET("DumpClassFile");
         }
-    if(config.debugDumpBindTree()) {
+        if (config.debugDumpBindTree()) {
             System.setProperty("com.splicemachine.enableLegacyAsserts",Boolean.TRUE.toString());
             SanityManager.DEBUG_SET("DumpBindTree");
-        }if(config.debugDumpOptimizedTree()) {
+        }
+        if (config.debugDumpOptimizedTree()) {
             System.setProperty("com.splicemachine.enableLegacyAsserts",Boolean.TRUE.toString());
             SanityManager.DEBUG_SET("DumpOptimizedTree");
         }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/PropertyConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/PropertyConglomerate.java
@@ -56,7 +56,7 @@ public class PropertyConglomerate {
 
     /* Constructors for This class: */
 
-	public PropertyConglomerate(TransactionController tc, boolean create, Properties properties, PropertyFactory pf) throws StandardException {
+	public PropertyConglomerate(TransactionController tc, boolean create, Properties startParams, PropertyFactory pf) throws StandardException {
 		serviceProperties = new Properties();
 		PropertyManager propertyManager=PropertyManagerService.loadPropertyManager();
 		this.pf = pf;
@@ -106,8 +106,11 @@ public class PropertyConglomerate {
 			serviceProperties.put(Property.DEFAULT_CONNECTION_MODE_PROPERTY, "fullAccess");
 			serviceProperties.put(Property.AUTHENTICATION_BUILTIN_ALGORITHM, Property.AUTHENTICATION_BUILTIN_ALGORITHM_DEFAULT);
 			serviceProperties.put(Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED, "false");
-            for (Object key: serviceProperties.keySet()) {
-				propertyManager.addProperty((String)key,serviceProperties.getProperty((String)key));
+            for (Object object: serviceProperties.keySet()) {
+            	String key = (String)object;
+            	String defaultValue = serviceProperties.getProperty(key);
+            	String value = startParams != null ? startParams.getProperty(key, defaultValue) : defaultValue;
+				propertyManager.addProperty(key, value);
 			}
 		}
 


### PR DESCRIPTION
A new fix checking for system property "derby.language.logStatementText", config property "splice.debug.logStatementContext" and passing them down via startParams to PropertyConglomerate.