### PR TITLE
SPLICE-2149 Make Sort Operations and Sorting in Window Functions Use …

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SortOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SortOperation.java
@@ -215,19 +215,10 @@ public class SortOperation extends SpliceBaseOperation{
             }
         }
 
-        //operationContext.pushScopeForOp(OperationContext.Scope.SORT_KEYER);
-        KeyerFunction f=new KeyerFunction(operationContext,keyColumns);
-        PairDataSet pair=dataSet.keyBy(f);
-        //operationContext.popScope();
 
-        //operationContext.pushScopeForOp(OperationContext.Scope.SHUFFLE);
-        PairDataSet sortedByKey=pair.sortByKey(new RowComparator(descColumns,nullsOrderedLow),
-            OperationContext.Scope.SORT.displayName(), operationContext);
-        //operationContext.popScope();
+        DataSet sortedValues = dataSet.orderBy(operationContext, keyColumns,descColumns,nullsOrderedLow);
 
-        //operationContext.pushScopeForOp(OperationContext.Scope.READ_SORTED);
-        DataSet sortedValues=sortedByKey.values(OperationContext.Scope.READ_SORTED.displayName());
-        //operationContext.popScope();
+
 
         try{
             //operationContext.pushScopeForOp(OperationContext.Scope.LOCATE);

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
@@ -23,14 +23,7 @@ import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.MultiProbeTableScanOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.window.WindowContext;
 import com.splicemachine.derby.stream.control.output.ControlExportDataSetWriter;
-import com.splicemachine.derby.stream.function.KeyerFunction;
-import com.splicemachine.derby.stream.function.MergeWindowFunction;
-import com.splicemachine.derby.stream.function.SpliceFlatMapFunction;
-import com.splicemachine.derby.stream.function.SpliceFunction;
-import com.splicemachine.derby.stream.function.SpliceFunction2;
-import com.splicemachine.derby.stream.function.SplicePairFunction;
-import com.splicemachine.derby.stream.function.SplicePredicateFunction;
-import com.splicemachine.derby.stream.function.TakeFunction;
+import com.splicemachine.derby.stream.function.*;
 import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.OperationContext;
 import com.splicemachine.derby.stream.iapi.PairDataSet;
@@ -112,6 +105,23 @@ public class ControlDataSet<V> implements DataSet<V> {
         } catch (Exception e) {
             throw Exceptions.getRuntimeException(e);
         }
+    }
+
+    @Override
+    public DataSet<V> orderBy(OperationContext operationContext, int[] keyColumns, boolean[] descColumns, boolean[] nullsOrderedLow) {
+        //operationContext.pushScopeForOp(OperationContext.Scope.SORT_KEYER);
+        KeyerFunction f=new KeyerFunction(operationContext,keyColumns);
+        PairDataSet pair=keyBy(f);
+        //operationContext.popScope();
+
+        //operationContext.pushScopeForOp(OperationContext.Scope.SHUFFLE);
+        PairDataSet sortedByKey=pair.sortByKey(new RowComparator(descColumns,nullsOrderedLow),
+                OperationContext.Scope.SORT.displayName(), operationContext);
+        //operationContext.popScope();
+
+        //operationContext.pushScopeForOp(OperationContext.Scope.READ_SORTED);
+        return sortedByKey.values(OperationContext.Scope.READ_SORTED.displayName());
+        //operationContext.popScope();
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
@@ -195,6 +195,8 @@ public interface DataSet<V> extends //Iterable<V>,
 
     DataSet<V> union(DataSet<V> dataSet, OperationContext operationContext);
 
+    DataSet<V> orderBy(OperationContext operationContext, int[] keyColumns, boolean[] descColumns, boolean[] nullsOrderedLow);
+
     DataSet<V> parallelProbe(List<ScanSetBuilder<ExecRow>> dataSets, OperationContext<MultiProbeTableScanOperation> operationContext) throws StandardException;
 
     DataSet<V> union(DataSet<V> dataSet, OperationContext operationContext, String name, boolean pushScope, String scopeDetail);


### PR DESCRIPTION
…Tungsten Encoding vs. ValueRowSerializer



Steps to reproduce experiment...

Load TPCH 1 LineItem table (6 Million Rows) on your laptop build of Splice Machine.

Run

select top 10 * from TPCH.LINEITEM order by L_PARTKEY, L_SUPPKEY;
With tungsten sort 69.693 Seconds.

Without tungsten sort ran 5 minutes and then crashed OOM.