### PR TITLE
SPLICE-2130 Modify selectivity assert to greater or equal than 0

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
@@ -1487,7 +1487,7 @@ public class BinaryRelationalOperatorNode
         } else { // No Right ColumnReference
             selectivity = super.joinSelectivity(optTable, currentCd, innerRowCount, outerRowCount, selectivityJoinType);
         }
-        assert selectivity > 0.0d:"selectivity is out of bounds " + selectivity + this + " right-> " + rightOperand + " left -> " + leftOperand;
+        assert selectivity >= 0.0d:"selectivity is out of bounds " + selectivity + this + " right-> " + rightOperand + " left -> " + leftOperand;
         return selectivity;
     }
 


### PR DESCRIPTION
The selectivity could be 0 if the predicate disqualifies all rows. And in other places of selectivity assert, we bounded its value in [0,1], which includes 0. So we suggest  to modify the assert selectivity from > 0 to >=0 . 