### PR TITLE
DB-6984 Remove the close of the file system

### DIFF
--- a/hbase_storage/src/main/java/org/apache/hadoop/hdfs/ProxiedFilesystem.java
+++ b/hbase_storage/src/main/java/org/apache/hadoop/hdfs/ProxiedFilesystem.java
@@ -133,7 +133,6 @@ public class ProxiedFilesystem extends DistributedFileSystem {
 
     @Override
     public void close() throws IOException {
-        super.close();
         try {
             connection.close();
         } catch (SQLException e) {


### PR DESCRIPTION
LocalFileSystem can support close but a HDFS File System will fail after closed.  

