### PR TITLE
Revert "SPLICE-2064 Add logging on System.exit() calls (#1633)"

### DIFF
--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -708,7 +708,7 @@
                             <groups>com.splicemachine.test.SerialTest</groups>
                             <excludedGroups>${excluded.categories}</excludedGroups>
                             <argLine>-Xmx3g</argLine>
-                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <dependenciesToScan>
                                 <dependency>com.splicemachine:splice_machine</dependency>
                             </dependenciesToScan>
@@ -735,7 +735,7 @@
                             <!-- -sf- single-threaded for now -->
                             <perCoreThreadCount>false</perCoreThreadCount>
                             <argLine>-Xmx5g</argLine>
-                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <dependenciesToScan>
                                 <dependency>com.splicemachine:splice_machine</dependency>
                             </dependenciesToScan>
@@ -759,7 +759,7 @@
                         <configuration>
                             <groups>com.splicemachine.test.RestoreTest</groups>
                             <argLine>-Xmx3g</argLine>
-                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <includes>
                                 <include>**/*RestoreIT.java</include>
                             </includes>

--- a/mem_sql/pom.xml
+++ b/mem_sql/pom.xml
@@ -210,7 +210,7 @@
                             <groups>com.splicemachine.test.SerialTest</groups>
                             <excludedGroups>com.splicemachine.test.HBaseTest, ${excluded.categories}</excludedGroups>
                             <argLine>-Xmx3g</argLine>
-                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <dependenciesToScan>
                                 <dependency>com.splicemachine:splice_machine</dependency>
                             </dependenciesToScan>
@@ -236,7 +236,7 @@
                             <threadCount>4</threadCount>
                             <perCoreThreadCount>false</perCoreThreadCount>
                             <argLine>-Xmx3g</argLine>
-                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <dependenciesToScan>
                                 <dependency>com.splicemachine:splice_machine</dependency>
                             </dependenciesToScan>

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
@@ -20,7 +20,6 @@ import org.junit.runner.Description;
 import org.junit.runners.model.MultipleFailureException;
 import org.spark_project.guava.collect.Lists;
 
-import java.security.Permission;
 import java.sql.*;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -35,20 +34,6 @@ import static org.spark_project.guava.base.Strings.isNullOrEmpty;
  * Not thread-safe, synchronize externally if using in a multi-threaded test case.
  */
 public class SpliceWatcher extends TestWatcher {
-    static {
-        System.setSecurityManager(new SecurityManager() {
-            @Override
-            public void checkPermission(Permission perm) {
-                if (perm instanceof RuntimePermission) {
-                    RuntimePermission rperm = (RuntimePermission) perm;
-                    if (rperm.getName().startsWith("exitVM")) {
-                        new RuntimeException().printStackTrace(System.out);
-                        System.out.println("exit called");
-                    }
-                }
-            }
-        });
-    }
 
     private static final Logger LOG = Logger.getLogger(SpliceWatcher.class);
 


### PR DESCRIPTION
This reverts commit e49d0c6ada5f23c09fba123f942b2f9cc51966d3.

Upgrading the surefire plugin seems to have fixed the "VM crashed" errors on master, so we can remove this extra logging from master