### PR TITLE
DB-6968 Repartition DataFrame before writing to avoid many small files

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
@@ -753,7 +753,15 @@ public class SparkDataSet<V> implements DataSet<V> {
             for (int i = 0; i < partitionBy.length; i++) {
                 partitionByCols.add(ValueRow.getNamedColumn(partitionBy[i]));
             }
-            insertDF.write().option(SPARK_COMPRESSION_OPTION,compression).partitionBy(partitionByCols.toArray(new String[partitionByCols.size()]))
+            if (partitionBy.length > 0) {
+                List<Column> repartitionCols = new ArrayList();
+                for (int i = 0; i < partitionBy.length; i++) {
+                    repartitionCols.add(new Column(ValueRow.getNamedColumn(partitionBy[i])));
+                }
+                insertDF = insertDF.repartition(scala.collection.JavaConversions.asScalaBuffer(repartitionCols).toList());
+            }
+            insertDF.write().option(SPARK_COMPRESSION_OPTION,compression)
+                    .partitionBy(partitionByCols.toArray(new String[partitionByCols.size()]))
                     .mode(SaveMode.Append).parquet(location);
             ValueRow valueRow=new ValueRow(1);
             valueRow.setColumn(1,new SQLLongint(context.getRecordsWritten()));
@@ -782,6 +790,13 @@ public class SparkDataSet<V> implements DataSet<V> {
             for (int i = 0; i < partitionBy.length; i++) {
                 partitionByCols.add(ValueRow.getNamedColumn(partitionBy[i]));
             }
+            if (partitionBy.length > 0) {
+                List<Column> repartitionCols = new ArrayList();
+                for (int i = 0; i < partitionBy.length; i++) {
+                    repartitionCols.add(new Column(ValueRow.getNamedColumn(partitionBy[i])));
+                }
+                insertDF = insertDF.repartition(scala.collection.JavaConversions.asScalaBuffer(repartitionCols).toList());
+            }
             insertDF.write().option(SPARK_COMPRESSION_OPTION,compression).partitionBy(partitionByCols.toArray(new String[partitionByCols.size()]))
                     .mode(SaveMode.Append).format("com.databricks.spark.avro").save(location);
             ValueRow valueRow=new ValueRow(1);
@@ -807,6 +822,13 @@ public class SparkDataSet<V> implements DataSet<V> {
             String[] partitionByCols = new String[partitionBy.length];
             for (int i = 0; i < partitionBy.length; i++) {
                 partitionByCols[i] = ValueRow.getNamedColumn(partitionBy[i]);
+            }
+            if (partitionBy.length > 0) {
+                List<Column> repartitionCols = new ArrayList();
+                for (int i = 0; i < partitionBy.length; i++) {
+                    repartitionCols.add(new Column(ValueRow.getNamedColumn(partitionBy[i])));
+                }
+                insertDF = insertDF.repartition(scala.collection.JavaConversions.asScalaBuffer(repartitionCols).toList());
             }
             insertDF.write().option(SPARK_COMPRESSION_OPTION,compression)
                     .partitionBy(partitionByCols)

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
@@ -27,6 +27,9 @@ import java.io.File;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 /**
  * Created by tgildersleeve on 6/30/17.
  * SPLICE-1621
@@ -64,35 +67,83 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col1) STORED AS PARQUET LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into parquet_part_1st values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_1st");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_1st");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_1st");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_1st");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_1st");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
                     "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+        } catch (SQLException e) {
+            Assert.fail("An exception should not be thrown");
+        }
+    }
+
+
+    @Test
+    public void testSparkGeneratesFewParquetFiles() throws Exception {
+        testSparkGeneratesFewFiles("parquet");
+    }
+    @Test
+    public void testSparkGeneratesFewOrcFiles() throws Exception {
+        testSparkGeneratesFewFiles("orc");
+    }
+    @Test
+    public void testSparkGeneratesFewAvroFiles() throws Exception {
+        testSparkGeneratesFewFiles("avro");
+    }
+    
+    public void testSparkGeneratesFewFiles(String format) throws Exception {
+        try {
+            String tablePath = getExternalResourceDirectory()+"/"+format+"_number_files";
+            methodWatcher.executeUpdate(String.format("create table %s_number_files_orig (col1 int, col2 int, col3 varchar(10))",format));
+            methodWatcher.executeUpdate(String.format("create external table %s_number_files (col1 int, col2 int, col3 varchar(10)) " +
+                    "partitioned by (col1) STORED AS %1$s LOCATION '%s'",format,tablePath));
+            methodWatcher.executeUpdate(String.format("insert into %s_number_files_orig values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')",format));
+            methodWatcher.executeUpdate(String.format("insert into %s_number_files_orig values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')",format));
+
+
+            methodWatcher.executeUpdate(String.format("insert into %1$s_number_files " +
+                    "select * from %1$s_number_files_orig --splice-properties useSpark=true \n" +
+                    "union all select * from %1$s_number_files_orig " +
+                    "union all select * from %1$s_number_files_orig " +
+                    "union all select * from %1$s_number_files_orig " +
+                    "union all select * from %1$s_number_files_orig " +
+                    "union all select * from %1$s_number_files_orig ",format));
+
+
+            ResultSet rs = methodWatcher.executeQuery(String.format("select count(*) from %s_number_files",format));
+
+            assertTrue(rs.next());
+            assertEquals(36, rs.getInt(1));
+
+            // There should be 11 entries:
+            // 3 data files (+3 crc files)
+            // 1 _SUCCESS file (+1 crc file)
+            // 3 subdirectories
+            assertEquals(11, getNumberOfFiles(tablePath));
         } catch (SQLException e) {
             Assert.fail("An exception should not be thrown");
         }
@@ -107,31 +158,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col1) STORED AS AVRO LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into avro_part_1st values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from avro_part_1st");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_1st");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_1st");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_1st");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_1st");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -149,31 +200,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col1) STORED AS ORC LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into orc_part_1st values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from orc_part_1st");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_1st");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_1st");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_1st");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_1st");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -181,17 +232,17 @@ public class ExternalTablePartitionIT {
 
             /* test query with predicates */
             ResultSet rs5 = methodWatcher.executeQuery("select * from orc_part_1st where col1=3");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs5));
 
             ResultSet rs6 = methodWatcher.executeQuery("select * from orc_part_1st where col2=4");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs6));
 
             ResultSet rs7 = methodWatcher.executeQuery("select * from orc_part_1st where col3='CCC'");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs7));
         } catch (SQLException e) {
@@ -207,31 +258,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col1) STORED AS TEXTFILE LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into textfile_part_1st values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_1st");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_1st");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_1st");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_1st");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_1st");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -249,31 +300,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col1,col2) STORED AS PARQUET LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into parquet_part_1st_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_1st_2nd");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_1st_2nd");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_1st_2nd");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_1st_2nd");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_1st_2nd");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -291,31 +342,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col1,col2) STORED AS AVRO LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into avro_part_1st_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from avro_part_1st_2nd");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_1st_2nd");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_1st_2nd");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_1st_2nd");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_1st_2nd");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -333,31 +384,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col1,col2) STORED AS ORC LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into orc_part_1st_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from orc_part_1st_2nd");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_1st_2nd");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_1st_2nd");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_1st_2nd");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_1st_2nd");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -365,17 +416,17 @@ public class ExternalTablePartitionIT {
 
             // test query with predicate
             ResultSet rs5 = methodWatcher.executeQuery("select * from orc_part_1st_2nd where col1=3");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs5));
 
             ResultSet rs6 = methodWatcher.executeQuery("select * from orc_part_1st_2nd where col2=4");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs6));
 
             ResultSet rs7 = methodWatcher.executeQuery("select * from orc_part_1st_2nd where col3='AAA'");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |",TestUtils.FormattedResult.ResultFactory.toString(rs7));
         } catch (SQLException e) {
@@ -391,31 +442,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col1,col2) STORED AS TEXTFILE LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into textfile_part_1st_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_1st_2nd");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_1st_2nd");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_1st_2nd");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_1st_2nd");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_1st_2nd");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -433,31 +484,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col2) STORED AS PARQUET LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into parquet_part_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_2nd");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_2nd");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_2nd");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_2nd");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_2nd");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -475,31 +526,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col2) STORED AS AVRO LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into avro_part_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from avro_part_2nd");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_2nd");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_2nd");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_2nd");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_2nd");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -518,31 +569,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col2) STORED AS ORC LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into orc_part_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from orc_part_2nd");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_2nd");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_2nd");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_2nd");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_2nd");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -550,15 +601,15 @@ public class ExternalTablePartitionIT {
 
             // test query with predicates
             ResultSet rs5 = methodWatcher.executeQuery("select * from orc_part_2nd where col1=3");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs5));
             ResultSet rs6 = methodWatcher.executeQuery("select * from orc_part_2nd where col2=4");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs6));
             ResultSet rs7 = methodWatcher.executeQuery("select * from orc_part_2nd where col3='CCC'");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs7));
         } catch (SQLException e) {
@@ -575,31 +626,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col2) STORED AS TEXTFILE LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into textfile_part_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_2nd");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_2nd");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_2nd");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_2nd");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_2nd");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -617,31 +668,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col3) STORED AS PARQUET LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into parquet_part_last values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_last");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_last");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_last");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_last");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_last");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -660,31 +711,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col3) STORED AS AVRO LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into avro_part_last values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from avro_part_last");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_last");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_last");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_last");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_last");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -702,31 +753,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col3) STORED AS ORC LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into orc_part_last values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from orc_part_last");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_last");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_last");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_last");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_last");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -734,15 +785,15 @@ public class ExternalTablePartitionIT {
 
             // test query with predicate
             ResultSet rs5 = methodWatcher.executeQuery("select * from orc_part_last where col1=3");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs5));
             ResultSet rs6 = methodWatcher.executeQuery("select * from orc_part_last where col2=4");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs6));
             ResultSet rs7 = methodWatcher.executeQuery("select * from orc_part_last where col3='CCC'");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs7));
         } catch (SQLException e) {
@@ -758,31 +809,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col3) STORED AS TEXTFILE LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into textfile_part_last values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_last");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_last");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_last");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_last");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_last");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -800,31 +851,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col3,col2) STORED AS PARQUET LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into parquet_part_3rd_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_3rd_2nd");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_3rd_2nd");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_3rd_2nd");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_3rd_2nd");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_3rd_2nd");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -842,31 +893,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col3,col2) STORED AS AVRO LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into avro_part_3rd_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from avro_part_3rd_2nd");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_3rd_2nd");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_3rd_2nd");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_3rd_2nd");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_3rd_2nd");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -884,31 +935,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col3,col2) STORED AS ORC LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into orc_part_3rd_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from orc_part_3rd_2nd");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_3rd_2nd");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_3rd_2nd");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_3rd_2nd");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_3rd_2nd");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -916,15 +967,15 @@ public class ExternalTablePartitionIT {
 
             //test query with prediate
             ResultSet rs5 = methodWatcher.executeQuery("select * from orc_part_3rd_2nd where col1=3");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs5));
             ResultSet rs6 = methodWatcher.executeQuery("select * from orc_part_3rd_2nd where col2=4");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs6));
             ResultSet rs7 = methodWatcher.executeQuery("select * from orc_part_3rd_2nd where col3='CCC'");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs7));
         } catch (SQLException e) {
@@ -940,31 +991,31 @@ public class ExternalTablePartitionIT {
                     "partitioned by (col3,col2) STORED AS TEXTFILE LOCATION '%s'",tablePath));
             methodWatcher.executeUpdate("insert into textfile_part_3rd_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
             ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_3rd_2nd");
-            Assert.assertEquals("COL1 |COL2 |COL3 |\n" +
+            assertEquals("COL1 |COL2 |COL3 |\n" +
                     "------------------\n" +
                     "  1  |  2  | AAA |\n" +
                     "  3  |  4  | BBB |\n" +
                     "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_3rd_2nd");
-            Assert.assertEquals("COL1 |\n" +
+            assertEquals("COL1 |\n" +
                     "------\n" +
                     "  1  |\n" +
                     "  3  |\n" +
                     "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
             ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_3rd_2nd");
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     "  2  |\n" +
                     "  4  |\n" +
                     "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
             ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_3rd_2nd");
-            Assert.assertEquals("COL3 |\n" +
+            assertEquals("COL3 |\n" +
                     "------\n" +
                     " AAA |\n" +
                     " BBB |\n" +
                     " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
             ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_3rd_2nd");
-            Assert.assertEquals("COL2 |COL3 |\n" +
+            assertEquals("COL2 |COL3 |\n" +
                     "------------\n" +
                     "  2  | AAA |\n" +
                     "  4  | BBB |\n" +
@@ -983,13 +1034,13 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate("insert into orc_aggressive values " +
                     "(111,'AAA',true,111, 1.1, 'a'),(222,'BBB',false,222, 2.2, 'b'),(333,'CCC',true,333, 3.3, 'c')");
             ResultSet rs = methodWatcher.executeQuery("select * from orc_aggressive");
-            Assert.assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
+            assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
                     "-------------------------------------\n" +
                     " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
                     " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
                     " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from orc_aggressive");
-            Assert.assertEquals("COL5 |COL2 |COL6 |\n" +
+            assertEquals("COL5 |COL2 |COL6 |\n" +
                     "------------------\n" +
                     " 1.1 | AAA |  a  |\n" +
                     " 2.2 | BBB |  b  |\n" +
@@ -1008,13 +1059,13 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate("insert into parquet_aggressive values " +
                     "(111,'AAA',true,111, 1.1, 'a'),(222,'BBB',false,222, 2.2, 'b'),(333,'CCC',true,333, 3.3, 'c')");
             ResultSet rs = methodWatcher.executeQuery("select * from parquet_aggressive");
-            Assert.assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
+            assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
                     "-------------------------------------\n" +
                     " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
                     " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
                     " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from parquet_aggressive");
-            Assert.assertEquals("COL5 |COL2 |COL6 |\n" +
+            assertEquals("COL5 |COL2 |COL6 |\n" +
                     "------------------\n" +
                     " 1.1 | AAA |  a  |\n" +
                     " 2.2 | BBB |  b  |\n" +
@@ -1033,13 +1084,13 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate("insert into avro_aggressive values " +
                     "(111,'AAA',true,111, 1.1, 'a'),(222,'BBB',false,222, 2.2, 'b'),(333,'CCC',true,333, 3.3, 'c')");
             ResultSet rs = methodWatcher.executeQuery("select * from avro_aggressive");
-            Assert.assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
+            assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
                     "-------------------------------------\n" +
                     " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
                     " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
                     " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from avro_aggressive");
-            Assert.assertEquals("COL5 |COL2 |COL6 |\n" +
+            assertEquals("COL5 |COL2 |COL6 |\n" +
                     "------------------\n" +
                     " 1.1 | AAA |  a  |\n" +
                     " 2.2 | BBB |  b  |\n" +
@@ -1058,13 +1109,13 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate("insert into textfile_aggressive values " +
                     "(111,'AAA',true,111, 1.1, 'a'),(222,'BBB',false,222, 2.2, 'b'),(333,'CCC',true,333, 3.3, 'c')");
             ResultSet rs = methodWatcher.executeQuery("select * from textfile_aggressive");
-            Assert.assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
+            assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
                     "-------------------------------------\n" +
                     " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
                     " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
                     " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from textfile_aggressive");
-            Assert.assertEquals("COL5 |COL2 |COL6 |\n" +
+            assertEquals("COL5 |COL2 |COL6 |\n" +
                     "------------------\n" +
                     " 1.1 | AAA |  a  |\n" +
                     " 2.2 | BBB |  b  |\n" +
@@ -1087,7 +1138,7 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_0 values " +
                     "('whoa',77.7,444,'crazy',21),('hey',11.11,222,'crazier',10)",format));
             ResultSet rs0 = methodWatcher.executeQuery(String.format("select col4, col2, col3 from %s_aggressive_2_0 where col5 = 21",format));
-            Assert.assertEquals("COL4  |COL2 |COL3 |\n" +
+            assertEquals("COL4  |COL2 |COL3 |\n" +
                     "-------------------\n" +
                     "crazy |77.7 | 444 |",TestUtils.FormattedResult.ResultFactory.toString(rs0));
 
@@ -1096,7 +1147,7 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_1 values " +
                     "(666,66.666,'z','zing',20),(555,55.555,'y','yowza',40),(1,1.1,'g','garish',7)",format));
             ResultSet rs1 = methodWatcher.executeQuery(String.format("select col2,col4 from %s_aggressive_2_1",format));
-            Assert.assertEquals("COL2  | COL4  |\n" +
+            assertEquals("COL2  | COL4  |\n" +
                     "----------------\n" +
                     "  1.1  |garish |\n" +
                     "55.555 | yowza |\n" +
@@ -1107,7 +1158,7 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_2 values " +
                     "('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1)",format));
             ResultSet rs2 = methodWatcher.executeQuery(String.format("select col2 from %s_aggressive_2_2",format));
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     " 1.1 |\n" +
                     " 1.1 |\n" +
@@ -1130,7 +1181,7 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_0 values " +
                     "('whoa',77.7,444,'crazy',21),('hey',11.11,222,'crazier',10)",format));
             ResultSet rs0 = methodWatcher.executeQuery(String.format("select col4, col2, col3 from %s_aggressive_2_0 where col5 = 21",format));
-            Assert.assertEquals("COL4  |COL2 |COL3 |\n" +
+            assertEquals("COL4  |COL2 |COL3 |\n" +
                     "-------------------\n" +
                     "crazy |77.7 | 444 |",TestUtils.FormattedResult.ResultFactory.toString(rs0));
 
@@ -1139,7 +1190,7 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_1 values " +
                     "(666,66.666,'z','zing',20),(555,55.555,'y','yowza',40),(1,1.1,'g','garish',7)",format));
             ResultSet rs1 = methodWatcher.executeQuery(String.format("select col2,col4 from %s_aggressive_2_1",format));
-            Assert.assertEquals("COL2  | COL4  |\n" +
+            assertEquals("COL2  | COL4  |\n" +
                     "----------------\n" +
                     "  1.1  |garish |\n" +
                     "55.555 | yowza |\n" +
@@ -1150,7 +1201,7 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_2 values " +
                     "('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1)",format));
             ResultSet rs2 = methodWatcher.executeQuery(String.format("select col2 from %s_aggressive_2_2",format));
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     " 1.1 |\n" +
                     " 1.1 |\n" +
@@ -1173,7 +1224,7 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_0 values " +
                     "('whoa',77.7,444,'crazy',21),('hey',11.11,222,'crazier',10)",format));
             ResultSet rs0 = methodWatcher.executeQuery(String.format("select col4, col2, col3 from %s_aggressive_2_0 where col5 = 21",format));
-            Assert.assertEquals("COL4  |COL2 |COL3 |\n" +
+            assertEquals("COL4  |COL2 |COL3 |\n" +
                     "-------------------\n" +
                     "crazy |77.7 | 444 |",TestUtils.FormattedResult.ResultFactory.toString(rs0));
 
@@ -1182,7 +1233,7 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_1 values " +
                     "(666,66.666,'z','zing',20),(555,55.555,'y','yowza',40),(1,1.1,'g','garish',7)",format));
             ResultSet rs1 = methodWatcher.executeQuery(String.format("select col2,col4 from %s_aggressive_2_1",format));
-            Assert.assertEquals("COL2  | COL4  |\n" +
+            assertEquals("COL2  | COL4  |\n" +
                     "----------------\n" +
                     "  1.1  |garish |\n" +
                     "55.555 | yowza |\n" +
@@ -1193,7 +1244,7 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_2 values " +
                     "('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1)",format));
             ResultSet rs2 = methodWatcher.executeQuery(String.format("select col2 from %s_aggressive_2_2",format));
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     " 1.1 |\n" +
                     " 1.1 |\n" +
@@ -1216,7 +1267,7 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_0 values " +
                     "('whoa',77.7,444,'crazy',21),('hey',11.11,222,'crazier',10)",format));
             ResultSet rs0 = methodWatcher.executeQuery(String.format("select col4, col2, col3 from %s_aggressive_2_0 where col5 = 21",format));
-            Assert.assertEquals("COL4  |COL2 |COL3 |\n" +
+            assertEquals("COL4  |COL2 |COL3 |\n" +
                     "-------------------\n" +
                     "crazy |77.7 | 444 |",TestUtils.FormattedResult.ResultFactory.toString(rs0));
 
@@ -1225,7 +1276,7 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_1 values " +
                     "(666,66.666,'z','zing',20),(555,55.555,'y','yowza',40),(1,1.1,'g','garish',7)",format));
             ResultSet rs1 = methodWatcher.executeQuery(String.format("select col2,col4 from %s_aggressive_2_1",format));
-            Assert.assertEquals("COL2  | COL4  |\n" +
+            assertEquals("COL2  | COL4  |\n" +
                     "----------------\n" +
                     "  1.1  |garish |\n" +
                     "55.555 | yowza |\n" +
@@ -1236,7 +1287,7 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_2 values " +
                     "('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1)",format));
             ResultSet rs2 = methodWatcher.executeQuery(String.format("select col2 from %s_aggressive_2_2",format));
-            Assert.assertEquals("COL2 |\n" +
+            assertEquals("COL2 |\n" +
                     "------\n" +
                     " 1.1 |\n" +
                     " 1.1 |\n" +
@@ -1254,13 +1305,13 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate(String.format("create external table parquet_partition_existing (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col char)" +
                     "partitioned by (col4, col2,col1) STORED AS PARQUET LOCATION '%s'", SpliceUnitTest.getResourceDirectory()+"parquet_partition_existing"));
             ResultSet rs = methodWatcher.executeQuery("select * from parquet_partition_existing");
-            Assert.assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
+            assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
                     "-------------------------------------\n" +
                     " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
                     " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
                     " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from parquet_partition_existing");
-            Assert.assertEquals("COL5 |COL2 |COL6 |\n" +
+            assertEquals("COL5 |COL2 |COL6 |\n" +
                     "------------------\n" +
                     " 1.1 | AAA |  a  |\n" +
                     " 2.2 | BBB |  b  |\n" +
@@ -1276,13 +1327,13 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate(String.format("create external table avro_partition_existing (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char)" +
                     "partitioned by (col4, col2, col1) STORED AS AVRO LOCATION '%s'", SpliceUnitTest.getResourceDirectory()+"avro_partition_existing"));
             ResultSet rs = methodWatcher.executeQuery("select * from avro_partition_existing");
-            Assert.assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
+            assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
                     "-------------------------------------\n" +
                     " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
                     " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
                     " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from avro_partition_existing");
-            Assert.assertEquals("COL5 |COL2 |COL6 |\n" +
+            assertEquals("COL5 |COL2 |COL6 |\n" +
                     "------------------\n" +
                     " 1.1 | AAA |  a  |\n" +
                     " 2.2 | BBB |  b  |\n" +
@@ -1298,13 +1349,13 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate(String.format("create external table orc_partition_existing (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char)" +
                     "partitioned by (col4, col2, col1) STORED AS ORC LOCATION '%s'", SpliceUnitTest.getResourceDirectory()+"orc_partition_existing"));
             ResultSet rs = methodWatcher.executeQuery("select * from orc_partition_existing");
-            Assert.assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
+            assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
                     "-------------------------------------\n" +
                     " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
                     " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
                     " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from orc_partition_existing");
-            Assert.assertEquals("COL5 |COL2 |COL6 |\n" +
+            assertEquals("COL5 |COL2 |COL6 |\n" +
                     "------------------\n" +
                     " 1.1 | AAA |  a  |\n" +
                     " 2.2 | BBB |  b  |\n" +
@@ -1321,13 +1372,13 @@ public class ExternalTablePartitionIT {
             methodWatcher.executeUpdate(String.format("create external table textfile_partition_existing (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char)" +
                     "partitioned by (col4, col2, col1) STORED AS TEXTFILE LOCATION '%s'", SpliceUnitTest.getResourceDirectory() + "textfile_partition_existing"));
             ResultSet rs = methodWatcher.executeQuery("select * from textfile_partition_existing");
-            Assert.assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
+            assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
                     "-------------------------------------\n" +
                     " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
                     " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
                     " 333 | CCC |true  | 333 | 3.3 |  c  |", TestUtils.FormattedResult.ResultFactory.toString(rs));
             ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from textfile_partition_existing");
-            Assert.assertEquals("COL5 |COL2 |COL6 |\n" +
+            assertEquals("COL5 |COL2 |COL6 |\n" +
                     "------------------\n" +
                     " 1.1 | AAA |  a  |\n" +
                     " 2.2 | BBB |  b  |\n" +
@@ -1340,6 +1391,26 @@ public class ExternalTablePartitionIT {
 
     public static String getExternalResourceDirectory() {
         return SpliceUnitTest.getHBaseDirectory()+"/target/external/";
+    }
+
+
+    private int getNumberOfFiles(String dirPath) {
+        int count = 0;
+        File f = new File(dirPath);
+        File[] files = f.listFiles();
+
+        if (files == null)
+            return 0;
+
+        for (int i = 0; i < files.length; i++) {
+            count++;
+            File file = files[i];
+
+            if (file.isDirectory()) {
+                count += getNumberOfFiles(file.getAbsolutePath());
+            }
+        }
+        return count;
     }
 
 }


### PR DESCRIPTION
In branch-2.5 I haven't included the IT because the ExternalTablePartitionIT file doesn't exist, hopefully we cover any possible regressions on master and branch-2.7