### PR TITLE
SPLICE-2171 Issue Granting Privileges to Sequences

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -15615,6 +15615,8 @@ usableObjects() throws StandardException :
    {
        return ReuseFactory.getInteger( PrivilegeNode.AGGREGATE_PRIVILEGES);
    }
+
+|
     <SEQUENCE>
     {
         return ReuseFactory.getInteger( PrivilegeNode.SEQUENCE_PRIVILEGES);

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/sequence/SpliceSequenceIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/sequence/SpliceSequenceIT.java
@@ -14,16 +14,18 @@
 
 package com.splicemachine.derby.impl.sql.execute.sequence;
 
-import com.splicemachine.derby.test.framework.SpliceDataWatcher;
-import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
-import com.splicemachine.derby.test.framework.SpliceTableWatcher;
-import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.derby.test.framework.*;
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -31,6 +33,12 @@ import static org.junit.Assert.assertTrue;
 public class SpliceSequenceIT {
 
     private static final String SCHEMA = SpliceSequenceIT.class.getSimpleName().toUpperCase();
+    private static final String USER = SCHEMA+"_USER";
+    private static final String PASSWORD = "password";
+    private static final String SEQUENCE = SCHEMA+"."+"testseq";
+
+
+
     private static SpliceWatcher spliceClassWatcher=new SpliceWatcher();
 
     @ClassRule
@@ -40,11 +48,13 @@ public class SpliceSequenceIT {
     public SpliceWatcher methodWatcher = new SpliceWatcher(SCHEMA);
 
     private static SpliceTableWatcher spliceTableWatcher = new SpliceTableWatcher("FOO",SCHEMA,"(col1 bigint)");
+    private static SpliceUserWatcher spliceUserWatcher = new SpliceUserWatcher(USER,PASSWORD);
 
     @ClassRule
     public static TestRule chain= RuleChain.outerRule(spliceClassWatcher)
             .around(spliceSchemaWatcher)
             .around(spliceTableWatcher)
+            .around(spliceUserWatcher)
             .around(new SpliceDataWatcher() {
                 @Override
                 protected void starting(Description description) {
@@ -74,86 +84,18 @@ public class SpliceSequenceIT {
 
         methodWatcher.executeUpdate("drop sequence SMALLSEQ restrict");
     }
-/*
-    @Test
-    public void testSparkSequenceGenerationWithCreateAndDrops() throws Exception {
-        for (int i=0;i<10;i++){
-            methodWatcher.executeUpdate("create sequence FOOSEQ");
-            Integer first = methodWatcher.query("select next value for FOOSEQ from foo");
-            assertEquals(first + 1, methodWatcher.query("select next value for FOOSEQ from foo"));
-            assertEquals(first + 2, methodWatcher.query("select next value for FOOSEQ from foo"));
-            assertEquals(first + 3, methodWatcher.query("select next value for FOOSEQ from foo"));
-            assertEquals(first + 4, methodWatcher.query("select next value for FOOSEQ from foo"));
-            assertEquals(first + 5, methodWatcher.query("select next value for FOOSEQ from foo"));
-            assertEquals(first + 6, methodWatcher.query("select next value for FOOSEQ from foo"));
-            assertEquals(first + 1000, methodWatcher.query("select next value for FOOSEQ from foo --splice-properties useSpark=true"));
-            // Spark by default allocates a 1K increment in the spark memory space
-            // the next OLTP query will go to the table to get the sequence value which should start after the allocated entry...
-            // from Spark.  Since Spark and Control run in different memory spaces, this is testing
-            // whether they allocate their correct amounts...
-            assertEquals(first + 7, methodWatcher.query("select next value for FOOSEQ from foo"));
-            assertEquals(first + 8, methodWatcher.query("select next value for FOOSEQ from foo"));
-            assertEquals(first + 9, methodWatcher.query("select next value for FOOSEQ from foo"));
-            // Verifying the Spark Buffer is still available.  This test would not work if there are several spark nodes.
-            assertEquals(first + 1001, methodWatcher.query("select next value for FOOSEQ from foo --splice-properties useSpark=true"));
-            assertEquals(first + 1002, methodWatcher.query("select next value for FOOSEQ from foo --splice-properties useSpark=true"));
-            methodWatcher.executeUpdate("drop sequence FOOSEQ restrict");
-        }
-    }
 
     @Test
-    public void testSparkSequenceGenerationWithCreateAndDropsStartsWith10000 () throws Exception {
-        for (int i=0;i<10;i++){
-            methodWatcher.executeUpdate("create sequence FOOSEQ2 start with 10000");
-            Integer first = methodWatcher.query("select next value for FOOSEQ2 from foo");
-            assertEquals(first,new Integer(10000));
-            assertEquals(first + 1, methodWatcher.query("select next value for FOOSEQ2 from foo"));
-            assertEquals(first + 2, methodWatcher.query("select next value for FOOSEQ2 from foo"));
-            assertEquals(first + 3, methodWatcher.query("select next value for FOOSEQ2 from foo"));
-            assertEquals(first + 4, methodWatcher.query("select next value for FOOSEQ2 from foo"));
-            assertEquals(first + 5, methodWatcher.query("select next value for FOOSEQ2 from foo"));
-            assertEquals(first + 6, methodWatcher.query("select next value for FOOSEQ2 from foo"));
-            assertEquals(first + 1000, methodWatcher.query("select next value for FOOSEQ2 from foo --splice-properties useSpark=true"));
-            // Spark by default allocates a 1K increment in the spark memory space
-            // the next OLTP query will go to the table to get the sequence value which should start after the allocated entry...
-            // from Spark.  Since Spark and Control run in different memory spaces, this is testing
-            // whether they allocate their correct amounts...
-            assertEquals(first + 7, methodWatcher.query("select next value for FOOSEQ2 from foo"));
-            assertEquals(first + 8, methodWatcher.query("select next value for FOOSEQ2 from foo"));
-            assertEquals(first + 9, methodWatcher.query("select next value for FOOSEQ2 from foo"));
-            // Verifying the Spark Buffer is still available.  This test would not work if there are several spark nodes.
-            assertEquals(first + 1001, methodWatcher.query("select next value for FOOSEQ2 from foo --splice-properties useSpark=true"));
-            assertEquals(first + 1002, methodWatcher.query("select next value for FOOSEQ2 from foo --splice-properties useSpark=true"));
-            methodWatcher.executeUpdate("drop sequence FOOSEQ2 restrict");
-        }
+    public void testGrantPrivileges() throws Exception {
+        try {methodWatcher.executeUpdate("drop sequence "+SEQUENCE + " restrict");} catch (Exception e) {}
+        methodWatcher.executeUpdate("create sequence "+SEQUENCE);
+        methodWatcher.executeUpdate(String.format("grant usage on SEQUENCE %s to %s",SEQUENCE,USER));
+        Connection connection = methodWatcher.createConnection(USER,PASSWORD);
+        ResultSet rs = connection.prepareStatement("values (next value for "+SEQUENCE+")").executeQuery();
+        assertTrue(rs.next());
+        assertEquals(-2147483648,rs.getInt(1));
+        rs.close();
+        connection.close();
     }
-
-    @Test
-    public void testSparkSequenceGenerationWithCreateAndDropsStartsWith10000IncrementsBy10 () throws Exception {
-        for (int i=0;i<10;i++){
-            methodWatcher.executeUpdate("create sequence FOOSEQ3 start with 10000 increment by 10");
-            Integer first = methodWatcher.query("select next value for FOOSEQ3 from foo");
-            assertEquals(first,new Integer(10000));
-            assertEquals(first + 10, methodWatcher.query("select next value for FOOSEQ3 from foo"));
-            assertEquals(first + 20, methodWatcher.query("select next value for FOOSEQ3 from foo"));
-            assertEquals(first + 30, methodWatcher.query("select next value for FOOSEQ3 from foo"));
-            assertEquals(first + 40, methodWatcher.query("select next value for FOOSEQ3 from foo"));
-            assertEquals(first + 50, methodWatcher.query("select next value for FOOSEQ3 from foo"));
-            assertEquals(first + 60, methodWatcher.query("select next value for FOOSEQ3 from foo"));
-            assertEquals(first + 1000, methodWatcher.query("select next value for FOOSEQ3 from foo --splice-properties useSpark=true"));
-            // Spark by default allocates a 1K increment in the spark memory space
-            // the next OLTP query will go to the table to get the sequence value which should start after the allocated entry...
-            // from Spark.  Since Spark and Control run in different memory spaces, this is testing
-            // whether they allocate their correct amounts...
-            assertEquals(first + 70, methodWatcher.query("select next value for FOOSEQ3 from foo"));
-            assertEquals(first + 80, methodWatcher.query("select next value for FOOSEQ3 from foo"));
-            assertEquals(first + 90, methodWatcher.query("select next value for FOOSEQ3 from foo"));
-            // Verifying the Spark Buffer is still available.  This test would not work if there are several spark nodes.
-            assertEquals(first + 1010, methodWatcher.query("select next value for FOOSEQ3 from foo --splice-properties useSpark=true"));
-            assertEquals(first + 1020, methodWatcher.query("select next value for FOOSEQ3 from foo --splice-properties useSpark=true"));
-            methodWatcher.executeUpdate("drop sequence FOOSEQ3 restrict");
-        }
-    }
-*/
 
 }

--- a/splice_machine/src/test/java/com/splicemachine/test_dao/SchemaDAO.java
+++ b/splice_machine/src/test/java/com/splicemachine/test_dao/SchemaDAO.java
@@ -67,6 +67,17 @@ public class SchemaDAO {
                 }
             }
 
+            // Delete Sequences
+
+            try(ResultSet resultSet = jdbcTemplate.getConnection().prepareStatement(String.format("select sequencename from sys.syssequences seq, sys.sysschemas sch where " +
+                    "seq.schemaid = sch.schemaid and SCHEMANAME = '%s'",uSchema)).executeQuery()) {
+                while(resultSet.next()){
+                    jdbcTemplate.executeUpdate(String.format("drop sequence %s.%s restrict",uSchema,resultSet.getString(1)));
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
             // Delete Triggers
 
             try(ResultSet resultSet = jdbcTemplate.getConnection().prepareStatement(String.format("select triggername from sys.systriggers, sys.sysschemas where " +


### PR DESCRIPTION
Fixing Permission Grants on Sequences.

@ghillerson Please notice that our docs are incorrect.

For sequences, grant usage on SEQUENCE _sequencename_ to _grantee_;


Syntax for User-defined Types
GRANT USAGE
   SQL Identifier
   TO grantees
[schema-name.] SQL Identifier

The type name is composed of an optional schemaName and a SQL Identifier. If a schemaName is not provided, the current schema is the default schema. If a qualified UDT name is specified, the schema name cannot begin with SYS.

grantees

The user(s) or role(s) to whom you are granting access. See the About Grantees section below for more information.