### PR TITLE
Fixed anchor link and paths to shell scripts (included 'bin')

### DIFF
--- a/platforms/std/docs/STD-installation.md
+++ b/platforms/std/docs/STD-installation.md
@@ -334,7 +334,7 @@ Start Splice Machine on your computer and run a few commands to verifythe instal
 2. Run the Splice Machine start-up script
 
    ````
-   ./start-splice.sh
+   ./bin/start-splice.sh
    ````
 
    Initialization of the database may take a couple minutes. It is ready for use when you see this message:
@@ -346,7 +346,7 @@ Start Splice Machine on your computer and run a few commands to verifythe instal
 3.  Start using the Splice Machine command line interpreter by launching the `sqlshell.sh` script:
 
    ````
-   ./sqlshell.sh
+   ./bin/sqlshell.sh
    ````
 
    Once you have launched the command line interpreter (the splice&gt; prompt), we recommend verifying that all is well by running a few sample commands. First:

--- a/platforms/std/docs/STD-installation.md
+++ b/platforms/std/docs/STD-installation.md
@@ -15,7 +15,7 @@ of Splice Machine; follow the instructions for your operating system:
 
 * [Mac OSX](#configure-mac-osx-for-splice-machine)
 * [Ubuntu Linux](#configure-ubuntu-linux-for-splice-machine)
-* [CentOS/Red Hat Enterprise Linux (RHEL)](#configure-centos/red-hat-enterprise-linux-(rhel)-for-splice-machine)
+* [CentOS/Red Hat Enterprise Linux (RHEL)](#configure-centosred-hat-enterprise-linux-rhel-for-splice-machine)
 
 ## Configure Mac OSX for Splice Machine
 


### PR DESCRIPTION
You should also probably fix the https://s3.amazonaws.com/splice-releases/2.7.0.1815/standalone/splicemachine-2.7.0.1815.tar.gz link at the bottom of the page, because 1) it doesn't work and 2) it's outdated