### PR TITLE
DB-6931 Import from S3 failed on HDP 2.5.5 (2.5)

### DIFF
--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -54,15 +54,14 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-hive_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-hive_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
             <exclusions>
                 <exclusion>
-                    <artifactId>httpclient</artifactId>
                     <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
java.lang.NoSuchMethodError: org.apache.http.HttpHost.getAddress()Ljava/net/InetAddress;
is caused by malformed splice-uber.jar. Two incompatible jars are included:

> [INFO] Including org.apache.httpcomponents:httpcore:jar:4.2.4 in the shaded jar.
> [INFO] Including org.apache.httpcomponents:httpclient:jar:4.5.2 in the shaded jar.
> 

The former is a transitive dependency of

> [DEBUG]       org.apache.spark:spark-hive_2.11:jar:2.1.0:compile
> [DEBUG]          org.apache.thrift:libthrift:jar:0.9.2:compile
> [DEBUG]             org.apache.httpcomponents:httpcore:jar:4.2.4:compile
> 

spark_hive already excludes org.apache.httpcomponents:httpclient but not org.apache.httpcomponents:httpcore.