### PR TITLE
 DB-7040 + SPLICE-2186

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/JoinStrategy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/JoinStrategy.java
@@ -377,14 +377,4 @@ public interface JoinStrategy {
 	 */
 	boolean isMemoryUsageUnderLimit(double totalMemoryConsumed);
 
-	/**
-	 * Is it OK for a hash-based join strategy to execute without
-	 * a hash key (without any equality join conditions).
-	 *
-	 * @return Whether or not the current join strategy being considered
-	 * is hashable with no hash key (no equijoin conditions).
-	 * @notes Currently broadcast join is the only hashable join strategy
-	 * that supports non-equijoin.
-	 */
-	public boolean isMissingHashKeyOK();
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseJoinStrategy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseJoinStrategy.java
@@ -263,5 +263,4 @@ public abstract class BaseJoinStrategy implements JoinStrategy{
         return true;
     }
 
-    public boolean isMissingHashKeyOK() {return false;}
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
@@ -287,7 +287,10 @@ public abstract class FromTable extends ResultSetNode implements Optimizable{
         JoinStrategy joinStrategy=currentAccessPath.getJoinStrategy();
         ap.setJoinStrategy(joinStrategy);
         ap.setHintedJoinStrategy(currentAccessPath.isHintedJoinStrategy());
-        ap.setMissingHashKeyOK(joinStrategy.isMissingHashKeyOK());
+        if (joinStrategy.getJoinStrategyType() == JoinStrategy.JoinStrategyType.BROADCAST)
+            ap.setMissingHashKeyOK(currentAccessPath.isMissingHashKeyOK());
+        else
+            ap.setMissingHashKeyOK(false);
 
         OptimizerTrace tracer=optimizer.tracer();
         tracer.trace(OptimizerFlag.REMEMBERING_JOIN_STRATEGY,tableNumber,0,0.0,joinStrategy);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/BroadcastJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/BroadcastJoinStrategy.java
@@ -133,7 +133,7 @@ public class BroadcastJoinStrategy extends HashableJoinStrategy {
         boolean isHinted = currentAccessPath.isHintedJoinStrategy();
 
         if (isHinted || estimatedMemoryMB<regionThreshold && estimatedRowCount<rowCountThreshold &&
-                (!missingHashKeyOK || (innerTable instanceof FromBaseTable &&  // non-equality broadcast join only costed if using spark
+                (!currentAccessPath.isMissingHashKeyOK() || (innerTable instanceof FromBaseTable &&  // non-equality broadcast join only costed if using spark
                 ((FromBaseTable)innerTable).isSpark(((FromBaseTable)innerTable).getdataSetProcessorTypeForAccessPath(currentAccessPath))))) {
             double joinSelectivity = SelectivityUtil.estimateJoinSelectivity(innerTable, cd, predList, (long) innerCost.rowCount(), (long) outerCost.rowCount(), outerCost);
             double totalOutputRows = SelectivityUtil.getTotalRows(joinSelectivity, outerCost.rowCount(), innerCost.rowCount());
@@ -172,14 +172,5 @@ public class BroadcastJoinStrategy extends HashableJoinStrategy {
         return (totalMemoryinMB < regionThreshold);
     }
 
-    /**
-     *
-     * Is it OK for the current broadcast join to execute without a hash key (without any equality join conditions).
-     * This determination is made in HashableJoinStrategy.feasible().
-     * If true, all rows in the hash table have the same hash key.
-     *
-     */
-    @Override
-    public boolean isMissingHashKeyOK() {return missingHashKeyOK;}
 }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/AbstractSequence.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/AbstractSequence.java
@@ -67,8 +67,6 @@ public abstract class AbstractSequence implements Sequence, Externalizable{
         boolean success=false;
         long absIncrement = incrementSteps < 0 ? -incrementSteps :
                                                   incrementSteps;
-        long blockBoundary = incrementSteps < 0 ?
-                                    -blockAllocationSize : blockAllocationSize;
         while(!success){
             updateLock.lock();
             try{

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/AbstractSequence.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/AbstractSequence.java
@@ -65,15 +65,16 @@ public abstract class AbstractSequence implements Sequence, Externalizable{
 
     private void allocateBlock(boolean peek) throws StandardException{
         boolean success=false;
+        long absIncrement = incrementSteps < 0 ? -incrementSteps : incrementSteps;
         while(!success){
             updateLock.lock();
             try{
                 if(remaining.getAndDecrement()>0)
                     return;
                 currPosition.set(getCurrentValue());
-                success=atomicIncrement(currPosition.get()+(incrementSteps>blockAllocationSize?incrementSteps:blockAllocationSize));
+                success=atomicIncrement(currPosition.get()+(absIncrement>blockAllocationSize?absIncrement:blockAllocationSize));
                 if(success){
-                    long v = blockAllocationSize/incrementSteps;
+                    long v = blockAllocationSize/absIncrement;
                     remaining.set(peek?v:v-1);
                 }
             }catch(IOException e){


### PR DESCRIPTION
[DB-7040](https://splicemachine.atlassian.net/browse/DB-7040):   Fix race condition in multi-row insert into identity column table which caused a duplicate primary key error.  Also, fix data corruption of insert into identity column table with a negative increment.

[SPLICE-2186](https://splice.atlassian.net/browse/SPLICE-2186):  Remove class variable missingHashKeyOK from JoinStrategy since multiple references to JoinStrategy are used in the code and updating missingHashKeyOK in a shared reference may be the cause of sporadic hash join related errors (possible regression of DB-6930).