### PR TITLE
DB-6419: add validate_backup system procedure

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/hbase/CheckTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/CheckTableIT.java
@@ -266,6 +266,24 @@ public class CheckTableIT extends SpliceUnitTest {
     @Test
     public void negativeTests() throws Exception {
 
+
+        try {
+            spliceClassWatcher.execute(String.format("call syscs_util.check_table('%s', '%s', null, 1, null)", SCHEMA_NAME, A, getResourceDirectory(), A));
+            Assert.assertTrue("Should fail!", false);
+        }
+        catch (SQLException e) {
+            Assert.assertEquals(e.getSQLState(), "TS008");
+        }
+
+        try {
+            spliceClassWatcher.execute(String.format("call syscs_util.check_table('%s', '%s', null, 1, ' ')", SCHEMA_NAME, A, getResourceDirectory(), A));
+            Assert.assertTrue("Should fail!", false);
+        }
+
+        catch (SQLException e) {
+            Assert.assertEquals(e.getSQLState(), "TS008");
+        }
+
         try {
             spliceClassWatcher.execute(String.format("call syscs_util.check_table('%s', '%s', null, 3, '%s/check-%s.out')", SCHEMA_NAME, A, getResourceDirectory(), A));
             Assert.assertTrue("Should fail!", false);

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/NoOpBackupManager.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/NoOpBackupManager.java
@@ -72,4 +72,9 @@ public class NoOpBackupManager implements BackupManager{
     public void cancelBackup() throws StandardException {
         throw StandardException.newException(SQLState.BACKUP_OPERATIONS_DISABLED);
     }
+
+    @Override
+    public void validateBackup(String dir, long backupId) throws StandardException {
+        throw StandardException.newException(SQLState.BACKUP_OPERATIONS_DISABLED);
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupManager.java
@@ -39,4 +39,6 @@ public interface BackupManager{
     void cancelDailyBackup(long jobId) throws StandardException;
 
     void cancelBackup() throws StandardException;
+
+    void validateBackup(String directory,long backupId)throws StandardException;
 }

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupManager.java
@@ -30,7 +30,7 @@ public interface BackupManager{
 
     long getRunningBackup() throws StandardException;
 
-    void restoreDatabase(String directory,long backupId, boolean sync)throws StandardException;
+    void restoreDatabase(String directory,long backupId, boolean sync, boolean validate)throws StandardException;
 
     void removeBackup(List<Long> backupIds) throws StandardException;
 

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupSystemProcedures.java
@@ -50,6 +50,46 @@ public class BackupSystemProcedures {
 
     private static Logger LOG = Logger.getLogger(BackupSystemProcedures.class);
 
+    public static void VALIDATE_BACKUP(String directory, long backupId, ResultSet[] resultSets) throws StandardException, SQLException {
+
+        IteratorNoPutResultSet inprs = null;
+        Connection conn = SpliceAdmin.getDefaultConn();
+        LanguageConnectionContext lcc = conn.unwrap(EmbedConnection.class).getLanguageConnection();
+        Activation activation = lcc.getLastActivation();
+
+        try {
+            BackupManager backupManager = EngineDriver.driver().manager().getBackupManager();
+            backupManager.validateBackup(directory, backupId);
+            ResultColumnDescriptor[] rcds = {
+                    new GenericColumnDescriptor("Results", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, 1024))
+            };
+            ExecRow template = new ValueRow(1);
+            template.setRowArray(new DataValueDescriptor[]{new SQLVarchar()});
+            List<ExecRow> rows = Lists.newArrayList();
+            SQLWarning warning = activation.getWarnings();
+            if (warning == null) {
+                template.getColumn(1).setValue("No corruptions found for backup.");
+                rows.add(template.getClone());
+            }
+            else {
+                while (warning != null) {
+                    String warningMessage = warning.getLocalizedMessage();
+                    template.getColumn(1).setValue(warningMessage);
+                    rows.add(template.getClone());
+                    warning = warning.getNextWarning();
+                }
+            }
+
+            inprs = new IteratorNoPutResultSet(rows, rcds, lcc.getLastActivation());
+            inprs.openCore();
+            resultSets[0] = new EmbedResultSet40(conn.unwrap(EmbedConnection.class),inprs,false,null,true);
+        } catch (Throwable t) {
+            resultSets[0] = ProcedureUtils.generateResult("Error", t.getLocalizedMessage());
+            SpliceLogUtils.error(LOG, "Backup validation error", t);
+            t.printStackTrace();
+        }
+    }
+
     public static void SYSCS_BACKUP_DATABASE(String directory, String type, ResultSet[] resultSets)
             throws StandardException, SQLException {
         type = type.trim();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -99,6 +99,7 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                                 .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
                                 .varchar("directory", 32672)
                                 .bigint("backupId")
+                                .arg("validate", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
                                 .build();
                         procedures.set(i, restore);
                     } else if(BACKUP_DATABASE_NAME.equals(sysProc.getName())) {
@@ -901,6 +902,7 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                             .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
                             .varchar("directory", 32672)
                             .bigint("backupId")
+                            .arg("validate", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
                             .build());
 
                     procedures.add(Procedure.newBuilder().name("VALIDATE_BACKUP")

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -903,6 +903,11 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                             .bigint("backupId")
                             .build());
 
+                    procedures.add(Procedure.newBuilder().name("VALIDATE_BACKUP")
+                            .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                            .varchar("directory", 32672)
+                            .bigint("backupId")
+                            .build());
                     /*
                      * Procedure to get a database property on all region servers in the cluster.
                      */

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceTableAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceTableAdmin.java
@@ -85,6 +85,12 @@ public class SpliceTableAdmin {
 
     public static void CHECK_TABLE(String schemaName, String tableName, String indexName, int level,
                                    String outputFile, final ResultSet[] resultSet) throws Exception {
+
+        if (outputFile == null || outputFile.trim().length() == 0) {
+            throw StandardException.newException(SQLState.INVALID_PARAMETER, "outputFile", outputFile==null?"null":outputFile);
+        }
+
+        outputFile = outputFile.trim();
         if (tableName == null && indexName == null) {
             CHECK_SCHEMA(schemaName, level, outputFile, resultSet);
         }


### PR DESCRIPTION
Adding a system procedure syscs_util.validate_backup to detect backup corruption caused by file transfer or media corruption, etc. The system procedure makes sure all files for the backup are in place and verifies their checksums.

Please also review ee branch.