### PR TITLE
DB-7171:remove zeppelin and hive dependency when installing splicemachine using ambari service

### DIFF
--- a/assembly/hdp2.6.3/build/var/lib/ambari-server/resources/common-services/SPLICEMACHINE/2.5.1/metainfo.xml
+++ b/assembly/hdp2.6.3/build/var/lib/ambari-server/resources/common-services/SPLICEMACHINE/2.5.1/metainfo.xml
@@ -41,7 +41,6 @@
                 <config-type>hdfs-site</config-type>
                 <config-type>hbase-site</config-type>
                 <config-type>hbase-env</config-type>
-                <config-type>hive-env</config-type>
                 <config-type>spark2-env</config-type>
                 <config-type>zoo.cfg</config-type>
                 <config-type>yarn-site</config-type>

--- a/assembly/hdp2.6.3/build/var/lib/ambari-server/resources/common-services/SPLICEMACHINE/2.5.1/metainfo.xml
+++ b/assembly/hdp2.6.3/build/var/lib/ambari-server/resources/common-services/SPLICEMACHINE/2.5.1/metainfo.xml
@@ -43,7 +43,6 @@
                 <config-type>hbase-env</config-type>
                 <config-type>hive-env</config-type>
                 <config-type>spark2-env</config-type>
-                <config-type>zeppelin-env</config-type>
                 <config-type>zoo.cfg</config-type>
                 <config-type>yarn-site</config-type>
             </configuration-dependencies>

--- a/assembly/hdp2.6.3/src/main/resources/common-services/SPLICEMACHINE/2.5.1/metainfo.xml
+++ b/assembly/hdp2.6.3/src/main/resources/common-services/SPLICEMACHINE/2.5.1/metainfo.xml
@@ -48,7 +48,6 @@
                 <config-type>hbase-env</config-type>
                 <config-type>hive-env</config-type>
                 <config-type>spark2-env</config-type>
-                <config-type>zeppelin-env</config-type>
                 <config-type>zoo.cfg</config-type>
                 <config-type>yarn-site</config-type>
             </configuration-dependencies>

--- a/assembly/hdp2.6.3/src/main/resources/common-services/SPLICEMACHINE/2.5.1/metainfo.xml
+++ b/assembly/hdp2.6.3/src/main/resources/common-services/SPLICEMACHINE/2.5.1/metainfo.xml
@@ -46,7 +46,6 @@
                 <config-type>hdfs-site</config-type>
                 <config-type>hbase-site</config-type>
                 <config-type>hbase-env</config-type>
-                <config-type>hive-env</config-type>
                 <config-type>spark2-env</config-type>
                 <config-type>zoo.cfg</config-type>
                 <config-type>yarn-site</config-type>

--- a/assembly/hdp2.6.3/src/main/resources/common-services/SPLICEMACHINE/2.5.1/package/scripts/params.py
+++ b/assembly/hdp2.6.3/src/main/resources/common-services/SPLICEMACHINE/2.5.1/package/scripts/params.py
@@ -27,8 +27,8 @@ config = Script.get_config()
 
 zookeeper_znode_parent = config['configurations']['hbase-site']['zookeeper.znode.parent']
 hbase_zookeeper_quorum = config['configurations']['hbase-site']['hbase.zookeeper.quorum']
-zeppelin_host = config['configurations']['zeppelin-ambari-config']['zeppelin.host.publicname']
-zeppelin_port = str(config['configurations']['zeppelin-config']['zeppelin.server.port'])
+#zeppelin_host = config['configurations']['zeppelin-ambari-config']['zeppelin.host.publicname']
+#zeppelin_port = str(config['configurations']['zeppelin-config']['zeppelin.server.port'])
 
 # detect spark queue
 # if 'spark.yarn.queue' in config['configurations']['spark-defaults']:


### PR DESCRIPTION
remove zeppelin and dependency when installing splicemachine using ambari service:
splicemachine doesn't need hive and zeppelin to function correctly, it is best it doesn't check their presence when installing.