### PR TITLE
DB-7214 (2.7) - always quote usernames

### DIFF
--- a/assembly/common/src/main/resources/bin/sqlshell.sh
+++ b/assembly/common/src/main/resources/bin/sqlshell.sh
@@ -212,7 +212,7 @@ else
       fi
    fi
    IJ_SYS_ARGS+=" -Dij.connection.splice=jdbc:splice://${HOST}:${PORT}/splicedb${SSL}${KERBEROS}"
-   export JAVA_TOOL_OPTIONS="-Dij.user=$USER -Dij.password=$PASS"
+   export JAVA_TOOL_OPTIONS="-Dij.user='\"$USER\"' -Dij.password=$PASS"
 fi
 
 if hash rlwrap 2>/dev/null; then


### PR DESCRIPTION
make username quoting the default, to be more friendly with ldap usernames like first.last@company.com