### PR TITLE
DB-7293 add logic to prune ProjectRestrictNode's result column list b…

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
@@ -625,6 +625,13 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
             }
         }
 
+        if (getCompilerContext().isProjectionPruningEnabled()) {
+            /* after building the optimized tree bottom-up, we know which fields are not referenced
+             * and can be pruned
+             */
+            resultColumns.doProjection(false);
+        }
+
         if((restrictionList!=null) && !alreadyPushed){
             restrictionList.pushUsefulPredicates((Optimizable)childResult);
         }

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ProjectionPruningIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ProjectionPruningIT.java
@@ -1080,4 +1080,20 @@ public class ProjectionPruningIT extends SpliceUnitTest {
             conn.setAutoCommit(oldAutoCommit);
         }
     }
+
+    @Test
+    public void testDB7293() throws Exception {
+        setProjectionPruningProperty(projectionPruningDisabled);
+
+        String sqlText = "select a4 from (select a1,b1 from t1 union values (4, 'ddd') except select a4,b4 from t4) dt(a1,b1) left join t4 on dt.a1 = a4";
+
+        String expected = "A4  |\n" +
+                "------\n" +
+                "NULL |";
+
+        ResultSet rs = methodWatcher.executeQuery(sqlText);
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        rs.close();
+
+    }
 }


### PR DESCRIPTION
…ased on the isReferenced flag for previously missing scenarios.

Please see [DB-7293](https://splicemachine.atlassian.net/browse/DB-7293) for details.