### PR TITLE
SPLICE-2204: Added support for Python user-defined function that returns

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/ClassInspector.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/ClassInspector.java
@@ -237,8 +237,9 @@ public class ClassInspector
 			return null;
 
 		// Resolve java wrapper method for Python relevant routine using its name
-		if(methodName.equals(StaticMethodCallNode.PYPROCEDURE_WRAPPER_METHOD_NAME)&&
-				receiverClass.getName().equals(StaticMethodCallNode.PYPROCEDURE_WRAPPER_CLASS_NAME)){
+		if(receiverClass.getName().equals(StaticMethodCallNode.PYROUTINE_WRAPPER_CLASS_NAME)&&
+				(methodName.equals(StaticMethodCallNode.PYPROCEDURE_WRAPPER_METHOD_NAME)||
+				methodName.equals(StaticMethodCallNode.PYFUNCTION_WRAPPER_METHOD_NAME))){
 			try{
 				Method resultMethod = receiverClass.getMethod(methodName, Object[].class);
 				return resultMethod;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StaticMethodCallNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StaticMethodCallNode.java
@@ -65,6 +65,7 @@ import com.splicemachine.db.catalog.AliasInfo;
 import com.splicemachine.db.catalog.TypeDescriptor;
 import com.splicemachine.db.catalog.types.RoutineAliasInfo;
 
+import java.sql.Types;
 import java.util.List;
 import java.lang.reflect.Modifier;
 
@@ -118,13 +119,14 @@ import java.lang.reflect.Modifier;
  *
  */
 public class StaticMethodCallNode extends MethodCallNode {
-	public static final String PYPROCEDURE_WRAPPER_CLASS_NAME = "com.splicemachine.derby.utils.PyRoutineWrapper";
+	public static final String PYROUTINE_WRAPPER_CLASS_NAME = "com.splicemachine.derby.utils.PyRoutineWrapper";
 	public static final String PYPROCEDURE_WRAPPER_METHOD_NAME = "pyProcedureWrapper";
+	public static final String PYFUNCTION_WRAPPER_METHOD_NAME = "pyFunctionWrapper";
 
 	private TableName procedureName;
 
 	private LocalField[] outParamArrays;
-	private int[]		 applicationParameterNumbers; 
+	private int[]		 applicationParameterNumbers;
 
 	private boolean		isSystemCode;
 	private boolean		alreadyBound;
@@ -144,7 +146,6 @@ public class StaticMethodCallNode extends MethodCallNode {
     private String routineDefiner = null;
 
 	AliasDescriptor	ad;
-	boolean resolvePyProc = false;
 
 	private AggregateNode   resolvedAggregate;
 	private boolean appearsInGroupBy = false;
@@ -169,7 +170,7 @@ public class StaticMethodCallNode extends MethodCallNode {
      * Get the aggregate, if any, which this method call resolves to.
      */
     public  AggregateNode   getResolvedAggregate() { return resolvedAggregate; }
-    
+
     /** Flag that this function invocation appears in a GROUP BY clause */
     public  void    setAppearsInGroupBy() { appearsInGroupBy = true; }
 
@@ -197,7 +198,7 @@ public class StaticMethodCallNode extends MethodCallNode {
 
 		bindParameters(fromList, subqueryList, aggregateVector);
 
-		
+
 		/* If javaClassName is null then we assume that the current methodName
 		 * is an alias and we must go to sysmethods to
 		 * get the real method and java class names for this alias.
@@ -209,7 +210,7 @@ public class StaticMethodCallNode extends MethodCallNode {
 			// look for a routine
 
 			String schemaName = procedureName.getSchemaName();
-								
+
 			boolean noSchema = schemaName == null;
 
 			SchemaDescriptor sd = getSchemaDescriptor(schemaName, schemaName != null);
@@ -217,7 +218,7 @@ public class StaticMethodCallNode extends MethodCallNode {
             // The field methodName is used by resolveRoutine and
             // is set to the name of the routine (procedureName.getTableName()).
 			resolveRoutine(fromList, subqueryList, aggregateVector, sd);
-			
+
 			// (Splice)	This logic, to implicitly check for routine using SYSFUN schema,
 			// was moved here from a few lines down, so that it has a chance to find
 			// aggregate functions in SYSFUN catalog too, such that it will get
@@ -243,7 +244,7 @@ public class StaticMethodCallNode extends MethodCallNode {
 			                         (
 				                     C_NodeTypes.AGGREGATE_NODE,
 				                     ((SQLToJavaValueNode) methodParms[ 0 ]).getSQLValueNode(),
-				                     new UserAggregateDefinition( ad ), 
+				                     new UserAggregateDefinition( ad ),
 				                     Boolean.FALSE,
 				                     ad.getJavaClassName(),
 				                     getContextManager()
@@ -254,17 +255,17 @@ public class StaticMethodCallNode extends MethodCallNode {
 			                    {
 			                        throw StandardException.newException(SQLState.LANG_AGGREGATE_IN_GROUPBY_LIST);
 			                    }
-			                   
+
 			    return this;
 			}
-				
+
 			/* Throw exception if no routine found */
 			if (ad == null)
 			{
 				throw StandardException.newException(
                         SQLState.LANG_NO_SUCH_METHOD_ALIAS, procedureName);
 			}
-	
+
             if ( !routineInfo.isDeterministic() )
             {
                 checkReliability( getMethodName(), CompilerContext.NON_DETERMINISTIC_ILLEGAL );
@@ -273,7 +274,7 @@ public class StaticMethodCallNode extends MethodCallNode {
             {
                 checkReliability( getMethodName(), CompilerContext.SQL_IN_ROUTINES_ILLEGAL );
             }
-			
+
 
 
                 cc.createDependency(ad);
@@ -281,7 +282,7 @@ public class StaticMethodCallNode extends MethodCallNode {
 
 			methodName = ad.getAliasInfo().getMethodName();
 			javaClassName = ad.getJavaClassName();
-            
+
             // DERBY-2330 Do not allow a routine to resolve to
             // a Java method that is part of the Derby runtime code base.
             // This is a security measure to stop user-defined routines
@@ -313,9 +314,9 @@ public class StaticMethodCallNode extends MethodCallNode {
 		// return type, then we need to push a CAST node.
 		if (routineInfo != null)
 		{
-			if (methodParms != null) 
+			if (methodParms != null)
 				optimizeDomainValueConversion();
-			
+
 			TypeDescriptor returnType = routineInfo.getReturnType();
 
             // create type dependency if return type is an ANSI UDT
@@ -338,19 +339,19 @@ public class StaticMethodCallNode extends MethodCallNode {
 								returnType.isNullable(),
 								returnType.getMaximumWidth()
 							);
-							
+
 
 					ValueNode returnValueToSQL = (ValueNode) getNodeFactory().getNode(
 								C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
-								this, 
+								this,
 								getContextManager());
 
 					ValueNode returnValueCastNode = (ValueNode) getNodeFactory().getNode(
 									C_NodeTypes.CAST_NODE,
-									returnValueToSQL, 
+									returnValueToSQL,
 									returnValueDtd,
 									getContextManager());
-                    
+
                     // DERBY-2972  Match the collation of the RoutineAliasInfo
                     returnValueCastNode.setCollationInfo(
                             returnType.getCollationType(),
@@ -359,7 +360,7 @@ public class StaticMethodCallNode extends MethodCallNode {
 
 					JavaValueNode returnValueToJava = (JavaValueNode) getNodeFactory().getNode(
 										C_NodeTypes.SQL_TO_JAVA_VALUE_NODE,
-										returnValueCastNode, 
+										returnValueCastNode,
 										getContextManager());
 					returnValueToJava.setCollationType(returnType.getCollationType());
 					return returnValueToJava.bindExpression(fromList, subqueryList, aggregateVector);
@@ -388,7 +389,7 @@ public class StaticMethodCallNode extends MethodCallNode {
         default:    return false;
         }
     }
-    
+
 	/**
 	 * If this SQL function has parameters which are SQLToJavaValueNode over
 	 * JavaToSQLValueNode and the java value node underneath is a SQL function
@@ -413,7 +414,7 @@ public class StaticMethodCallNode extends MethodCallNode {
         // comment above.
         //
         if ( !routineInfo.calledOnNullInput() ) { return; }
-        
+
 		int		count = methodParms.length;
 		for (int parm = 0; parm < count; parm++)
 		{
@@ -422,7 +423,7 @@ public class StaticMethodCallNode extends MethodCallNode {
             // a runtime check to make sure that the argument is not null. See DERBY-4459.
             //
             if ( (methodParms != null) && methodParms[ parm ].mustCastToPrimitive() ) { continue; }
-            
+
 			if (methodParms[parm] instanceof SQLToJavaValueNode &&
 				((SQLToJavaValueNode)methodParms[parm]).getSQLValueNode() instanceof
 				JavaToSQLValueNode)
@@ -699,7 +700,9 @@ public class StaticMethodCallNode extends MethodCallNode {
 			if(this.routineInfo!=null && this.routineInfo.getLanguage() != null &&this.routineInfo.getLanguage().equals("PYTHON"))
 			{
 
-				this.resolvePyProc = true;
+				// determine whether the routine is for a procedure or function
+				boolean isFunction = !forCallStatement;
+				this.methodName = isFunction?PYFUNCTION_WRAPPER_METHOD_NAME:PYPROCEDURE_WRAPPER_METHOD_NAME;
 				// need to add compiled Python code bytes into signature and methodParms
 				byte[] compiledPyCode = this.routineInfo.getCompiledPyCode();
 
@@ -723,7 +726,7 @@ public class StaticMethodCallNode extends MethodCallNode {
 						compiledPyCode.length);
 
 				// update the routineInfo and the AliasDescriptor
-				this.routineInfo = new RoutineAliasInfo(PYPROCEDURE_WRAPPER_METHOD_NAME,
+				this.routineInfo = new RoutineAliasInfo(this.methodName,
 						"JAVA",
 						updatedParmCnt,
 						updatedParmNames,
@@ -742,7 +745,7 @@ public class StaticMethodCallNode extends MethodCallNode {
 						ad.getUUID(),
 						ad.getName(),
 						ad.getSchemaUUID(),
-						PYPROCEDURE_WRAPPER_CLASS_NAME,
+						PYROUTINE_WRAPPER_CLASS_NAME,
 						ad.getAliasType(),
 						ad.getNameSpace(),
 						ad.getSystemAlias(),
@@ -862,7 +865,7 @@ public class StaticMethodCallNode extends MethodCallNode {
 		SQLToJavaValueNode sql2j = null;
 		if (methodParms[parameterNumber] instanceof SQLToJavaValueNode)
 			sql2j = (SQLToJavaValueNode) methodParms[parameterNumber];
-		
+
 		if (routineInfo != null) {
 			parameterMode = routineInfo.getParameterModes()[parameterNumber];
 		} else {
@@ -875,7 +878,7 @@ public class StaticMethodCallNode extends MethodCallNode {
 			if (sql2j != null) {
 				if (sql2j.getSQLValueNode().requiresTypeFromContext()) {
 	  				ParameterNode pn;
-		  			if (sql2j.getSQLValueNode() instanceof UnaryOperatorNode) 
+		  			if (sql2j.getSQLValueNode() instanceof UnaryOperatorNode)
 		  				pn = ((UnaryOperatorNode)sql2j.getSQLValueNode()).getParameterOperand();
 		  			else
 		  				pn = (ParameterNode) (sql2j.getSQLValueNode());
@@ -900,7 +903,7 @@ public class StaticMethodCallNode extends MethodCallNode {
 						constructor.endStatement();
 					}
 				}
-			} 
+			}
 		}
 
 		switch (parameterMode) {
@@ -957,7 +960,7 @@ public class StaticMethodCallNode extends MethodCallNode {
 	/**
 	 * Categorize this predicate.  Initially, this means
 	 * building a bit map of the referenced tables for each predicate.
-	 * If the source of this ColumnReference (at the next underlying level) 
+	 * If the source of this ColumnReference (at the next underlying level)
 	 * is not a ColumnReference or a VirtualColumnNode then this predicate
 	 * will not be pushed down.
 	 *
@@ -1035,8 +1038,10 @@ public class StaticMethodCallNode extends MethodCallNode {
 									throws StandardException
 	{
 		boolean isPy = false;
-		if(routineInfo != null && getMethodName().equals(StaticMethodCallNode.PYPROCEDURE_WRAPPER_METHOD_NAME)&&
-				getJavaClassName().equals(StaticMethodCallNode.PYPROCEDURE_WRAPPER_CLASS_NAME)){
+		if(routineInfo != null &&
+				(getMethodName().equals(StaticMethodCallNode.PYPROCEDURE_WRAPPER_METHOD_NAME) ||
+				getMethodName().equals(StaticMethodCallNode.PYFUNCTION_WRAPPER_METHOD_NAME))&&
+				getJavaClassName().equals(StaticMethodCallNode.PYROUTINE_WRAPPER_CLASS_NAME)){
 			isPy = true;
 		}
 
@@ -1074,7 +1079,7 @@ public class StaticMethodCallNode extends MethodCallNode {
 			short sqlAllowed = routineInfo.getSQLAllowed();
 
 			// Before we set up our authorization level, add a check to see if this
-			// method can be called. If the routine is NO SQL or CONTAINS SQL 
+			// method can be called. If the routine is NO SQL or CONTAINS SQL
 			// then there is no need for a check. As follows:
 			//
 			// Current Level = NO_SQL - CALL will be rejected when getting CALL result set
@@ -1083,21 +1088,21 @@ public class StaticMethodCallNode extends MethodCallNode {
 
 			if (sqlAllowed != RoutineAliasInfo.NO_SQL)
 			{
-				
+
 				int sqlOperation;
-				
+
 				if (sqlAllowed == RoutineAliasInfo.READS_SQL_DATA)
 					sqlOperation = Authorizer.SQL_SELECT_OP;
 				else if (sqlAllowed == RoutineAliasInfo.MODIFIES_SQL_DATA)
 					sqlOperation = Authorizer.SQL_WRITE_OP;
 				else
 					sqlOperation = Authorizer.SQL_ARBITARY_OP;
-				
+
 				generateAuthorizeCheck((ActivationClassBuilder) acb, mb, sqlOperation);
 			}
 
 			int statmentContextReferences = isSystemCode ? 2 : 1;
-			
+
 			boolean isFunction = routineInfo.getReturnType() != null;
 
 			if (isFunction)
@@ -1136,7 +1141,7 @@ public class StaticMethodCallNode extends MethodCallNode {
 
 			// for a function we need to fetch the current SQL control
 			// so that we can reset it once the function is complete.
-			// 
+			//
 			if (isFunction)
 			{
 				functionEntrySQLAllowed = acb.newFieldDeclaration(Modifier.PRIVATE, "short");
@@ -1145,8 +1150,8 @@ public class StaticMethodCallNode extends MethodCallNode {
 				mb.setField(functionEntrySQLAllowed);
 
 			}
-			
-			
+
+
 			// Set up the statement context to reflect the
 			// restricted SQL execution allowed by this routine.
 
@@ -1209,9 +1214,9 @@ public class StaticMethodCallNode extends MethodCallNode {
 							mb.setArrayElement(i+nargs); // Set the Object[] array's element
 						}
 					}
-				} 
+				}
 
-				// complete the method that returns the ResultSet[][] to the 
+				// complete the method that returns the ResultSet[][] to the
 				gdr.methodReturn();
 				gdr.complete();
 
@@ -1245,7 +1250,7 @@ public class StaticMethodCallNode extends MethodCallNode {
 			// for objects is easy.
 			mbnc.pushNull(javaReturnType);
 
-			mbnc.startElseCode();	
+			mbnc.startElseCode();
 
 			if (!actualMethodReturnType.equals(javaReturnType))
 				mbnc.pushNewStart(javaReturnType);
@@ -1260,9 +1265,42 @@ public class StaticMethodCallNode extends MethodCallNode {
 		}
 
 		if(isPy){
-			// The Java wrapper method only takes in one argument
+			// The Python Java wrapper method only takes in one argument
 			mbcm.callMethod(VMOpcode.INVOKESTATIC, method.getDeclaringClass().getName(), methodName,
 					actualMethodReturnType, 1);
+			// for function, casting the result type
+			if(!forCallStatement){
+				DataTypeDescriptor returntd = DataTypeDescriptor.getType(routineInfo.getReturnType());
+				//The actual return type for the wrapper function is Object
+				// Hence need to cast the result to the desired return type upon return
+				int returnJDBCTypeId =  returntd.getJDBCTypeId();
+				switch (returnJDBCTypeId){
+					case(Types.CLOB):
+						mb.cast("java.lang.String");
+						break;
+					case(Types.REAL):
+					case(Types.DOUBLE):
+					case(Types.FLOAT):
+						// Although FLOAT can be mapped to java.lang.Double and java.lang.Float
+						// In the implementation, it is mapped to java.lang.Double, which does not
+						// cause loss of precision. Accordingly, here FLOAT is cast to java.lang.Double
+						mb.cast("java.lang.Double");
+						break;
+					case(Types.INTEGER):
+						mb.cast("java.lang.Integer");
+						break;
+					case(Types.BIGINT):
+						mb.cast("java.lang.Long");
+						break;
+					case(Types.DECIMAL):
+					case(Types.NUMERIC):
+						mb.cast("java.math.BigDecimal");
+						break;
+					default:
+						mb.cast(javaReturnType);
+						break;
+				}
+			}
 		}
 		else{
 			mbcm.callMethod(VMOpcode.INVOKESTATIC, method.getDeclaringClass().getName(), methodName,

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/pyprocedure/PyCodeUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/pyprocedure/PyCodeUtil.java
@@ -29,7 +29,7 @@ public class PyCodeUtil{
 
     // Setup the wrapper method
     private static final String SETUP = "def execute(*args):\n" +
-            "    run(*args)\n" +
+            "    return run(*args)\n" +
             "factory = None\n" +
             "def setFactory(*args):\n" +
             "    global factory\n" +

--- a/hbase_sql/src/test/java/com/splicemachine/derby/transactions/PyFunctionIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/transactions/PyFunctionIT.java
@@ -1,0 +1,423 @@
+package com.splicemachine.derby.transactions;
+
+import java.sql.*;
+
+import org.junit.*;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.test.SerialTest;
+import com.splicemachine.test.Transactions;
+
+/**
+ * This class is the IT test for Python user-defined function.
+ * it tests functions that take in different data types as a function's arguments and
+ * return these data types as the functions' results. These includes BIGINT, CHAR, DATE,
+ * DECIMAL, DOUBLE, DOUBLE PRECISION, FLOAT, INTEGER, NUMERIC, REAL, SMALLINT, TIMESTAMP,
+ * TIME, VARCHAR
+ * Since LONG VARCHAR, CLOB, TEXT should not be used as user-defined funciton's parameters,
+ * These types are tested only as return value
+ * @author Ao Zeng
+ *		 Created on: 8/1/2018
+ */
+@Category({Transactions.class,SerialTest.class})
+public class PyFunctionIT extends SpliceUnitTest {
+
+    public static final String CLASS_NAME = PyFunctionIT.class.getSimpleName().toUpperCase();
+
+    protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher();
+    protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
+
+    // Names of files and SQL objects.
+    private static final String SCHEMA_NAME = CLASS_NAME;
+
+    @ClassRule
+    public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
+            .around(spliceSchemaWatcher);
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher();
+
+    // Scripts to create and drop testing Python user-defined function
+    private static final String CREATE_TEST_BIGINT = String.format("CREATE FUNCTION %s.TEST_BIGINT(var BIGINT) RETURNS BIGINT PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'def run(var):\n" +
+            "    return var - 1'",SCHEMA_NAME);
+
+    private static final String DROP_TEST_BIGINT  = String.format("DROP FUNCTION %s.TEST_BIGINT",SCHEMA_NAME);
+
+    private static final String CREATE_TEST_BOOLEAN = String.format("CREATE FUNCTION %s.TEST_BOOLEAN(var BOOLEAN) RETURNS BOOLEAN PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'def run(var):\n" +
+            "    return not var'", SCHEMA_NAME);
+
+    private static final String DROP_TEST_BOOLEAN  = String.format("DROP FUNCTION %s.TEST_BOOLEAN",SCHEMA_NAME);
+
+    private static final String CREATE_TEST_CHAR = String.format("CREATE FUNCTION %s.TEST_CHAR(var CHAR) RETURNS CHAR PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'def run(var):\n" +
+            "    if var == \"a\":\n" +
+            "        return \"s\"\n" +
+            "    return \"n\"'", SCHEMA_NAME);
+
+    private static final String DROP_TEST_CHAR  = String.format("DROP FUNCTION %s.TEST_CHAR",SCHEMA_NAME);
+
+    private static final String CREATE_TEST_DATE = String.format("CREATE FUNCTION %s.TEST_DATE(var DATE) RETURNS DATE PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'import datetime\n" +
+            "def run(var):\n" +
+            "    return datetime.date.today()'",SCHEMA_NAME);
+
+    private static final String DROP_TEST_DATE  = String.format("DROP FUNCTION %s.TEST_DATE",SCHEMA_NAME);
+
+    private static final String CREATE_TEST_DECIMAL = String.format("CREATE FUNCTION %s.TEST_DECIMAL(var DECIMAL) RETURNS DECIMAL PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'from java.math import BigDecimal\n" +
+            "def run(var):\n" +
+            "    return var.add(BigDecimal(0.1))'",SCHEMA_NAME);
+
+    private static final String DROP_TEST_DECIMAL  = String.format("DROP FUNCTION %s.TEST_DECIMAL",SCHEMA_NAME);
+
+    private static final String CREATE_TEST_NUMERIC = String.format("CREATE FUNCTION %s.TEST_NUMERIC(var NUMERIC) RETURNS NUMERIC PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'from java.math import BigDecimal\n" +
+            "def run(var):\n" +
+            "    return var.add(BigDecimal(0.1))'", SCHEMA_NAME);
+
+    private static final String DROP_TEST_NUMERIC  = String.format("DROP FUNCTION %s.TEST_NUMERIC",SCHEMA_NAME);
+
+    private static final String CREATE_TEST_DOUBLE = String.format("CREATE FUNCTION %s.TEST_DOUBLE(var DOUBLE) RETURNS DOUBLE PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'from java.math import BigDecimal\n" +
+            "def run(var):\n" +
+            "    return 1.79769E+308'", SCHEMA_NAME);
+
+    private static final String DROP_TEST_DOUBLE  = String.format("DROP FUNCTION %s.TEST_DOUBLE",SCHEMA_NAME);
+
+    private static final String CREATE_TEST_DOUBLE_PRECISION = String.format("CREATE FUNCTION %s.TEST_DOUBLE_PRECISION(var DOUBLE PRECISION) RETURNS DOUBLE PRECISION PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'def run(var):\n" +
+            "    return 1.79769E+308'", SCHEMA_NAME);
+
+    private static final String DROP_TEST_DOUBLE_PRECISION  = String.format("DROP FUNCTION %s.TEST_DOUBLE_PRECISION",SCHEMA_NAME);
+
+    private static final String CREATE_TEST_FLOAT = String.format("CREATE FUNCTION %s.TEST_FLOAT(var FLOAT) RETURNS FLOAT PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'def run(var):\n" +
+            "    return 2.225E-307'", SCHEMA_NAME);
+
+    private static final String DROP_TEST_FLOAT  = String.format("DROP FUNCTION %s.TEST_FLOAT",SCHEMA_NAME);
+
+    private static final String CREATE_TEST_INTEGER = String.format("CREATE FUNCTION %s.TEST_INTEGER(var INTEGER) RETURNS INTEGER PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'def run(var):\n" +
+            "    return var - 2'", SCHEMA_NAME);
+
+    private static final String DROP_TEST_INTEGER  = String.format("DROP FUNCTION %s.TEST_INTEGER",SCHEMA_NAME);
+
+    private static final String CREATE_TEST_REAL = String.format("CREATE FUNCTION %s.TEST_REAL(var REAL) RETURNS REAL PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'def run(var):\n" +
+            "    return 3.402E+38'", SCHEMA_NAME);
+
+    private static final String DROP_TEST_REAL  = String.format("DROP FUNCTION %s.TEST_REAL",SCHEMA_NAME);
+
+    private static final String CREATE_TEST_SMALLINT = String.format("CREATE FUNCTION %s.TEST_SMALLINT (var SMALLINT) RETURNS SMALLINT PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'def run(var):\n" +
+            "    return 3267'", SCHEMA_NAME);
+
+    private static final String DROP_TEST_SMALLINT  = String.format("DROP FUNCTION %s.TEST_SMALLINT",SCHEMA_NAME);
+
+    private static final String CREATE_TEST_TIME = String.format("CREATE FUNCTION %s.TEST_TIME(var TIME) RETURNS TIME PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'import datetime\n" +
+            "def run(var):\n" +
+            "    return datetime.time(13,0,0)'", SCHEMA_NAME);
+
+    private static final String DROP_TEST_TIME  = String.format("DROP FUNCTION %s.TEST_TIME",SCHEMA_NAME);
+
+    private static final String CREATE_TEST_TIMESTAMP = String.format("CREATE FUNCTION %s.TEST_TIMESTAMP(var TIMESTAMP) RETURNS TIMESTAMP PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'import datetime\n" +
+            "def run(var):\n" +
+            "    return datetime.datetime.now()'", SCHEMA_NAME);
+
+    private static final String DROP_TEST_TIMESTAMP  = String.format("DROP FUNCTION %s.TEST_TIMESTAMP",SCHEMA_NAME);
+
+    private static final String CREATE_TEST_VARCHAR = String.format("CREATE FUNCTION %s.TEST_VARCHAR(var VARCHAR(50)) RETURNS VARCHAR(50) PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'def run(var):\n" +
+            "    return var + \"Testing VARCHAR datatype\"'", SCHEMA_NAME);
+
+    private static final String DROP_TEST_VARCHAR  = String.format("DROP FUNCTION %s.TEST_VARCHAR",SCHEMA_NAME);
+
+    private static final String CREATE_TEST_CLOB = String.format("CREATE FUNCTION %s.TEST_CLOB() RETURNS CLOB PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'def run():\n" +
+            "    return \"Testing CLOB datatype\"'", SCHEMA_NAME);
+
+    private static final String DROP_TEST_CLOB  = String.format("DROP FUNCTION %s.TEST_CLOB",SCHEMA_NAME);
+
+    private static final String CREATE_TEST_TEXT = String.format("CREATE FUNCTION %s.TEST_TEXT() RETURNS TEXT PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'def run():\n" +
+            "    return \"Testing TEXT datatype\"'", SCHEMA_NAME);
+
+    private static final String DROP_TEST_TEXT  = String.format("DROP FUNCTION %s.TEST_TEXT",SCHEMA_NAME);
+
+    private static final String CREATE_TEST_LONGVARCHAR = String.format("CREATE FUNCTION %s.TEST_LONGVARCHAR() RETURNS LONG VARCHAR PARAMETER STYLE JAVA NO SQL LANGUAGE PYTHON AS 'def run():\n" +
+            "    return \"Testing LONG VARCHAR datatype\"'", SCHEMA_NAME);
+
+    private static final String DROP_TEST_LONGVARCHAR  = String.format("DROP FUNCTION %s.TEST_LONGVARCHAR",SCHEMA_NAME);
+
+    // SQL statement to evaluate the function
+    private static final String CALL_TEST_BIGINT = String.format("VALUES %s.TEST_BIGINT(9223372036854775807)", SCHEMA_NAME);
+    private static final String CALL_TEST_BOOLEAN = String.format("VALUES %s.TEST_BOOLEAN(true)", SCHEMA_NAME);
+    private static final String CALL_TEST_CHAR = String.format("VALUES %s.TEST_CHAR('a')", SCHEMA_NAME);
+    private static final String CALL_TEST_DATE = String.format("VALUES %s.TEST_DATE('1993-09-23')", SCHEMA_NAME);
+    private static final String CALL_TEST_DECIMAL = String.format("VALUES %s.TEST_DECIMAL(2.798765)", SCHEMA_NAME);
+    private static final String CALL_TEST_NUMERIC = String.format("VALUES %s.TEST_NUMERIC(2.798765)", SCHEMA_NAME);
+    private static final String CALL_TEST_DOUBLE = String.format("VALUES %s.TEST_DOUBLE(2.798765)", SCHEMA_NAME);
+    private static final String CALL_TEST_DOUBLE_PRECISION = String.format("VALUES %s.TEST_DOUBLE_PRECISION(2.798765)", SCHEMA_NAME);
+    private static final String CALL_TEST_INTEGER = String.format("VALUES %s.TEST_INTEGER(2)", SCHEMA_NAME);
+    private static final String CALL_TEST_FLOAT = String.format("VALUES %s.TEST_FLOAT(2.798765)", SCHEMA_NAME);
+    private static final String CALL_TEST_REAL = String.format("VALUES %s.TEST_REAL(2.798765)", SCHEMA_NAME);
+    private static final String CALL_TEST_SMALLINT = String.format("VALUES %s.TEST_SMALLINT(1)", SCHEMA_NAME);
+    private static final String CALL_TEST_TIME = String.format("VALUES %s.TEST_TIME('15:09:02')", SCHEMA_NAME);
+    private static final String CALL_TEST_TIMESTAMP = String.format("VALUES %s.TEST_TIMESTAMP('2013-03-23 19:45:00')", SCHEMA_NAME);
+    private static final String CALL_TEST_VARCHAR = String.format("VALUES %s.TEST_VARCHAR('THIS IS A TEST ')", SCHEMA_NAME);
+    private static final String CALL_TEST_CLOB = String.format("VALUES %s.TEST_CLOB()", SCHEMA_NAME);
+    private static final String CALL_TEST_TEXT = String.format("VALUES %s.TEST_TEXT()", SCHEMA_NAME);
+    private static final String CALL_TEST_LONGVARCHAR = String.format("VALUES %s.TEST_LONGVARCHAR()", SCHEMA_NAME);
+
+    // Error message
+    private static final String INCORRECT_CODE_RESULT_COUNT = "Incorrect return code or result count returned!";
+
+    @Test
+    public void testBigInt() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_BIGINT);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_BIGINT);
+        rs.next();
+        long retrievedVal = rs.getLong(1);
+        Assert.assertEquals(9223372036854775806L, retrievedVal);
+        rc = methodWatcher.executeUpdate(DROP_TEST_BIGINT);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+
+    @Test
+    public void testBoolean() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_BOOLEAN);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_BOOLEAN);
+        rs.next();
+        boolean retrievedVal = rs.getBoolean(1);
+        Assert.assertEquals(false, retrievedVal);
+        rc = methodWatcher.executeUpdate(DROP_TEST_BOOLEAN);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+
+    @Test
+    public void testChar() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_CHAR);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_CHAR);
+        rs.next();
+        String retrievedVal = rs.getString(1);
+        Assert.assertEquals("s", retrievedVal);
+        rc = methodWatcher.executeUpdate(DROP_TEST_CHAR);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+
+    @Test
+    public void testDate() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_DATE);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_DATE);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 1, resultSetSize(rs));
+        rc = methodWatcher.executeUpdate(DROP_TEST_DATE);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+
+    /**
+     * The following test is currently ignored due to existing bug in type conversion for
+     * BigDecimal -- DB-7321
+     */
+    @Ignore
+    @Test
+    public void testDecimal() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_DECIMAL);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_DECIMAL);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 1, resultSetSize(rs));
+        rc = methodWatcher.executeUpdate(DROP_TEST_DECIMAL);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+
+    /**
+     * The following test is currently ignored due to existing bug in type conversion for
+     * BigDecimal -- DB-7321
+     */
+    @Ignore
+    @Test
+    public void testNumeric() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_NUMERIC);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_NUMERIC);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 1, resultSetSize(rs));
+        rc = methodWatcher.executeUpdate(DROP_TEST_NUMERIC);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+
+    @Test
+    public void testDouble() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_DOUBLE);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_DOUBLE);
+        rs.next();
+        Double retrievedVal = rs.getDouble(1);
+        Assert.assertEquals((Double )1.79769E+308,retrievedVal);
+        rc = methodWatcher.executeUpdate(DROP_TEST_DOUBLE);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+
+    @Test
+    public void testDoublePrecision() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_DOUBLE_PRECISION);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_DOUBLE_PRECISION);
+        rs.next();
+        Double retrievedVal = rs.getDouble(1);
+        Assert.assertEquals((Double )1.79769E+308,retrievedVal);
+        rc = methodWatcher.executeUpdate(DROP_TEST_DOUBLE_PRECISION);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+
+    @Test
+    public void testInteger() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_INTEGER);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_INTEGER);
+        rs.next();
+        int retrievedVal = rs.getInt(1);
+        Assert.assertEquals(0,retrievedVal);
+        rc = methodWatcher.executeUpdate(DROP_TEST_INTEGER);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+
+    @Test
+    public void testFloat() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_FLOAT);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_FLOAT);
+        rs.next();
+        Double retrievedVal = rs.getDouble(1);
+        Assert.assertEquals((Double)2.225E-307, retrievedVal);
+        rc = methodWatcher.executeUpdate(DROP_TEST_FLOAT);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+
+    @Test
+    public void testReal() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_REAL);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_REAL);
+        rs.next();
+        Double retrievedVal = rs.getDouble(1);
+        Assert.assertEquals((Double)3.4020000005553803E38, retrievedVal);
+        rc = methodWatcher.executeUpdate(DROP_TEST_REAL);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+
+    @Test
+    public void testSmallint() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_SMALLINT);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_SMALLINT);
+        rs.next();
+        Short retrievedVal = rs.getShort(1);
+        short expectedShort = (short) 3267;
+        Assert.assertEquals((Short) expectedShort, retrievedVal);
+        rc = methodWatcher.executeUpdate(DROP_TEST_SMALLINT);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+
+    @Test
+    public void testTime() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_TIME);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_TIME);
+        rs.next();
+        Time retrievedVal = rs.getTime(1);
+        Assert.assertEquals(retrievedVal.toString(),"13:00:00");
+        rc = methodWatcher.executeUpdate(DROP_TEST_TIME);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+
+    @Test
+    public void testTimestamp() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_TIMESTAMP);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_TIMESTAMP);
+        rs.next();
+        Time retrievedVal = rs.getTime(1);
+        Assert.assertTrue(retrievedVal!= null);
+        rc = methodWatcher.executeUpdate(DROP_TEST_TIMESTAMP);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+
+    @Test
+    public void testVarchar() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_VARCHAR);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_VARCHAR);
+        rs.next();
+        String retrievedVal = rs.getString(1);
+        Assert.assertEquals("THIS IS A TEST Testing VARCHAR datatype",retrievedVal);
+        rc = methodWatcher.executeUpdate(DROP_TEST_VARCHAR);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+
+    @Test
+    public void testClob() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_CLOB);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_CLOB);
+        rs.next();
+        Clob retrievedVal = rs.getClob(1);
+        Assert.assertTrue(retrievedVal!= null);
+        rs.close();
+        rc = methodWatcher.executeUpdate(DROP_TEST_CLOB);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+
+    @Test
+    public void testText() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_TEXT);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_TEXT);
+        rs.next();
+        Clob retrievedVal = rs.getClob(1);
+        Assert.assertTrue(retrievedVal!= null);
+        rs.close();
+        rc = methodWatcher.executeUpdate(DROP_TEST_TEXT);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+
+    @Test
+    public void testLongvarchar() throws Exception {
+        int rc;
+        ResultSet rs;
+        rc = methodWatcher.executeUpdate(CREATE_TEST_LONGVARCHAR);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+        rs = methodWatcher.executeQuery(CALL_TEST_LONGVARCHAR);
+        rs.next();
+        String retrievedVal = rs.getString(1);
+        Assert.assertEquals("Testing LONG VARCHAR datatype", retrievedVal);
+        rc = methodWatcher.executeUpdate(DROP_TEST_LONGVARCHAR);
+        Assert.assertEquals(INCORRECT_CODE_RESULT_COUNT, 0, rc);
+    }
+}

--- a/hbase_sql/src/test/java/com/splicemachine/derby/transactions/PyProcedureIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/transactions/PyProcedureIT.java
@@ -14,15 +14,12 @@
 
 package com.splicemachine.derby.transactions;
 
-import static org.junit.Assert.assertTrue;
-
 import java.sql.*;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -33,7 +30,6 @@ import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
 import com.splicemachine.test.SerialTest;
 import com.splicemachine.test.Transactions;
-import scala.Predef;
 
 /**
  * This class is the IT test for Python Stored Procedure. It has two parts.
@@ -50,7 +46,7 @@ import scala.Predef;
 @Category({Transactions.class,SerialTest.class}) //made serial because it loads a jar
 public class PyProcedureIT extends SpliceUnitTest {
 
-    public static final String CLASS_NAME = CallableTransactionIT.class.getSimpleName().toUpperCase();
+    public static final String CLASS_NAME = PyProcedureIT.class.getSimpleName().toUpperCase();
 
     protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher();
     protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/PyRoutineWrapper.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/PyRoutineWrapper.java
@@ -1,11 +1,15 @@
 package com.splicemachine.derby.utils;
 
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.impl.sql.pyprocedure.PyCodeUtil;
 import com.splicemachine.db.impl.sql.pyprocedure.PyInterpreterPool;
 import com.splicemachine.db.impl.sql.pyprocedure.PyStoredProcedureResultSetFactory;
 import org.python.core.PyFunction;
+import org.python.core.PyLong;
+import org.python.core.PyObject;
 import org.python.util.PythonInterpreter;
 
+import java.math.BigInteger;
 import java.sql.ResultSet;
 
 public class PyRoutineWrapper {
@@ -40,15 +44,9 @@ public class PyRoutineWrapper {
 
             // set pyScript
             if(rsDelim == null){
-                if(nargs == 0 || !(args[nargs-1] instanceof byte[])){
-                    // Might need to raise exception as compiled Bytecode does not exist
-                }
                 pyScriptIdx = nargs - 1;
             }
             else{
-                if(rsDelim-1 < 0 ||!(args[rsDelim - 1] instanceof byte[])){
-                    // Might need to raise exception as compiled Bytecode does not exist
-                }
                 pyScriptIdx = rsDelim - 1;
             }
             compiledCode = (byte[]) args[pyScriptIdx];
@@ -85,7 +83,79 @@ public class PyRoutineWrapper {
             }else{
                 userFunc._jcall(pyArgs);
             }
-        }finally{
+        }
+        catch (Exception e){
+            throw StandardException.plainWrapException(e);
+        }
+        finally{
+            if(pool != null && interpreter != null){
+                pool.release(interpreter);
+            }
+        }
+    }
+
+    /**
+     * A wrapper static method for Python user-defined function
+     *
+     * @param args if the registered stored procedure has n parameters, the args[0] to args[n-1] are these parameters.
+     * The args[n] must be a String which contains the Python script.
+     */
+    public static Object pyFunctionWrapper(Object... args)
+            throws Exception
+    {
+        PyInterpreterPool pool = null;
+        PythonInterpreter interpreter = null;
+        String setFacFuncName = "setFactory";
+        String funcName = "execute";
+        PyObject pyResult = null;
+        Object javaResult = null;
+
+        try {
+            byte[] compiledCode;
+            int nargs = args.length;
+            int pyScriptIdx = args.length - 1;
+
+            // set pyScript
+            compiledCode = (byte[]) args[pyScriptIdx];
+
+            // set the Object[] to pass in
+            Object[] pyArgs;
+            if(nargs - 1 ==0){
+                pyArgs = null;
+            }
+            else{
+                pyArgs = new Object[nargs - 1];
+                System.arraycopy(args, 0, pyArgs, 0, nargs - 1);
+            }
+
+            pool = PyInterpreterPool.getInstance();
+            interpreter = pool.acquire();
+            PyCodeUtil.exec(compiledCode, interpreter);
+            // add global variable factory, so that the user can use it to construct JDBC ResultSet
+            Object[] factoryArg = {new PyStoredProcedureResultSetFactory()};
+            PyFunction addFacFunc = interpreter.get(setFacFuncName, PyFunction.class);
+            addFacFunc._jcall(factoryArg);
+
+            // execute the user defined function, the user needs to fill the ResultSet himself,
+            // just like the original Java Stored Procedure
+            PyFunction userFunc = interpreter.get(funcName, PyFunction.class);
+            if(pyArgs == null){
+                pyResult = userFunc.__call__();
+            }else{
+                pyResult = userFunc._jcall(pyArgs);
+            }
+            javaResult = pyResult.__tojava__(Object.class);
+            if(pyResult instanceof PyLong){
+                // When the result has type PyLong, the result's corresponding
+                // sql type should be BigInt.
+                javaResult = ((BigInteger) javaResult).longValue();
+            }
+            return javaResult;
+        }
+        catch (Exception e){
+            throw StandardException.plainWrapException(e);
+        }
+        finally{
             if(pool != null && interpreter != null){
                 pool.release(interpreter);
             }


### PR DESCRIPTION
Pull Request Message:
Added support for Python user-defined function that returns a single value.
This Branch is based on SPLICE-2029 and has rebased on build 2.8.0.1832.

For more detailed documentation please look at the google doc: https://docs.google.com/document/d/1KiEkLw3YKfoY6J3WKRYefVxE5uGhu3993rBKY3ZZrYk/edit?usp=sharing

The files that have been modified based on SPLICE-2029 by Ao are:

1. .../java/com/splicemachine/db/iapi/services/loader/ClassInspector.java
2. .../main/java/com/splicemachine/db/impl/sql/compile/MethodCallNode.java
3. .../java/com/splicemachine/db/impl/sql/compile/StaticMethodCallNode.java
4. .../main/java/com/splicemachine/db/impl/sql/pyprocedure/PyCodeUtil.java
5. .../src/test/java/com/splicemachine/derby/transactions/PyFunctionIT.java
6. .../src/test/java/com/splicemachine/derby/transactions/PyProcedureIT.java
7. .../src/main/java/com/splicemachine/derby/utils/PyRoutineWrapper.java
8. .../derby/impl/sql/pyprocedure/PyStoredProcedureResultSetFactoryIT.java
A brief summary of changes in each files above:

.../java/com/splicemachine/db/iapi/services/loader/ClassInspector.java - Added Python user-defined wrapper function's name when resolving the method.
.../main/java/com/splicemachine/db/impl/sql/compile/MethodCallNode.java - Skip the process of matching method's return type when resolving the method. This is because the return value of the wrapper function is a general java.lang.Object. The actual type of the return value is not known until runtime.
.../java/com/splicemachine/db/impl/sql/compile/StaticMethodCallNode.java - Added Python user-defined wrapper function's name when resolving the method. Changed some naming and comments.
.../main/java/com/splicemachine/db/impl/sql/pyprocedure/PyCodeUtil.java - Added return statement to the Python script. Since the user-defined function has return value.
.../src/test/java/com/splicemachine/derby/transactions/PyFunctionIT.java - Added IT tests for Python user-defined function. Testing whether it can handle different Datatypes.
.../src/test/java/com/splicemachine/derby/transactions/PyProcedureIT.java - Changed the SCHEMA NAME used in the test.
.../src/main/java/com/splicemachine/derby/utils/PyRoutineWrapper.java - Added the public static wrapper funciton for Python user-defined function.
.../derby/impl/sql/pyprocedure/PyStoredProcedureResultSetFactoryIT.java -- Fix the arguments' order for Assert.assertEquals method.