### PR TITLE
DB-7302 MapR 6.0.0 ITs fixed

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -426,7 +426,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                 fs = FileSystem.get(URI.create(location), conf);
                 String fileName = getFile(fs, location);
                 if (fileName != null) {
-                    temp = new Path(location, "_temp");
+                    temp = new Path(location, "temp");
                     fs.mkdirs(temp);
                     SpliceLogUtils.info(LOG, "created temporary directory %s", temp);
 

--- a/hbase_sql/src/test/resources/core-site.xml
+++ b/hbase_sql/src/test/resources/core-site.xml
@@ -1,0 +1,42 @@
+<!--
+  ~ Copyright (c) 2012 - 2018 Splice Machine, Inc.
+  ~
+  ~ This file is part of Splice Machine.
+  ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+  ~ GNU Affero General Public License as published by the Free Software Foundation, either
+  ~ version 3, or (at your option) any later version.
+  ~ Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  ~ See the GNU Affero General Public License for more details.
+  ~ You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+  ~ If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<configuration>
+    <property>
+        <name>fs.default.name</name>
+         <value>file:///</value>
+    </property>
+
+    <property>
+        <name>fs.maprfs.impl</name>
+        <value>org.apache.hadoop.fs.LocalFileSystem</value>
+    </property>
+
+    <property>
+        <name>fs.hdfs.impl</name>
+        <value>org.apache.hadoop.fs.LocalFileSystem</value>
+    </property>
+
+    <property>
+        <name>io.file.buffer.size</name>
+        <value>65536</value>
+    </property>
+
+
+    <property>
+        <name>fs.defaultFS</name>
+        <value>file:///</value>
+    </property>
+</configuration>
+

--- a/platforms/mapr6.0.0/pom.xml
+++ b/platforms/mapr6.0.0/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>spliceengine-parent</artifactId>
         <groupId>com.splicemachine</groupId>
-        <version>2.8.0.1831-SNAPSHOT</version>
+        <version>2.8.0.1833-SNAPSHOT</version>
     </parent>
     <profiles>
         <profile>


### PR DESCRIPTION
Restored core-site.xml for testing. It selects LocalFileSystem instead of MapRFS, which is not ready to be used in ITs/standalone.
Removed _ from the name of a temporary directory used to infer avro schema. All such names are filtered out in PartitioningAwareFileIndex.shouldFilterOut() (spark-sql).
Fixed version in platforms/mapr6.0.0/pom.xml.

Tested with SPLICE-2219_v2 on centos7 (required for MapR6.0.0)