### PR TITLE
SPLICE-2231 Fix inconsistencies in start/stop scripts

### DIFF
--- a/assembly/standalone/template/bin/functions.sh
+++ b/assembly/standalone/template/bin/functions.sh
@@ -9,9 +9,9 @@ _kill_em_all () {
    [[ -n $P ]] && echo "Found Splice. Stopping it." && for pid in $P; do kill -$SIG `echo $pid`; done
 
    P=$(ps -ef | awk '/spliceYarn|SpliceTestYarnPlatform|CoarseGrainedScheduler|ExecutorLauncher/ && !/awk/ {print $2}')
-   [[ -n $P ]] && echo "Found Yarn. Stopping it." && for pid in $P; do kill -$SIG `echo $pid`; done
+   [[ -n $P ]] && echo "Found YARN. Stopping it." && for pid in $P; do kill -$SIG `echo $pid`; done
 
-   P=$(ps -ef | awk '/zookeeper/ && !/awk/ {print $2}')
+   P=$(ps -ef | awk '/ZooKeeper/ && !/awk/ {print $2}')
    [[ -n $P ]] && echo "Found ZooKeeper. Stopping it." && for pid in $P; do kill -$SIG `echo $pid`; done
 
    P=$(ps -ef | awk '/TestKafkaCluster/ && !/awk/ {print $2}')

--- a/assembly/standalone/template/bin/start-splice.sh
+++ b/assembly/standalone/template/bin/start-splice.sh
@@ -17,8 +17,8 @@
 ##################################################################################
 
 # if server still running, fail - must stop first
-SPID=$(ps -ef | awk '/SpliceTestPlatform|SpliceSinglePlatform|SpliceTestClusterParticipant/ && !/awk/ {print $2}')
-ZPID=$(ps -ef | awk '/zookeeper/ && !/awk/ {print $2}')
+SPID=$(ps -ef | awk '/SpliceTestPlatform|SpliceSinglePlatform|SpliceTestClusterParticipant|OlapServerMaster/ && !/awk/ {print $2}')
+ZPID=$(ps -ef | awk '/ZooKeeper/ && !/awk/ {print $2}')
 YPID=$(ps -ef | awk '/spliceYarn|SpliceTestYarnPlatform|CoarseGrainedScheduler|ExecutorLauncher/ && !/awk/ {print $2}')
 KPID=$(ps -ef | awk '/TestKafkaCluster/ && !/awk/ {print $2}')
 if [[ -n ${SPID} || -n ${ZPID} ]] || [[ -n ${YPID} || -n ${KPID} ]]; then
@@ -148,7 +148,7 @@ _startYarn "${BASE_DIR}" "${CP}" "${YARN_LOG}"
 
 KAFKALOG="${RUN_DIR}"/kafka.log
 # Start Kafka in background.
-echo "Starting Kafka, Log file is ${KAFKALOG}"
+echo "Starting Kafka. Log file is ${KAFKALOG}"
 
 _startKafka "${BASE_DIR}" "${CP}" "${KAFKALOG}" "${LOG4J_FILE}"
 

--- a/start-splice-cluster
+++ b/start-splice-cluster
@@ -20,10 +20,10 @@ _kill_em_all () {
    local P=$(ps -ef | awk '/SpliceTestPlatform|SpliceSinglePlatform|SpliceTestClusterParticipant|OlapServerMaster/ && !/awk/ {print $2}')
    [[ -n $P ]] && echo "Found Splice. Stopping it." && for pid in $P; do kill -$SIG `echo $pid`; done
 
-   P=$(ps -ef | awk '/spliceYarn|CoarseGrainedScheduler|ExecutorLauncher/ && !/awk/ {print $2}')
-   [[ -n $P ]] && echo "Found Yarn. Stopping it." && for pid in $P; do kill -$SIG `echo $pid`; done
+   P=$(ps -ef | awk '/spliceYarn|SpliceTestYarnPlatform|CoarseGrainedScheduler|ExecutorLauncher/ && !/awk/ {print $2}')
+   [[ -n $P ]] && echo "Found YARN. Stopping it." && for pid in $P; do kill -$SIG `echo $pid`; done
 
-   P=$(ps -ef | awk '/zookeeper/ && !/awk/ {print $2}')
+   P=$(ps -ef | awk '/ZooKeeper/ && !/awk/ {print $2}')
    [[ -n $P ]] && echo "Found ZooKeeper. Stopping it." && for pid in $P; do kill -$SIG `echo $pid`; done
 
    P=$(ps -ef | awk '/TestKafkaCluster/ && !/awk/ {print $2}')
@@ -215,7 +215,7 @@ echo "Starting YARN. Log file is ${YARN_LOG}"
 
 KAFKALOG="${RUN_DIR}"/kafka.log
 # Start Kafka in background.
-echo "Starting Kafka, log file is ${KAFKALOG}"
+echo "Starting Kafka. Log file is ${KAFKALOG}"
 (${MVN} exec:exec -P${PROFILE},spliceKafka > ${KAFKALOG} 2>&1) &
 
 SPLICE_LOG="${RUN_DIR}/splice.log"


### PR DESCRIPTION
* In all of the scripts, fixed capture of ZooKeeper PID to be more
specific so as not to mistakenly capture non-ZooKeeper PIDs (this was
causing the Kafka PID to be captured, so no "Found Kafka" message was
ever shown since the Kafka process was already killed)
* In `start-splice.sh`, added OlapServerMaster to Splice PID capture
pattern to be consistent with the other scripts
* In `start-splice-cluster`, added `SpliceTestYarnPattern` to YARN PID
capture to be consistent with the other scripts
* Changed all occurrences of `Yarn` to `YARN` in messages for
consistency with existing occurrences
* Changed some punctuation in messages for consistency