### PR TITLE
DB-7365  Check external table location is not a directory

### DIFF
--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -2010,15 +2010,16 @@ public interface SQLState {
 	String ACCESSING_S3_EXCEPTION                                   = "EXT34";
 	String EXISTING_PIN_VIOLATION									= "EXT35";
 	String ROW_FORMAT_NOT_ALLOWED_WITH_AVRO						   	= "EXT36";
-	String NO_GRANT_PERMISSIONS_WITH_RANGER                                = "EXT37";
-	String NO_REVOKE_PERMISSIONS_WITH_RANGER                                = "EXT38";
-	String ACCESS_DENIED_SENTRY                                = "EXT39";
-	String ROLE_ALREADY_EXISTS_SENTRY                                = "EXT40";
+	String NO_GRANT_PERMISSIONS_WITH_RANGER                         = "EXT37";
+	String NO_REVOKE_PERMISSIONS_WITH_RANGER                        = "EXT38";
+	String ACCESS_DENIED_SENTRY                                     = "EXT39";
+	String ROLE_ALREADY_EXISTS_SENTRY                               = "EXT40";
+	String EXTERNAL_TABLES_LOCATION_NOT_EXIST		   			    = "EXT41";
 
 	String SNAPSHOT_EXISTS											= "SNA01";
 	String SNAPSHOT_NOT_EXISTS										= "SNA02";
 	String SNAPSHOT_NAME_ILLEGAL									= "SNA03";
-	String SNAPSHOT_EXTERNAL_TABLE_UNSUPPORTED							= "SNA04";
+	String SNAPSHOT_EXTERNAL_TABLE_UNSUPPORTED					    = "SNA04";
 
     String SPLITKEY_EQUALS_STARTKEY                                 = "TS001";
 	String NO_PRIMARY_KEY											= "TS002";

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -9308,6 +9308,12 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
                <text>Role {0} already exists in Sentry.</text>
                <arg>role</arg>
            </msg>
+
+           <msg>
+               <name>EXT41</name>
+               <text>Location does not exist: {0}</text>
+               <arg>location</arg>
+           </msg>
        </family>
     </section>
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -59,7 +59,6 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.sql.*;
-import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import scala.Tuple2;
@@ -310,6 +309,9 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             Dataset<Row> table = null;
 
             try {
+                if (!ExternalTableUtils.isExisting(location))
+                    throw StandardException.newException(SQLState.EXTERNAL_TABLES_LOCATION_NOT_EXIST, location);
+
                 if (ExternalTableUtils.isEmptyDirectory(location)) // Handle Empty Directory
                     return getEmpty();
 
@@ -354,6 +356,9 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         try {
             Dataset<Row> table = null;
             try {
+                if (!ExternalTableUtils.isExisting(location))
+                    throw StandardException.newException(SQLState.EXTERNAL_TABLES_LOCATION_NOT_EXIST, location);
+
                 if (ExternalTableUtils.isEmptyDirectory(location)) // Handle Empty Directory
                     return getEmpty();
 
@@ -607,6 +612,9 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         assert baseColumnMap != null:"baseColumnMap Null";
         assert partitionColumnMap != null:"partitionColumnMap Null";
         try {
+            if (!ExternalTableUtils.isExisting(location))
+                throw StandardException.newException(SQLState.EXTERNAL_TABLES_LOCATION_NOT_EXIST, location);
+
             if (ExternalTableUtils.isEmptyDirectory(location)) // Handle Empty Directory
                 return getEmpty();
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -310,8 +310,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             Dataset<Row> table = null;
 
             try {
-                String[] files = ImportUtils.getFileSystem(location).getExistingFiles(location, "*");
-                if (files.length == 1 && files[0].equals("_SUCCESS")) // Handle Empty Directory
+                if (ExternalTableUtils.isEmptyDirectory(location)) // Handle Empty Directory
                     return getEmpty();
 
                 // Infer schema from external files\
@@ -355,8 +354,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         try {
             Dataset<Row> table = null;
             try {
-                String[] files = ImportUtils.getFileSystem(location).getExistingFiles(location, "*");
-                if (files.length == 1 && files[0].equals("_SUCCESS")) // Handle Empty Directory
+                if (ExternalTableUtils.isEmptyDirectory(location)) // Handle Empty Directory
                     return getEmpty();
 
                 // Infer schema from external files\
@@ -405,8 +403,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         if ((e instanceof AnalysisException || e instanceof FileNotFoundException) && e.getMessage() != null &&
                 (e.getMessage().startsWith("Unable to infer schema") || e.getMessage().startsWith("No Avro files found"))) {
             // Lets check if there are existing files...
-            String[] files = ImportUtils.getFileSystem(location).getExistingFiles(location, "*");
-            if (files.length == 1 && files[0].equals("_SUCCESS")) // Handle Empty Directory
+           if (ExternalTableUtils.isEmptyDirectory(location)) // Handle Empty Directory
                 return getEmpty();
         }
         throw e;
@@ -610,8 +607,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         assert baseColumnMap != null:"baseColumnMap Null";
         assert partitionColumnMap != null:"partitionColumnMap Null";
         try {
-            String[] files = ImportUtils.getFileSystem(location).getExistingFiles(location, "*");
-            if (files.length == 1 && files[0].equals("_SUCCESS")) // Handle Empty Directory
+            if (ExternalTableUtils.isEmptyDirectory(location)) // Handle Empty Directory
                 return getEmpty();
 
             SpliceORCPredicate predicate = new SpliceORCPredicate(qualifiers,baseColumnMap,execRow.createStructType(baseColumnMap));

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -468,7 +468,7 @@ public class ExternalTableIT extends SpliceUnitTest{
                     " STORED AS AVRO LOCATION '%s'", temp.getAbsolutePath()));
             Assert.fail("Exception not thrown");
         } catch (SQLException ee) {
-            Assert.assertEquals("Wrong Exception","EXT33" ,ee.getSQLState());
+            Assert.assertEquals("Wrong Exception","XJ001" ,ee.getSQLState());
         }
     }
 
@@ -481,7 +481,7 @@ public class ExternalTableIT extends SpliceUnitTest{
                     " STORED AS PARQUET LOCATION '%s'",temp.getAbsolutePath()));
             Assert.fail("Exception not thrown");
         } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT33",e.getSQLState());
+            Assert.assertEquals("Wrong Exception","XJ001",e.getSQLState());
         }
     }
 
@@ -2674,5 +2674,38 @@ public class ExternalTableIT extends SpliceUnitTest{
                 "100.23 |  1  |";
 
         Assert.assertEquals(actual, expected, actual);
+    }
+
+    @Test
+    public void testPureEmptyDirectory() throws  Exception{
+        String tablePath = getExternalResourceDirectory()+"pure_empty_directory";
+        File path =  new File(tablePath);
+        path.mkdir();
+        methodWatcher.executeUpdate(String.format("create external table pure_empty_directory (col1 varchar(24), col2 varchar(24), col3 varchar(24))" +
+                    " STORED AS PARQUET LOCATION '%s'",tablePath));
+        FileUtils.cleanDirectory(path);
+
+        ResultSet rs = methodWatcher.executeQuery("select * from pure_empty_directory");
+        String actual = TestUtils.FormattedResult.ResultFactory.toString(rs);
+        String expected = "";
+        Assert.assertEquals(actual, expected, actual);
+    }
+
+    @Test
+    public void testNotExistDirectory() throws  Exception{
+        try {
+            String tablePath = getExternalResourceDirectory()+"empty_directory_not_exist";
+            File path =  new File(tablePath);
+            path.mkdir();
+            methodWatcher.executeUpdate(String.format("create external table empty_directory_not_exist (col1 varchar(24), col2 varchar(24), col3 varchar(24))" +
+                    " STORED AS PARQUET LOCATION '%s'",tablePath));
+            FileUtils.deleteDirectory(path);
+
+            methodWatcher.executeQuery("select * from empty_directory_not_exist");
+            Assert.fail("Exception not thrown");
+        }
+        catch (SQLException e) {
+            Assert.assertEquals("Wrong Exception","EXT11",e.getSQLState());
+        }
     }
 }

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -468,7 +468,7 @@ public class ExternalTableIT extends SpliceUnitTest{
                     " STORED AS AVRO LOCATION '%s'", temp.getAbsolutePath()));
             Assert.fail("Exception not thrown");
         } catch (SQLException ee) {
-            Assert.assertEquals("Wrong Exception","XJ001" ,ee.getSQLState());
+            Assert.assertEquals("Wrong Exception","EXT33" ,ee.getSQLState());
         }
     }
 
@@ -481,7 +481,7 @@ public class ExternalTableIT extends SpliceUnitTest{
                     " STORED AS PARQUET LOCATION '%s'",temp.getAbsolutePath()));
             Assert.fail("Exception not thrown");
         } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","XJ001",e.getSQLState());
+            Assert.assertEquals("Wrong Exception","EXT33",e.getSQLState());
         }
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
@@ -469,7 +469,7 @@ public class CreateTableConstantOperation extends DDLConstantOperation {
                 // test constraint only if the external file exits
                 DistributedFileSystem fileSystem = SIDriver.driver().getFileSystem(location);
                 FileInfo fileInfo = fileSystem.getInfo(location);
-                if(!fileInfo.exists() || ExternalTableUtils.isEmptyDirectory(location)) {
+                if(!fileInfo.exists() || (fileInfo.isDirectory() && ExternalTableUtils.isEmptyDirectory(location))) {
                     // need the create the external file if the location provided is empty
                     String pathToParent = location.substring(0, location.lastIndexOf("/"));
                     ImportUtils.validateWritable(pathToParent, false);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
@@ -24,6 +24,7 @@ import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.ddl.DDLMessage;
 import com.splicemachine.derby.ddl.DDLDriver;
 import com.splicemachine.derby.impl.load.ImportUtils;
+import com.splicemachine.derby.stream.utils.ExternalTableUtils;
 import com.splicemachine.pipeline.Exceptions;
 import com.splicemachine.procedures.external.DistributedCreateExternalTableJob;
 import com.splicemachine.derby.impl.store.access.SpliceTransactionManager;
@@ -468,8 +469,7 @@ public class CreateTableConstantOperation extends DDLConstantOperation {
                 // test constraint only if the external file exits
                 DistributedFileSystem fileSystem = SIDriver.driver().getFileSystem(location);
                 FileInfo fileInfo = fileSystem.getInfo(location);
-                String[] files = fileSystem.getExistingFiles(location, "*");
-                if(!fileInfo.exists() || (files.length == 0) || (files.length == 1 && files[0].equals("_SUCCESS"))) {
+                if(!fileInfo.exists() || ExternalTableUtils.isEmptyDirectory(location)) {
                     // need the create the external file if the location provided is empty
                     String pathToParent = location.substring(0, location.lastIndexOf("/"));
                     ImportUtils.validateWritable(pathToParent, false);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
@@ -469,10 +469,10 @@ public class CreateTableConstantOperation extends DDLConstantOperation {
                 DistributedFileSystem fileSystem = SIDriver.driver().getFileSystem(location);
                 FileInfo fileInfo = fileSystem.getInfo(location);
                 String[] files = fileSystem.getExistingFiles(location, "*");
-                if(!fileInfo.exists() || (files.length == 1 && files[0].equals("_SUCCESS"))) {
+                if(!fileInfo.exists() || (files.length == 0) || (files.length == 1 && files[0].equals("_SUCCESS"))) {
                     // need the create the external file if the location provided is empty
                     String pathToParent = location.substring(0, location.lastIndexOf("/"));
-                    ImportUtils.validateWritable(pathToParent.toString(), false);
+                    ImportUtils.validateWritable(pathToParent, false);
                     EngineDriver.driver().getOlapClient().execute(new DistributedCreateExternalTableJob(delimited, escaped, lines, storedAs, location, compression, partitionby, jobGroup, columnInfo));
 
                 } else if(fileInfo.exists() && fileInfo.isDirectory() && fileInfo.fileCount() > 0 && storedAs.compareToIgnoreCase("t") != 0) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ExternalTableUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ExternalTableUtils.java
@@ -24,6 +24,7 @@ import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
+import com.splicemachine.derby.impl.load.ImportUtils;
 import com.splicemachine.derby.jdbc.SpliceTransactionResourceImpl;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
 import com.splicemachine.si.api.txn.Txn;
@@ -228,5 +229,13 @@ public class ExternalTableUtils {
                 }
             }
         }
+    }
+
+    public static boolean isEmptyDirectory(String location) throws Exception {
+        String[] files = ImportUtils.getFileSystem(location).getExistingFiles(location, "*");
+        if ((files.length == 0) || (files.length == 1 && files[0].equals("_SUCCESS")))
+            return true;
+        else
+            return false;
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ExternalTableUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ExternalTableUtils.java
@@ -15,6 +15,7 @@
 
 package com.splicemachine.derby.stream.utils;
 
+import com.splicemachine.access.api.FileInfo;
 import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
@@ -234,6 +235,14 @@ public class ExternalTableUtils {
     public static boolean isEmptyDirectory(String location) throws Exception {
         String[] files = ImportUtils.getFileSystem(location).getExistingFiles(location, "*");
         if ((files.length == 0) || (files.length == 1 && files[0].equals("_SUCCESS")))
+            return true;
+        else
+            return false;
+    }
+
+    public static boolean isExisting(String location) throws Exception {
+        FileInfo fileInfo = ImportUtils.getFileSystem(location).getInfo(location);
+        if (fileInfo.exists())
             return true;
         else
             return false;


### PR DESCRIPTION
When checking if a location is empty, checking it is a directory or not at first.