### PR TITLE
DB-7365 Check external table location is not a directory

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -468,7 +468,7 @@ public class ExternalTableIT extends SpliceUnitTest{
                     " STORED AS AVRO LOCATION '%s'", temp.getAbsolutePath()));
             Assert.fail("Exception not thrown");
         } catch (SQLException ee) {
-            Assert.assertEquals("Wrong Exception","XJ001" ,ee.getSQLState());
+            Assert.assertEquals("Wrong Exception","EXT33" ,ee.getSQLState());
         }
     }
 
@@ -481,7 +481,7 @@ public class ExternalTableIT extends SpliceUnitTest{
                     " STORED AS PARQUET LOCATION '%s'",temp.getAbsolutePath()));
             Assert.fail("Exception not thrown");
         } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","XJ001",e.getSQLState());
+            Assert.assertEquals("Wrong Exception","EXT33",e.getSQLState());
         }
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
@@ -469,7 +469,7 @@ public class CreateTableConstantOperation extends DDLConstantOperation {
                 // test constraint only if the external file exits
                 DistributedFileSystem fileSystem = SIDriver.driver().getFileSystem(location);
                 FileInfo fileInfo = fileSystem.getInfo(location);
-                if(!fileInfo.exists() || ExternalTableUtils.isEmptyDirectory(location)) {
+                if(!fileInfo.exists() || (fileInfo.isDirectory() && ExternalTableUtils.isEmptyDirectory(location))) {
                     // need the create the external file if the location provided is empty
                     String pathToParent = location.substring(0, location.lastIndexOf("/"));
                     ImportUtils.validateWritable(pathToParent, false);


### PR DESCRIPTION
When checking if a location is empty, checking it is a directory or not at first.