### PR TITLE
DB-7393 Change Sentry related SQLState to keep it the same with branch master/2.7 (2.5)

### DIFF
--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -2027,8 +2027,8 @@ public interface SQLState {
 	String NO_REVOKE_PERMISSIONS_WITH_RANGER                                = "EXT38";
 	String ACCESS_DENIED_SENTRY                                = "EXT39";
 	String ROLE_ALREADY_EXISTS_SENTRY                                = "EXT40";
-	String NO_GRANT_PERMISSIONS_WITH_SENTRY                                = "EXT41";
-	String NO_REVOKE_PERMISSIONS_WITH_SENTRY                               = "EXT42";
+	String NO_GRANT_PERMISSIONS_WITH_SENTRY                                = "EXT42";
+	String NO_REVOKE_PERMISSIONS_WITH_SENTRY                               = "EXT43";
 
 
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -9274,12 +9274,12 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
                <arg>role</arg>
            </msg>
            <msg>
-               <name>EXT41</name>
+               <name>EXT42</name>
                <text>Cannot grant permissions when Splice Machine is attached to Sentry.  Please use the Sentry CLI.</text>
            </msg>
 
            <msg>
-               <name>EXT42</name>
+               <name>EXT43</name>
                <text>Cannot revoke permissions when Splice Machine is attached to Sentry.  Please use the Sentry CLI.</text>
            </msg>
 


### PR DESCRIPTION
This is on branch 2.5. See #2214 and #2215 .