### PR TITLE
DB-7404 CheckTableIT fails to run in IDE

### DIFF
--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -168,6 +168,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>commons-dbutils</groupId>
+            <artifactId>commons-dbutils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
             <version>0.144</version>


### PR DESCRIPTION
The `commons-dbutils` test scope dependency is not transitively propagated from the `splice_machine` project.
Has to be explicitly specified where used.