### PR TITLE
SPLICE-2239 Version 4.0 Date serializer. Store year, month and day only, not time.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLDate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLDate.java
@@ -104,11 +104,26 @@ public final class SQLDate extends DataType
         return BASE_MEMORY_USAGE;
     } // end of estimateMemoryUsage
 
-    int getEncodedDate()
+    public int getEncodedDate()
     {
         return encodedDate;
     }
-    
+
+	// Try to make modern dates close to the year 2020 take up less space.
+	// Subtracting this value from a disk-encoded date allows us to use
+	// 1 or 2 bytes for dates around year 2020 plus or minus 15 years,
+	// vs. 3 or 4 bytes.
+	public static final int DATE_ENCODING_OFFSET = 0xFC800;
+
+	public int getDiskEncodedDate()
+	{
+		return (getYear(encodedDate)  << 9)  +
+		       (getMonth(encodedDate) << 5)  +
+		        getDay(encodedDate)          -
+		       DATE_ENCODING_OFFSET;
+	}
+
+
 	/*
 	** DataValueDescriptor interface
 	** (mostly implemented in DataType)

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTABLESRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTABLESRowFactory.java
@@ -97,7 +97,7 @@ public class SYSTABLESRowFactory extends CatalogRowFactory
 	 */
 	public static final String ORIGINAL_TABLE_VERSION = "1.0";
 	//the current version for creating new tables with
-	public static final String CURRENT_TABLE_VERSION = "3.0";
+	public static final String CURRENT_TABLE_VERSION = "4.0";
 	
 	// all indexes are unique.
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/BatchOnceFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/BatchOnceFunction.java
@@ -21,6 +21,7 @@ import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.types.HBaseRowLocation;
 import com.splicemachine.db.iapi.types.SQLRef;
+import com.splicemachine.db.impl.sql.catalog.SYSTABLESRowFactory;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.db.shared.common.reference.SQLState;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
@@ -185,7 +186,7 @@ public class BatchOnceFunction<Op extends SpliceOperation>
         for(int i=0;i<keyColumns.length;i++){
             keyColumns[i] = pkCols[i] -1;
         }
-        DescriptorSerializer[] serializers = VersionedSerializers.forVersion("3.0", true).getSerializers(execRowDefinition);
+        DescriptorSerializer[] serializers = VersionedSerializers.forVersion(SYSTABLESRowFactory.CURRENT_TABLE_VERSION, true).getSerializers(execRowDefinition);
         dataHash = BareKeyHash.encoder(keyColumns,null, SpliceKryoRegistry.getInstance(),serializers);
         return new KeyEncoder(NoOpPrefix.INSTANCE,dataHash,NoOpPostfix.INSTANCE);
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/V4SerializerMap.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/V4SerializerMap.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.utils.marshall.dvd;
+
+import com.splicemachine.SpliceKryoRegistry;
+
+/**
+ * @author Mark Sirek
+ *         Date: 9/15/18
+ */
+public class V4SerializerMap extends V3SerializerMap {
+
+        public static final V4SerializerMap SPARSE_MAP = new V4SerializerMap(true);
+		public static final V4SerializerMap DENSE_MAP = new V4SerializerMap(false);
+
+		public static final String VERSION = "4.0";
+
+		public static V4SerializerMap instance(boolean sparse){
+				return sparse? SPARSE_MAP: DENSE_MAP;
+		}
+
+		public V4SerializerMap(boolean sparse) {
+				super(sparse);
+		}
+
+		@Override
+		protected void populateFactories(boolean sparse) {
+				factories[0]  = NullDescriptorSerializer.nullFactory(BooleanDescriptorSerializer.INSTANCE_FACTORY,sparse);
+				factories[1]  = NullDescriptorSerializer.nullFactory(ScalarDescriptorSerializer.INSTANCE_FACTORY,sparse);
+				factories[2]  = NullDescriptorSerializer.floatChecker(RealDescriptorSerializer.INSTANCE_FACTORY, sparse);
+				factories[3]  = NullDescriptorSerializer.doubleChecker(DoubleDescriptorSerializer.INSTANCE_FACTORY, sparse);
+				factories[4]  = NullDescriptorSerializer.nullFactory(StringDescriptorSerializer.INSTANCE_FACTORY, sparse);
+				factories[5]  = NullDescriptorSerializer.nullFactory(KryoDescriptorSerializer.newFactory(SpliceKryoRegistry.getInstance()),sparse);
+				factories[6]  = NullDescriptorSerializer.nullFactory(DateV4DescriptorSerializer.INSTANCE_FACTORY,sparse);
+				factories[7]  = NullDescriptorSerializer.nullFactory(TimeDescriptorSerializer.INSTANCE_FACTORY,sparse);
+				factories[8]  = NullDescriptorSerializer.nullFactory(TimestampV3DescriptorSerializer.INSTANCE_FACTORY,sparse);
+				factories[9]  = NullDescriptorSerializer.nullFactory(UnsortedBinaryDescriptorSerializer.INSTANCE_FACTORY,sparse);
+				factories[10] = NullDescriptorSerializer.nullFactory(DecimalDescriptorSerializer.INSTANCE_FACTORY,sparse);
+				factories[11] = NullDescriptorSerializer.nullFactory(RefDescriptorSerializer.INSTANCE_FACTORY, sparse);
+				factories[12] = NullDescriptorSerializer.nullFactory(UDTDescriptorSerializer.INSTANCE_FACTORY, sparse);
+
+			    eagerFactories[0]  = NullDescriptorSerializer.nullFactory(BooleanDescriptorSerializer.INSTANCE_FACTORY,sparse);
+				eagerFactories[1]  = NullDescriptorSerializer.nullFactory(ScalarDescriptorSerializer.INSTANCE_FACTORY,sparse);
+				eagerFactories[2]  = NullDescriptorSerializer.floatChecker(RealDescriptorSerializer.INSTANCE_FACTORY, sparse);
+				eagerFactories[3]  = NullDescriptorSerializer.doubleChecker(DoubleDescriptorSerializer.INSTANCE_FACTORY, sparse);
+				eagerFactories[4]  = NullDescriptorSerializer.nullFactory(StringDescriptorSerializer.INSTANCE_FACTORY, sparse);
+				eagerFactories[5]  = NullDescriptorSerializer.nullFactory(KryoDescriptorSerializer.newFactory(SpliceKryoRegistry.getInstance()),sparse);
+				eagerFactories[6]  = NullDescriptorSerializer.nullFactory(DateV4DescriptorSerializer.INSTANCE_FACTORY,sparse);
+				eagerFactories[7]  = NullDescriptorSerializer.nullFactory(TimeDescriptorSerializer.INSTANCE_FACTORY,sparse);
+				eagerFactories[8]  = NullDescriptorSerializer.nullFactory(TimestampV3DescriptorSerializer.INSTANCE_FACTORY,sparse);
+				eagerFactories[9]  = NullDescriptorSerializer.nullFactory(UnsortedBinaryDescriptorSerializer.INSTANCE_FACTORY,sparse);
+				eagerFactories[10] = NullDescriptorSerializer.nullFactory(DecimalDescriptorSerializer.INSTANCE_FACTORY,sparse);
+				eagerFactories[11] = NullDescriptorSerializer.nullFactory(RefDescriptorSerializer.INSTANCE_FACTORY,sparse);
+				eagerFactories[12] = NullDescriptorSerializer.nullFactory(UDTDescriptorSerializer.INSTANCE_FACTORY, sparse);
+
+		}
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/VersionedSerializers.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/VersionedSerializers.java
@@ -26,7 +26,9 @@ public class VersionedSerializers {
     }
 
     public static TypeProvider typesForVersion(String version) {
-        if (V3SerializerMap.VERSION.equals(version))
+        if (V4SerializerMap.VERSION.equals(version))
+            return V4SerializerMap.instance(true);
+        else if (V3SerializerMap.VERSION.equals(version))
             return V3SerializerMap.instance(true);
         else if (V2SerializerMap.VERSION.equals(version))
             return V2SerializerMap.instance(true);
@@ -44,7 +46,9 @@ public class VersionedSerializers {
         /*
          * Statically defined version checked versioning
          */
-        if (V3SerializerMap.VERSION.equals(version))
+        if (V4SerializerMap.VERSION.equals(version))
+            return V4SerializerMap.instance(sparse);
+        else if (V3SerializerMap.VERSION.equals(version))
             return V3SerializerMap.instance(sparse);
         else if (V2SerializerMap.VERSION.equals(version))
             return V2SerializerMap.instance(sparse);
@@ -62,7 +66,7 @@ public class VersionedSerializers {
      * @return a serializer map for the latest encoding version.
      */
     public static SerializerMap latestVersion(boolean sparse) {
-        return V3SerializerMap.instance(sparse);
+        return V4SerializerMap.instance(sparse);
     }
 
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/FixedSITableScannerTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/FixedSITableScannerTest.java
@@ -18,6 +18,7 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.*;
+import com.splicemachine.db.impl.sql.catalog.SYSTABLESRowFactory;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.derby.impl.sql.execute.operations.scanner.SIFilterFactory;
 import com.splicemachine.derby.impl.sql.execute.operations.scanner.SITableScanner;
@@ -311,7 +312,7 @@ public class FixedSITableScannerTest{
         }
                 .scan(scan)
                 .scanner(scanner)
-                .tableVersion("3.0")
+                .tableVersion(SYSTABLESRowFactory.CURRENT_TABLE_VERSION)
                 .rowDecodingMap(rowDecodingMap);
         builder = ((TableScannerBuilder)builder)
                 .filterFactory(

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/marshall/BareKeyHashTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/marshall/BareKeyHashTest.java
@@ -137,6 +137,7 @@ public class BareKeyHashTest {
 
 		@Test
 		public void testProperlyEncodesValues() throws Exception {
+
 				ExecRow execRow = new ValueRow(dataTypes.length);
 				for(int i=0;i<dataTypes.length;i++){
 						execRow.setColumn(i + 1, row[i].cloneValue(true));

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/marshall/dvd/DateV4DescriptorSerializerTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/marshall/dvd/DateV4DescriptorSerializerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.utils.marshall.dvd;
+
+
+import com.splicemachine.db.iapi.db.DatabaseContext;
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.services.context.ContextService;
+import com.splicemachine.db.iapi.services.i18n.LocaleFinder;
+import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.db.iapi.types.SQLDate;
+import com.splicemachine.encoding.Encoding;
+import com.splicemachine.si.testenv.ArchitectureIndependent;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.time.ZoneId;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+
+
+/**
+ * Created by msirek on 9/13/18.
+ */
+@Category(ArchitectureIndependent.class)
+public class DateV4DescriptorSerializerTest {
+
+
+    String dates[] = {"2020-01-01","2035-01-01","2004-01-01","2000-01-01","2006-02-28","2012-10-28",
+                      "2037-04-01","2038-12-11","2040-04-30","2018-01-01","2022-01-01","2019-05-31",
+                      "1932-03-31","1582-10-04", "1984-02-29","9999-12-31","0001-01-01","1111-02-03",
+                      "2222-03-04","4444-04-05","1776-07-04","1196-05-25","1741-11-10", "1847-08-09",
+                      "1850-04-18", "1879-02-26", "2061-11-30", "1999-12-31", "8888-08-08"};
+
+    private void testSingleDate(String dateString, LocaleFinder localeFinder, ZoneId zoneId,
+                                DescriptorSerializer descriptorSerializer) throws StandardException {
+        byte[] bytes;
+        GregorianCalendar cal = new GregorianCalendar(TimeZone.getTimeZone(zoneId));
+        DataValueDescriptor dvdSource = new SQLDate(dateString, false, localeFinder, cal);
+        DataValueDescriptor dvdTarget = new SQLDate(null);
+        bytes = Encoding.encode(((SQLDate) dvdSource).getDiskEncodedDate(), false);
+        descriptorSerializer.decodeDirect(dvdTarget, bytes, 0, bytes.length, false);
+        assertEquals(dvdSource, dvdTarget);
+    }
+
+    @Test
+    public void testDates() throws StandardException {
+
+        DatabaseContext dc = (DatabaseContext) ContextService.getContext(DatabaseContext.CONTEXT_ID);
+        LocaleFinder localeFinder = (dc == null) ? null : dc.getDatabase();
+        DescriptorSerializer dateDescriptorSerializer = DateV4DescriptorSerializer.INSTANCE_FACTORY.newInstance();
+
+        try {
+            // Encoding/decoding of dates should not be timezone-sensitive.
+            for (String zId : ZoneId.getAvailableZoneIds()) {
+                ZoneId zoneId = ZoneId.of(zId);
+                for (String date : dates)
+                    testSingleDate(date, localeFinder, zoneId, dateDescriptorSerializer);
+            }
+        } catch (Exception e) {
+            Assert.fail("Exception while testing Date encoding/decoding.");
+        }
+    }
+}

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/test/TestingDataType.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/test/TestingDataType.java
@@ -19,6 +19,7 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
+import com.splicemachine.derby.utils.marshall.dvd.DateV4DescriptorSerializer;
 import com.splicemachine.derby.utils.marshall.dvd.TimestampV3DescriptorSerializer;
 import com.splicemachine.encoding.MultiFieldDecoder;
 import com.splicemachine.encoding.MultiFieldEncoder;
@@ -316,7 +317,7 @@ public enum TestingDataType {
             if(decoder.nextIsNull())
                 dvd.setToNull();
             else
-						  dvd.setValue(new java.sql.Date(decoder.decodeNextLong()));
+                dvd.setValue(DateV4DescriptorSerializer.diskEncodingToInMemEncoding(decoder.decodeNextInt()));
         }
 
         @Override


### PR DESCRIPTION
This changes the Date encoding from storing milliseconds to:

(year << 9) + (month << 5) + day

Which changes what's stored from a point in DateTime, to simply a pure date.
See [SPLICE-2239](https://splice.atlassian.net/browse/SPLICE-2239?focusedCommentId=27567&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-27567)