### PR TITLE
DB-7471-2.7 Update standalone tarball link

### DIFF
--- a/platforms/std/docs/STD-installation.md
+++ b/platforms/std/docs/STD-installation.md
@@ -317,7 +317,7 @@ using it!
 
 3. Install Splice Machine:
 
-   Unpack the tarball `gz` file that you downloaded, for example: <a href="https://s3.amazonaws.com/splice-releases/2.7.0.1815/standalone/SPLICEMACHINE-2.7.0.1815.standalone.tar.gz">https://s3.amazonaws.com/splice-releases/2.7.0.1815/standalone/SPLICEMACHINE-2.7.0.1815.standalone.tar.gz</a>
+   Unpack the tarball `gz` file that you downloaded, for example: <a href="https://s3.amazonaws.com/splice-releases/2.7.0.1835/standalone/SPLICEMACHINE-2.7.0.1835.standalone.tar.gz">https://s3.amazonaws.com/splice-releases/2.7.0.1835/standalone/SPLICEMACHINE-2.7.0.1835.standalone.tar.gz</a>
 
    This creates a `splicemachine` subdirectory and installs Splice Machine software in it.
 


### PR DESCRIPTION
Tarball that was associated with the download link on the site/email was updated, so the linked documentation markdown should be updated.