### PR TITLE
DB-7471 Update standalone tarball link

### DIFF
--- a/platforms/std/docs/STD-installation.md
+++ b/platforms/std/docs/STD-installation.md
@@ -296,7 +296,7 @@ using it!
 
 3. Install Splice Machine:
 
-   Unpack the tarball `gz` file that you downloaded: <a href="https://s3.amazonaws.com/splice-releases/2.5.0.1802/standalone/splicemachine-2.5.0.1729.tar.gz">https://s3.amazonaws.com/splice-releases/2.5.0.1802/standalone/splicemachine-2.5.0.1729.tar.gz</a>
+   Unpack the tarball `gz` file that you downloaded: <a href="https://s3.amazonaws.com/splice-releases/2.7.0.1835/standalone/SPLICEMACHINE-2.7.0.1835.standalone.tar.gz">https://s3.amazonaws.com/splice-releases/2.7.0.1835/standalone/SPLICEMACHINE-2.7.0.1835.standalone.tar.gz</a>
 
    This creates a `splicemachine` subdirectory and installs Splice Machine software in it.
 


### PR DESCRIPTION
Tarball in the installation markdown returns a access denied code. The standalone tarball is updated to the new standalone link provided in the email/website.