### PR TITLE
DB-7484: batch load HFile

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkImportFunction.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkImportFunction.java
@@ -15,15 +15,16 @@
 
 package com.splicemachine.derby.stream.function;
 
+import com.clearspring.analytics.util.Lists;
 import com.splicemachine.access.HConfiguration;
 import com.splicemachine.access.api.PartitionFactory;
 import com.splicemachine.derby.impl.SpliceSpark;
 import com.splicemachine.si.impl.driver.SIDriver;
-import com.splicemachine.storage.ClientPartition;
 import com.splicemachine.storage.Partition;
 import com.splicemachine.storage.SkeletonHBaseClientPartition;
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.client.HTable;
@@ -36,12 +37,17 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Created by dgomezferro on 5/17/17.
  */
-public class BulkImportFunction implements VoidFunction<BulkImportPartition>, Externalizable {
+public class BulkImportFunction implements VoidFunction<Iterator<BulkImportPartition>>, Externalizable {
     private static final Logger LOG = Logger.getLogger(BulkImportFunction.class);
+    private Map<Long, List<BulkImportPartition>> partitionMap;
 
     // serialization
     public BulkImportFunction() {}
@@ -53,23 +59,40 @@ public class BulkImportFunction implements VoidFunction<BulkImportPartition>, Ex
     String bulkImportDirectory;
 
     @Override
-    public void call(BulkImportPartition importPartition) throws Exception {
+    public void call(Iterator<BulkImportPartition> importPartitions) throws Exception {
+
+        init(importPartitions);
         Configuration conf = HConfiguration.unwrapDelegate();
         LoadIncrementalHFiles loader = new LoadIncrementalHFiles(conf);
         FileSystem fs = FileSystem.get(URI.create(bulkImportDirectory), conf);
-        Long conglomerateId = importPartition.getConglomerateId();
-        PartitionFactory tableFactory= SIDriver.driver().getTableFactory();
-        try(Partition partition=tableFactory.getTable(Long.toString(conglomerateId))){
-            Path path = new Path(importPartition.getFilePath()).getParent();
-            if (fs.exists(path)) {
-                loader.doBulkLoad(path,(HTable) ((SkeletonHBaseClientPartition)partition).unwrapDelegate());
-                fs.delete(path, true);
-            } else {
-                LOG.warn("Path doesn't exist, nothing to load into this partition? " + path);
+        for (Long conglomId : partitionMap.keySet()) {
+            PartitionFactory tableFactory= SIDriver.driver().getTableFactory();
+            Partition partition=tableFactory.getTable(Long.toString(conglomId));
+            List<BulkImportPartition> partitionList = partitionMap.get(conglomId);
+            // For each batch of BulkImportPartition, use the first partition as staging area
+            Path path = new Path(partitionList.get(0).getFilePath());
+            if (!fs.exists(path)) {
+                fs.mkdirs(path);
             }
-            if (LOG.isDebugEnabled()) {
-                SpliceLogUtils.debug(LOG, "Loaded file %s", path.toString());
+
+            // Move files from all partitions to the first partition
+            for (int i = 1; i < partitionList.size(); ++i) {
+                Path sourceDir = new Path(partitionList.get(i).getFilePath());
+                if (fs.exists(sourceDir)) {
+                    FileStatus[] statuses = fs.listStatus(sourceDir);
+                    for (FileStatus status : statuses) {
+                        Path filePath = status.getPath();
+                        Path destPath = new Path(path, filePath.getName());
+                        fs.rename(filePath, destPath);
+                        if (LOG.isDebugEnabled()) {
+                            SpliceLogUtils.debug(LOG, "Move file %s to ", filePath.toString(), destPath.toString());
+                        }
+                    }
+                    fs.delete(sourceDir.getParent(), true);
+                }
             }
+            loader.doBulkLoad(path.getParent(), (HTable) ((SkeletonHBaseClientPartition)partition).unwrapDelegate());
+            fs.delete(path, true);
         }
     }
 
@@ -82,5 +105,19 @@ public class BulkImportFunction implements VoidFunction<BulkImportPartition>, Ex
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
         bulkImportDirectory = (String) in.readObject();
         SpliceSpark.setupSpliceStaticComponents();
+    }
+
+    private void init(Iterator<BulkImportPartition> importPartitions) throws Exception {
+        partitionMap = new HashMap<>();
+        while (importPartitions.hasNext()) {
+            BulkImportPartition partition = importPartitions.next();
+            Long conglom = partition.getConglomerateId();
+            List<BulkImportPartition> partitionList = partitionMap.get(conglom);
+            if (partitionList == null) {
+                partitionList = Lists.newArrayList();
+                partitionMap.put(conglom, partitionList);
+            }
+            partitionList.add(partition);
+        }
     }
 }

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BulkDataSetWriter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BulkDataSetWriter.java
@@ -195,7 +195,7 @@ public class BulkDataSetWriter  {
         int numTasks = Math.max(bulkImportPartitions.size()/regionsPerTask, 1);
         SpliceSpark.pushScope(prefix + " Load HFiles");
         SpliceSpark.getContext().parallelize(bulkImportPartitions, numTasks)
-                .foreach(new BulkImportFunction(bulkImportDirectory));
+                .foreachPartition(new BulkImportFunction(bulkImportDirectory));
         SpliceSpark.popScope();
     }
 

--- a/hbase_storage/src/main/java/com/splicemachine/access/hbase/H10PartitionAdmin.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/hbase/H10PartitionAdmin.java
@@ -166,7 +166,7 @@ public class H10PartitionAdmin implements PartitionAdmin{
             } catch (IOException e) {
                 String errMsg = e.getMessage();
                 if (errMsg.compareTo("should not give a splitkey which equals to startkey!") == 0) {
-                    SpliceLogUtils.warn(LOG, errMsg + ": " + Bytes.toStringBinary(splitPoint));
+                    SpliceLogUtils.warn(LOG, "%s : %s", errMsg, Bytes.toStringBinary(splitPoint));
                     SQLWarning warning =
                             StandardException.newWarning(SQLState.SPLITKEY_EQUALS_STARTKEY, Bytes.toStringBinary(splitPoint));
                     try {

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/PipelineConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/PipelineConfiguration.java
@@ -162,7 +162,7 @@ public class PipelineConfiguration implements ConfigurationDefault {
     private static final int DEFAULT_BULK_IMPORT_TASKS_PER_REGION = 1;
 
     public static final String REGION_TOLOAD_PER_TASK = "splice.region.toLoad.perTask";
-    private static final int DEFAULT_REGION_TOLOAD_PER_TASK = 10;
+    private static final int DEFAULT_REGION_TOLOAD_PER_TASK = 30;
 
 
     @Override


### PR DESCRIPTION
By default, move HFiles from 30 regions into a staging directory, and load all of them. The number of regions to be batch loaded is configured by "splice.region.toLoad.perTask"