### PR TITLE
DBAAS-1817 Add Anonymous Login Creds for S3 

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/fs/s3/PrestoS3FileSystem.java
+++ b/hbase_sql/src/main/java/com/splicemachine/fs/s3/PrestoS3FileSystem.java
@@ -685,7 +685,7 @@ public class PrestoS3FileSystem
         }
 
         if (isNullOrEmpty(accessKey) || isNullOrEmpty(secretKey)) {
-            return Optional.empty();
+            return Optional.of(new AnonymousAWSCredentials());
         }
         return Optional.of(new BasicAWSCredentials(accessKey, secretKey));
     }


### PR DESCRIPTION
Uses the AnonymousAWSCredentials() to create credentials if none is given. Allows S3A to download from public buckets. 