### PR TITLE
DB-7545 SynchronousWriteControl creates contention

### DIFF
--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineDriver.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineDriver.java
@@ -35,6 +35,7 @@ import com.splicemachine.pipeline.client.WriteCoordinator;
 import com.splicemachine.pipeline.contextfactory.ContextFactoryDriver;
 import com.splicemachine.pipeline.contextfactory.ContextFactoryLoader;
 import com.splicemachine.pipeline.security.AclChecker;
+import com.splicemachine.pipeline.traffic.AtomicSpliceWriteControl;
 import com.splicemachine.pipeline.traffic.SpliceWriteControl;
 import com.splicemachine.pipeline.traffic.SynchronousWriteControl;
 import com.splicemachine.pipeline.utils.PipelineCompressor;
@@ -88,7 +89,7 @@ public class PipelineDriver{
         this.compressor = compressor;
         this.pipelineMeter= meter;
         this.writePipelineFactory = writePipelineFactory;
-        this.writeControl= new SynchronousWriteControl(
+        this.writeControl= new AtomicSpliceWriteControl(
                 config.getMaxDependentWriteThreads(),
                 config.getMaxIndependentWriteThreads(),
                 config.getMaxIndependentWrites(),

--- a/pipeline_api/src/test/java/com/splicemachine/pipeline/traffic/SpliceWriteControlTest.java
+++ b/pipeline_api/src/test/java/com/splicemachine/pipeline/traffic/SpliceWriteControlTest.java
@@ -18,7 +18,11 @@ import com.splicemachine.si.testenv.ArchitectureIndependent;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.ThreadLocalRandom;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 @Category(ArchitectureIndependent.class)
 public class SpliceWriteControlTest {
@@ -37,4 +41,133 @@ public class SpliceWriteControlTest {
         assertEquals("{ dependentWriteThreads=0, independentWriteThreads=1, dependentWriteCount=0, independentWriteCount=25 }", writeControl.getWriteStatus().toString());
     }
 
+    private volatile boolean done;
+    private final AtomicInteger curDependentThreads = new AtomicInteger();
+    private final AtomicInteger curDependentCount = new AtomicInteger();
+    private final AtomicInteger maxDependentThreads = new AtomicInteger();
+    private final AtomicInteger maxDependentCount = new AtomicInteger();
+    private final AtomicInteger curIndependentThreads = new AtomicInteger();
+    private final AtomicInteger curIndependentCount = new AtomicInteger();
+    private final AtomicInteger maxIndependentThreads = new AtomicInteger();
+    private final AtomicInteger maxIndependentCount = new AtomicInteger();
+
+    class BenchmarkThread extends Thread {
+
+        int idx;
+        SpliceWriteControl writeControl;
+        int avgDependent;
+        int avgIndependent;
+        long numIter = 0;
+        long rejected = 0;
+
+        public BenchmarkThread(int idx, SpliceWriteControl writeControl) {
+            this.idx = idx;
+            this.writeControl = writeControl;
+            avgDependent = writeControl.maxDependentWriteCount() / writeControl.maxDependendentWriteThreads();
+            avgIndependent = writeControl.maxIndependentWriteCount() / writeControl.maxIndependentWriteThreads();
+        }
+
+        @Override
+        public void run() {
+            while (!done) {
+                boolean dependent = ThreadLocalRandom.current().nextInt(3) == 0;
+                int origin = dependent ? avgDependent/2 : avgIndependent/2;
+                int numWrites = ThreadLocalRandom.current().nextInt(origin, 3 * origin);
+
+                SpliceWriteControl.Status status = dependent ? writeControl.performDependentWrite(numWrites)
+                        : writeControl.performIndependentWrite(numWrites);
+
+                switch (status) {
+                    case REJECTED:
+                        ++rejected;
+                        break;
+                    case INDEPENDENT: {
+                        int t = curDependentThreads.incrementAndGet();
+                        int c = curDependentCount.addAndGet(numWrites);
+                        maxDependentThreads.accumulateAndGet(t, (a, b) -> Math.max(a, b));
+                        maxDependentCount.accumulateAndGet(c, (a, b) -> Math.max(a, b));
+                        curDependentThreads.decrementAndGet();
+                        curDependentCount.addAndGet(-numWrites);
+                        writeControl.finishIndependentWrite(numWrites);
+                        break;
+                    }
+                    case DEPENDENT: {
+                        int t = curIndependentThreads.incrementAndGet();
+                        int c = curIndependentCount.addAndGet(numWrites);
+                        maxIndependentThreads.accumulateAndGet(t, (a, b) -> Math.max(a, b));
+                        maxIndependentCount.accumulateAndGet(c, (a, b) -> Math.max(a, b));
+                        curIndependentThreads.decrementAndGet();
+                        curIndependentCount.addAndGet(-numWrites);
+                        writeControl.finishDependentWrite(numWrites);
+                        break;
+                    }
+                    default:
+                        fail("Unknown status: " + status);
+                        break;
+                }
+
+                ++numIter;
+            }
+        }
+    }
+
+//    @Test
+    public void writeControlBenchmark() {
+        int maxThreads = 160;
+        int maxCount   = 32000;
+        SpliceWriteControl writeControl = new AtomicSpliceWriteControl(maxThreads/2, maxThreads/2, maxCount/2, maxCount/2);
+
+        BenchmarkThread[] threads = new BenchmarkThread[200];
+        for (int i = 0; i < threads.length; ++i) {
+            threads[i] = new BenchmarkThread(i, writeControl);
+        }
+        for (BenchmarkThread t : threads) {
+            t.start();
+        }
+
+        try {
+            Thread.sleep(30_000);
+        }
+        catch (InterruptedException ie) {
+            System.out.println("ERROR: Benchmark has been interrupted");
+        }
+
+        done = true;
+        for (BenchmarkThread t : threads) {
+            try {
+                t.join();
+            }
+            catch (InterruptedException ie) {}
+        }
+
+        WriteStatus status = writeControl.getWriteStatus();
+        assertEquals(status.dependentWriteThreads, 0);
+        assertEquals(status.dependentWriteCount, 0);
+        assertEquals(status.independentWriteThreads, 0);
+        assertEquals(status.independentWriteCount, 0);
+
+        long totalSum = 0;
+        long totalMin = Long.MAX_VALUE;
+        long totalMax = 0;
+        long successSum = 0;
+        long successMin = Long.MAX_VALUE;
+        long successMax = 0;
+
+        for (BenchmarkThread t : threads) {
+            totalSum += t.numIter;
+            totalMin = Math.min(totalMin, t.numIter);
+            totalMax = Math.max(totalMax, t.numIter);
+
+            long success = t.numIter - t.rejected;
+            successSum += success;
+            successMin = Math.min(successMin, success);
+            successMax = Math.max(successMax, success);
+        }
+        System.out.println("Dependent maxThreads:   " + writeControl.maxDependendentWriteThreads() + " measured: " + maxDependentThreads.get());
+        System.out.println("Dependent maxCount:     " + writeControl.maxDependentWriteCount() + " measured: " + maxDependentCount.get());
+        System.out.println("Independent maxThreads: " + writeControl.maxIndependentWriteThreads() + " measured: " + maxIndependentThreads.get());
+        System.out.println("Independent maxCount:   " + writeControl.maxIndependentWriteCount() + " measured: " + maxIndependentCount.get());
+        System.out.println("Total requests (min/avg/max):      " + totalMin + " / " + (totalSum + threads.length/2)/threads.length + " / " + totalMax);
+        System.out.println("Successful requests (min/avg/max): " + successMin + " / " + (successSum + threads.length/2)/threads.length + " / " + successMax);
+    }
 }


### PR DESCRIPTION
Use java.util.concurrent.atomic.LongAdder to update individual counters. Don't use WriteStatus as simultaneous updates of two counters don't have to be "transactional": f.e. it's OK to read dependentWriteThreads == 0 and dependentWriteCount != 0.