### PR TITLE
DB-7572 Remove link in standalone install docs (2.5)

### DIFF
--- a/platforms/std/docs/STD-installation.md
+++ b/platforms/std/docs/STD-installation.md
@@ -317,7 +317,7 @@ using it!
 
 3. Install Splice Machine:
 
-   Unpack the tarball `gz` file that you downloaded, for example: <a href="https://s3.amazonaws.com/splice-releases/2.5.0.1815/standalone/SPLICEMACHINE-2.5.0.1815.standalone.tar.gz">https://s3.amazonaws.com/splice-releases/2.5.0.1815/standalone/SPLICEMACHINE-2.5.0.1815.standalone.tar.gz</a>
+   Unpack the tarball `gz` file that you downloaded.
 
    This creates a `splicemachine` subdirectory and installs Splice Machine software in it.
 


### PR DESCRIPTION
Eliminates the need to maintain the link along with stopping people from bypassing our main website download.