### PR TITLE
DB-7566 Broadcast credentials for Spark adapter once per app

### DIFF
--- a/splice_spark/src/main/spark2.2/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
+++ b/splice_spark/src/main/spark2.2/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
@@ -49,6 +49,17 @@ import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
 
 object Holder extends Serializable {
   @transient lazy val log = Logger.getLogger(getClass.getName)
+
+  var broadcastCredentials: Broadcast[SerializableWritable[Credentials]] = null
+
+  def broadcastCreds(credentials: Credentials) : Unit = this.synchronized {
+    if (broadcastCredentials != null)
+      return
+    
+    SpliceSpark.logCredentialsInformation(credentials)
+    broadcastCredentials = SpliceSpark.getContext.broadcast(new SerializableWritable(credentials))
+    SpliceSpark.setCredentials(broadcastCredentials)
+  }
 }
 
 /**
@@ -65,7 +76,6 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
   }
 
   @transient var credentials = UserGroupInformation.getCurrentUser().getCredentials()
-  var broadcastCredentials: Broadcast[SerializableWritable[Credentials]] = null
   JdbcDialects.registerDialect(new SplicemachineDialect)
 
   private[this] def initConnection() = {
@@ -116,8 +126,7 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
 
           // Add it to credentials and broadcast them
           credentials.addToken(getUniqueAlias(token), token)
-          broadcastCreds
-          SpliceSpark.setCredentials(broadcastCredentials)
+          Holder.broadcastCreds(credentials)
 
           Holder.log.debug(f"Broadcasted credentials")
 
@@ -129,11 +138,6 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
       
       initConnection()
     }
-  }
-
-  def broadcastCreds = {
-    SpliceSpark.logCredentialsInformation(credentials)
-    broadcastCredentials = SpliceSpark.getContext.broadcast(new SerializableWritable(credentials))
   }
 
   /**

--- a/splice_spark/src/main/spark2.3/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
+++ b/splice_spark/src/main/spark2.3/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
@@ -49,6 +49,17 @@ import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
 
 object Holder extends Serializable {
   @transient lazy val log = Logger.getLogger(getClass.getName)
+
+  var broadcastCredentials: Broadcast[SerializableWritable[Credentials]] = null
+
+  def broadcastCreds(credentials: Credentials) : Unit = this.synchronized {
+    if (broadcastCredentials != null)
+      return
+
+    SpliceSpark.logCredentialsInformation(credentials)
+    broadcastCredentials = SpliceSpark.getContext.broadcast(new SerializableWritable(credentials))
+    SpliceSpark.setCredentials(broadcastCredentials)
+  }
 }
 
 /**
@@ -65,7 +76,6 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
   }
 
   @transient var credentials = UserGroupInformation.getCurrentUser().getCredentials()
-  var broadcastCredentials: Broadcast[SerializableWritable[Credentials]] = null
   JdbcDialects.registerDialect(new SplicemachineDialect)
 
   private[this] def initConnection() = {
@@ -116,8 +126,7 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
 
           // Add it to credentials and broadcast them
           credentials.addToken(getUniqueAlias(token), token)
-          broadcastCreds
-          SpliceSpark.setCredentials(broadcastCredentials)
+          Holder.broadcastCreds(credentials)
 
           Holder.log.debug(f"Broadcasted credentials")
 
@@ -129,11 +138,6 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
       
       initConnection()
     }
-  }
-
-  def broadcastCreds = {
-    SpliceSpark.logCredentialsInformation(credentials)
-    broadcastCredentials = SpliceSpark.getContext.broadcast(new SerializableWritable(credentials))
   }
 
   /**


### PR DESCRIPTION
This is a new iteration on the same issue, the first PR was https://github.com/splicemachine/spliceengine/pull/2342

In this case I'm only making the broadcastCredentials a singleton, rather than the connection, and that should simplify things considerably