### PR TITLE
DB-7553: Checking in initial working copies of rpm spec files (2.7)

### DIFF
--- a/assembly/mapr6.0.1/build/Makefile
+++ b/assembly/mapr6.0.1/build/Makefile
@@ -1,0 +1,19 @@
+# Comments are allowed
+
+RPMROOT=$(shell pwd)/rpmbuild
+BUILDROOT=$(RPMROOT)/BUILDROOT
+
+all: prep rpm
+
+clean: 
+	rm -rf ${BUILDROOT}
+
+prep:
+	mkdir -p ${RPMROOT}/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+
+rpm: *.spec
+	rpmbuild --buildroot=${BUILDROOT} --target noarch-splicemachine-linux -bb splicemachine-mapr-master.spec
+	rpmbuild --buildroot=$(BUILDROOT) --target noarch-splicemachine-linux -bb splicemachine-mapr-region.spec
+	rpmbuild --buildroot=${BUILDROOT} --target noarch-splicemachine-linux -bb splicemachine-mapr-hbase-conf.spec
+	rpmbuild --buildroot=${BUILDROOT} --target noarch-splicemachine-linux -bb splicemachine-mapr-hbase-bin.spec
+

--- a/assembly/mapr6.0.1/build/sample.spec
+++ b/assembly/mapr6.0.1/build/sample.spec
@@ -1,0 +1,39 @@
+
+#
+# Splice Machine sample spec file
+#
+Summary: Splice Machine binary components for MapR platform
+Name: sample
+Version: 1.0
+Release: 1
+License: GPL
+Group: Applications/Sound
+Source: ftp://ftp.gnomovision.com/pub/cdplayer/cdplayer-1.0.tgz
+URL: http://www.gnomovision.com/cdplayer/cdplayer.html
+Distribution: WSS Linux
+Vendor: Splice Machine, Inc.
+Packager: Murray Brown <mbrown@splicemachine.com>
+
+%description
+Splice Machine's scale-out database is the world
+leader in the OLPP space.
+
+%prep
+# commands to do things to prepare files
+
+%build
+# commands to make binary files from source
+
+%install
+# commands to stage files for rpm
+
+%files
+# ownership listing
+
+%pre
+%post
+%preun
+%postun
+
+%clean
+# remove temp build files 

--- a/assembly/mapr6.0.1/build/splicemachine-mapr-hbase-bin.spec
+++ b/assembly/mapr6.0.1/build/splicemachine-mapr-hbase-bin.spec
@@ -1,0 +1,151 @@
+#
+Summary: Splice Machine HBase binary components for MapR platform
+Name: splicemachine-mapr-hbase-bin
+Version: 2.7.0.1834
+Release: 1
+License: AGPL
+Group: SpliceMachine
+Distribution: Linux
+BuildArch: noarch
+#Source: http://repository.splicemachine.com/some-path-to/file.tgz
+URL: https://doc.splicemachine.com/onprem_install_intro.html
+Vendor: Splice Machine, Inc.
+Packager: Murray Brown <mbrown@splicemachine.com>
+Provides: splicemachine-hbase-binary
+
+%description
+Splice Machine, the only Hadoop RDBMS, is designed to scale real-time applications
+using commodity hardware without application rewrites. The Splice Machine database is a
+modern, scale-out alternative to traditional RDBMSs, such as Oracle®, MySQL™, IBM DB2®
+and Microsoft SQL Server®, that can deliver over a 10x improvement in price/performance.
+As a full-featured SQL-on-Hadoop RDBMS with ACID transactions, the Splice Machine
+database helps customers power real-time applications and operational analytics,
+especially as they approach big data scale.
+
+Splice Machine's scale-out database is the world leader in the OLPP space.
+
+%prep
+# no prep required
+
+%clean
+rm -r %{buildroot}
+
+%build
+mkdir -p %{buildroot}
+
+%install
+mkdir -p -m 755 %{buildroot}/opt/splice/SPLICEMACHINE-%{version}.mapr6.0.1.p1.13
+ln -s /opt/splice/SPLICEMACHINE-%{version}.mapr6.0.1.p1.13/ %{buildroot}/opt/splice/default
+
+mkdir -p -m 755 %{buildroot}/opt/splice/SPLICEMACHINE-%{version}.mapr6.0.1.p1.13/bin/
+install -m 755 %{buildroot}/../../../splice-tarball/bin/sqlshell.sh                             %{buildroot}/opt/splice/SPLICEMACHINE-%{version}.mapr6.0.1.p1.13/bin/
+install -m 755 %{buildroot}/../../../splice-tarball/scripts/start-hbase.sh                      %{buildroot}/opt/splice/SPLICEMACHINE-%{version}.mapr6.0.1.p1.13/bin/ 
+install -m 755 %{buildroot}/../../../splice-tarball/scripts/stop-hbase.sh                       %{buildroot}/opt/splice/SPLICEMACHINE-%{version}.mapr6.0.1.p1.13/bin/
+
+mkdir -p -m 755 %{buildroot}/opt/splice/SPLICEMACHINE-%{version}.mapr6.0.1.p1.13/lib/
+install -m 644 %{buildroot}/../../../splice-tarball/lib/*.jar                                   %{buildroot}/opt/splice/SPLICEMACHINE-%{version}.mapr6.0.1.p1.13/lib/
+
+mkdir -p -m 755 %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/logs/
+mkdir -p -m 755 %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/bin/
+install -m 755 %{buildroot}/../../../hbase-bespoke/bin/hbase                                    %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/bin/
+install -m 755 %{buildroot}/../../../hbase-bespoke/bin/hbase-jruby                              %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/bin/
+install -m 755 %{buildroot}/../../../hbase-bespoke/bin/*.sh                                     %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/bin/
+install -m 755 %{buildroot}/../../../hbase-bespoke/bin/*.rb                                     %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/bin/
+mkdir -p -m 750 %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/master/WEB-INF/
+install -m 640 %{buildroot}/../../../hbase-bespoke/hbase-webapps/master/index.html              %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/master/
+install -m 640 %{buildroot}/../../../hbase-bespoke/hbase-webapps/master/WEB-INF/web.xml         %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/master/WEB-INF/
+mkdir -p -m 750 %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/regionserver/WEB-INF/
+install -m 640 %{buildroot}/../../../hbase-bespoke/hbase-webapps/regionserver/index.html        %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/regionserver/
+install -m 640 %{buildroot}/../../../hbase-bespoke/hbase-webapps/regionserver/WEB-INF/web.xml   %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/regionserver/WEB-INF/
+mkdir -p -m 750 %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/rest/WEB-INF/
+install -m 640 %{buildroot}/../../../hbase-bespoke/hbase-webapps/rest/index.html                %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/rest/
+install -m 640 %{buildroot}/../../../hbase-bespoke/hbase-webapps/rest/WEB-INF/web.xml           %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/rest/WEB-INF/
+mkdir -p -m 750 %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/
+install -m 640 %{buildroot}/../../../hbase-bespoke/hbase-webapps/static/hbase_logo.png          %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/
+install -m 640 %{buildroot}/../../../hbase-bespoke/hbase-webapps/static/hbase_logo_med.gif      %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/
+install -m 640 %{buildroot}/../../../hbase-bespoke/hbase-webapps/static/hbase_logo_small.png    %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/
+install -m 640 %{buildroot}/../../../hbase-bespoke/hbase-webapps/static/jumping-orca_*png       %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/
+mkdir -p -m 750 %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/css/
+install -m 640 %{buildroot}/../../../hbase-bespoke/hbase-webapps/static/css/*.css               %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/css/
+mkdir -p -m 750 %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/fonts/
+install -m 640 %{buildroot}/../../../hbase-bespoke/hbase-webapps/static/fonts/glyphicons*       %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/fonts/
+mkdir -p -m 750 %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/js/
+install -m 640 %{buildroot}/../../../hbase-bespoke/hbase-webapps/static/js/*.js                 %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/js/
+mkdir -p -m 750 %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/thrift/WEB-INF/
+install -m 640 %{buildroot}/../../../hbase-bespoke/hbase-webapps/thrift/index.html              %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/thrift/ 
+install -m 640 %{buildroot}/../../../hbase-bespoke/hbase-webapps/thrift/WEB-INF/web.xml         %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/thrift/WEB-INF/
+mkdir -p -m 755 %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/lib/
+install -m 644 %{buildroot}/../../../hbase-bespoke/lib/*.jar                                    %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/lib/
+ln -s /opt/splice/default/lib/javax.servlet-api-3.1.0.jar                                       %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/lib/servlet-api-2.5-6.1.14.jar
+ln -s /opt/splice/default/lib/javax.servlet-api-3.1.0.jar                                       %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/lib/servlet-api-2.5.jar
+
+%files
+%defattr(-,mapr,mapr)
+%dir /opt/mapr/hbase/hbase-1.1.8-splice/bin
+%dir /opt/mapr/hbase/hbase-1.1.8-splice/lib
+%dir /opt/mapr/hbase/hbase-1.1.8-splice/logs
+
+# re-generate this list by removing it and then capturing the error from rpmbuild
+/opt/mapr/hbase/hbase-1.1.8-splice/bin/*.sh
+/opt/mapr/hbase/hbase-1.1.8-splice/bin/draining_servers.rb
+/opt/mapr/hbase/hbase-1.1.8-splice/bin/get-active-master.rb
+/opt/mapr/hbase/hbase-1.1.8-splice/bin/hbase
+/opt/mapr/hbase/hbase-1.1.8-splice/bin/hbase-jruby
+/opt/mapr/hbase/hbase-1.1.8-splice/bin/hirb.rb
+/opt/mapr/hbase/hbase-1.1.8-splice/bin/region_mover.rb
+/opt/mapr/hbase/hbase-1.1.8-splice/bin/region_status.rb
+/opt/mapr/hbase/hbase-1.1.8-splice/bin/shutdown_regionserver.rb
+/opt/mapr/hbase/hbase-1.1.8-splice/bin/thread-pool.rb
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/master/WEB-INF/web.xml
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/master/index.html
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/regionserver/WEB-INF
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/regionserver/index.html
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/rest/WEB-INF/web.xml
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/rest/index.html
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/css/bootstrap-theme.css
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/css/bootstrap-theme.min.css
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/css/bootstrap.css
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/css/bootstrap.min.css
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/css/hbase.css
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/fonts/glyphicons-halflings-regular.eot
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/fonts/glyphicons-halflings-regular.svg
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/fonts/glyphicons-halflings-regular.ttf
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/fonts/glyphicons-halflings-regular.woff
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/hbase_logo.png
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/hbase_logo_med.gif
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/hbase_logo_small.png
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/js/bootstrap.js
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/js/bootstrap.min.js
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/js/jquery.min.js
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/js/tab.js
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/static/jumping-orca_rotated_12percent.png
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/thrift/WEB-INF/web.xml
+/opt/mapr/hbase/hbase-1.1.8-splice/hbase-webapps/thrift/index.html
+/opt/mapr/hbase/hbase-1.1.8-splice/lib/*.jar
+%dir /opt/mapr/hbase/hbase-1.1.8-splice/logs
+/opt/splice/default
+/opt/splice/SPLICEMACHINE-2.7.0.1834.mapr6.0.1.p1.13/bin/sqlshell.sh
+/opt/splice/SPLICEMACHINE-2.7.0.1834.mapr6.0.1.p1.13/bin/start-hbase.sh
+/opt/splice/SPLICEMACHINE-2.7.0.1834.mapr6.0.1.p1.13/bin/stop-hbase.sh
+/opt/splice/SPLICEMACHINE-2.7.0.1834.mapr6.0.1.p1.13/lib/db-client-2.7.0.1834-SNAPSHOT.jar
+/opt/splice/SPLICEMACHINE-2.7.0.1834.mapr6.0.1.p1.13/lib/db-drda-2.7.0.1834-SNAPSHOT.jar
+/opt/splice/SPLICEMACHINE-2.7.0.1834.mapr6.0.1.p1.13/lib/db-shared-2.7.0.1834-SNAPSHOT.jar
+/opt/splice/SPLICEMACHINE-2.7.0.1834.mapr6.0.1.p1.13/lib/db-tools-i18n-2.7.0.1834-SNAPSHOT.jar
+/opt/splice/SPLICEMACHINE-2.7.0.1834.mapr6.0.1.p1.13/lib/db-tools-ij-2.7.0.1834-SNAPSHOT.jar
+/opt/splice/SPLICEMACHINE-2.7.0.1834.mapr6.0.1.p1.13/lib/javax.servlet-api-3.1.0.jar
+/opt/splice/SPLICEMACHINE-2.7.0.1834.mapr6.0.1.p1.13/lib/javax.ws.rs-api-2.0.1.jar
+/opt/splice/SPLICEMACHINE-2.7.0.1834.mapr6.0.1.p1.13/lib/jython-standalone-2.5.3.jar
+/opt/splice/SPLICEMACHINE-2.7.0.1834.mapr6.0.1.p1.13/lib/splice_machine-assembly-uber.jar
+/opt/splice/SPLICEMACHINE-2.7.0.1834.mapr6.0.1.p1.13/lib/splice_machine-assembly-yarn-webproxy.jar
+
+%pre
+%post
+%preun
+%postun
+
+%changelog
+* Sat Oct 20 2018 Murray Brown<mbrown@splicemachine.com
+ - Working build scripts
+
+* Thu Oct 11 2018 Murray Brown<mbrown@splicemachine.com>
+ - Initial package attempt

--- a/assembly/mapr6.0.1/build/splicemachine-mapr-hbase-conf.spec
+++ b/assembly/mapr6.0.1/build/splicemachine-mapr-hbase-conf.spec
@@ -1,0 +1,63 @@
+
+Summary: Splice Machine HBase configuration files for MapR platform
+Name: splicemachine-mapr-hbase-conf
+Version: 2.7.0.1834
+Release: 1
+License: AGPL
+Group: SpliceMachine
+Distribution: Linux
+BuildArch: noarch
+#Source: http://repository.splicemachine.com/some-path-to/file.tgz
+URL: https://doc.splicemachine.com/onprem_install_intro.html
+Vendor: Splice Machine, Inc.
+Packager: Murray Brown <mbrown@splicemachine.com>
+Provides: splicemachine-hbase-config
+Requires: splicemachine-hbase-binary
+
+%description
+Splice Machine, the only Hadoop RDBMS, is designed to scale real-time applications
+using commodity hardware without application rewrites. The Splice Machine database is a
+modern, scale-out alternative to traditional RDBMSs, such as Oracle®, MySQL™, IBM DB2®
+and Microsoft SQL Server®, that can deliver over a 10x improvement in price/performance.
+As a full-featured SQL-on-Hadoop RDBMS with ACID transactions, the Splice Machine
+database helps customers power real-time applications and operational analytics,
+especially as they approach big data scale.
+
+Splice Machine's scale-out database is the world leader in the OLPP space.
+
+%prep
+# no prep required
+
+%clean
+rm -r %{buildroot}
+
+%build
+mkdir -p %{buildroot}
+
+%install
+mkdir -p %{buildroot}/opt/mapr/conf
+# /opt/mapr/conf/mapr-splice-hbase-config.sh
+install -m 755 %{buildroot}/../../../templates/mapr-splice-hbase-config.sh   %{buildroot}/opt/mapr/conf/
+mkdir -p %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/bin
+install -m 755 %{buildroot}/../../../templates/hbase-daemon.sh               %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/bin/
+mkdir -p %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/conf
+install -m 644 %{buildroot}/../../../templates/hbase-site.xml                %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/conf/
+install -m 744 %{buildroot}/../../../templates/hbase-env.sh                  %{buildroot}/opt/mapr/hbase/hbase-1.1.8-splice/conf/
+
+%files
+%config %attr(-, mapr, mapr) /opt/mapr/conf/mapr-splice-hbase-config.sh
+%config %attr(-, mapr, mapr) /opt/mapr/hbase/hbase-1.1.8-splice/bin/hbase-daemon.sh
+%config %attr(-, mapr, mapr) /opt/mapr/hbase/hbase-1.1.8-splice/conf/hbase-site.xml
+%config %attr(-, mapr, mapr) /opt/mapr/hbase/hbase-1.1.8-splice/conf/hbase-env.sh
+
+%pre
+%post
+%preun
+%postun
+
+%changelog
+* Sat Oct 20 2018 Murray Brown<mbrown@splicemachine.com
+ - Working build scripts
+
+* Thu Oct 11 2018 Murray Brown<mbrown@splicemachine.com>
+ - Initial package attempt

--- a/assembly/mapr6.0.1/build/splicemachine-mapr-master.spec
+++ b/assembly/mapr6.0.1/build/splicemachine-mapr-master.spec
@@ -1,0 +1,57 @@
+
+Summary: Splice Machine binary components for MapR platform
+Name: splicemachine-mapr-master
+Version: 2.7.0.1834
+Release: 1
+License: AGPL
+Group: SpliceMachine
+Distribution: Linux
+BuildArch: noarch
+#Source: http://repository.splicemachine.com/some-path-to/file.tgz
+URL: https://doc.splicemachine.com/onprem_install_intro.html
+Vendor: Splice Machine, Inc.
+Packager: Murray Brown <mbrown@splicemachine.com>
+Provides: splicemachine-master-script
+Requires: splicemachine-hbase-binary
+
+%description
+Splice Machine, the only Hadoop RDBMS, is designed to scale real-time applications
+using commodity hardware without application rewrites. The Splice Machine database is a
+modern, scale-out alternative to traditional RDBMSs, such as Oracle®, MySQL™, IBM DB2®
+and Microsoft SQL Server®, that can deliver over a 10x improvement in price/performance.
+As a full-featured SQL-on-Hadoop RDBMS with ACID transactions, the Splice Machine
+database helps customers power real-time applications and operational analytics,
+especially as they approach big data scale.
+
+Splice Machine's scale-out database is the world leader in the OLPP space.
+
+#%prep
+## no prep required
+
+%clean
+rm -r %{buildroot}
+
+%build
+mkdir -p %{buildroot}
+
+%install
+# commands to stage files for rpm
+mkdir -p %{buildroot}/etc/rc.d/init.d/
+install -m 755 %{buildroot}/../../../templates/splice-init-script %{buildroot}/etc/rc.d/init.d/splice-masterserver
+
+%files
+%attr(-, root, root) /etc/rc.d/init.d/splice-masterserver
+
+%pre
+%post
+chkconfig --add splice-masterserver
+
+%preun
+%postun
+
+%changelog
+* Sat Oct 20 2018 Murray Brown<mbrown@splicemachine.com
+ - Working build scripts
+
+* Thu Oct 11 2018 Murray Brown<mbrown@splicemachine.com>
+ - Initial package attempt

--- a/assembly/mapr6.0.1/build/splicemachine-mapr-region.spec
+++ b/assembly/mapr6.0.1/build/splicemachine-mapr-region.spec
@@ -1,0 +1,57 @@
+
+Summary: Splice Machine binary components for MapR platform
+Name: splicemachine-mapr-region
+Version: 2.7.0.1834
+Release: 1
+License: AGPL
+Group: SpliceMachine
+Distribution: Linux
+BuildArch: noarch
+#Source: http://repository.splicemachine.com/some-path-to/file.tgz
+URL: https://doc.splicemachine.com/onprem_install_intro.html
+Vendor: Splice Machine, Inc.
+Packager: Murray Brown <mbrown@splicemachine.com>
+Provides: splicemachine-region-script
+Requires: splicemachine-hbase-binary
+
+%description
+Splice Machine, the only Hadoop RDBMS, is designed to scale real-time applications
+using commodity hardware without application rewrites. The Splice Machine database is a
+modern, scale-out alternative to traditional RDBMSs, such as Oracle®, MySQL™, IBM DB2®
+and Microsoft SQL Server®, that can deliver over a 10x improvement in price/performance.
+As a full-featured SQL-on-Hadoop RDBMS with ACID transactions, the Splice Machine
+database helps customers power real-time applications and operational analytics,
+especially as they approach big data scale.
+
+Splice Machine's scale-out database is the world leader in the OLPP space.
+
+%prep
+# no prep required
+
+%clean
+rm -r %{buildroot}
+
+%build
+mkdir -p %{buildroot}
+
+%install
+# commands to stage files for rpm
+mkdir -p %{buildroot}/etc/rc.d/init.d/
+install -m 755 %{buildroot}/../../../templates/splice-init-script %{buildroot}/etc/rc.d/init.d/splice-regionserver
+
+%files
+%attr(-, root, root) /etc/rc.d/init.d/splice-regionserver
+
+%pre
+%post
+chkconfig --add splice-regionserver
+
+%preun
+%postun
+
+%changelog
+* Sat Oct 20 2018 Murray Brown<mbrown@splicemachine.com
+ - Working build scripts
+
+* Thu Oct 11 2018 Murray Brown<mbrown@splicemachine.com>
+ - Initial package attempt

--- a/assembly/mapr6.0.1/templates/hbase-daemon.sh
+++ b/assembly/mapr6.0.1/templates/hbase-daemon.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+#
+#/**
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+# 
+# Runs a Hadoop hbase command as a daemon.
+#
+# Environment Variables
+#
+#   HBASE_CONF_DIR   Alternate hbase conf dir. Default is ${HBASE_HOME}/conf.
+#   HBASE_LOG_DIR    Where log files are stored.  PWD by default.
+#   HBASE_PID_DIR    The pid files are stored. /tmp by default.
+#   HBASE_IDENT_STRING   A string representing this instance of hadoop. $USER by default
+#   HBASE_NICENESS The scheduling priority for daemons. Defaults to 0.
+#   HBASE_STOP_TIMEOUT  Time, in seconds, after which we kill -9 the server if it has not stopped.
+#                        Default 1200 seconds.
+#
+# Modelled after $HADOOP_HOME/bin/hadoop-daemon.sh
+
+usage="Usage: hbase-daemon.sh [--config <conf-dir>]\
+ (start|stop|restart|status|autorestart|foreground_start) <hbase-command> \
+ <args...>"
+
+# if no args specified, show usage
+if [ $# -le 1 ]; then
+  echo $usage
+  exit 1
+fi
+
+bin=`dirname "${BASH_SOURCE-$0}"`
+bin=`cd "$bin">/dev/null; pwd`
+
+. "$bin"/hbase-config.sh
+. "$bin"/hbase-common.sh
+
+# get arguments
+startStop=$1
+shift
+
+command=$1
+shift
+
+hbase_rotate_log ()
+{
+    log=$1;
+    num=5;
+    if [ -n "$2" ]; then
+    num=$2
+    fi
+    if [ -f "$log" ]; then # rotate logs
+    while [ $num -gt 1 ]; do
+        prev=`expr $num - 1`
+        [ -f "$log.$prev" ] && mv -f "$log.$prev" "$log.$num"
+        num=$prev
+    done
+    mv -f "$log" "$log.$num";
+    fi
+}
+
+cleanAfterRun() {
+  if [ -f ${HBASE_PID} ]; then
+    # If the process is still running time to tear it down.
+    kill -9 `cat ${HBASE_PID}` > /dev/null 2>&1
+    rm -f ${HBASE_PID} > /dev/null 2>&1
+  fi
+
+  if [ -f ${HBASE_ZNODE_FILE} ]; then
+    if [ "$command" = "master" ]; then
+      HBASE_OPTS="$HBASE_OPTS $HBASE_MASTER_OPTS" $bin/hbase master clear > /dev/null 2>&1
+    else
+      #call ZK to delete the node
+      ZNODE=`cat ${HBASE_ZNODE_FILE}`
+      HBASE_OPTS="$HBASE_OPTS $HBASE_REGIONSERVER_OPTS" $bin/hbase zkcli delete ${ZNODE} > /dev/null 2>&1
+    fi
+    rm ${HBASE_ZNODE_FILE}
+  fi
+}
+
+check_before_start(){
+    #ckeck if the process is not running
+    mkdir -p "$HBASE_PID_DIR"
+    if [ -f $HBASE_PID ]; then
+      if kill -0 `cat $HBASE_PID` > /dev/null 2>&1; then
+        echo $command running as process `cat $HBASE_PID`.  Stop it first.
+        exit 1
+      fi
+    fi
+}
+
+wait_until_done ()
+{
+    p=$1
+    cnt=${HBASE_SLAVE_TIMEOUT:-300}
+    origcnt=$cnt
+    while kill -0 $p > /dev/null 2>&1; do
+      if [ $cnt -gt 1 ]; then
+        cnt=`expr $cnt - 1`
+        sleep 1
+      else
+        echo "Process did not complete after $origcnt seconds, killing."
+        kill -9 $p
+        exit 1
+      fi
+    done
+    return 0
+}
+
+wait_for_filesystem()
+{
+    # Wait for filesystem to initialize
+    i=0
+    while [ $i -lt 600 ]; do
+      if [ `expr $i % 60` = "0" ]; then
+        # Log message for every 60 seconds
+        echo "`date` Waiting for filesystem to come up"  >> $HBASE_LOGLOG 2>&1
+      fi
+      hadoop fs -stat "/" >/dev/null 2>&1
+      if [ $? -eq 0 ] ; then
+       i=9999
+       break
+      fi
+
+      sleep 3
+      i=$[i+3]
+    done
+
+    if [ $i -ne 9999 ] ; then
+      echo "`date` Giving up after 600 attempts"  >> $HBASE_LOGLOG 2>&1
+      exit 1
+    fi
+
+    # Create Hbase volume and set compression off
+    hbaseVolume=${HBASE_VOLUME:-splice.hbase}
+    mountDir=$(grep "maprfs://" "${HBASE_CONF_DIR}"/hbase-site.xml | sed "s/^.*maprfs:\/\///" | sed "s/<\/.*$//")
+    maprcli volume info -name "${hbaseVolume}" > /dev/null 2>&1
+    if [ $? -eq 0 ] ; then
+      echo "`date` HBase root is on volume '${hbaseVolume}'."  >> $HBASE_LOGLOG 2>&1
+    else
+      echo "`date` HBase volume '${hbaseVolume}' not found, creating."  >> $HBASE_LOGLOG 2>&1
+      maprcli volume create -name "${hbaseVolume}" -path "${mountDir}" -replicationtype low_latency >> $HBASE_LOGLOG 2>&1
+    fi
+
+    # set 64M chunksize and turn off compression
+    hadoop mfs -setcompression off "${mountDir}" >> $HBASE_LOGLOG 2>&1
+    hadoop mfs -setchunksize 67108864 "${mountDir}" >> $HBASE_LOGLOG 2>&1
+}
+
+# get log directory
+if [ "$HBASE_LOG_DIR" = "" ]; then
+  export HBASE_LOG_DIR="$HBASE_HOME/logs"
+fi
+mkdir -p "$HBASE_LOG_DIR"
+
+if [ "$HBASE_PID_DIR" = "" ]; then
+  HBASE_PID_DIR=/tmp
+fi
+
+if [ "$HBASE_IDENT_STRING" = "" ]; then
+  export HBASE_IDENT_STRING="$USER"
+fi
+
+# Some variables
+# Work out java location so can print version into log.
+if [ "$JAVA_HOME" != "" ]; then
+  #echo "run java in $JAVA_HOME"
+  JAVA_HOME=$JAVA_HOME
+fi
+if [ "$JAVA_HOME" = "" ]; then
+  echo "Error: JAVA_HOME is not set."
+  exit 1
+fi
+
+JAVA=$JAVA_HOME/bin/java
+export HBASE_LOG_PREFIX=hbase-$HBASE_IDENT_STRING-$command-$HOSTNAME
+export HBASE_LOGFILE=$HBASE_LOG_PREFIX.log
+
+if [ -z "${HBASE_ROOT_LOGGER}" ]; then
+export HBASE_ROOT_LOGGER=${HBASE_ROOT_LOGGER:-"INFO,RFA"}
+fi
+
+if [ -z "${HBASE_SECURITY_LOGGER}" ]; then 
+export HBASE_SECURITY_LOGGER=${HBASE_SECURITY_LOGGER:-"INFO,RFAS"}
+fi
+
+HBASE_LOGOUT=${HBASE_LOGOUT:-"$HBASE_LOG_DIR/$HBASE_LOG_PREFIX.out"}
+HBASE_LOGGC=${HBASE_LOGGC:-"$HBASE_LOG_DIR/$HBASE_LOG_PREFIX.gc"}
+HBASE_LOGLOG=${HBASE_LOGLOG:-"${HBASE_LOG_DIR}/${HBASE_LOGFILE}"}
+HBASE_PID=$HBASE_PID_DIR/hbase-$HBASE_IDENT_STRING-$command.pid
+export HBASE_ZNODE_FILE=$HBASE_PID_DIR/hbase-$HBASE_IDENT_STRING-$command.znode
+export HBASE_START_FILE=$HBASE_PID_DIR/hbase-$HBASE_IDENT_STRING-$command.autorestart
+
+if [ -n "$SERVER_GC_OPTS" ]; then
+  export SERVER_GC_OPTS=${SERVER_GC_OPTS/"-Xloggc:<FILE-PATH>"/"-Xloggc:${HBASE_LOGGC}"}
+fi
+if [ -n "$CLIENT_GC_OPTS" ]; then
+  export CLIENT_GC_OPTS=${CLIENT_GC_OPTS/"-Xloggc:<FILE-PATH>"/"-Xloggc:${HBASE_LOGGC}"}
+fi
+
+# Set default scheduling priority
+if [ "$HBASE_NICENESS" = "" ]; then
+    export HBASE_NICENESS=0
+fi
+
+thiscmd="$bin/$(basename ${BASH_SOURCE-$0})"
+args=$@
+
+case $startStop in
+
+(start)
+    check_before_start
+    hbase_rotate_log $HBASE_LOGOUT
+    hbase_rotate_log $HBASE_LOGGC
+    echo starting $command, logging to $HBASE_LOGOUT
+    wait_for_filesystem
+    nohup $thiscmd --config "${HBASE_CONF_DIR}" \
+        foreground_start $command $args < /dev/null > ${HBASE_LOGOUT} 2>&1  &
+    sleep 1; head "${HBASE_LOGOUT}"
+  ;;
+
+(autorestart)
+    check_before_start
+    hbase_rotate_log $HBASE_LOGOUT
+    hbase_rotate_log $HBASE_LOGGC
+    nohup $thiscmd --config "${HBASE_CONF_DIR}" \
+        internal_autorestart $command $args < /dev/null > ${HBASE_LOGOUT} 2>&1  &
+  ;;
+
+(foreground_start)
+    # Add to the command log file vital stats on our environment.
+    echo "`date` Starting $command on `hostname`" >> ${HBASE_LOGLOG}
+    echo "`ulimit -a`" >> "$HBASE_LOGLOG" 2>&1
+    # in case the parent shell gets the kill make sure to trap signals.
+    # Only one will get called. Either the trap or the flow will go through.
+    trap cleanAfterRun SIGHUP SIGINT SIGTERM EXIT
+    nice -n $HBASE_NICENESS "$HBASE_HOME"/bin/hbase \
+        --config "${HBASE_CONF_DIR}" \
+        $command "$@" start >> ${HBASE_LOGOUT} 2>&1 &
+    hbase_pid=$!
+    echo $hbase_pid > ${HBASE_PID}
+    wait $hbase_pid
+  ;;
+
+(internal_autorestart)
+    touch "$HBASE_START_FILE"
+    #keep starting the command until asked to stop. Reloop on software crash
+    while true
+      do
+        lastLaunchDate=`date +%s`
+        $thiscmd --config "${HBASE_CONF_DIR}" foreground_start $command $args
+
+        #if the file does not exist it means that it was not stopped properly by the stop command
+        if [ ! -f "$HBASE_START_FILE" ]; then
+          exit 1
+        fi
+
+        #if the cluster is being stopped then do not restart it again.
+        zparent=`$bin/hbase org.apache.hadoop.hbase.util.HBaseConfTool zookeeper.znode.parent`
+        if [ "$zparent" == "null" ]; then zparent="/hbase"; fi
+        zkrunning=`$bin/hbase org.apache.hadoop.hbase.util.HBaseConfTool zookeeper.znode.state`
+        if [ "$zkrunning" == "null" ]; then zkrunning="running"; fi
+        zkFullRunning=$zparent/$zkrunning
+        $bin/hbase zkcli stat $zkFullRunning 2>&1 | grep "Node does not exist"  1>/dev/null 2>&1
+        #grep returns 0 if it found something, 1 otherwise
+        if [ $? -eq 0 ]; then
+          exit 1
+        fi
+
+        #If ZooKeeper cannot be found, then do not restart
+        $bin/hbase zkcli stat $zkFullRunning 2>&1 | grep Exception | grep ConnectionLoss  1>/dev/null 2>&1
+        if [ $? -eq 0 ]; then
+          exit 1
+        fi
+
+        #if it was launched less than 5 minutes ago, then wait for 5 minutes before starting it again.
+        curDate=`date +%s`
+        limitDate=`expr $lastLaunchDate + 300`
+        if [ $limitDate -gt $curDate ]; then
+          sleep 300
+        fi
+      done
+    ;;
+
+(stop)
+    rm -f "$HBASE_START_FILE"
+    if [ -f $HBASE_PID ]; then
+      pidToKill=`cat $HBASE_PID`
+      # kill -0 == see if the PID exists
+      if kill -0 $pidToKill > /dev/null 2>&1; then
+        echo -n stopping $command
+        echo "`date` Terminating $command" >> $HBASE_LOGLOG
+        kill $pidToKill > /dev/null 2>&1
+        waitForProcessEnd $pidToKill $command
+      else
+        retval=$?
+        echo no $command to stop because kill -0 of pid $pidToKill failed with status $retval
+      fi
+    else
+      echo no $command to stop because no pid file $HBASE_PID
+    fi
+    rm -f $HBASE_PID
+  ;;
+
+(status)
+    if [ -f "$HBASE_PID" ]; then
+      if kill -0 `cat $HBASE_PID` > /dev/null 2>&1; then
+        echo $command running as process `cat $HBASE_PID`.
+        exit 0
+      fi
+        echo $HBASE_PID exists with pid `cat $HBASE_PID` but no $command.
+        exit 1
+    fi
+    echo $command not running.
+    exit 1
+  ;;
+
+(restart)
+    # stop the command
+    $thiscmd --config "${HBASE_CONF_DIR}" stop $command $args &
+    wait_until_done $!
+    # wait a user-specified sleep period
+    sp=${HBASE_RESTART_SLEEP:-3}
+    if [ $sp -gt 0 ]; then
+      sleep $sp
+    fi
+    # start the command
+    $thiscmd --config "${HBASE_CONF_DIR}" start $command $args &
+    wait_until_done $!
+  ;;
+
+(*)
+  echo $usage
+  exit 1
+  ;;
+esac
+

--- a/assembly/mapr6.0.1/templates/hbase-env.sh
+++ b/assembly/mapr6.0.1/templates/hbase-env.sh
@@ -30,8 +30,9 @@
 # export HBASE_CLASSPATH=
 
 SPLICELIBDIR="/opt/splice/default/lib"
-APPENDSTRING=`echo $SPLICELIBDIR/*.jar | sed 's/ /:/g'`
-export HBASE_CLASSPATH="$HBASE_CLASSPATH:$APPENDSTRING"
+HADOOPTOOLSDIR="/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/tools/lib"
+PREPENDSTRING="$SPLICELIBDIR/*:$HADOOPTOOLSDIR"
+export HBASE_CLASSPATH="${PREPENDSTRING}:${HBASE_CLASSPATH}"
 
 # The maximum amount of heap to use. Default is left to JVM default.
 # export HBASE_HEAPSIZE=1G

--- a/assembly/mapr6.0.1/templates/hbase-env.sh
+++ b/assembly/mapr6.0.1/templates/hbase-env.sh
@@ -1,0 +1,233 @@
+#
+#/**
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+
+# Set environment variables here.
+
+# This script sets variables multiple times over the course of starting an hbase process,
+# so try to keep things idempotent unless you want to take an even deeper look
+# into the startup scripts (bin/hbase, etc.)
+
+# The java implementation to use.  Java 1.7+ required.
+# export JAVA_HOME=/usr/java/jdk1.6.0/
+
+# Extra Java CLASSPATH elements.  Optional.
+# export HBASE_CLASSPATH=
+
+SPLICELIBDIR="/opt/splice/default/lib"
+APPENDSTRING=`echo $SPLICELIBDIR/*.jar | sed 's/ /:/g'`
+export HBASE_CLASSPATH="$HBASE_CLASSPATH:$APPENDSTRING"
+
+# The maximum amount of heap to use. Default is left to JVM default.
+# export HBASE_HEAPSIZE=1G
+
+# Uncomment below if you intend to use off heap cache. For example, to allocate 8G of 
+# offheap, set the value to "8G".
+# export HBASE_OFFHEAPSIZE=1G
+
+# FOR Splice Machine
+# build these out in a clear manner
+
+### Java Configuration Options for HBase Master
+SPLICE_HBASE_MASTER_OPTS=""
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -XX:+HeapDumpOnOutOfMemoryError"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -XX:MaxDirectMemorySize=2g"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -XX:+AlwaysPreTouch"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -XX:+UseParNewGC"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -XX:+UseConcMarkSweepGC"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -XX:CMSInitiatingOccupancyFraction=70"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -XX:+CMSParallelRemarkEnabled"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dcom.sun.management.jmxremote.ssl=false"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dcom.sun.management.jmxremote.port=10101"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.enabled=true"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.yarn.appMasterEnv.HADOOP_USER=mapr"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.yarn.appMasterEnv.HBASE_USER=mapr"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.yarn.user=mapr"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.app.name=SpliceMachine"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.master=yarn-client"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.logConf=true"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.driver.maxResultSize=1g"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.driver.memory=1g"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.dynamicAllocation.enabled=true"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.dynamicAllocation.executorIdleTimeout=600"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.dynamicAllocation.minExecutors=0"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.io.compression.lz4.blockSize=32k"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.kryo.referenceTracking=false"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.kryo.registrator=com.splicemachine.derby.impl.SpliceSparkKryoRegistrator"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.kryoserializer.buffer.max=512m"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.kryoserializer.buffer=4m"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.locality.wait=100"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.scheduler.mode=FAIR"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.serializer=org.apache.spark.serializer.KryoSerializer"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.shuffle.compress=false"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.shuffle.file.buffer=128k"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.shuffle.memoryFraction=0.7"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.shuffle.service.enabled=true"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.storage.memoryFraction=0.1"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.yarn.am.extraLibraryPath=/opt/mapr/hadoop/hadoop-2.7.0/lib/native"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.yarn.am.waitTime=10s"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.yarn.executor.memoryOverhead=2048"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.driver.extraJavaOptions=-Dlog4j.configuration=file:/etc/spark/conf/log4j.properties"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.driver.extraLibraryPath=/opt/mapr/hadoop/hadoop-2.7.0/lib/native"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.driver.extraClassPath=/opt/mapr/hbase/hbase-1.1.8-splice/conf:/opt/mapr/hbase/hbase-1.1.8-splice/lib/*:/opt/splice/default/lib/*"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.executor.extraJavaOptions=-Dlog4j.configuration=file:/etc/spark/conf/log4j.properties"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.executor.extraLibraryPath=/opt/mapr/hadoop/hadoop-2.7.0/lib/native"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.executor.extraClassPath=/opt/mapr/hbase/hbase-1.1.8-splice/conf:/opt/mapr/hbase/hbase-1.1.8-splice/lib/*:/opt/splice/default/lib/*"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.ui.retainedJobs=100"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.ui.retainedStages=100"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.worker.ui.retainedExecutors=100"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.worker.ui.retainedDrivers=100"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.streaming.ui.retainedBatches=100"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.executor.cores=4"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.executor.memory=8g"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dspark.compaction.reserved.slots=4"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.eventLog.enabled=true"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.eventLog.dir=maprfs:///user/splice/history" # this needs to be created before startup
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.dynamicAllocation.maxExecutors=11" # this is installation specific
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.local.dir=/tmp"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.authenticate=false"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.authenticate.enableSaslEncryption=false"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.ssl.akka.enabled=false"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.ssl.fs.enabled=false"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.ssl.keyPassword=mapr123"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.ssl.keyStore=/opt/mapr/conf/ssl_keystore"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.ssl.keyStorePassword=mapr123"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.ssl.trustStore=/opt/mapr/conf/ssl_truststore"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.ssl.trustStorePassword=mapr123"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.ssl.protocol=TLSv1.2"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.ssl.enabledAlgorithms=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.yarn.jars=${SPLICELIBDIR}/*"
+# SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -enableassertions"
+
+### Java Configuration Options for HBase RegionServer
+SPLICE_HBASE_REGIONSERVER_OPTS=""
+SPLICE_HBASE_REGIONSERVER_OPTS="$SPLICE_HBASE_REGIONSERVER_OPTS -XX:+HeapDumpOnOutOfMemoryError"
+SPLICE_HBASE_REGIONSERVER_OPTS="$SPLICE_HBASE_REGIONSERVER_OPTS -XX:MaxDirectMemorySize=2g"
+SPLICE_HBASE_REGIONSERVER_OPTS="$SPLICE_HBASE_REGIONSERVER_OPTS -XX:+AlwaysPreTouch"
+SPLICE_HBASE_REGIONSERVER_OPTS="$SPLICE_HBASE_REGIONSERVER_OPTS -XX:+UseG1GC"
+SPLICE_HBASE_REGIONSERVER_OPTS="$SPLICE_HBASE_REGIONSERVER_OPTS -XX:MaxNewSize=4g"
+SPLICE_HBASE_REGIONSERVER_OPTS="$SPLICE_HBASE_REGIONSERVER_OPTS -XX:InitiatingHeapOccupancyPercent=60"
+SPLICE_HBASE_REGIONSERVER_OPTS="$SPLICE_HBASE_REGIONSERVER_OPTS -XX:ParallelGCThreads=24"
+SPLICE_HBASE_REGIONSERVER_OPTS="$SPLICE_HBASE_REGIONSERVER_OPTS -XX:+ParallelRefProcEnabled"
+SPLICE_HBASE_REGIONSERVER_OPTS="$SPLICE_HBASE_REGIONSERVER_OPTS -XX:MaxGCPauseMillis=5000"
+SPLICE_HBASE_REGIONSERVER_OPTS="$SPLICE_HBASE_REGIONSERVER_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
+SPLICE_HBASE_REGIONSERVER_OPTS="$SPLICE_HBASE_REGIONSERVER_OPTS -Dcom.sun.management.jmxremote.ssl=false"
+SPLICE_HBASE_REGIONSERVER_OPTS="$SPLICE_HBASE_REGIONSERVER_OPTS -Dcom.sun.management.jmxremote.port=10102"
+# SPLICE_HBASE_REGIONSERVER_OPTS="$SPLICE_HBASE_REGIONSERVER_OPTS -enableassertions"
+# SPLICE_HBASE_REGIONSERVER_OPTS="$SPLICE_HBASE_REGIONSERVER_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=4000"
+
+# the $HBASE_OPTS are commented out in favor of $SPLICE_HBASE_MASTER_OPTS to avoid
+# conflict between G1GC for the RegionServer and CMS + ParNew for the Master
+
+# Extra Java runtime options.
+# Below are what we set by default.  May only work with SUN JVM.
+# For more on why as well as other possible settings,
+# see http://wiki.apache.org/hadoop/PerformanceTuning
+# export HBASE_OPTS="-XX:+UseConcMarkSweepGC"
+# and http://www.scribd.com/doc/37127094/GCTuningPresentationFISL10
+# export HBASE_OPTS="$HBASE_OPTS -XX:+UseParNewGC -XX:NewRatio=16 -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSInitiatingOccupancyOnly -XX:MaxGCPauseMillis=100"
+
+# the $HBASE_{MASTER,REGIONSERVER}_OPTS are commented out in favor of $SPLICE_HBASE_{MASTER,REGIONSERVER}_OPTS
+# Configure PermSize. Only needed in JDK7. You can safely remove it for JDK8+
+# export HBASE_MASTER_OPTS="$HBASE_MASTER_OPTS -XX:PermSize=128m -XX:MaxPermSize=128m"
+# export HBASE_REGIONSERVER_OPTS="$HBASE_REGIONSERVER_OPTS -XX:PermSize=128m -XX:MaxPermSize=128m"
+
+# Uncomment one of the below three options to enable java garbage collection logging for the server-side processes.
+
+# This enables basic gc logging to the .out file.
+# export SERVER_GC_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps"
+
+# This enables basic gc logging to its own file.
+# If FILE-PATH is not replaced, the log file(.gc) would still be generated in the HBASE_LOG_DIR .
+# export SERVER_GC_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:<FILE-PATH>"
+
+# This enables basic GC logging to its own file with automatic log rolling. Only applies to jdk 1.6.0_34+ and 1.7.0_2+.
+# If FILE-PATH is not replaced, the log file(.gc) would still be generated in the HBASE_LOG_DIR .
+# export SERVER_GC_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:<FILE-PATH> -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=1 -XX:GCLogFileSize=512M"
+
+# Uncomment one of the below three options to enable java garbage collection logging for the client processes.
+
+# This enables basic gc logging to the .out file.
+# export CLIENT_GC_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps"
+
+# This enables basic gc logging to its own file.
+# If FILE-PATH is not replaced, the log file(.gc) would still be generated in the HBASE_LOG_DIR .
+# export CLIENT_GC_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:<FILE-PATH>"
+
+# This enables basic GC logging to its own file with automatic log rolling. Only applies to jdk 1.6.0_34+ and 1.7.0_2+.
+# If FILE-PATH is not replaced, the log file(.gc) would still be generated in the HBASE_LOG_DIR .
+# export CLIENT_GC_OPTS="-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:<FILE-PATH> -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=1 -XX:GCLogFileSize=512M"
+
+# See the package documentation for org.apache.hadoop.hbase.io.hfile for other configurations
+# needed setting up off-heap block caching. 
+
+# Uncomment and adjust to enable JMX exporting
+# See jmxremote.password and jmxremote.access in $JRE_HOME/lib/management to configure remote password access.
+# More details at: http://java.sun.com/javase/6/docs/technotes/guides/management/agent.html
+# NOTE: HBase provides an alternative JMX implementation to fix the random ports issue, please see JMX
+# section in HBase Reference Guide for instructions.
+
+export HBASE_JMX_BASE="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+export HBASE_MASTER_OPTS="$HBASE_MASTER_OPTS $HBASE_JMX_BASE $SPLICE_HBASE_MASTER_OPTS -Dcom.sun.management.jmxremote.port=10101"
+export HBASE_REGIONSERVER_OPTS="$HBASE_REGIONSERVER_OPTS $HBASE_JMX_BASE $SPLICE_HBASE_REGIONSERVER_OPTS -Dcom.sun.management.jmxremote.port=10102"
+# export HBASE_THRIFT_OPTS="$HBASE_THRIFT_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10103"
+export HBASE_ZOOKEEPER_OPTS="$HBASE_ZOOKEEPER_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10104"
+# export HBASE_REST_OPTS="$HBASE_REST_OPTS $HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10105"
+
+# File naming hosts on which HRegionServers will run.  $HBASE_HOME/conf/regionservers by default.
+# export HBASE_REGIONSERVERS=${HBASE_HOME}/conf/regionservers
+
+# Uncomment and adjust to keep all the Region Server pages mapped to be memory resident
+#HBASE_REGIONSERVER_MLOCK=true
+#HBASE_REGIONSERVER_UID="hbase"
+
+# File naming hosts on which backup HMaster will run.  $HBASE_HOME/conf/backup-masters by default.
+# export HBASE_BACKUP_MASTERS=${HBASE_HOME}/conf/backup-masters
+
+# Extra ssh options.  Empty by default.
+# export HBASE_SSH_OPTS="-o ConnectTimeout=1 -o SendEnv=HBASE_CONF_DIR"
+
+# Where log files are stored.  $HBASE_HOME/logs by default.
+# export HBASE_LOG_DIR=${HBASE_HOME}/logs
+
+# Enable remote JDWP debugging of major HBase processes. Meant for Core Developers 
+# export HBASE_MASTER_OPTS="$HBASE_MASTER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8070"
+# export HBASE_REGIONSERVER_OPTS="$HBASE_REGIONSERVER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8071"
+# export HBASE_THRIFT_OPTS="$HBASE_THRIFT_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8072"
+# export HBASE_ZOOKEEPER_OPTS="$HBASE_ZOOKEEPER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8073"
+
+# A string representing this instance of hbase. $USER by default.
+# export HBASE_IDENT_STRING=$USER
+
+# The scheduling priority for daemon processes.  See 'man nice'.
+# export HBASE_NICENESS=10
+
+# The directory where pid files are stored. /tmp by default.
+export HBASE_PID_DIR=/opt/mapr/pid
+
+# Seconds to sleep between slave commands.  Unset by default.  This
+# can be useful in large clusters, where, e.g., slave rsyncs can
+# otherwise arrive faster than the master can service them.
+# export HBASE_SLAVE_SLEEP=0.1
+
+# Tell HBase whether it should manage it's own instance of Zookeeper or not.
+# export HBASE_MANAGES_ZK=true
+
+# The default log rolling policy is RFA, where the log file is rolled as per the size defined for the 
+# RFA appender.

--- a/assembly/mapr6.0.1/templates/hbase-site.xml
+++ b/assembly/mapr6.0.1/templates/hbase-site.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+/**
+ * Copyright 2010 The Apache Software Foundation
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<configuration>
+
+  <property>
+    <name>hbase.rootdir</name>
+    <value>maprfs:///splice-hbase</value>
+  </property>
+
+  <property>
+    <name>hbase.cluster.distributed</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>hbase.zookeeper.quorum</name>
+    <value>###ZK_QUORUM_LIST###</value>
+  </property>
+
+  <property>
+    <name>hbase.zookeeper.property.clientPort</name>
+    <value>5181</value>
+  </property>
+
+  <property>
+    <name>dfs.support.append</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>hbase.fsutil.maprfs.impl</name>
+    <value>org.apache.hadoop.hbase.util.FSMapRUtils</value>
+  </property>
+
+  <property>
+    <name>hbase.regionserver.handler.count</name>
+    <value>400</value>
+    <!-- default is 25 -->
+  </property>
+
+  <!-- uncomment this to enable fileclient logging
+  <property>
+    <name>fs.mapr.trace</name>
+    <value>debug</value>
+  </property>
+  -->
+
+  <!-- Allows file/db client to use 64 threads -->
+  <property>
+    <name>fs.mapr.threads</name>
+    <value>64</value>
+  </property>
+
+  <property>
+    <name>mapr.hbase.default.db</name>
+    <value>hbase</value>
+  </property>
+
+  <property>
+    <name>hbase.coprocessor.region.classes</name>
+    <value>com.splicemachine.hbase.MemstoreAwareObserver,com.splicemachine.derby.hbase.SpliceIndexObserver,com.splicemachine.derby.hbase.SpliceIndexEndpoint,com.splicemachine.hbase.RegionSizeEndpoint,com.splicemachine.si.data.hbase.coprocessor.TxnLifecycleEndpoint,com.splicemachine.si.data.hbase.coprocessor.SIObserver,com.splicemachine.hbase.BackupEndpointObserver</value>
+    <description>Region coprocessors for Splice Machine</description>
+  </property>
+
+  <property>
+    <name>hbase.coprocessor.master.classes</name>
+    <value>com.splicemachine.hbase.SpliceMasterObserver</value>
+    <description>Master coprocessors for Splice Machine</description>
+  </property>
+
+  <property>
+    <name>hbase.coprocessor.regionserver.classes</name>
+    <value>com.splicemachine.hbase.RegionServerLifecycleObserver</value>
+  </property>
+
+  <property><name>hbase.balancer.period</name><value>60000</value></property>
+  <property><name>hbase.client.ipc.pool.size</name><value>10</value></property>
+  <property><name>hbase.client.keyvalue.maxsize</name><value>10485760</value></property>
+  <property><name>hbase.client.max.perregion.tasks</name><value>100</value></property>
+  <property><name>hbase.client.pause</name><value>90</value></property>
+  <property><name>hbase.client.retries.number</name><value>40</value></property>
+  <property><name>hbase.client.scanner.caching</name><value>1000</value></property>
+  <property><name>hbase.client.scanner.timeout.period</name><value>1200000</value></property>
+  <property><name>hbase.client.write.buffer</name><value>2097152</value></property>
+  <property><name>hbase.hregion.majorcompaction.jitter</name><value>0.5</value></property>
+  <property><name>hbase.hregion.majorcompaction</name><value>604800000</value></property>
+  <property><name>hbase.hregion.max.filesize</name><value>10737418240</value></property>
+  <property><name>hbase.hregion.memstore.block.multiplier</name><value>4</value></property>
+  <property><name>hbase.hregion.memstore.flush.size</name><value>134217728</value></property>
+  <property><name>hbase.hregion.memstore.mslab.chunksize</name><value>2097152</value></property>
+  <property><name>hbase.hregion.memstore.mslab.enabled</name><value>true</value></property>
+  <property><name>hbase.hregion.memstore.mslab.max.allocation</name><value>262144</value></property>
+  <property><name>hbase.hregion.preclose.flush.size</name><value>5242880</value></property>
+  <property><name>hbase.hstore.blockingStoreFiles</name><value>20</value></property>
+  <property><name>hbase.hstore.blockingWaitTime</name><value>90000</value></property>
+  <property><name>hbase.hstore.compaction.max.size</name><value>260046848</value></property>
+  <property><name>hbase.hstore.compaction.max</name><value>7</value></property>
+  <property><name>hbase.hstore.compaction.min.size</name><value>16777216</value></property>
+  <property><name>hbase.hstore.compaction.min</name><value>5</value></property>
+  <property><name>hbase.hstore.compactionThreshold</name><value>5</value></property>
+  <property><name>hbase.hstore.defaultengine.compactionpolicy.class</name><value>com.splicemachine.compactions.SpliceDefaultCompactionPolicy</value></property>
+  <property><name>hbase.hstore.defaultengine.compactor.class</name><value>com.splicemachine.compactions.SpliceDefaultCompactor</value></property>
+  <property><name>hbase.htable.threads.max</name><value>96</value></property>
+  <property><name>hbase.ipc.warn.response.size</name><value>-1</value></property>
+  <property><name>hbase.ipc.warn.response.time</name><value>-1</value></property>
+  <property><name>hbase.master.handler.count</name><value>25</value></property>
+  <property><name>hbase.master.loadbalance.bytable</name><value>true</value></property>
+  <property><name>hbase.master.logcleaner.ttl</name><value>60000</value></property>
+  <property><name>hbase.mvcc.impl</name><value>org.apache.hadoop.hbase.regionserver.SIMultiVersionConsistencyControl</value></property>
+  <property><name>hbase.region.replica.replication.enabled</name><value>false</value></property>
+  <property><name>hbase.regions.slop</name><value>0.01</value></property>
+  <property><name>hbase.regionserver.codecs</name><value></value></property>
+  <property><name>hbase.regionserver.global.memstore.lowerLimit</name><value>0.38</value></property>
+  <property><name>hbase.regionserver.global.memstore.size.lower.limit</name><value>0.9</value></property>
+  <property><name>hbase.regionserver.global.memstore.size</name><value>0.25</value></property>
+  <property><name>hbase.regionserver.global.memstore.upperLimit</name><value>0.4</value></property>
+  <property><name>hbase.regionserver.hlog.blocksize</name><value>134217728</value></property>
+  <property><name>hbase.regionserver.logroll.period</name><value>3600000</value></property>
+  <property><name>hbase.regionserver.maxlogs</name><value>48</value></property>
+  <property><name>hbase.regionserver.metahandler.count</name><value>10</value></property>
+  <property><name>hbase.regionserver.msginterval</name><value>3000</value></property>
+  <property><name>hbase.regionserver.nbreservationblocks</name><value>4</value></property>
+  <property><name>hbase.regionserver.optionallogflushinterval</name><value>1000</value></property>
+  <property><name>hbase.regionserver.regionSplitLimit</name><value>2147483647</value></property>
+  <property><name>hbase.regionserver.thread.compaction.large</name><value>4</value></property>
+  <property><name>hbase.regionserver.thread.compaction.small</name><value>4</value></property>
+  <property><name>hbase.regionserver.wal.enablecompression</name><value>true</value></property>
+  <property><name>hbase.rowlock.wait.duration</name><value>0</value></property>
+  <property><name>hbase.rpc.timeout</name><value>1200000</value></property>
+  <property><name>hbase.server.thread.wakefrequency</name><value>10000</value></property>
+  <property><name>hbase.splitlog.manager.timeout</name><value>300000</value></property>
+  <property><name>hbase.wal.disruptor.batch</name><value>true</value></property>
+  <property><name>hbase.wal.provider</name><value>multiwal</value></property>
+  <property><name>hbase.wal.regiongrouping.numgroups</name><value>16</value></property>
+  <property><name>hfile.block.bloom.cacheonwrite</name><value>true</value></property>
+  <property><name>hfile.block.cache.size</name><value>0.25</value></property>
+  <property><name>io.storefile.bloom.error.rate</name><value>0.005</value></property>
+  <property><name>splice.authentication.native.algorithm</name><value>SHA-512</value></property>
+  <property><name>splice.authentication</name><value>NATIVE</value></property>
+  <property><name>splice.client.numConnections</name><value>1</value></property>
+  <property><name>splice.client.write.maxDependentWrites</name><value>40000</value></property>
+  <property><name>splice.client.write.maxIndependentWrites</name><value>40000</value></property>
+  <property><name>splice.compression</name><value>snappy</value></property>
+  <property><name>splice.marshal.kryoPoolSize</name><value>1100</value></property>
+  <property><name>splice.olap_server.clientWaitTime</name><value>90000</value></property>
+  <property><name>splice.ring.bufferSize</name><value>131072</value></property>
+  <property><name>splice.splitBlockSize</name><value>67108864</value></property>
+  <property><name>splice.task.priority.dmlRead.default</name><value>0</value></property>
+  <property><name>splice.task.priority.dmlWrite.default</name><value>0</value></property>
+  <property><name>splice.timestamp_server.clientWaitTime</name><value>120000</value></property>
+  <property><name>splice.txn.activeTxns.cacheSize</name><value>10240</value></property>
+  <property><name>splice.txn.completedTxns.concurrency</name><value>128</value></property>
+  <property><name>splice.txn.concurrencyLevel</name><value>4096</value></property>
+  <property><name>zookeeper.session.timeout</name><value>120000</value></property>
+  <property><name>spark.authenticate</name><value>false</value></property>
+  <property><name>hbase.master.port</name><value>60001</value></property>
+  <property><name>hbase.master.info.port</name><value>60011</value></property>
+  <property><name>hbase.regionserver.port</name><value>60021</value></property>
+  <property><name>hbase.regionserver.info.port</name><value>60031</value></property>
+  <property><name>hbase.status.multicast.address.port</name><value>60101</value></property>
+  <property><name>zookeeper.znode.parent</name><value>/splice-hbase</value></property>
+</configuration>

--- a/assembly/mapr6.0.1/templates/mapr-splice-hbase-config.sh
+++ b/assembly/mapr6.0.1/templates/mapr-splice-hbase-config.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Splice Machine-customized /opt/conf/mapr-hbase-config.sh
+
+MAPR_HOME="${MAPR_HOME:-/opt/mapr}"
+HBASE_VER=1.1.8-splice
+HBASE_HOME="${MAPR_HOME}/hbase/hbase-${HBASE_VER}"
+
+EXTRA_JARS="gateway-*.jar"
+for jar in ${EXTRA_JARS} ; do
+  JARS=`echo $(ls ${MAPR_HOME}/lib/${jar} 2> /dev/null) | sed 's/\s\+/:/g'`
+  if [ "${JARS}" != "" ]; then
+    HBASE_MAPR_EXTRA_JARS=${HBASE_MAPR_EXTRA_JARS}:${JARS}
+  fi
+done
+
+# Remove any additional ':' from the tail
+HBASE_MAPR_EXTRA_JARS="${HBASE_MAPR_EXTRA_JARS#:}"
+
+export HBASE_MAPR_EXTRA_JARS
+
+# Need to call this to continue the daisy chain of config scripts
+if [ -f "${HBASE_HOME}/bin/mapr-config.sh" ] ; then
+    . "${HBASE_HOME}/bin/mapr-config.sh"
+fi

--- a/assembly/mapr6.0.1/templates/splice-init-script
+++ b/assembly/mapr6.0.1/templates/splice-init-script
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+#
+# chkconfig: 35 99 01
+# description:  Enables Splice Machine services
+#
+# LSB compliant service control script
+#
+### BEGIN INIT INFO
+# Provides:       splice-machine
+# Required-Start: $mapr-warden
+# Required-Stop:  
+# Should-Start:
+# Should-Stop:
+# Default-Start:  3 5
+# Default-Stop:   0 1 2 6
+# Short-Description: Start Splice Machine services
+### END INIT INFO
+
+scriptname=$(basename "${0}")
+
+whoami | grep -q ^root$ || {
+	echo "${scriptname}: please run this script as root" 1>&2
+	exit 1
+}
+
+# bail out early if we do not have an HBase install
+maprtop="/opt/mapr"
+maprhbase="${maprtop}/hbase"
+test -e ${maprhbase} || {
+	echo "${scriptname}: ${maprhbase} not found; exiting" 1>&2
+	exit 1
+}
+hbase_ver=1.1.8-splice
+hbase_home="${maprhbase}/hbase-${hbase_ver}"
+hbase_conf="${hbase_home}/conf"
+hbase_bin="${hbase_home}/bin"
+hbase_daemon="${hbase_bin}/hbase-daemon.sh"
+test -e ${hbase_conf} || {
+	echo "${scriptname}: ${hbase_conf} not found; exiting" 1>&2
+	exit 1
+}
+test -e ${hbase_daemon} || {
+	echo "${scriptname}: ${hbase_daemon} not found; exiting" 1>&2
+	exit 1
+}
+
+mapruser="mapr"
+splice_hbase_id="splice"
+splice_hbase_role=""
+initd="/etc/init.d"
+
+usage() {
+	cat <<- EOF
+	${scriptname}: (start|stop|restart|status)
+	  start : start up ${splice_hbase_id} ${splice_hbase_role}
+	  stop : stop ${splice_hbase_id} ${splice_hbase_role}
+	  restart : restart ${splice_hbase_id} ${splice_hbase_role}
+	  status : check status of ${splice_hbase_id} ${splice_hbase_role}
+	EOF
+	exit 1
+}
+
+if ! $(echo "${scriptname}" | egrep -q "${splice_hbase_id}-(master|regionserver)") ; then
+	cat <<- EOF
+	${scriptname}: this script should be symlinked to one of the following locations based on roles:
+	  ${initd}/${splice_hbase_id}-master - Splice Machine HBase Master
+	  ${initd}/${splice_hbase_id}-regionserver - Splice Machine HBase RegionServer
+	EOF
+	exit 1
+else
+	if [[ "${scriptname}" =~ "${splice_hbase_id}-master" ]] ; then
+		splice_hbase_role="master"
+	elif [[ "${scriptname}" =~ "${splice_hbase_id}-regionserver" ]] ; then
+		splice_hbase_role="regionserver"
+	fi
+fi
+if [ -z "${splice_hbase_role}" ] ; then
+	echo "${scriptname}: could not figure out role type; exiting"
+	exit 1
+fi
+
+case "${1}" in
+	start)
+		su - ${mapruser} -c "HBASE_IDENT_STRING=${splice_hbase_id} ${hbase_daemon} --config ${hbase_conf} start ${splice_hbase_role}"
+		;;
+	stop)
+		su - ${mapruser} -c "HBASE_IDENT_STRING=${splice_hbase_id} ${hbase_daemon} --config ${hbase_conf} stop ${splice_hbase_role}"
+		;;
+	restart)
+		su - ${mapruser} -c "HBASE_IDENT_STRING=${splice_hbase_id} ${hbase_daemon} --config ${hbase_conf} restart ${splice_hbase_role}"
+		;;
+	status)
+		su - ${mapruser} -c "HBASE_IDENT_STRING=${splice_hbase_id} ${hbase_daemon} --config ${hbase_conf} status ${splice_hbase_role}"
+		;;
+	*)
+		usage
+		exit 1
+		;;
+esac
+exit $?


### PR DESCRIPTION
this initial set of files built rpms that worked on mapr 6.0.1, based on the same binary files compiled for mapr 6.0.0 and tested there. I think this structure therefore works on both versions of mapr 6