### PR TITLE
SPLICE-2264 Correctly import dates with a TZ transition at midnight.

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
@@ -785,7 +785,7 @@ public class SpliceRegionAdmin {
 
         // return the primary key or index value in ExecRow
         ExecRow dataRow = FileFunction.getRow(read, quotedColumns, null,
-                execRow, null, timeFormat, dateFormat, timestampFormat);
+                execRow, null, timeFormat, dateFormat, timestampFormat, null);
 
         // Encoded row value
         DataHash dataHash = getEncoder(td, index, execRow);

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AbstractFileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AbstractFileFunction.java
@@ -31,6 +31,7 @@ import com.splicemachine.derby.impl.sql.execute.operations.VTIOperation;
 import com.splicemachine.derby.stream.iapi.OperationContext;
 import com.splicemachine.derby.stream.output.WriteReadUtils;
 import com.splicemachine.derby.stream.utils.BooleanList;
+import com.splicemachine.derby.utils.SpliceDateFormatter;
 import com.splicemachine.derby.utils.SpliceDateFunctions;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.supercsv.prefs.CsvPreference;
@@ -42,6 +43,8 @@ import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
+
+import static com.splicemachine.derby.utils.SpliceDateFunctions.TO_DATE;
 
 /**
  *
@@ -57,6 +60,7 @@ public abstract class AbstractFileFunction<I> extends SpliceFlatMapFunction<Spli
     protected ExecRow execRow;
     private String timeFormat;
     private String dateTimeFormat;
+    private SpliceDateFormatter formatter;
     private String timestampFormat;
     private int[] columnIndex;
 
@@ -77,6 +81,10 @@ public abstract class AbstractFileFunction<I> extends SpliceFlatMapFunction<Spli
         this.dateTimeFormat = dateTimeFormat;
         this.timestampFormat = timestampFormat;
         this.columnIndex = columnIndex;
+
+        // Create a date formatter that can be reused, to save memory, instead of
+        // constructing a new one every to TO_DATE is called.
+        this.formatter = new SpliceDateFormatter(dateTimeFormat);
     }
 
     @Override
@@ -128,14 +136,15 @@ public abstract class AbstractFileFunction<I> extends SpliceFlatMapFunction<Spli
     @SuppressFBWarnings(value = "REC_CATCH_EXCEPTION",justification = "Intentional")
     public ExecRow call(List<String> values,BooleanList quotedColumns) throws Exception {
         return getRow(values, quotedColumns, operationContext, execRow, calendar, timeFormat,
-                dateTimeFormat, timestampFormat);
+                dateTimeFormat, timestampFormat, this.formatter);
     }
 
 
     public static ExecRow getRow(List<String> values,BooleanList quotedColumns,
                                  OperationContext operationContext, ExecRow execRow,
                                  Calendar calendar, String timeFormat,
-                                 String dateTimeFormat, String timestampFormat)  throws Exception {
+                                 String dateTimeFormat, String timestampFormat,
+                                 SpliceDateFormatter dateFormatter)  throws Exception {
         int columnID = 0;
         String columnValue = null;
         int numofColumnsinTable = 0;
@@ -199,7 +208,7 @@ public abstract class AbstractFileFunction<I> extends SpliceFlatMapFunction<Spli
                         if (dateTimeFormat == null || value == null)
                             ((DateTimeDataValue)dvd).setValue(value,calendar);
                         else
-                            dvd.setValue(SpliceDateFunctions.TO_DATE(value, dateTimeFormat),calendar);
+                            dvd.setValue(TO_DATE(value, dateTimeFormat, dateFormatter),calendar);
                         break;
                     case StoredFormatIds.SQL_TIMESTAMP_ID:
                         if(calendar==null)

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateFormatter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateFormatter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.utils;
+
+public class SpliceDateFormatter {
+
+    private String format = null;
+    private java.time.format.DateTimeFormatter formatter;
+
+    public SpliceDateFormatter(String format) {
+        this.format = format != null ? format : "yyyy-MM-dd";
+        this.formatter =
+              java.time.format.DateTimeFormatter.ofPattern(this.format);
+    }
+    public String getFormat() {
+        return format;
+    }
+    public java.time.format.DateTimeFormatter getFormatter() { return formatter; }
+    public void setFormatter(java.time.format.DateTimeFormatter newFormatter) {formatter = newFormatter;}
+}

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceDateFunctionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceDateFunctionsIT.java
@@ -15,14 +15,11 @@
 package com.splicemachine.derby.utils;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.sql.*;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
+import com.splicemachine.derby.test.framework.SpliceDataWatcher;
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceTableWatcher;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.homeless.TestUtils;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -31,11 +28,11 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 
-import com.splicemachine.derby.test.framework.SpliceDataWatcher;
-import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
-import com.splicemachine.derby.test.framework.SpliceTableWatcher;
-import com.splicemachine.derby.test.framework.SpliceWatcher;
-import com.splicemachine.homeless.TestUtils;
+import java.sql.*;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.Assert.*;
 
 public class SpliceDateFunctionsIT {
 
@@ -97,7 +94,7 @@ public class SpliceDateFunctionsIT {
                         "insert into " + tableWatcherA + " (col1, col2, col3) values (date('2014-01-17'), -1, " +
                             "date('2013-12-17'))").execute();
                     classWatcher.prepareStatement(
-                        "insert into " + tableWatcherB + " (col1, col2, col3) values ('01/27/2001', 'mm/dd/yyyy'," +
+                        "insert into " + tableWatcherB + " (col1, col2, col3) values ('01/27/2001', 'MM/dd/yyyy'," +
                             " date('2001-01-27'))").execute();
                     classWatcher.prepareStatement(
                         "insert into " + tableWatcherB + " (col1, col2, col3) values ('2002/02/26', 'yyyy/MM/dd'," +
@@ -122,10 +119,10 @@ public class SpliceDateFunctionsIT {
                             "('2014-04-29'), 1.0)").execute();
                     classWatcher.prepareStatement(
                         "insert into " + tableWatcherF + " (col1, col2, col3) values (date('2014-05-29'), " +
-                            "'mm/dd/yyyy', '05/29/2014')").execute();
+                            "'MM/dd/yyyy', '05/29/2014')").execute();
                     classWatcher.prepareStatement(
                         "insert into " + tableWatcherF + " (col1, col2, col3) values (date('2012-12-31'), " +
-                            "'yyyy/mm/dd', '2012/12/31')").execute();
+                            "'yyyy/MM/dd', '2012/12/31')").execute();
                     classWatcher.prepareStatement(
                         "insert into " + tableWatcherG + " (col1, col2, col3) values (Timestamp('2012-12-31 " +
                             "20:38:40'), 'hour', Timestamp('2012-12-31 20:00:00'))").execute();
@@ -217,7 +214,7 @@ public class SpliceDateFunctionsIT {
             String expected =
                 "DATESTR  |  PATTERN  |  TODATE   |   DATE    |\n" +
                     "------------------------------------------------\n" +
-                    "01/27/2001 |mm/dd/yyyy |2001-01-27 |2001-01-27 |\n" +
+                    "01/27/2001 |MM/dd/yyyy |2001-01-27 |2001-01-27 |\n" +
                     "2002/02/26 |yyyy/MM/dd |2002-02-26 |2002-02-26 |";
             assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         }

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceDateFunctionsTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceDateFunctionsTest.java
@@ -16,7 +16,6 @@ package com.splicemachine.derby.utils;
 
 import com.splicemachine.pipeline.ErrorState;
 import com.splicemachine.si.testenv.ArchitectureIndependent;
-
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -30,6 +29,7 @@ import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.TimeZone;
 
@@ -135,6 +135,19 @@ public class SpliceDateFunctionsTest {
     }
 
     @Test
+    public void toDateWithTimezoneTransitionAtMidnight() throws Exception {
+        String source = "1908-04-01";
+        DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+        Date date = new Date(formatter.parse("1908-04-01").getTime());
+
+        try {
+            assertEquals(date, SpliceDateFunctions.TO_DATE(source, "yyyy-MM-dd", ZoneId.of("Asia/Seoul")));
+        } catch (SQLException e) {
+            fail("Failed to parse date with timezone transition at midnight.");
+        }
+    }
+
+    @Test
     public void toDateDefaultWrongPattern() throws Exception {
         String source = "2014/06/24";
         DateFormat formatter = new SimpleDateFormat("MM/dd/yy");
@@ -144,7 +157,7 @@ public class SpliceDateFunctionsTest {
             assertEquals(date, SpliceDateFunctions.TO_DATE(source));
             fail("Expected to get an exception for parsing the wrong date pattern.");
         } catch (SQLException e) {
-           assertEquals("Error parsing datetime 2014/06/24 with pattern: null. Try using an ISO8601 pattern such " +
+           assertEquals("Error parsing datetime 2014/06/24 with pattern: yyyy-MM-dd. Try using an ISO8601 pattern such " +
                             "as, yyyy-MM-dd'T'HH:mm:ss.SSSZZ, yyyy-MM-dd'T'HH:mm:ssZ or yyyy-MM-dd",
                         e.getLocalizedMessage());
         }

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/test/DecoderIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/test/DecoderIT.java
@@ -16,6 +16,15 @@ package com.splicemachine.derby.utils.test;
 
 import com.splicemachine.derby.test.framework.*;
 import com.splicemachine.homeless.TestUtils;
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
@@ -23,15 +32,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.LinkedList;
 import java.util.List;
-import org.apache.log4j.Logger;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
 
 /**
  * Test for Bug DB-923.
@@ -73,7 +73,7 @@ public class DecoderIT {
             try {
                 PreparedStatement ps =
                         SpliceNetConnection.getConnection().prepareStatement(
-                                String.format("call SYSCS_UTIL.IMPORT_DATA('%s','%s', null, '%s', ',', null, null,null,null,0,null,true,null)",
+                                String.format("call SYSCS_UTIL.IMPORT_DATA('%s','%s', null, '%s', ',', null, null,'yyyy-M-d',null,0,null,true,null)",
                                         SCHEMA_NAME, TransactionHeaderTable.TABLE_NAME, csvLocation));
                 ResultSet rs = ps.executeQuery();
                 while (rs.next()) {
@@ -93,7 +93,7 @@ public class DecoderIT {
             try {
                 PreparedStatement ps =
                         SpliceNetConnection.getConnection().prepareStatement(
-                                String.format("call SYSCS_UTIL.IMPORT_DATA('%s','%s', null, '%s', ',', null, null,null,null,0,null,true,null)",
+                                String.format("call SYSCS_UTIL.IMPORT_DATA('%s','%s', null, '%s', ',', null, null,'yyyy-M-d',null,0,null,true,null)",
                                         SCHEMA_NAME, TransactionHeaderTable.TABLE_NAME2, csvLocation2));
                 ResultSet rs = ps.executeQuery();
                 while (rs.next()) {


### PR DESCRIPTION
Import of dates which have a transition to daylight savings time at midnight in the Korean time zone fails.  See [SPLICE-2264](https://splice.atlassian.net/browse/SPLICE-2264?focusedCommentId=27629&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-27629).

