### PR TITLE
DB-6913 Query fails when output of CONVERT_TO_DATE is used in GROUP BY clause

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextService.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextService.java
@@ -179,7 +179,8 @@ public final class ContextService{
      * @see #newContextManager()
      * @see SystemContext#cleanupOnError(Throwable)
      */
-    private final Set<ContextManager> allContexts = new HashSet<>();
+    private final Set<ContextManager> allContexts = Collections.newSetFromMap(
+            new WeakHashMap<ContextManager, Boolean>());
 
     // TODO: remove duplicate
     public static ContextService getService(){

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMRecordReaderImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMRecordReaderImpl.java
@@ -22,8 +22,6 @@ import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.RowLocation;
 import com.splicemachine.derby.impl.sql.execute.operations.scanner.SITableScanner;
 import com.splicemachine.derby.impl.sql.execute.operations.scanner.TableScannerBuilder;
-import com.splicemachine.derby.stream.ActivationHolder;
-import com.splicemachine.derby.stream.spark.SparkOperationContext;
 import com.splicemachine.metrics.Metrics;
 import com.splicemachine.mrio.MRConstants;
 import com.splicemachine.primitives.Bytes;
@@ -34,8 +32,6 @@ import com.splicemachine.si.constants.SIConstants;
 import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.storage.*;
 import com.splicemachine.utils.SpliceLogUtils;
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.lang.SerializationUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.Table;
@@ -50,7 +46,6 @@ import org.apache.spark.TaskContext;
 import org.apache.spark.util.TaskFailureListener;
 
 import java.io.IOException;
-import java.sql.SQLException;
 import java.util.*;
 
 public class SMRecordReaderImpl extends RecordReader<RowLocation, ExecRow> implements TaskFailureListener {
@@ -67,7 +62,6 @@ public class SMRecordReaderImpl extends RecordReader<RowLocation, ExecRow> imple
 	private List<AutoCloseable> closeables = new ArrayList<>();
     private boolean statisticsRun = false;
 	private Txn localTxn;
-	private ActivationHolder activationHolder;
 	private volatile boolean closed = false;
 	private String closeExceptionString;
 	private InputSplit split;
@@ -94,17 +88,12 @@ public class SMRecordReaderImpl extends RecordReader<RowLocation, ExecRow> imple
 			TaskContext.get().addTaskFailureListener(this);
 		}
 		String tableScannerAsString = config.get(MRConstants.SPLICE_SCAN_INFO);
-		String operationContextAsString = config.get(MRConstants.SPLICE_OPERATION_CONTEXT);
         if (tableScannerAsString == null)
 			throw new IOException("splice scan info was not serialized to task, failing");
 		byte[] scanStartKey = null;
 		byte[] scanStopKey = null;
 		try {
 			builder = TableScannerBuilder.getTableScannerBuilderFromBase64String(tableScannerAsString);
-			SparkOperationContext operationContext = null;
-			if (operationContextAsString != null) {
-				operationContext = (SparkOperationContext) SerializationUtils.deserialize(Base64.decodeBase64(operationContextAsString));
-			}
 			if (LOG.isTraceEnabled())
 				SpliceLogUtils.trace(LOG, "config loaded builder=%s", builder);
 			TableSplit tSplit = ((SMSplit) split).getSplit();
@@ -124,12 +113,6 @@ public class SMRecordReaderImpl extends RecordReader<RowLocation, ExecRow> imple
 			// TODO (wjk): this seems weird (added with DB-4483)
 			this.statisticsRun = AbstractSMInputFormat.oneSplitPerRegion(config);
 			restart(scan.getStartKey());
-
-			if (operationContext != null) {
-				activationHolder = operationContext.getActivationHolder();
-				if (activationHolder != null)
-					activationHolder.reinitialize(null);
-			}
 		} catch (IOException ioe) {
 			LOG.error(String.format("Received exception with scan %s, original start key %s, original stop key %s, split %s",
 					scan, Bytes.toStringBinary(scanStartKey), Bytes.toStringBinary(scanStopKey), split), ioe);
@@ -187,9 +170,6 @@ public class SMRecordReaderImpl extends RecordReader<RowLocation, ExecRow> imple
 					}
 					lastThrown = ioe;
 				}
-			}
-			if (activationHolder != null) {
-				activationHolder.close();
 			}
 
 			for (AutoCloseable c : closeables) {

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMSQLUtil.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMSQLUtil.java
@@ -492,7 +492,7 @@ public class SMSQLUtil  {
             StandardException.plainWrapException(ioe);
         }
         ActivationHolder ah = (ActivationHolder) SerializationUtils.deserialize(activationHolderBytes);
-        ah.init(txnView);
+        ah.reinitialize(txnView);
         return ah.getActivation();
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
@@ -128,8 +128,9 @@ public class ActivationHolder implements Externalizable {
         }
     }
 
-    public Activation getActivation() {
-        // Reinitialize if deserialized
+    public synchronized Activation getActivation() {
+        // Only directly instantiated ActivationHolders have initialized == true
+        // Those deserialized will check if impl.get() and activation are both set
         if (!initialized) {
             init(txn, true);
         }
@@ -150,7 +151,7 @@ public class ActivationHolder implements Externalizable {
         SIDriver.driver().getOperationFactory().writeTxn(txn,out);
     }
 
-    private synchronized void init(TxnView txn, boolean reinit){
+    private void init(TxnView txn, boolean reinit){
         try {
             SpliceTransactionResourceImpl txnResource = impl.get();
             if (txnResource != null && activation != null) return;

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
@@ -15,6 +15,7 @@
 package com.splicemachine.derby.stream;
 
 import com.splicemachine.EngineDriver;
+import com.splicemachine.db.iapi.services.context.ContextService;
 import com.splicemachine.db.impl.jdbc.EmbedConnection;
 import com.splicemachine.db.impl.jdbc.EmbedConnectionContext;
 import com.splicemachine.derby.utils.StatisticsOperation;
@@ -60,9 +61,7 @@ public class ActivationHolder implements Externalizable {
     private SpliceObserverInstructions soi;
     private TxnView txn;
     private boolean initialized = false;
-    private int reinitCount = 0;
-    private SpliceTransactionResourceImpl impl;
-    private boolean prepared = false;
+    private static ThreadLocal<SpliceTransactionResourceImpl> impl = new ThreadLocal<>();
 
     public ActivationHolder() {
 
@@ -130,7 +129,10 @@ public class ActivationHolder implements Externalizable {
     }
 
     public Activation getActivation() {
-        init();
+        // Reinitialize if deserialized
+        if (!initialized) {
+            init(txn, true);
+        }
         return activation;
     }
 
@@ -148,30 +150,28 @@ public class ActivationHolder implements Externalizable {
         SIDriver.driver().getOperationFactory().writeTxn(txn,out);
     }
 
-    public void init(){
-        init(txn);
-    }
-
-    public synchronized void init(TxnView txn){
-        if(initialized)
-            return;
-        initialized = true;
+    private synchronized void init(TxnView txn, boolean reinit){
         try {
-            impl = new SpliceTransactionResourceImpl();
-            prepared =  impl.marshallTransaction(txn);
-            activation = soi.getActivation(this, impl.getLcc());
+            SpliceTransactionResourceImpl txnResource = impl.get();
+            if (txnResource != null && activation != null) return;
 
-            SpliceOperationContext context = SpliceOperationContext.newContext(activation);
-            for(SpliceOperation so: operationsList){
-                so.init(context);
+            txnResource = new SpliceTransactionResourceImpl();
+            txnResource.marshallTransaction(txn);
+            impl.set(txnResource);
+            activation = soi.getActivation(this, txnResource.getLcc());
+
+            // Push internal connection to the current context manager
+            EmbedConnection internalConnection = (EmbedConnection)EngineDriver.driver().getInternalConnection();
+            new EmbedConnectionContext(ContextService.getService().getCurrentContextManager(), internalConnection);
+
+            if (reinit) {
+                SpliceOperationContext context = SpliceOperationContext.newContext(activation);
+                for (SpliceOperation so : operationsList) {
+                    so.init(context);
+                }
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
-        } finally {
-            if (prepared) {
-                impl.close();
-                prepared = false;
-            }
         }
     }
 
@@ -199,40 +199,15 @@ public class ActivationHolder implements Externalizable {
     }
 
     public synchronized void reinitialize(TxnView otherTxn, boolean reinit) {
-        TxnView txnView = otherTxn!=null ? otherTxn : this.txn;
-        initialized = true;
-        reinitCount += 1;
-        try {
-            if (prepared) {
-                impl.close();
-                prepared = false;
-            }
-
-            impl = new SpliceTransactionResourceImpl();
-            prepared =  impl.marshallTransaction(txnView);
-            activation = soi.getActivation(this, impl.getLcc());
-
-            // Push internal connection to the current context manager
-            EmbedConnection internalConnection = (EmbedConnection)EngineDriver.driver().getInternalConnection();
-            new EmbedConnectionContext(impl.getLcc().getContextManager(), internalConnection);
-
-            if (reinit) {
-                SpliceOperationContext context = SpliceOperationContext.newContext(activation);
-                for (SpliceOperation so : operationsList) {
-                    so.init(context);
-                }
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        close();
+        init(otherTxn != null ? otherTxn : txn, reinit);
     }
 
-    public synchronized void close() {
-        if (--reinitCount == 0) {
-            if (prepared) {
-                impl.close();
-                prepared = false;
-            }
+    public void close() {
+        SpliceTransactionResourceImpl txnResource = impl.get();
+        if (txnResource != null) {
+            txnResource.close();
+            impl.set(null);
         }
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlOperationContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlOperationContext.java
@@ -99,7 +99,6 @@ public class ControlOperationContext<Op extends SpliceOperation> implements Oper
             out.writeObject(activationHolder);
             out.writeInt(op.resultSetNumber());
             out.writeObject(badRecordsRecorder);
-            SIDriver.driver().getOperationFactory().writeTxn(txn, out);
        }
 
         @Override
@@ -108,12 +107,8 @@ public class ControlOperationContext<Op extends SpliceOperation> implements Oper
             int rsn = in.readInt();
             op = (Op)activationHolder.getOperationsMap().get(rsn);
             badRecordsRecorder = (BadRecordsRecorder) in.readObject();
-            txn = SIDriver.driver().getOperationFactory().readTxn(in);
-            boolean prepared = false;
+            txn = activationHolder.getTxn();
             try {
-                impl = new SpliceTransactionResourceImpl();
-
-                prepared = impl.marshallTransaction(txn);
                 activation = activationHolder.getActivation();
                 context = SpliceOperationContext.newContext(activation);
                 op.init(context);
@@ -121,9 +116,7 @@ public class ControlOperationContext<Op extends SpliceOperation> implements Oper
             } catch (Exception e) {
                 SpliceLogUtils.logAndThrowRuntime(LOG, e);
             } finally {
-                if (prepared) {
-                    impl.close();
-                }
+                activationHolder.close();
             }
         }
 

--- a/splice_machine/src/test/java/com/splicemachine/customer/Price.java
+++ b/splice_machine/src/test/java/com/splicemachine/customer/Price.java
@@ -15,6 +15,7 @@
 package com.splicemachine.customer;
 
 import com.splicemachine.db.shared.common.udt.UDTBase;
+
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
@@ -24,6 +25,9 @@ public class Price extends UDTBase
   private static final int FIRST_VERSION = 0;
   public String currencyCode;
   public double amount;
+  private static final long serialVersionUID = -3305252721311660886L;
+
+  public static double getAmount(Price price ) { return price.amount; }
 
   public Price()
   {


### PR DESCRIPTION
Ensure ContextManager is always setup after ActivationHolder deserialization (affects Control, OlapServer, Spark executors).
Tested: ITs (mem, cdh), TPC-H 100g, HTAP-25 in cluster.
Monitored RS, OlapServer, Spark executors for memory leaks (number of alive ContextManagers).
