### PR TITLE
SPLICE-2278 Return 'Schema not found' error instead of NPE.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -1388,6 +1388,8 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
                 }
             return retval;
         }
+        if (schemaUUID == null)
+            throw StandardException.newException(SQLState.LANG_SCHEMA_DOES_NOT_EXIST, sd.getSchemaName());
         retval = getTableDescriptorIndex1Scan(tableName,schemaUUID.toString());
         if (retval!=null) {
             dataDictionaryCache.nameTdCacheAdd(tableKey, retval);

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/UserFunctionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/UserFunctionsIT.java
@@ -18,15 +18,15 @@ import com.splicemachine.derby.test.framework.SpliceDataWatcher;
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
 import com.splicemachine.homeless.TestUtils;
-import org.junit.AfterClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 
+import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.core.Is.is;
@@ -52,12 +52,15 @@ public class UserFunctionsIT {
 
     @Rule
     public SpliceWatcher methodWatcher = new SpliceWatcher(CLASS_NAME);
+    public SpliceWatcher forestWatcher = new SpliceWatcher(EXISTING_USER_NAME_4);
 
     private static final String EXISTING_USER_NAME = "FOO";
 
     private static final String EXISTING_USER_NAME_2 = "JDoe";
 
     private static final String EXISTING_USER_NAME_3 = "GHITA";
+
+    private static final String EXISTING_USER_NAME_4 = "FOREST";
 
     @ClassRule
     public static TestRule chain = RuleChain.outerRule(classWatcher)
@@ -69,6 +72,7 @@ public class UserFunctionsIT {
                         // TBD
                         classWatcher.prepareStatement("CALL SYSCS_UTIL.SYSCS_CREATE_USER('" + EXISTING_USER_NAME + "', 'bar')").execute();
                         classWatcher.prepareStatement("CALL SYSCS_UTIL.SYSCS_CREATE_USER('" + EXISTING_USER_NAME_2 + "', 'jdoe')").execute();
+                        classWatcher.prepareStatement("CALL SYSCS_UTIL.SYSCS_CREATE_USER('" + EXISTING_USER_NAME_4 + "', 'bubba_gump')").execute();
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     } finally {
@@ -84,6 +88,39 @@ public class UserFunctionsIT {
         classWatcher.prepareStatement("CALL SYSCS_UTIL.SYSCS_DROP_USER('" + EXISTING_USER_NAME_2 + "')").execute();
         classWatcher.prepareStatement("CALL SYSCS_UTIL.SYSCS_DROP_USER('" + EXISTING_USER_NAME_3 + "')").execute();
         classWatcher.prepareStatement("DROP SCHEMA " + EXISTING_USER_NAME_3.toUpperCase() +" RESTRICT").execute();
+        classWatcher.prepareStatement("CALL SYSCS_UTIL.SYSCS_DROP_USER('" + EXISTING_USER_NAME_4 + "')").execute();
+    }
+
+    @Test
+    public void testSchemaNotExist() throws Exception {
+
+
+        Connection connection = forestWatcher.getOrCreateConnection();
+        Statement statement = connection.createStatement();
+        statement.execute("set schema " + EXISTING_USER_NAME_4);
+
+        String query = String.format("create table t1 (a1 int, b1 int, c1 int)");
+        try {
+            methodWatcher.execute(query);
+            query = String.format("create table t2 (a2 int, b2 int, c2 int)");
+            methodWatcher.execute(query);
+            query = String.format("drop schema %s restrict", EXISTING_USER_NAME_4.toUpperCase());
+            methodWatcher.execute(query);
+        }
+        catch (Exception e){
+            fail("Could not set up SchemaNotExist test.");
+        }
+
+        try {
+            statement.execute("with v1 as\n" +
+                "(select a1 from USERFUNCTIONSIT.t1)\n" +
+                "select count(distinct b2)\n" +
+                "from USERFUNCTIONSIT.t2 inner join v1 on a1=a2");
+            fail("Expected query to fail.");
+        }
+        catch(SQLException e) {
+            Assert.assertEquals("Unexpected failure: "+ e.getMessage(), "Schema 'FOREST' does not exist", e.getMessage());
+        }
     }
 
     /**


### PR DESCRIPTION
Return error message in getTableDescriptor method instead of trying to access a null reference.

See [SPLICE-2278](https://splice.atlassian.net/browse/SPLICE-2278)