### PR TITLE
SPLICE-1958 Fix reference column matching when update target table has alias

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UpdateNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UpdateNode.java
@@ -522,9 +522,8 @@ public final class UpdateNode extends DMLModStatementNode
 		 */
 		// Splice fork: leave table names present in special case
         // of multi column update with single source select.
-        if (!isUpdateWithSubquery) {
-			checkTableNameAndScrubResultColumns(resultColumnList);
-		}
+        checkTableNameAndScrubResultColumns(resultColumnList,isUpdateWithSubquery);
+
 
 		/* Set the new result column list in the result set */
 		resultSet.setResultColumns(resultColumnList);
@@ -1357,7 +1356,7 @@ public final class UpdateNode extends DMLModStatementNode
 	 * 
 	 * @exception StandardExcepion if invalid column/table is specified.
 	 */
-	private void checkTableNameAndScrubResultColumns(ResultColumnList rcl) 
+	private void checkTableNameAndScrubResultColumns(ResultColumnList rcl, boolean isUpdateWithSubquery)
 			throws StandardException
 	{
 		int columnCount = rcl.size();
@@ -1367,20 +1366,25 @@ public final class UpdateNode extends DMLModStatementNode
 		{
 			boolean foundMatchingTable = false;			
 			ResultColumn	column = (ResultColumn) rcl.elementAt( i );
+			String columnTableName = column.getTableName();
 
-			if (column.getTableName() != null) {
+			if (columnTableName != null) {
 				for (int j = 0; j < tableCount; j++) {
 					FromTable fromTable = (FromTable) ((SelectNode)resultSet).
 							fromList.elementAt(j);
 					final String tableName;
-					if ( fromTable instanceof CurrentOfNode ) { 
+					final String exposedTableName;
+					if ( fromTable instanceof CurrentOfNode ) {
 						tableName = ((CurrentOfNode)fromTable).
 								getBaseCursorTargetTableName().getTableName();
-					} else { 
+						exposedTableName = ((CurrentOfNode) fromTable).getExposedTableName().getTableName();
+
+					} else {
 						tableName = fromTable.getBaseTableName();
+                        exposedTableName = fromTable.getExposedName();
 					}
 
-					if (column.getTableName().equals(tableName)) {
+					if (columnTableName.equals(tableName) || columnTableName.equals(exposedTableName)) {
 						foundMatchingTable = true;
 						break;
 					}
@@ -1393,16 +1397,31 @@ public final class UpdateNode extends DMLModStatementNode
 				}
 			}
 
-			/* The table name is
-			 * unnecessary for an update.  More importantly, though, it
-			 * creates a problem in the degenerate case with a positioned
-			 * update.  The user must specify the base table name for a
-			 * positioned update.  If a correlation name was specified for
-			 * the cursor, then a match for the ColumnReference would not
-			 * be found if we didn't null out the name.  (Aren't you
-			 * glad you asked?)
-			 */
-			column.clearTableName();
+
+			if (!isUpdateWithSubquery) {
+                /* The table name is
+                 * unnecessary for an update.  More importantly, though, it
+                 * creates a problem in the degenerate case with a positioned
+                 * update.  The user must specify the base table name for a
+                 * positioned update.  If a correlation name was specified for
+                 * the cursor, then a match for the ColumnReference would not
+                 * be found if we didn't null out the name.  (Aren't you
+                 * glad you asked?)
+                 */
+                column.clearTableName();
+            }
+            else {
+                /* Make the column reference's table name to target table's correlation name
+                 which is consistent with getMatchingColumn in FromBaseTable
+                */
+                String crn = targetTable.correlationName;
+                String baseTableName = targetTable.getBaseTableName();
+                if (crn != null) {
+      	          ValueNode expression = column.getExpression();
+					if (!column.updated() && expression != null && expression instanceof ColumnReference && baseTableName.equals(expression.getTableName()))
+						((ColumnReference) expression).setTableNameNode(makeTableName(null,crn));
+				}
+            }
 		}
 	}
 	
@@ -1423,7 +1442,7 @@ public final class UpdateNode extends DMLModStatementNode
         { 
             return; 
         }
-		
+
 		TableName tableNameNode;
 		if (fromTable instanceof CurrentOfNode)
 		{ 

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateOperationIT.java
@@ -17,6 +17,7 @@ package com.splicemachine.derby.impl.sql.execute.operations;
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
 import com.splicemachine.derby.test.framework.TestConnection;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.homeless.TestUtils;
 import com.splicemachine.test_tools.TableCreator;
 import org.junit.Assert;
@@ -259,6 +260,24 @@ public class UpdateOperationIT {
                         "NUM | ZIP  |\n" +
                         "-------------\n" +
                         " 101 |94114 |",
+                TestUtils.FormattedResult.ResultFactory.toString(rs));
+
+        updated = methodWatcher.getStatement().executeUpdate("update b1 X set (num, zip) =(select LOCATION.num+2, LOCATION.zip from LOCATION where LOCATION.zip = X.zip)");
+        assertEquals("Incorrect num rows updated!", 1, updated);
+        rs = methodWatcher.executeQuery("select num, zip from b1");
+        assertEquals("" +
+                        "NUM | ZIP  |\n" +
+                        "-------------\n" +
+                        " 102 |94114 |",
+                TestUtils.FormattedResult.ResultFactory.toString(rs));
+
+        updated = methodWatcher.getStatement().executeUpdate("update b1 X set (num, zip) =(select num, zip from LOCATION where LOCATION.zip = '94114')");
+        assertEquals("Incorrect num rows updated!", 1, updated);
+        rs = methodWatcher.executeQuery("select num, zip from b1");
+        assertEquals("" +
+                        "NUM | ZIP  |\n" +
+                        "-------------\n" +
+                        " 100 |94114 |",
                 TestUtils.FormattedResult.ResultFactory.toString(rs));
     }
 
@@ -682,6 +701,24 @@ public class UpdateOperationIT {
             conn.rollback();
             conn.setAutoCommit(oldAutoCommit);
         }
+    }
+
+    @Test
+    public void testUpdateWithTableAlias() throws Exception {
+        new TableCreator(methodWatcher.getOrCreateConnection())
+                .withCreate("create table alias1 (a1 int, b1 int, c1 int)")
+                .create();
+
+        new TableCreator(methodWatcher.getOrCreateConnection())
+                .withCreate("create table alias2 (a2 int, b2 int, c2 int)")
+                .create();
+
+        Assert.assertTrue("expected result having Update",
+                SpliceUnitTest.getExplainMessage(1,"explain update alias1 X set a1 = (select y.a2 from alias2 y where b1=y.b2)",methodWatcher).contains("Update"));
+        Assert.assertTrue("expected result having Update",
+            SpliceUnitTest.getExplainMessage(1,"explain update alias1 X set (a1) = (select y.a2 from alias2 y where b1=y.b2)",methodWatcher).contains("Update"));
+        Assert.assertTrue("expected result having Update",
+                SpliceUnitTest.getExplainMessage(1,"explain update updateoperationit.alias1 set (a1) = (select a2 from updateoperationit.alias2 y)",methodWatcher).contains("Update"));
     }
 
 }


### PR DESCRIPTION
If update target table has correlation name, set result columns (column.updated() is false) expression table name as target table's correlation name. 
Resolved the previous PR's UpportIT failed test case.  