### PR TITLE
DB-7647 query timed out after 300 seconds, Spark job finished successfully

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
@@ -324,6 +324,7 @@ public class SpliceSpark {
         // TODO can this be set/overridden fwith system property, why do we use SpliceConstants?
         conf.set("spark.io.compression.codec",HConfiguration.getConfiguration().getSparkIoCompressionCodec());
         conf.set("spark.sql.avro.compression.codec","uncompressed");
+        conf.set("spark.sql.broadcastTimeout", System.getProperty("splice.spark.sql.broadcastTimeout", Long.toString(Long.MAX_VALUE)));
 
          /*
             Application Properties

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
@@ -324,7 +324,7 @@ public class SpliceSpark {
         // TODO can this be set/overridden fwith system property, why do we use SpliceConstants?
         conf.set("spark.io.compression.codec",HConfiguration.getConfiguration().getSparkIoCompressionCodec());
         conf.set("spark.sql.avro.compression.codec","uncompressed");
-        conf.set("spark.sql.broadcastTimeout", System.getProperty("splice.spark.sql.broadcastTimeout", Long.toString(Long.MAX_VALUE)));
+        conf.set("spark.sql.broadcastTimeout", System.getProperty("splice.spark.sql.broadcastTimeout", Integer.toString(Integer.MAX_VALUE)));
 
          /*
             Application Properties


### PR DESCRIPTION
Set _spark.sql.broadcastTimeout_ to "infinity" by default