### PR TITLE
DB-7779 Prevent rolled back txns from masking WW conflicts

### DIFF
--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/server/SITransactor.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/server/SITransactor.java
@@ -568,8 +568,8 @@ public class SITransactor implements Transactor{
         if(updateTransaction.getTxnId()!=dataTransactionId){
             final TxnView dataTransaction=txnSupplier.getTransaction(dataTransactionId);
             if(dataTransaction.getState()==Txn.State.ROLLEDBACK){
-                if (dataTransaction.getBeginTimestamp() > updateTransaction.getBeginTimestamp()) {
-                    // If we ignore this transaction it could mask other writes with which we do conflict, see DB-7582 for details
+                if (dataTransaction.getEffectiveBeginTimestamp() > updateTransaction.getEffectiveBeginTimestamp()) {
+                    // If we ignore this transaction it could mask other writes with which we do conflict, see DB-7582 and DB-7779 for details
                     if(LOG.isTraceEnabled()){
                         SpliceLogUtils.trace(LOG,"Write conflict on row "
                                 +Bytes.toHex(cell.keyArray(),cell.keyOffset(),cell.keyLength()));


### PR DESCRIPTION
Use effective begin timestamp when checking conflicts against rolled
back transactions