### PR TITLE
DB-7621 Multiprobe scan for multiple IN lists.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/BaseTypeIdImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/BaseTypeIdImpl.java
@@ -293,6 +293,7 @@ public class BaseTypeIdImpl implements Formatable
             else if ( TypeId.TIME_NAME.equals( unqualifiedName ) ) { return StoredFormatIds.TIME_TYPE_ID_IMPL; }
             else if ( TypeId.TIMESTAMP_NAME.equals( unqualifiedName ) ) { return StoredFormatIds.TIMESTAMP_TYPE_ID_IMPL; }
             else if ( TypeId.XML_NAME.equals( unqualifiedName ) ) { return StoredFormatIds.XML_TYPE_ID_IMPL; }
+            else if (TypeId.LIST_NAME.equals(unqualifiedName)) {  return StoredFormatIds.LIST_TYPE_ID_IMPL; }
             else { return 0; }
         }
     }
@@ -355,6 +356,13 @@ public class BaseTypeIdImpl implements Formatable
     {
         switch (getTypeFormatId())
         {
+    
+          case StoredFormatIds.LIST_TYPE_ID_IMPL:
+              schemaName = null;
+              unqualifiedName = TypeId.LIST_NAME;
+              JDBCTypeId = Types.OTHER;
+              break;
+              
           case StoredFormatIds.BOOLEAN_TYPE_ID_IMPL:
               schemaName = null;
               unqualifiedName = TypeId.BOOLEAN_NAME;

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/TypesImplInstanceGetter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/TypesImplInstanceGetter.java
@@ -59,6 +59,7 @@ public class TypesImplInstanceGetter extends FormatableInstanceGetter {
                   case StoredFormatIds.BLOB_TYPE_ID_IMPL:
                   case StoredFormatIds.CLOB_TYPE_ID_IMPL:
                   case StoredFormatIds.XML_TYPE_ID_IMPL:
+                  case StoredFormatIds.LIST_TYPE_ID_IMPL:
                           return new BaseTypeIdImpl(fmtId);
                   case StoredFormatIds.DECIMAL_TYPE_ID_IMPL:
                           return new DecimalTypeIdImpl(false);

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/ast/ISpliceVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/ast/ISpliceVisitor.java
@@ -214,5 +214,6 @@ public interface ISpliceVisitor {
     Visitable visit(ArrayOperatorNode node) throws StandardException;
     Visitable visit(ArrayConstantNode node) throws StandardException;
     Visitable visit(SetSessionPropertyNode node) throws StandardException;
+    Visitable visit(ListValueNode node) throws StandardException;
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/StoredFormatIds.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/StoredFormatIds.java
@@ -1364,6 +1364,15 @@ public interface StoredFormatIds {
     int SQL_VARCHAR_ID =
             (MIN_ID_2 + 85);
 
+    int LIST_ID =
+        (MIN_ID_2 + 478);
+    
+    int LIST_TYPE_ID_IMPL =
+        (MIN_ID_2 + 480);
+    
+    int LIST_TYPE_ID =
+        (MIN_ID_2 + 481);
+    
     //public static final int SQL_USERTYPE_ID = 
     //      (MIN_ID_2 + 86);
 
@@ -1751,7 +1760,7 @@ public interface StoredFormatIds {
      * Make sure this is updated when a new module is added
      */
    int MAX_ID_2 =
-    		(MIN_ID_2 + 477);
+    		(MIN_ID_2 + 481);
 
     // DO NOT USE 4 BYTE IDS ANYMORE
     int MAX_ID_4 =

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/C_NodeTypes.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/C_NodeTypes.java
@@ -270,9 +270,10 @@ int CREATE_INDEX_NODE = 146;
 	int SET_SESSION_PROPERTY_NODE = 259;
 	int CURRENT_SESSION_PROPERTY_NODE = 260;
 	int BINARY_EXPORT_NODE = 261;
+	int LIST_VALUE_NODE = 262;
 
 	// Final value in set, keep up to date!
-	int FINAL_VALUE = BINARY_EXPORT_NODE;
+	int FINAL_VALUE = LIST_VALUE_NODE;
 
     /**
      * Extensions to this interface can use nodetypes > MAX_NODE_TYPE with out fear of collision

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
@@ -154,6 +154,8 @@ public interface CompilerContext extends Context
 	int			AGGREGATE_RESTRICTION		= NEXT_VALUE_FOR_ILLEGAL;
 	int			CONDITIONAL_RESTRICTION		= NEXT_VALUE_FOR_ILLEGAL;
 	int			GROUP_BY_RESTRICTION		= NEXT_VALUE_FOR_ILLEGAL;
+	int         DEFAULT_MAX_MULTICOLUMN_PROBE_VALUES              = 10000;
+	boolean     DEFAULT_MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED = false;
 
 	/////////////////////////////////////////////////////////////////////////////////////
 	//
@@ -651,5 +653,13 @@ public interface CompilerContext extends Context
 	public boolean isProjectionPruningEnabled();
 
 	public void setProjectionPruningEnabled(boolean onOff);
+	
+	public int getMaxMulticolumnProbeValues();
+	
+	public void setMaxMulticolumnProbeValues(int newValue);
+	
+	public void setMulticolumnInlistProbeOnSparkEnabled(boolean newValue);
+	
+	public boolean getMulticolumnInlistProbeOnSparkEnabled();
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
@@ -156,6 +156,7 @@ public interface CompilerContext extends Context
 	int			GROUP_BY_RESTRICTION		= NEXT_VALUE_FOR_ILLEGAL;
 	int         DEFAULT_MAX_MULTICOLUMN_PROBE_VALUES              = 10000;
 	boolean     DEFAULT_MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED = false;
+	boolean     DEFAULT_CONVERT_MULTICOLUMN_DNF_PREDICATES_TO_INLIST = true;
 
 	/////////////////////////////////////////////////////////////////////////////////////
 	//
@@ -661,5 +662,9 @@ public interface CompilerContext extends Context
 	public void setMulticolumnInlistProbeOnSparkEnabled(boolean newValue);
 	
 	public boolean getMulticolumnInlistProbeOnSparkEnabled();
+	
+	public void setConvertMultiColumnDNFPredicatesToInList(boolean newValue);
+	
+	public boolean getConvertMultiColumnDNFPredicatesToInList();
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecutionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecutionFactory.java
@@ -31,18 +31,19 @@
 
 package com.splicemachine.db.iapi.sql.execute;
 
-import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.iapi.sql.ResultColumnDescriptor;
-import com.splicemachine.db.iapi.sql.ResultDescription;
-import com.splicemachine.db.iapi.store.access.DynamicCompiledOpenConglomInfo;
-import com.splicemachine.db.iapi.store.access.Qualifier;
-import com.splicemachine.db.iapi.sql.dictionary.IndexRowGenerator;
-import com.splicemachine.db.iapi.store.access.StaticCompiledOpenConglomInfo;
-import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.services.loader.GeneratedMethod;
-import com.splicemachine.db.iapi.services.context.ContextManager;
+import com.splicemachine.db.iapi.sql.Activation;
+import com.splicemachine.db.iapi.sql.ResultColumnDescriptor;
+import com.splicemachine.db.iapi.sql.ResultDescription;
+import com.splicemachine.db.iapi.sql.dictionary.IndexRowGenerator;
+import com.splicemachine.db.iapi.store.access.DynamicCompiledOpenConglomInfo;
+import com.splicemachine.db.iapi.store.access.Qualifier;
+import com.splicemachine.db.iapi.store.access.StaticCompiledOpenConglomInfo;
+import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.db.iapi.types.ListDataType;
 
 /**
 	This is the factory for creating a factories needed by
@@ -267,4 +268,7 @@ public interface ExecutionFactory {
 		This returns the value row as an indexable row 
 	 */
 	ExecIndexRow	getIndexableRow(ExecRow valueRow);
+	
+	// Get a new ListDataType object that holds "numberOfValues" data values.
+    ListDataType getListData(int numberOfValues);
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueFactoryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueFactoryImpl.java
@@ -1238,7 +1238,7 @@ public abstract class DataValueFactoryImpl implements DataValueFactory, ModuleCo
             BIT(StoredFormatIds.SQL_BIT_ID),
             ROW_LOCATION(StoredFormatIds.ACCESS_HEAP_ROW_LOCATION_V1_ID),
             ARRAY(StoredFormatIds.SQL_ARRAY_ID),
-            LIST(StoredFormatIds.LIST_ID),;
+            LIST(StoredFormatIds.LIST_ID);
 
             private final int storedFormatId;
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueFactoryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueFactoryImpl.java
@@ -31,27 +31,24 @@
 
 package com.splicemachine.db.iapi.types;
 
+import com.splicemachine.db.iapi.db.DatabaseContext;
 import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.reference.Attribute;
+import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.services.context.ContextService;
 import com.splicemachine.db.iapi.services.i18n.LocaleFinder;
 import com.splicemachine.db.iapi.services.io.RegisteredFormatIds;
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 import com.splicemachine.db.iapi.services.monitor.ModuleControl;
 import com.splicemachine.db.iapi.services.monitor.ModuleFactory;
 import com.splicemachine.db.iapi.services.monitor.Monitor;
-import com.splicemachine.db.iapi.reference.Attribute;
-import com.splicemachine.db.iapi.reference.SQLState;
-import java.sql.Blob;
-import java.sql.Clob;
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
+import com.splicemachine.db.iapi.services.sanity.SanityManager;
+
+import java.sql.*;
 import java.text.Collator;
 import java.text.RuleBasedCollator;
-import java.util.Properties;
 import java.util.Locale;
-import com.splicemachine.db.iapi.db.DatabaseContext;
-import com.splicemachine.db.iapi.services.context.ContextService;
+import java.util.Properties;
 
 /**
  * Core implementation of DataValueFactory. Does not implement
@@ -1240,7 +1237,8 @@ public abstract class DataValueFactoryImpl implements DataValueFactory, ModuleCo
             BLOB(StoredFormatIds.SQL_BLOB_ID),
             BIT(StoredFormatIds.SQL_BIT_ID),
             ROW_LOCATION(StoredFormatIds.ACCESS_HEAP_ROW_LOCATION_V1_ID),
-            ARRAY(StoredFormatIds.SQL_ARRAY_ID);
+            ARRAY(StoredFormatIds.SQL_ARRAY_ID),
+            LIST(StoredFormatIds.LIST_ID),;
 
             private final int storedFormatId;
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/ListDataType.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/ListDataType.java
@@ -74,7 +74,9 @@ import java.sql.ResultSet;
  * <p>
  * If any of the elements of the ListDataType holds a null, the
  * ListDataType item itself can be considered as a null value since
- * (null OP X) AND (A OP B) and (C OP D) ... is always UNKNOWN.
+ * (null OP X) AND (A OP B) and (C OP D) ... is never TRUE,
+ * and a multicolumn IN list is never negated (we never apply
+ * the NOT operator on it).
  * <p>
  */
 public final class ListDataType extends DataType {

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/ListDataType.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/ListDataType.java
@@ -1,0 +1,563 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.iapi.types;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.services.cache.ClassSize;
+import com.splicemachine.db.iapi.services.io.ArrayInputStream;
+import com.splicemachine.db.iapi.services.io.StoredFormatIds;
+import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.execute.ExecRow;
+import com.splicemachine.db.iapi.types.DataValueFactoryImpl.Format;
+import com.yahoo.sketches.theta.UpdateSketch;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
+import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeArrayWriter;
+import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+
+import java.io.*;
+import java.sql.ResultSet;
+
+/**
+ * ListDataType satisfies the DataValueDescriptor
+ * interfaces (i.e., OrderableDataType). It implements a list of
+ * DataValueDescriptors, for example (SQLLongint, SQLTimestamp, SQLChar).
+ * <p>
+ * The main purpose for this class is to facilitate representation
+ * of multicolumn IN lists, e.g. (col_1, col2) IN ((1,2), (3,4))
+ * One use of this is the conversion of equality predicates in DNF form,
+ * e.g.  (c1 = 1 and c2 = 2) or (c1 = 2 and c2 = 3)
+ * ... into an IN list predicate:  (c1,c2) in ((1,2), (2,3))
+ * in order to enable optimizations such as MultiProbeTableScan.
+ * <p>
+ * A comparison operation between two ListDataTypes is true iff
+ * the two ListDataTypes being compared have the same number of
+ * elements and the comparison operation is true for each pairwise
+ * comparison of same-positioned elements from the two lists,
+ * for example, the comparison:
+ * (1, '2001-01-01', 'Widget') = (1, '2001-01-01', 'Sprocket')
+ * is evaluated as the following boolean expression:
+ * (1 = 1) AND ('2001-01-01' = '2001-01-01') and 'Widget' = 'Sprocket'
+ * <p>
+ * If any of the elements of the ListDataType holds a null, the
+ * ListDataType item itself can be considered as a null value since
+ * (null OP X) AND (A OP B) and (C OP D) ... is always UNKNOWN.
+ * <p>
+ */
+public final class ListDataType extends DataType {
+
+	int numElements = 0;
+	DataValueDescriptor[] dvd = null;
+
+    @Override
+	public int getLength()
+	{
+		return numElements;
+	}
+
+	public void setLength(int len) {
+        numElements = len;
+        dvd = new DataValueDescriptor[len];
+    }
+
+
+    // this is for DataType's error generator
+    @Override
+    public String getTypeName() {
+        return TypeId.LIST_NAME;
+    }
+
+    @Override
+    public String getString() throws StandardException
+    {
+        String theString = new String();
+        theString.concat("( ");
+        for (int i = 0; i < numElements; i++) {
+            String stringToAdd = dvd[i].getString();
+            theString.concat(stringToAdd != null ? stringToAdd : "NULL");
+            if (i != numElements - 1)
+                theString.concat(", ");
+        }
+        theString.concat(")");
+        return theString;
+    }
+
+    @Override
+    public String getTraceString() throws StandardException
+    {
+        return getString();
+    }
+
+    @Override
+    public boolean isNull() {
+        boolean localIsNull = true;
+        
+        if (numElements > 1) {
+            int i;
+            for (i = 0; i < numElements; i++) {
+                if (dvd[i] == null || dvd[i].isNull())
+                    break;
+            }
+            if (i == numElements)
+                localIsNull = false;
+        }
+        setIsNull(localIsNull);
+        return localIsNull;
+    }
+
+    @Override
+    public void restoreToNull()
+    {
+        for (int i = 0; i < numElements; i++) {
+            dvd[i].restoreToNull();
+        }
+        setIsNull(true);
+    }
+
+	/**
+		Return my format identifier.
+
+		@see com.splicemachine.db.iapi.services.io.TypedFormat#getTypeFormatId
+	*/
+    @Override
+	public int getTypeFormatId() {
+		return StoredFormatIds.LIST_ID;
+	}
+
+    @Override
+	public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeBoolean(isNull);
+		out.writeInt(numElements);
+        for (int i = 0; i < numElements; i++) {
+            out.writeBoolean(dvd[i] != null);
+            if (dvd[i] != null)
+                out.writeObject(dvd[i]);
+        }
+	}
+
+	/** @see java.io.Externalizable#readExternal */
+	@Override
+	public void readExternal(ObjectInput in) throws IOException {
+        isNull = in.readBoolean();
+        setLength(in.readInt());
+        try {
+            for (int i = 0; i < numElements; i++) {
+                if (in.readBoolean())
+                    dvd[i] = (DataValueDescriptor) in.readObject();
+            }
+        }
+        catch (ClassNotFoundException e) {
+            throw new IOException(
+                String.format("Class not found while deserializing %s", this.getClass().getName()), e);
+        }
+	}
+
+    @Override
+	public void readExternalFromArray(ArrayInputStream in) throws IOException {
+        isNull = in.readBoolean();
+        numElements = in.readInt();
+        try {
+            for (int i = 0; i < numElements; i++)
+                if (in.readBoolean())
+                    dvd[i] = (DataValueDescriptor) in.readObject();
+        }
+        catch(ClassNotFoundException e) {
+            throw new IOException(
+                String.format("Class not found while deserializing %s", this.getClass().getName()), e);
+        }
+	}
+
+	/*
+	 * DataValueDescriptor interface
+	 */
+
+    public void setFrom(DataValueDescriptor theValue, int index)
+        throws StandardException
+    {
+        if (index >= numElements || index < 0)
+            throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE, "LIST");
+
+        dvd[index] = theValue;
+    }
+    
+    public void setFrom(ExecRow row)
+        throws StandardException {
+        if (row.size() != numElements)
+            throw StandardException.newException(SQLState.LANG_INVALID_FUNCTION_ARGUMENT);
+        
+        for (int i = 0; i < row.size(); i++) {
+            dvd[i] = row.getColumn(i + 1);
+        }
+    }
+
+	/** @see DataValueDescriptor#cloneValue */
+	@Override
+	public DataValueDescriptor cloneValue(boolean forceMaterialization)
+	{
+	    ListDataType ldt = new ListDataType();
+        ldt.setLength(numElements);
+        ldt.setIsNull(getIsNull());
+        for (int i = 0; i < numElements; i++)
+            if (dvd[i] != null)
+                ldt.dvd[i] = dvd[i].cloneValue(forceMaterialization);
+		return ldt;
+	}
+
+	/**
+	 * @see DataValueDescriptor#getNewNull
+	 */
+    @Override
+	public DataValueDescriptor getNewNull()
+	{
+		return new ListDataType();
+	}
+
+
+	/*
+	 * class interface
+	 */
+
+	/*
+	 * constructors
+	 */
+
+	/** no-arg constructor, required by Formattable */
+	public ListDataType()
+	{
+		isNull = true;
+	}
+
+	public ListDataType(int numElements)
+	{
+        isNull = true;
+        setLength(numElements);
+	}
+
+	
+    public DataValueDescriptor getDVD(int index) {
+        return dvd[index];
+    }
+    
+	/*
+	 * DataValueDescriptor interface
+	 */
+
+	/** @see DataValueDescriptor#typePrecedence */
+    @Override
+	public int typePrecedence()
+	{
+		return TypeId.LIST_PRECEDENCE;
+	}
+ 
+	private boolean predSatisfied(int result, int op)
+    
+    {
+        switch (op) {
+            case ORDER_OP_LESSTHAN:
+                return (result < 0);   // this <  other
+            case ORDER_OP_EQUALS:
+                return (result == 0);  // this == other
+            case ORDER_OP_LESSOREQUALS:
+                return (result <= 0);  // this <= other
+            // flipped operators
+            case ORDER_OP_GREATERTHAN:
+                return (result > 0);   // this > other
+            case ORDER_OP_GREATEROREQUALS:
+                return (result >= 0);  // this >= other
+            default:
+                if (SanityManager.DEBUG)
+                    SanityManager.THROWASSERT("Invalid Operator");
+                return false;
+        }
+    }
+    /** @exception StandardException		Thrown on error */
+    @Override
+    public final int compare(DataValueDescriptor arg) throws StandardException {
+        return compare(arg, false);
+    }
+    
+    @Override
+    public int compare(DataValueDescriptor other, boolean nullsOrderedLow)
+        throws StandardException {
+        assert other instanceof ListDataType : "illegal comparison of list with non-list.";
+        assert other.getLength() == getLength() : "Trying to compare unequal length lists.";
+        if (this.isNull() || other.isNull()) {
+            if (!isNull())
+                return nullsOrderedLow ? 1 : -1;
+            if (!other.isNull())
+                return nullsOrderedLow ? -1 : 1;
+            return 0; // both null
+        }
+        int result;
+        for (int i = 0; i < numElements; i++) {
+            result = dvd[i].compare(((ListDataType) other).getDVD(i));
+            // List data can be thought of as a concatenation of all the
+            // list data items, so as soon as one part of that "key" is
+            // greater than or less than the other, we know the result.
+            if (result != 0)
+                return result;
+        }
+        return 0;
+    }
+    
+    @Override
+    public boolean compare(int op,
+						   DataValueDescriptor other,
+						   boolean orderedNulls,
+						   boolean unknownRV)
+		throws StandardException
+	{
+        return compare(op, other, orderedNulls, false, unknownRV);
+	}
+ 
+	@Override
+    public boolean compare(int op,
+                           DataValueDescriptor other,
+                           boolean orderedNulls,
+                           boolean nullsOrderedLow,
+                           boolean unknownRV) throws StandardException {
+        
+        assert other != null : "argument is null";
+        assert other instanceof ListDataType : "illegal comparison of list with non-list.";
+        assert other.getLength() == getLength() : "Trying to compare unequal length lists.";
+        
+        // If any of the DVDs in the left or right are null, the
+        // entire ANDed expression is null.
+        if (!orderedNulls && (this.isNull() || other.isNull()))
+            return unknownRV;
+        
+        int result;
+        
+        for (int i = 0; i < numElements; i++) {
+            result = dvd[i].compare(((ListDataType) other).getDVD(i), nullsOrderedLow);
+            // If the "i"th predicate is false, the entire ANDed
+            // expression is false.
+            if (!predSatisfied(result, op))
+                return false;
+        }
+        return true;
+    }
+	/*
+	 * String display of values
+	 */
+
+	public String toString()
+	{
+	    try {
+            return getString();
+        }
+        catch (Exception e) {
+	        return "";
+        }
+	}
+    
+    /*
+     * Hash code
+     */
+    @Override
+    public int hashCode() {
+        final int prime = 37;
+        int result = 17;
+    
+        for (int i = 0; i < numElements; i++) {
+            result = result * prime + dvd[i].hashCode();
+        }
+        return result;
+    }
+    
+    @Override
+	public Format getFormat() {
+		return Format.LIST;
+		
+	}
+    
+    private static final int BASE_MEMORY_USAGE = ClassSize.estimateBaseFromCatalog(ListDataType.class);
+    
+    public int estimateMemoryUsage() {
+        int memEstimate = BASE_MEMORY_USAGE;
+        for (int i = 0; i < numElements; i++) {
+            memEstimate += dvd[i].estimateMemoryUsage();
+        }
+        return memEstimate;
+    }
+    
+
+    // ListDataType cannot be in a ResultSet, so do nothing (for now).
+    public void setValueFromResultSet(ResultSet resultSet, int colNumber,
+                                      boolean isNullable) {
+
+    }
+    
+
+    public byte[] serialize() throws StandardException{
+        byte[] theBytes;
+        try {
+            try (ByteArrayOutputStream bout = new ByteArrayOutputStream(512)) {
+                ObjectOutputStream out = new ObjectOutputStream(bout);
+                out.writeBoolean(isNull);
+                out.write(numElements);
+                for (int i = 0; i < numElements; i++) {
+                    out.writeBoolean(dvd[i] != null);
+                    if (dvd[i] != null)
+                        out.writeObject(dvd[i]);
+                }
+                out.close();
+                theBytes = bout.toByteArray();
+            }
+        }
+        catch (IOException e) {
+            throw StandardException.newException(SQLState.LANG_UNKNOWN, e);
+        }
+        return theBytes;
+    }
+    
+    public void deserialize(byte[] data) throws StandardException {
+        try {
+            try (ByteArrayInputStream bin = new ByteArrayInputStream(data)) {
+                ObjectInputStream in = new ObjectInputStream(bin);
+                isNull = in.readBoolean();
+                setLength(in.read());
+                for (int i = 0; i < numElements; i++) {
+                    if (in.readBoolean())
+                        dvd[i] = (DataValueDescriptor) in.readObject();
+                    else
+                        dvd[i] = null;
+                }
+                in.close();
+            }
+        }
+        catch (Exception e) {
+            throw StandardException.newException(SQLState.LANG_UNKNOWN, e);
+        }
+    }
+    
+    @Override
+    public Object getSparkObject() throws StandardException {
+        return serialize();
+    }
+    
+    @Override
+    public void setSparkObject(Object sparkObject) throws StandardException {
+        deserialize((byte []) sparkObject);
+    }
+    
+    /**
+     * Write to a Project Tungsten Format.  Serializes the objects as byte[]
+     *
+     * @param unsafeRowWriter
+     * @param ordinal
+     * @throws StandardException
+     * @see UnsafeRowWriter#write(int, byte[])
+     */
+    @Override
+    public void write(UnsafeRowWriter unsafeRowWriter, int ordinal) throws StandardException {
+        if (isNull())
+            unsafeRowWriter.setNullAt(ordinal);
+        else
+            unsafeRowWriter.write(ordinal, serialize());
+    }
+    
+    /**
+     * Write Element into Positioned Array
+     *
+     * @param unsafeArrayWriter
+     * @param ordinal
+     * @throws StandardException
+     */
+    @Override
+    public void writeArray(UnsafeArrayWriter unsafeArrayWriter, int ordinal) throws StandardException {
+        if (isNull())
+            unsafeArrayWriter.setNull(ordinal);
+        else
+            unsafeArrayWriter.write(ordinal, serialize());
+    }
+    
+    /**
+     * Read Element from Positioned Array
+     *
+     * @param unsafeArrayData
+     * @param ordinal
+     * @throws StandardException
+     */
+    @Override
+    public void read(UnsafeArrayData unsafeArrayData, int ordinal) throws StandardException {
+        if (unsafeArrayData.isNullAt(ordinal))
+            setToNull();
+        else {
+            deserialize(unsafeArrayData.getBinary(ordinal));
+        }
+    }
+    
+    /**
+     * Read from a Project Tungsten Format.  Reads the object as a byte[]
+     *
+     * @param unsafeRow
+     * @param ordinal
+     * @throws StandardException
+     * @see UnsafeRow#getBinary(int)
+     */
+    @Override
+    public void read(UnsafeRow unsafeRow, int ordinal) throws StandardException {
+        if (unsafeRow.isNullAt(ordinal))
+            setToNull();
+        else {
+            deserialize(unsafeRow.getBinary(ordinal));
+        }
+    }
+    
+    @Override
+    public void read(Row row, int ordinal) throws StandardException {
+        if (row.isNullAt(ordinal))
+            setToNull();
+        else {
+            isNull = false;
+            Object object = row.get(ordinal);
+            deserialize((byte[]) object);
+        }
+    }
+    
+    @Override
+    public StructField getStructField(String columnName) {
+        return DataTypes.createStructField(columnName, DataTypes.BinaryType, true);
+    }
+    
+    // ListDataType is not a valid column value for a row in a table,
+    // so do nothing for theta sketch.
+    public void updateThetaSketch(UpdateSketch updateSketch) {
+    
+    }
+
+}

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/ListDataType.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/ListDataType.java
@@ -108,7 +108,7 @@ public final class ListDataType extends DataType {
         String theString = new String();
         theString.concat("( ");
         for (int i = 0; i < numElements; i++) {
-            String stringToAdd = dvd[i].getString();
+            String stringToAdd = dvd[i] == null ? null : dvd[i].getString();
             theString.concat(stringToAdd != null ? stringToAdd : "NULL");
             if (i != numElements - 1)
                 theString.concat(", ");
@@ -127,15 +127,13 @@ public final class ListDataType extends DataType {
     public boolean isNull() {
         boolean localIsNull = true;
         
-        if (numElements > 1) {
-            int i;
-            for (i = 0; i < numElements; i++) {
-                if (dvd[i] == null || dvd[i].isNull())
-                    break;
-            }
-            if (i == numElements)
-                localIsNull = false;
+        int i;
+        for (i = 0; i < numElements; i++) {
+            if (dvd[i] == null || dvd[i].isNull())
+                break;
         }
+        if (i == numElements)
+            localIsNull = false;
         setIsNull(localIsNull);
         return localIsNull;
     }
@@ -144,7 +142,8 @@ public final class ListDataType extends DataType {
     public void restoreToNull()
     {
         for (int i = 0; i < numElements; i++) {
-            dvd[i].restoreToNull();
+            if (dvd[i] != null)
+                dvd[i].restoreToNull();
         }
         setIsNull(true);
     }
@@ -395,7 +394,8 @@ public final class ListDataType extends DataType {
         int result = 17;
     
         for (int i = 0; i < numElements; i++) {
-            result = result * prime + dvd[i].hashCode();
+            if (dvd[i] != null)
+                result = result * prime + dvd[i].hashCode();
         }
         return result;
     }
@@ -411,7 +411,8 @@ public final class ListDataType extends DataType {
     public int estimateMemoryUsage() {
         int memEstimate = BASE_MEMORY_USAGE;
         for (int i = 0; i < numElements; i++) {
-            memEstimate += dvd[i].estimateMemoryUsage();
+            if (dvd[i] != null)
+                memEstimate += dvd[i].estimateMemoryUsage();
         }
         return memEstimate;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/TypeId.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/TypeId.java
@@ -167,6 +167,7 @@ public class TypeId{
     public static final String VARBINARY_NAME="VARBINARY";
     public static final String LONGVARBINARY_NAME="LONGVARBINARY";
     public static final String BOOLEAN_NAME="BOOLEAN";
+    public static final String LIST_NAME = "LIST";
     public static final String REF_NAME="REF";
     public static final String NATIONAL_CHAR_NAME="NATIONAL CHAR";
     public static final String NATIONAL_VARCHAR_NAME="NATIONAL CHAR VARYING";
@@ -220,6 +221,7 @@ public class TypeId{
     public static final int LONGVARCHAR_PRECEDENCE=12;
     public static final int VARCHAR_PRECEDENCE=10;
     public static final int CHAR_PRECEDENCE=0;
+    public static final int LIST_PRECEDENCE=2000;
 
     /*
     ** Static runtime fields for typeIds
@@ -234,8 +236,9 @@ public class TypeId{
     public static final TypeId CHAR_ID=create(StoredFormatIds.CHAR_TYPE_ID,StoredFormatIds.CHAR_TYPE_ID_IMPL);
 
     public static final TypeId DOUBLE_ID=create(StoredFormatIds.DOUBLE_TYPE_ID,StoredFormatIds.DOUBLE_TYPE_ID_IMPL);
-
-
+    
+    public static final TypeId LIST_ID = create(StoredFormatIds.LIST_TYPE_ID, StoredFormatIds.LIST_TYPE_ID_IMPL);
+    
         /*
         ** Others are created on demand by the getBuiltInTypeId(int),
         ** if they are built-in (i.e.? Part of JDBC .Types),
@@ -264,7 +267,8 @@ public class TypeId{
     private static final TypeId BLOB_ID=create(StoredFormatIds.BLOB_TYPE_ID,StoredFormatIds.BLOB_TYPE_ID_IMPL);
     private static final TypeId CLOB_ID=create(StoredFormatIds.CLOB_TYPE_ID,StoredFormatIds.CLOB_TYPE_ID_IMPL);
     private static final TypeId XML_ID=create(StoredFormatIds.XML_TYPE_ID,StoredFormatIds.XML_TYPE_ID_IMPL);
-
+    
+    
     private static final TypeId[] ALL_BUILTIN_TYPE_IDS= {
                     BOOLEAN_ID,
                     SMALLINT_ID,
@@ -555,7 +559,10 @@ public class TypeId{
         if(SQLTypeName.equals(ARRAY_NAME)){
             return ARRAY_ID;
         }
-
+    
+        if (SQLTypeName.equals(LIST_NAME)) {
+            return LIST_ID;
+        }
 
         // Types defined below here are SQL types and non-JDBC types that are
         // supported by Derby
@@ -1361,6 +1368,9 @@ public class TypeId{
 
             case StoredFormatIds.BOOLEAN_TYPE_ID:
                 return new SQLBoolean();
+    
+            case StoredFormatIds.LIST_TYPE_ID:
+                return new ListDataType();
 
             case StoredFormatIds.CHAR_TYPE_ID:
                 return new SQLChar();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/AbstractSpliceVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/AbstractSpliceVisitor.java
@@ -880,4 +880,9 @@ public abstract class AbstractSpliceVisitor implements ISpliceVisitor {
     public Visitable visit(SetSessionPropertyNode node) throws StandardException {
         return defaultVisit(node);
     }
+    
+    @Override
+    public Visitable visit(ListValueNode node) throws StandardException {
+        return defaultVisit(node);
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -484,6 +484,17 @@ public class GenericStatement implements Statement{
                 // just use the default setting.
             }
             cc.setMulticolumnInlistProbeOnSparkEnabled(multicolumnInlistProbeOnSparkEnabled);
+    
+            String convertMultiColumnDNFPredicatesToInListString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.CONVERT_MULTICOLUMN_DNF_PREDICATES_TO_INLIST);
+            boolean convertMultiColumnDNFPredicatesToInList = CompilerContext.DEFAULT_CONVERT_MULTICOLUMN_DNF_PREDICATES_TO_INLIST;
+            try {
+                if (convertMultiColumnDNFPredicatesToInListString != null)
+                    convertMultiColumnDNFPredicatesToInList = Boolean.valueOf(convertMultiColumnDNFPredicatesToInListString);
+            } catch (Exception e) {
+                // If the property value failed to convert to a boolean, don't throw an error,
+                // just use the default setting.
+            }
+            cc.setConvertMultiColumnDNFPredicatesToInList(convertMultiColumnDNFPredicatesToInList);
 
             fourPhasePrepare(lcc,paramDefaults,timestamps,beginTimestamp,foundInCache,cc);
         }catch(StandardException se){

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -450,10 +450,40 @@ public class GenericStatement implements Statement{
             String projectionPruningOptimizationString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.PROJECTION_PRUNING_DISABLED);
             // if database property is not set, treat it as false
             Boolean projectionPruningOptimizationDisabled = false;
-            if (projectionPruningOptimizationString != null)
-                projectionPruningOptimizationDisabled = Boolean.valueOf(projectionPruningOptimizationString);
-
+            try {
+                if (projectionPruningOptimizationString != null)
+                    projectionPruningOptimizationDisabled = Boolean.valueOf(projectionPruningOptimizationString);
+            } catch (Exception e) {
+                // If the property value failed to convert to a boolean, don't throw an error,
+                // just use the default setting.
+            }
             cc.setProjectionPruningEnabled(!projectionPruningOptimizationDisabled);
+    
+            // User can specify the max length of multicolumn IN list the optimizer may build for
+            // use as a probe predicate.  Single-column IN lists can be combined up until the point
+            // where adding in the next IN predicate would push us over the limit.
+            String maxMulticolumnProbeValuesString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.MAX_MULTICOLUMN_PROBE_VALUES);
+            int maxMulticolumnProbeValues = CompilerContext.DEFAULT_MAX_MULTICOLUMN_PROBE_VALUES;
+            try {
+                if (maxMulticolumnProbeValuesString != null)
+                    maxMulticolumnProbeValues = Integer.valueOf(maxMulticolumnProbeValuesString);
+            }
+            catch (Exception e) {
+                // If the property value failed to convert to an int, don't throw an error,
+                // just use the default setting.
+            }
+            cc.setMaxMulticolumnProbeValues(maxMulticolumnProbeValues);
+    
+            String multicolumnInlistProbeOnSparkEnabledString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED);
+            boolean multicolumnInlistProbeOnSparkEnabled = CompilerContext.DEFAULT_MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED;
+            try {
+                if (multicolumnInlistProbeOnSparkEnabledString != null)
+                    multicolumnInlistProbeOnSparkEnabled = Boolean.valueOf(multicolumnInlistProbeOnSparkEnabledString);
+            } catch (Exception e) {
+                // If the property value failed to convert to a boolean, don't throw an error,
+                // just use the default setting.
+            }
+            cc.setMulticolumnInlistProbeOnSparkEnabled(multicolumnInlistProbeOnSparkEnabled);
 
             fourPhasePrepare(lcc,paramDefaults,timestamps,beginTimestamp,foundInCache,cc);
         }catch(StandardException se){

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AndNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AndNode.java
@@ -307,4 +307,40 @@ public class AndNode extends BinaryLogicalOperatorNode{
     void postBindFixup() throws StandardException{
         setType(resolveLogicalBinaryOperator(leftOperand.getTypeServices(),rightOperand.getTypeServices()));
     }
+    
+    /**
+     * Is this a set of AND nodes that should not be broken up because they
+     * are part of a set of probe qualifiers?
+     */
+    boolean isGroupedMultiprobePreds() throws StandardException {
+        if (this.getLeftOperand().isInListProbeNode() &&
+            this.getRightOperand() instanceof AndNode &&
+            ((AndNode) (this.getRightOperand())).getLeftOperand().isInListProbeNode()) {
+            InListOperatorNode inListOp1 =
+                ((BinaryRelationalOperatorNode) (this.getLeftOperand())).getInListOp();
+            InListOperatorNode inListOp2 =
+                ((BinaryRelationalOperatorNode) (((AndNode) (this.getRightOperand())).
+                    getLeftOperand())).getInListOp();
+            return inListOp1.isEquivalent(inListOp2);
+        }
+        return false;
+    }
+    
+    /**
+     * Are the current node and next node in the AND chain both IN list probe
+     * predicates deriving from the same original IN list?
+     */
+    boolean isNextAndedPredInSameMultiprobeSet() throws StandardException {
+        if (this.getLeftOperand().isInListProbeNode() &&
+            this.getRightOperand() instanceof AndNode &&
+            ((AndNode) (this.getRightOperand())).getLeftOperand().isInListProbeNode()) {
+            InListOperatorNode inListOp1 =
+                ((BinaryRelationalOperatorNode) (this.getLeftOperand())).getInListOp();
+            InListOperatorNode inListOp2 =
+                ((BinaryRelationalOperatorNode) (((AndNode) (this.getRightOperand())).
+                    getLeftOperand())).getInListOp();
+            return inListOp1.isEquivalent(inListOp2);
+        }
+        return false;
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AndNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AndNode.java
@@ -307,25 +307,7 @@ public class AndNode extends BinaryLogicalOperatorNode{
     void postBindFixup() throws StandardException{
         setType(resolveLogicalBinaryOperator(leftOperand.getTypeServices(),rightOperand.getTypeServices()));
     }
-    
-    /**
-     * Is this a set of AND nodes that should not be broken up because they
-     * are part of a set of probe qualifiers?
-     */
-    boolean isGroupedMultiprobePreds() throws StandardException {
-        if (this.getLeftOperand().isInListProbeNode() &&
-            this.getRightOperand() instanceof AndNode &&
-            ((AndNode) (this.getRightOperand())).getLeftOperand().isInListProbeNode()) {
-            InListOperatorNode inListOp1 =
-                ((BinaryRelationalOperatorNode) (this.getLeftOperand())).getInListOp();
-            InListOperatorNode inListOp2 =
-                ((BinaryRelationalOperatorNode) (((AndNode) (this.getRightOperand())).
-                    getLeftOperand())).getInListOp();
-            return inListOp1.isEquivalent(inListOp2);
-        }
-        return false;
-    }
-    
+
     /**
      * Are the current node and next node in the AND chain both IN list probe
      * predicates deriving from the same original IN list?

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BetweenOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BetweenOperatorNode.java
@@ -53,7 +53,7 @@ public class BetweenOperatorNode extends BinaryListOperatorNode
 	 * @param betweenValues		The between values in list form
 	 */
 
-	public void init(Object leftOperand, Object betweenValues)
+	public void init(Object leftOperand, Object betweenValues) throws StandardException
 	{
 		if (SanityManager.DEBUG)
 		{
@@ -121,7 +121,7 @@ public class BetweenOperatorNode extends BinaryListOperatorNode
 		leftBCO = (BinaryComparisonOperatorNode) 
 					nodeFactory.getNode(
 									C_NodeTypes.BINARY_LESS_THAN_OPERATOR_NODE,
-									leftOperand, 
+									getLeftOperand(),
 								 	rightOperandList.elementAt(0),
 									cm);
 		/* Set type info for the operator node */
@@ -130,8 +130,8 @@ public class BetweenOperatorNode extends BinaryListOperatorNode
         // DERBY-4388: If leftOperand is a ColumnReference, it may be remapped
         // during optimization, and that requires the less-than node and the
         // greater-than node to have separate objects.
-        ValueNode leftClone = (leftOperand instanceof ColumnReference) ?
-            leftOperand.getClone() : leftOperand;
+        ValueNode leftClone = (getLeftOperand() instanceof ColumnReference) ?
+            getLeftOperand().getClone() : getLeftOperand();
 
 		/* leftO > rightOList.elementAt(1) */
 		rightBCO = (BinaryComparisonOperatorNode) 
@@ -191,7 +191,7 @@ public class BetweenOperatorNode extends BinaryListOperatorNode
 		 * c1 BETWEEN value1 AND value2 -> c1 >= value1 AND c1 <= value2
 		 * This transformation is only done if the leftOperand is a ColumnReference.
 		 */
-		if (!(leftOperand instanceof ColumnReference))
+		if (!(getLeftOperand() instanceof ColumnReference))
 		{
 			return this;
 		}
@@ -200,7 +200,7 @@ public class BetweenOperatorNode extends BinaryListOperatorNode
 		 * a ColumnReference because reusing them in Qualifiers for a scan
 		 * does not work.  
 		 */
-		leftClone1 = leftOperand.getClone();
+		leftClone1 = getLeftOperand().getClone();
 
 		/* The transformed tree has to be normalized:
 		 *				AND
@@ -241,7 +241,7 @@ public class BetweenOperatorNode extends BinaryListOperatorNode
 		BinaryComparisonOperatorNode greaterEqual = 
 			(BinaryComparisonOperatorNode) nodeFactory.getNode(
 					C_NodeTypes.BINARY_GREATER_EQUALS_OPERATOR_NODE,
-					leftOperand, 
+					getLeftOperand(),
 					rightOperandList.elementAt(0),
 					cm);
 
@@ -300,7 +300,7 @@ public class BetweenOperatorNode extends BinaryListOperatorNode
 		leftBCO = (BinaryComparisonOperatorNode) 
 					nodeFactory.getNode(
 							C_NodeTypes.BINARY_GREATER_EQUALS_OPERATOR_NODE,
-							leftOperand, 
+							getLeftOperand(),
 							rightOperandList.elementAt(0),
 							cm);
 		/* Set type info for the operator node */
@@ -310,7 +310,7 @@ public class BetweenOperatorNode extends BinaryListOperatorNode
 		rightBCO = (BinaryComparisonOperatorNode) 
 					nodeFactory.getNode(
 						C_NodeTypes.BINARY_LESS_EQUALS_OPERATOR_NODE,
-						leftOperand, 
+						getLeftOperand(),
 						rightOperandList.elementAt(1),
 						cm);
 		/* Set type info for the operator node */
@@ -327,7 +327,7 @@ public class BetweenOperatorNode extends BinaryListOperatorNode
 	}
 	
 	public int hashCode(){
-		int result = leftOperand==null? 0: leftOperand.hashCode();
+		int result = getLeftOperand()==null? 0: getLeftOperand().hashCode();
 		result = 31*result+(rightOperandList==null?0:rightOperandList.hashCode());
 		return result;
 	}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryListOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryListOperatorNode.java
@@ -256,16 +256,8 @@ public abstract class BinaryListOperatorNode extends ValueNode{
 		** nullable, the result of the comparison must be nullable, too, so
 		** we can represent the unknown truth value.
 		*/
-		boolean leftNullable = false;
-        for (int index = 0; index < leftOperandList.size(); index++) {
-            ValueNode ln = (ValueNode) leftOperandList.elementAt(index);
-            if (ln.getTypeServices().isNullable()) {
-                leftNullable = true;
-                break;
-            }
-        }
-        nullableResult= leftNullable ||
-                rightOperandList.isNullable();
+        nullableResult= leftOperandList.isNullable() ||
+                        rightOperandList.isNullable();
         setType(new DataTypeDescriptor(TypeId.BOOLEAN_ID,nullableResult));
     }
 
@@ -442,7 +434,7 @@ public abstract class BinaryListOperatorNode extends ValueNode{
     }
 
     public boolean isConstantOrParameterTreeNode() {
-        if (leftOperandList != null && !leftOperandList.isConstantOrParameterTreeNode())
+        if (leftOperandList != null && !leftOperandList.containsOnlyConstantAndParamNodes())
             return false;
 
         if (rightOperandList != null && !rightOperandList.containsOnlyConstantAndParamNodes())

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
@@ -1,4 +1,4 @@
-/*
+ /*
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
  * GNU Affero General Public License as published by the Free Software Foundation, either
@@ -157,7 +157,7 @@ public class BinaryRelationalOperatorNode
      * left operand of the inListProbeSource is set correctly before
      * returning it.
      */
-    public InListOperatorNode getInListOp(){
+    public InListOperatorNode getInListOp() throws StandardException {
         if(inListProbeSource!=null){
             /* Depending on where this probe predicate currently sits
 			 * in the query tree, this.leftOperand *may* have been
@@ -186,7 +186,9 @@ public class BinaryRelationalOperatorNode
 			 * to ensure the underlying InListOperatorNode also has an
 			 * up-to-date leftOperand is to set it to this.leftOperand.
 			 */
-            inListProbeSource.setLeftOperand(this.leftOperand);
+            // No remapping of multicolumn IN list for now.
+            if (inListProbeSource.leftOperandList.size() == 1)
+                inListProbeSource.setLeftOperand(this.leftOperand);
         }
 
         return inListProbeSource;
@@ -1019,7 +1021,7 @@ public class BinaryRelationalOperatorNode
         }
     }
 
-    private boolean isKnownConstant(ValueNode node, boolean considerParameters) {
+    public static boolean isKnownConstant(ValueNode node, boolean considerParameters) {
         if (node instanceof CastNode)
             node = ((CastNode) node).castOperand;
 
@@ -1648,7 +1650,7 @@ public class BinaryRelationalOperatorNode
      * inListProbeSource's leftOperand through this method.
      */
     @Override
-    public boolean isInListProbeNode(){
+    public boolean  isInListProbeNode(){
         return (inListProbeSource!=null);
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/C_NodeNames.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/C_NodeNames.java
@@ -72,6 +72,8 @@ public interface C_NodeNames
 	String BIT_CONSTANT_NODE_NAME = "com.splicemachine.db.impl.sql.compile.BitConstantNode";
 
 	String BOOLEAN_CONSTANT_NODE_NAME = "com.splicemachine.db.impl.sql.compile.BooleanConstantNode";
+	
+	String LIST_VALUE_NODE_NAME = "com.splicemachine.db.impl.sql.compile.ListValueNode";
 
 	String CALL_STATEMENT_NODE_NAME = "com.splicemachine.db.impl.sql.compile.CallStatementNode";
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
@@ -139,6 +139,7 @@ public class CompilerContextImpl extends ContextImpl
         skipStatsTableList.clear();
         selectivityEstimationIncludingSkewedDefault = false;
         projectionPruningEnabled = false;
+        maxMulticolumnProbeValues = DEFAULT_MAX_MULTICOLUMN_PROBE_VALUES;
 	}
 
 	//
@@ -214,6 +215,21 @@ public class CompilerContextImpl extends ContextImpl
 	public void setProjectionPruningEnabled(boolean onOff) {
 		projectionPruningEnabled = onOff;
 	}
+	
+	public int getMaxMulticolumnProbeValues() {
+		return maxMulticolumnProbeValues;
+	}
+	
+	public void setMaxMulticolumnProbeValues(int newValue) {
+		maxMulticolumnProbeValues = newValue;
+	}
+	
+	public void setMulticolumnInlistProbeOnSparkEnabled(boolean newValue) {
+		multicolumnInlistProbeOnSparkEnabled = newValue;
+	}
+	
+	public boolean getMulticolumnInlistProbeOnSparkEnabled() { return multicolumnInlistProbeOnSparkEnabled; }
+	
 	/**
 	 * Get the current next subquery number from this CompilerContext.
 	 *
@@ -1034,6 +1050,8 @@ public class CompilerContextImpl extends ContextImpl
 	private int                 maximalPossibleTableCount;
 	private boolean             selectivityEstimationIncludingSkewedDefault = false;
 	private boolean             projectionPruningEnabled;
+	private int                 maxMulticolumnProbeValues = DEFAULT_MAX_MULTICOLUMN_PROBE_VALUES;
+	private boolean             multicolumnInlistProbeOnSparkEnabled = DEFAULT_MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED;
 
 	/**
 	 * Saved execution time default schema, if we need to change it

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
@@ -228,6 +228,14 @@ public class CompilerContextImpl extends ContextImpl
 		multicolumnInlistProbeOnSparkEnabled = newValue;
 	}
 	
+	public void setConvertMultiColumnDNFPredicatesToInList(boolean newValue) {
+		convertMultiColumnDNFPredicatesToInList = newValue;
+	}
+	
+	public boolean getConvertMultiColumnDNFPredicatesToInList() {
+		return convertMultiColumnDNFPredicatesToInList;
+	}
+	
 	public boolean getMulticolumnInlistProbeOnSparkEnabled() { return multicolumnInlistProbeOnSparkEnabled; }
 	
 	/**
@@ -1052,6 +1060,7 @@ public class CompilerContextImpl extends ContextImpl
 	private boolean             projectionPruningEnabled;
 	private int                 maxMulticolumnProbeValues = DEFAULT_MAX_MULTICOLUMN_PROBE_VALUES;
 	private boolean             multicolumnInlistProbeOnSparkEnabled = DEFAULT_MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED;
+	private boolean             convertMultiColumnDNFPredicatesToInList= DEFAULT_CONVERT_MULTICOLUMN_DNF_PREDICATES_TO_INLIST;
 
 	/**
 	 * Saved execution time default schema, if we need to change it

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstantNode.java
@@ -301,6 +301,11 @@ public abstract class ConstantNode extends ValueNode
 	public long nonZeroCardinality(long numberOfRows) throws StandardException {
 		return 1;
 	}
+	
+	@Override
+	public int hashCode() {
+		return value.hashCode();
+	}
 
 	@Override
 	public boolean isConstantOrParameterTreeNode() {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FindNonConstantsVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FindNonConstantsVisitor.java
@@ -1,0 +1,95 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+
+package com.splicemachine.db.impl.sql.compile;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.compile.Visitable;
+import com.splicemachine.db.iapi.sql.compile.Visitor;
+
+
+/**
+ * Created by msirek on 2018-12-18.
+ */
+public class FindNonConstantsVisitor implements Visitor 
+{
+    private boolean nonConstantsFound = false;
+
+    public FindNonConstantsVisitor()
+    {
+        
+    }
+
+    ////////////////////////////////////////////////
+    //
+    // VISITOR INTERFACE
+    //
+    ////////////////////////////////////////////////
+
+
+    public Visitable visit(Visitable node, QueryTreeNode parent)
+        throws StandardException
+    {
+        if (node instanceof ColumnReference ||
+            node instanceof ResultSetNode ||
+            node instanceof NextSequenceNode)
+        {
+            nonConstantsFound = true;
+        }
+
+        return node;
+    }
+
+    /**
+     * No need to go below a Predicate or ResultSet.
+     *
+     * @return Whether or not to go below the node.
+     */
+    public boolean skipChildren(Visitable node)
+    {
+        return (nonConstantsFound ||
+                node instanceof ColumnReference ||
+                node instanceof ResultSetNode);
+    }
+
+    public boolean visitChildrenFirst(Visitable node)
+    {
+        return false;
+    }
+
+    public boolean stopTraversal()
+    {
+        return nonConstantsFound;
+    }
+
+    public boolean getNonConstantsFound() { return nonConstantsFound; }
+}    

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
@@ -238,7 +238,11 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 			 * will have.  In that case we'll sort the values at execution
 			 * time. 
 			 */
-			if (allConstants) {
+			// Disable sorting of multicolumn IN lists here for now.
+			// These will typically long lists, and using bubble sort
+			// is not good.  The probe values will end up getting
+			// sorted, and duplicates removed, at execution time.
+			if (allConstants && leftOperandList.size() == 1) {
                 /* When sorting or choosing min/max in the list, if types
                  * are not an exact match then we have to use the *dominant*
                  * type across all values, where "all values" includes the

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
@@ -31,20 +31,24 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
-import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.ClassName;
-import com.splicemachine.db.iapi.types.TypeId;
-import com.splicemachine.db.iapi.types.DataTypeDescriptor;
-import com.splicemachine.db.iapi.types.DataValueDescriptor;
-import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.services.classfile.VMOpcode;
 import com.splicemachine.db.iapi.services.compiler.LocalField;
+import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.loader.ClassFactory;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
+import com.splicemachine.db.iapi.sql.compile.NodeFactory;
 import com.splicemachine.db.iapi.sql.compile.Optimizable;
-import com.splicemachine.db.iapi.services.classfile.VMOpcode;
+import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.db.iapi.types.ListDataType;
+import com.splicemachine.db.iapi.types.TypeId;
 
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 
 /**
  * An InListOperatorNode represents an IN list.
@@ -63,7 +67,7 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 	 * @param rightOperandList	The right operand list of the node
 	 */
 
-	public void init(Object leftOperand, Object rightOperandList)
+	public void init(Object leftOperand, Object rightOperandList) throws StandardException
 	{
 		init(leftOperand, rightOperandList, "IN", "in");
 	}
@@ -98,7 +102,7 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 		InListOperatorNode ilon =
 			 (InListOperatorNode)getNodeFactory().getNode(
 				C_NodeTypes.IN_LIST_OPERATOR_NODE,
-				leftOperand,
+				leftOperandList,
 				rightOperandList,
 				getContextManager());
 
@@ -131,37 +135,42 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 								FromList outerFromList,
 								SubqueryList outerSubqueryList,
 								PredicateList outerPredicateList) 
+					throws StandardException {
+        super.preprocess(numTables,
+            outerFromList, outerSubqueryList,
+            outerPredicateList);
+        
+        return convertToAndedEqualityProbePredicate();
+    }
+    
+    public ValueNode convertToAndedEqualityProbePredicate()
 					throws StandardException
-	{
-		super.preprocess(numTables,
-						 outerFromList, outerSubqueryList,
-						 outerPredicateList);
-
+    {
 		/* Check for the degenerate case of a single element in the IN list.
 		 * If found, then convert to "=".
 		 */
-		if (rightOperandList.size() == 1)
+		if (rightOperandList.size() == 1 && singleLeftOperand)
 		{
 			ValueNode value = (ValueNode)rightOperandList.elementAt(0);
-            if ((value instanceof CharConstantNode) && (leftOperand instanceof ColumnReference)) {
-				DataTypeDescriptor targetType = leftOperand.getTypeServices();
+            if ((value instanceof CharConstantNode) && (getLeftOperand() instanceof ColumnReference)) {
+				DataTypeDescriptor targetType = getLeftOperand().getTypeServices();
 				if (targetType.getTypeName().equals(TypeId.CHAR_NAME)) {
-					int maxSize = leftOperand.getTypeServices().getMaximumWidth();
+					int maxSize = getLeftOperand().getTypeServices().getMaximumWidth();
 					ValueNodeList.rightPadCharConstantNode((CharConstantNode) value, maxSize);
 				}
 			}
 			BinaryComparisonOperatorNode equal =
 				(BinaryComparisonOperatorNode) getNodeFactory().getNode(
 						C_NodeTypes.BINARY_EQUALS_OPERATOR_NODE,
-						leftOperand, 
+						getLeftOperand(),
 						value,
 						getContextManager());
 			/* Set type info for the operator node */
 			equal.bindComparisonOperator();
 			return equal;
 		}
-		else if ((leftOperand instanceof ColumnReference) &&
-				 rightOperandList.containsOnlyConstantAndParamNodes())
+		else if (allLeftOperandsColumnReferences() &&
+			     rightOperandList.containsOnlyConstantAndParamNodes())
 		{
 			/* At this point we have an IN-list made up of constant and/or
 			 * parameter values.  Ex.:
@@ -229,58 +238,76 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 			 * will have.  In that case we'll sort the values at execution
 			 * time. 
 			 */
-			if (allConstants)
-			{
-				/* When sorting or choosing min/max in the list, if types
-				 * are not an exact match then we have to use the *dominant*
-				 * type across all values, where "all values" includes the
-				 * left operand.  Otherwise we can end up with incorrect
-				 * results.
-				 *
-				 * Note that it is *not* enough to just use the left operand's
-				 * type as the judge because we have no guarantee that the
-				 * left operand has the dominant type.  If, for example, the
-				 * left operand has type INTEGER and all (or any) values in
-				 * the IN list have type DECIMAL, use of the left op's type
-				 * would lead to comparisons with truncated values and could
-				 * therefore lead to an incorrect sort order. DERBY-2256.
-				 */
-				DataTypeDescriptor targetType = leftOperand.getTypeServices();
-				TypeId judgeTypeId = targetType.getTypeId();
-
-				if (!rightOperandList.allSamePrecendence(
-					judgeTypeId.typePrecedence()))
-				{
-					/* Iterate through the entire list of values to find out
-					 * what the dominant type is.
-					 */
-					ClassFactory cf = getClassFactory();
-					int sz = rightOperandList.size();
-					for (int i = 0; i < sz; i++)
-					{
-						ValueNode vn = (ValueNode)rightOperandList.elementAt(i);
-						targetType =
-							targetType.getDominantType(
-								vn.getTypeServices(), cf);
-					}
-				}
-				rightOperandList.eliminateDuplicates(targetType);
-
-				/* Now sort the list in ascending order using the dominant
-				 * type found above.
-				 */
-				DataValueDescriptor judgeODV = targetType.getNull();
+			if (allConstants) {
+                /* When sorting or choosing min/max in the list, if types
+                 * are not an exact match then we have to use the *dominant*
+                 * type across all values, where "all values" includes the
+                 * left operand.  Otherwise we can end up with incorrect
+                 * results.
+                 *
+                 * Note that it is *not* enough to just use the left operand's
+                 * type as the judge because we have no guarantee that the
+                 * left operand has the dominant type.  If, for example, the
+                 * left operand has type INTEGER and all (or any) values in
+                 * the IN list have type DECIMAL, use of the left op's type
+                 * would lead to comparisons with truncated values and could
+                 * therefore lead to an incorrect sort order. DERBY-2256.
+                 */
+                ArrayList targetTypes = new ArrayList<DataTypeDescriptor>();
+                
+                for (int j = 0; j < leftOperandList.size(); j++) {
+                    ValueNode leftOperand = (ValueNode) leftOperandList.elementAt(j);
+                    DataTypeDescriptor targetType = leftOperand.getTypeServices();
+                    
+                    TypeId judgeTypeId = targetType.getTypeId();
+                    
+                    if (!rightOperandList.allSamePrecendence(
+                        judgeTypeId.typePrecedence(), j)) {
+                        /* Iterate through the entire list of values to find out
+                         * what the dominant type is.
+                         */
+                        ClassFactory cf = getClassFactory();
+                        int sz = rightOperandList.size();
+                        for (int i = 0; i < sz; i++) {
+                            ValueNode vn = (ValueNode) rightOperandList.elementAt(i);
+                            if (!singleLeftOperand)
+                                vn = ((ListValueNode) vn).getValue(j);
+                            targetType =
+                                targetType.getDominantType(
+                                    vn.getTypeServices(), cf);
+                        }
+                    }
+                    targetTypes.add(targetType);
+                }
+                rightOperandList.eliminateDuplicates(targetTypes);
+                
+                /* Now sort the list in ascending order using the dominant
+                 * type found above.
+                 */
+                
+                DataValueDescriptor judgeODV = null;
+                
+                if (singleLeftOperand) {
+                    judgeODV = ((DataTypeDescriptor) targetTypes.get(0)).getNull();
+                }
+                else {
+                    ListDataType ldt = new ListDataType(leftOperandList.size());
+                    for (int j = 0; j < leftOperandList.size(); j++) {
+                        ldt.setFrom(((DataTypeDescriptor) targetTypes.get(j)).getNull(), j);
+                    }
+                    judgeODV = ldt;
+                }
 
 				rightOperandList.sortInAscendingOrder(judgeODV);
 				isOrdered = true;
 
-				if (rightOperandList.size() == 1)
+				if (rightOperandList.size() == 1 && singleLeftOperand)
 				{
 					ValueNode value = (ValueNode)rightOperandList.elementAt(0);
 					BinaryComparisonOperatorNode equal =
 						(BinaryComparisonOperatorNode)getNodeFactory().getNode(
 							C_NodeTypes.BINARY_EQUALS_OPERATOR_NODE,
-							leftOperand, 
+							getLeftOperand(),
 							value,
 							getContextManager());
 					/* Set type info for the operator node */
@@ -288,74 +315,107 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 					return equal;
 				}
 			}
+            
+            BinaryComparisonOperatorNode equal = null;
+            ValueNode andNode = null;
+            ValueNode lastAnd = null;
+            for (int i = 0; i < leftOperandList.size(); i++) {
 
-			/* Create a parameter node to serve as the right operand of
-			 * the probe predicate.  We intentionally use a parameter node
-			 * instead of a constant node because the IN-list has more than
-			 * one value (some of which may be unknown at compile time, i.e.
-			 * if they are parameters), so we don't want an estimate based
-			 * on any single literal.  Instead we want a generic estimate
-			 * of the cost to retrieve the rows matching some _unspecified_
-			 * value (namely, one of the values in the IN-list, but we
-			 * don't know which one).  That's exactly what a parameter
-			 * node gives us.
-			 *
-			 * Note: If the IN-list only had a single value then we would
-			 * have taken the "if (rightOperandList.size() == 1)" branch
-			 * above and thus would not be here.
-			 *
-			 * We create the parameter node based on the first value in
-			 * the list.  This is arbitrary and should not matter in the
-			 * big picture.
-			 */
-			ValueNode srcVal = (ValueNode) rightOperandList.elementAt(0);
-			ParameterNode pNode =
-				(ParameterNode) getNodeFactory().getNode(
-					C_NodeTypes.PARAMETER_NODE,
+                /* Create a parameter node to serve as the right operand of
+                 * the probe predicate.  We intentionally use a parameter node
+                 * instead of a constant node because the IN-list has more than
+                 * one value (some of which may be unknown at compile time, i.e.
+                 * if they are parameters), so we don't want an estimate based
+                 * on any single literal.  Instead we want a generic estimate
+                 * of the cost to retrieve the rows matching some _unspecified_
+                 * value (namely, one of the values in the IN-list, but we
+                 * don't know which one).  That's exactly what a parameter
+                 * node gives us.
+                 *
+                 * Note: If the IN-list only had a single value then we would
+                 * have taken the "if (rightOperandList.size() == 1)" branch
+                 * above and thus would not be here.
+                 *
+                 * We create the parameter node based on the first value in
+                 * the list.  This is arbitrary and should not matter in the
+                 * big picture.
+                 */
+                ValueNode srcVal = (ValueNode) rightOperandList.elementAt(0);
+                ValueNode leftOperand = (ValueNode) leftOperandList.elementAt(i);
+                if (srcVal instanceof ListValueNode)
+                    srcVal = ((ListValueNode)srcVal).getValue(i);
+                ParameterNode pNode =
+                    (ParameterNode) getNodeFactory().getNode(
+                        C_NodeTypes.PARAMETER_NODE,
                         0,
-					null, // default value
-					getContextManager());
+                        null, // default value
+                        getContextManager());
+    
+                DataTypeDescriptor pType = srcVal.getTypeServices();
+                pNode.setType(pType);
+    
+                /* If we choose to use the new predicate for execution-time
+                 * probing then the right operand will function as a start-key
+                 * "place-holder" into which we'll store the different IN-list
+                 * values as we iterate through them.  This means we have to
+                 * generate a valid value for the parameter node--i.e. for the
+                 * right side of the probe predicate--in order to have a valid
+                 * execution-time placeholder.  To do that we pass the source
+                 * value from which we found the type down to the new, "fake"
+                 * parameter node.  Then, when it comes time to generate the
+                 * parameter node, we'll just generate the source value as our
+                 * place-holder.  See ParameterNode.generateExpression().
+                 *
+                 * Note: the actual value of the "place-holder" does not matter
+                 * because it will be clobbered by the various IN-list values
+                 * (which includes "srcVal" itself) as we iterate through them
+                 * during execution.
+                 */
+                pNode.setValueToGenerate(srcVal);
+    
+                /* Finally, create the "column = ?" equality that serves as the
+                 * basis for the probe predicate.  We store a reference to "this"
+                 * node inside the probe predicate so that, if we later decide
+                 * *not* to use the probe predicate for execution time index
+                 * probing, we can revert it back to its original form (i.e.
+                 * to "this").
+                 */
 
-			DataTypeDescriptor pType = srcVal.getTypeServices();
-			pNode.setType(pType);
-
-			/* If we choose to use the new predicate for execution-time
-			 * probing then the right operand will function as a start-key
-			 * "place-holder" into which we'll store the different IN-list
-			 * values as we iterate through them.  This means we have to
-			 * generate a valid value for the parameter node--i.e. for the
-			 * right side of the probe predicate--in order to have a valid
-			 * execution-time placeholder.  To do that we pass the source
-			 * value from which we found the type down to the new, "fake"
-			 * parameter node.  Then, when it comes time to generate the
-			 * parameter node, we'll just generate the source value as our
-			 * place-holder.  See ParameterNode.generateExpression().
-			 *
-			 * Note: the actual value of the "place-holder" does not matter
-			 * because it will be clobbered by the various IN-list values
-			 * (which includes "srcVal" itself) as we iterate through them
-			 * during execution.
-			 */
-			pNode.setValueToGenerate(srcVal);
-
-			/* Finally, create the "column = ?" equality that serves as the
-			 * basis for the probe predicate.  We store a reference to "this"
-			 * node inside the probe predicate so that, if we later decide
-			 * *not* to use the probe predicate for execution time index
-			 * probing, we can revert it back to its original form (i.e.
-			 * to "this").
-			 */
-			BinaryComparisonOperatorNode equal = 
-				(BinaryComparisonOperatorNode) getNodeFactory().getNode(
-					C_NodeTypes.BINARY_EQUALS_OPERATOR_NODE,
-					leftOperand, 
-					pNode,
-					this,
-					getContextManager());
-
-			/* Set type info for the operator node */
-			equal.bindComparisonOperator();
-			return equal;
+                equal =
+                    (BinaryComparisonOperatorNode) getNodeFactory().getNode(
+                        C_NodeTypes.BINARY_EQUALS_OPERATOR_NODE,
+                        leftOperand,
+                        pNode,
+                        this,
+                        getContextManager());
+    
+                /* Set type info for the operator node */
+                equal.bindComparisonOperator();
+    
+                // Build a chain of AND'ed binary comparisons for each
+                // of the columns in a multicolumn IN list.
+                if (!isSingleLeftOperand()) {
+                    NodeFactory nodeFactory = getNodeFactory();
+                    QueryTreeNode trueNode = (QueryTreeNode) nodeFactory.getNode(
+                        C_NodeTypes.BOOLEAN_CONSTANT_NODE,
+                        Boolean.TRUE,
+                        getContextManager());
+                    ValueNode temp;
+                    temp = (AndNode) nodeFactory.getNode(
+                        C_NodeTypes.AND_NODE,
+                        equal,
+                        trueNode,
+                        getContextManager());
+                    ((AndNode) temp).postBindFixup();
+                    if (lastAnd != null)
+                        ((AndNode) lastAnd).setRightOperand(temp);
+        
+                    lastAnd = temp;
+                    if (andNode == null)
+                        andNode = temp;
+                }
+            }
+            return (andNode == null) ? equal : andNode;
 		}
 		else
 		{
@@ -396,6 +456,9 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 		{
 			return this;
 		}
+		
+		if (!singleLeftOperand)
+            throw StandardException.newException(SQLState.LANG_UNKNOWN);
 
 		/* we want to convert the IN List into = OR = ... as
 		 * described below.  
@@ -414,7 +477,7 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 		/* If leftOperand is a ColumnReference, it may be remapped during optimization, and that
 		 * requires each <> node to have a separate object.
 		 */
-		ValueNode leftClone = (leftOperand instanceof ColumnReference) ? leftOperand.getClone() : leftOperand;
+		ValueNode leftClone = (getLeftOperand() instanceof ColumnReference) ? getLeftOperand().getClone() : getLeftOperand();
 		leftBCO = (BinaryComparisonOperatorNode) 
 					getNodeFactory().getNode(
 						C_NodeTypes.BINARY_NOT_EQUALS_OPERATOR_NODE,
@@ -430,7 +493,7 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 		{
 
 			/* leftO <> rightOList.elementAt(elemsDone) */
-			leftClone = (leftOperand instanceof ColumnReference) ? leftOperand.getClone() : leftOperand;
+			leftClone = (getLeftOperand() instanceof ColumnReference) ? getLeftOperand().getClone() : getLeftOperand();
 			rightBCO = (BinaryComparisonOperatorNode) 
 						getNodeFactory().getNode(
 							C_NodeTypes.BINARY_NOT_EQUALS_OPERATOR_NODE,
@@ -529,8 +592,6 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 		** to the new method.
 		*/
 
-		receiver = leftOperand;
-
 		/* Figure out the result type name */
 		resultTypeName = getTypeCompiler().interfaceName();
 
@@ -551,7 +612,37 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 		//LocalField receiverField =
 		//	acb.newFieldDeclaration(Modifier.PRIVATE, receiverType);
 
-		leftOperand.generateExpression(acb, mb);
+        if (leftOperandList.size() == 1) {
+            getLeftOperand().generateExpression(acb, mb);
+        }
+        else {
+            // Build a new ListDataType
+            LocalField vals = PredicateList.generateListData(acb,
+                                                             leftOperandList.size());
+    
+            for (int i = 0; i < leftOperandList.size(); i++) {
+    
+                ValueNode colRef = (ValueNode)leftOperandList.elementAt(i);
+                
+                // Call instance method setFrom to populate an entry in
+                // the new ListDataType node with a data value from the
+                // ValueNodeList (in this case these are column references).
+                mb.getField(vals);
+                colRef.generateExpression(acb, mb);
+                mb.upCast(ClassName.DataValueDescriptor);
+                // Populate the "i"th value.
+                mb.push(i);
+    
+                mb.callMethod(VMOpcode.INVOKEVIRTUAL,
+                    ClassName.ListDataType,
+                    "setFrom",
+                    "void", 2);
+            }
+            // Push the ListDataType on the stack as a DataValueDescriptor.
+            mb.getField(vals);
+            mb.upCast(ClassName.DataValueDescriptor);
+            
+        }
 		mb.dup();
 		//mb.putField(receiverField); // instance for method call
 		/*mb.getField(receiverField);*/ mb.upCast(leftInterfaceType); // first arg
@@ -560,7 +651,70 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 		mb.callMethod(VMOpcode.INVOKEINTERFACE, receiverType, methodName, resultTypeName, 3);
 	}
 
-	/**
+	// It is expected that a DVD to move into the array has been pushed to the stack
+	// before this method is called.
+	protected void setDVDItemInArray(MethodBuilder mb, LocalField arrayField, int index,
+								     int constIdx, int numValsInSet) throws StandardException {
+		if (mb != null) {
+			if (numValsInSet > 1) {
+				// Push the ListDataType instance in prep for calling setFrom.
+				mb.getField(arrayField);
+				mb.getArrayElement(index);
+				mb.cast(ClassName.ListDataType);
+
+				mb.swap();
+				mb.push(constIdx);
+
+				mb.callMethod(VMOpcode.INVOKEVIRTUAL,
+						(String) null,
+						"setFrom",
+						"void", 2);
+			} else {
+				// Push the DVD array field in preparation of calling setArrayElement.
+				mb.getField(arrayField);
+				mb.swap();
+				mb.setArrayElement(index);
+			}
+		}
+	}
+	
+	protected void buildDVDInArray(MethodBuilder mb, LocalField arrayField, int index,
+								   LocalField rowArray, int numValsInSet) throws StandardException {
+		if (mb != null) {
+			if (numValsInSet > 1) {
+				// Push the ListDataType instance in prep for calling setFrom.
+				mb.getField(arrayField);
+				mb.getArrayElement(index);
+				mb.cast(ClassName.ListDataType);
+				
+				// Push the row as argument to setFrom.
+				mb.getField(rowArray);
+				mb.getArrayElement(index);
+				mb.upCast(ClassName.ExecRow);
+				
+				mb.callMethod(VMOpcode.INVOKEVIRTUAL,
+					(String) null,
+					"setFrom",
+					"void", 1);
+			} else {
+				// Push the DVD array field in preparation of calling setArrayElement.
+				mb.getField(arrayField);
+				
+				// Push the ExecRow in preparation of calling getColumn.
+				mb.getField(rowArray);
+				mb.getArrayElement(index);
+				mb.cast(ClassName.ValueRow);
+				mb.push(1);
+				mb.callMethod(VMOpcode.INVOKEVIRTUAL,
+					(String) null,
+					"getColumn",
+					ClassName.DataValueDescriptor, 1);
+				mb.setArrayElement(index);
+			}
+		}
+	}
+	
+    /**
 	 * Generate the code to create an array of DataValueDescriptors that
 	 * will hold the IN-list values at execution time.  The array gets
 	 * created in the constructor.  All constant elements in the array
@@ -582,53 +736,87 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 		cb.pushNewArray(ClassName.DataValueDescriptor, listSize);
 		cb.setField(arrayField);
 
+        // Count the number of "constants" in each group.
+        ValueNode constants = (ValueNode)rightOperandList.elementAt(0);
+        int numValsInSet = constants instanceof ListValueNode ?
+            ((ListValueNode) constants).numValues() : 1;
+        
 		/* Set the array elements that are constant */
-		int numConstants = 0;
-		MethodBuilder nonConstantMethod = null;
+        MethodBuilder nonConstantMethod = null;
 		MethodBuilder currentConstMethod = cb;
+
 		for (int index = 0; index < listSize; index++)
 		{
-			MethodBuilder setArrayMethod;
+            ValueNode topLevelLiteral = (ValueNode) rightOperandList.elementAt(index);
+            ValueNode dataLiteral;
+            MethodBuilder setArrayMethod = null;
+			int numConstants = 0;
+			int numNonConstants = 0;
+
+            for (int constIdx = 0; constIdx < numValsInSet; constIdx++) {
+
+                if (topLevelLiteral instanceof ListValueNode)
+                    dataLiteral = ((ListValueNode) topLevelLiteral).getValue(constIdx);
+                else
+                    dataLiteral = topLevelLiteral;
+    
+                if (dataLiteral instanceof ConstantNode) {
+                    numConstants++;
+        
+                    /*if too many statements are added  to a  method,
+                     *size of method can hit  65k limit, which will
+                     *lead to the class format errors at load time.
+                     *To avoid this problem, when number of statements added
+                     *to a method is > 2048, remaing statements are added to  a new function
+                     *and called from the function which created the function.
+                     *See Beetle 5135 or 4293 for further details on this type of problem.
+                     */
+                    if (constIdx == 0 &&
+						currentConstMethod.statementNumHitLimit(numConstants)) {
+                        MethodBuilder genConstantMethod = acb.newGeneratedFun("void", Modifier.PRIVATE);
+                        currentConstMethod.pushThis();
+                        currentConstMethod.callMethod(VMOpcode.INVOKEVIRTUAL,
+                            (String) null,
+                            genConstantMethod.getName(),
+                            "void", 0);
+                        //if it is a generate function, close the metod.
+                        if (currentConstMethod != cb) {
+                            currentConstMethod.methodReturn();
+                            currentConstMethod.complete();
+                        }
+                        currentConstMethod = genConstantMethod;
+                    }
+                    setArrayMethod = currentConstMethod;
+                } else {
+					numNonConstants++;
+                    if (nonConstantMethod == null)
+                        nonConstantMethod = acb.newGeneratedFun("void", Modifier.PROTECTED);
+                    setArrayMethod = nonConstantMethod;
+        
+                }
+                if (constIdx == 0) {
+                    if (numValsInSet > 1) {
+						// Push the DVD array reference on the stack
+						cb.getField(arrayField);
 	
-			if (rightOperandList.elementAt(index) instanceof ConstantNode)
-			{
-				numConstants++;
-		
-				/*if too many statements are added  to a  method, 
-				*size of method can hit  65k limit, which will
-				*lead to the class format errors at load time.
-				*To avoid this problem, when number of statements added 
-				*to a method is > 2048, remaing statements are added to  a new function
-				*and called from the function which created the function.
-				*See Beetle 5135 or 4293 for further details on this type of problem.
-				*/
-				if(currentConstMethod.statementNumHitLimit(1))
-				{
-					MethodBuilder genConstantMethod = acb.newGeneratedFun("void", Modifier.PRIVATE);
-					currentConstMethod.pushThis();
-					currentConstMethod.callMethod(VMOpcode.INVOKEVIRTUAL,
-												  (String) null, 
-												  genConstantMethod.getName(),
-												  "void", 0);
-					//if it is a generate function, close the metod.
-					if(currentConstMethod != cb){
-						currentConstMethod.methodReturn();
-						currentConstMethod.complete();
+						// Build a new ListDataType, and place on the stack.
+						PredicateList.generateListDataOnStack(acb, numValsInSet);
+						cb.upCast(ClassName.DataValueDescriptor);
+	
+						// Store the list data in the DVD array.
+						cb.setArrayElement(index);
 					}
-					currentConstMethod = genConstantMethod;
-				}
-				setArrayMethod = currentConstMethod;
-			} else {
-				if (nonConstantMethod == null)
-					nonConstantMethod = acb.newGeneratedFun("void", Modifier.PROTECTED);
-				setArrayMethod = nonConstantMethod;
+                }
 
-			}
+				// Build the DVD to add to the DVD array, pushing it to the stack
+				// cast as a DataValueDescriptor.
+				dataLiteral.generateExpression(acb, setArrayMethod);
+				setArrayMethod.upCast(ClassName.DataValueDescriptor);
 
-			setArrayMethod.getField(arrayField); // first arg
-			((ValueNode) rightOperandList.elementAt(index)).generateExpression(acb, setArrayMethod);
-			setArrayMethod.upCast(ClassName.DataValueDescriptor); // second arg
-			setArrayMethod.setArrayElement(index);
+				// Move the built DVD into the DVD array, using the proper
+				// constant or non-constant method.
+				setDVDItemInArray(setArrayMethod, arrayField, index, constIdx, numValsInSet);
+            }
 		}
 
 		//if a generated function was created to reduce the size of the methods close the functions.
@@ -667,70 +855,73 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 		 * the min/max value of the operands on the right side.  Judge's type
 		 * is important for us, and is input parameter to min/maxValue.
 		 */
-		int leftTypeFormatId = leftOperand.getTypeId().getTypeFormatId();
-		int leftJDBCTypeId = leftOperand.getTypeId().isUserDefinedTypeId() ?
-								leftOperand.getTypeId().getJDBCTypeId() : -1;
-
-		int listSize = rightOperandList.size();
-		int numLoops, numValInLastLoop, currentOpnd = 0;
-
-		/* We first calculate how many times (loops) we generate a call to
-		 * min/maxValue function accumulatively, since each time it at most
-		 * takes 4 input values.  An example of the calls generated will be:
-		 * minVal(minVal(...minVal(minVal(v1,v2,v3,v4,judge), v5,v6,v7,judge),
-		 *        ...), vn-1, vn, NULL, judge)
-		 * Unused value parameters in the last call are filled with NULLs.
-		 */
-		if (listSize < 5)
-		{
-			numLoops = 1;
-			numValInLastLoop = (listSize - 1) % 4 + 1;
-		}
-		else
-		{
-			numLoops = (listSize - 5) / 3 + 2;
-			numValInLastLoop = (listSize - 5) % 3 + 1;
-		}
-
-		for (int i = 0; i < numLoops; i++)
-		{
-			/* generate value parameters of min/maxValue
-			 */
-			int numVals = (i == numLoops - 1) ? numValInLastLoop :
-							  ((i == 0) ? 4 : 3);
-			for (int j = 0; j < numVals; j++)
-			{
-				ValueNode vn = (ValueNode) rightOperandList.elementAt(currentOpnd++);
-				vn.generateExpression(acb, mb);
-				mb.upCast(ClassName.DataValueDescriptor);
-			}
-
-			/* since we have fixed number of input values (4), unused ones
-			 * in the last loop are filled with NULLs
-			 */
-			int numNulls = (i < numLoops - 1) ? 0 :
-							((i == 0) ? 4 - numValInLastLoop : 3 - numValInLastLoop);
-			for (int j = 0; j < numNulls; j++)
-				mb.pushNull(ClassName.DataValueDescriptor);
-
-			/* have to put judge's types in the end
-			 */
-			mb.push(leftTypeFormatId);
-			mb.push(leftJDBCTypeId);
-
-			/* decide to get min or max value
-			 */
-			String methodName;
-			if ((isAsc && isStartKey) || (! isAsc && ! isStartKey))
-				methodName = "minValue";
-			else
-				methodName = "maxValue";
-		
-			mb.callMethod(VMOpcode.INVOKESTATIC, ClassName.BaseExpressionActivation, methodName, ClassName.DataValueDescriptor, 6);
-
-		}
+		// TODO-msirek: Handle multiple start/stop keys for multicolumn in list.
+		if (leftOperandList.size() > 1)
+			SanityManager.THROWASSERT("Not expecting multiple start/stop keys on multicolumn in list.");
+        for (int listIdx = 0; listIdx < leftOperandList.size(); listIdx++) {
+            ValueNode leftOperand = (ValueNode) leftOperandList.elementAt(listIdx);
+            int leftTypeFormatId = leftOperand.getTypeId().getTypeFormatId();
+            int leftJDBCTypeId = leftOperand.getTypeId().isUserDefinedTypeId() ?
+                leftOperand.getTypeId().getJDBCTypeId() : -1;
+    
+            int listSize = rightOperandList.size();
+            int numLoops, numValInLastLoop, currentOpnd = 0;
+    
+            /* We first calculate how many times (loops) we generate a call to
+             * min/maxValue function accumulatively, since each time it at most
+             * takes 4 input values.  An example of the calls generated will be:
+             * minVal(minVal(...minVal(minVal(v1,v2,v3,v4,judge), v5,v6,v7,judge),
+             *        ...), vn-1, vn, NULL, judge)
+             * Unused value parameters in the last call are filled with NULLs.
+             */
+            if (listSize < 5) {
+                numLoops = 1;
+                numValInLastLoop = (listSize - 1) % 4 + 1;
+            } else {
+                numLoops = (listSize - 5) / 3 + 2;
+                numValInLastLoop = (listSize - 5) % 3 + 1;
+            }
+    
+            for (int i = 0; i < numLoops; i++) {
+                /* generate value parameters of min/maxValue
+                 */
+                int numVals = (i == numLoops - 1) ? numValInLastLoop :
+                    ((i == 0) ? 4 : 3);
+                for (int j = 0; j < numVals; j++) {
+                    ValueNode vn = (ValueNode) rightOperandList.elementAt(currentOpnd++);
+                    //if (vn instanceof ListValueNode)
+                    //    vn = ((ListValueNode)vn).getValue(listIdx);
+                    vn.generateExpression(acb, mb);
+                    mb.upCast(ClassName.DataValueDescriptor);
+                }
+        
+                /* since we have fixed number of input values (4), unused ones
+                 * in the last loop are filled with NULLs
+                 */
+                int numNulls = (i < numLoops - 1) ? 0 :
+                    ((i == 0) ? 4 - numValInLastLoop : 3 - numValInLastLoop);
+                for (int j = 0; j < numNulls; j++)
+                    mb.pushNull(ClassName.DataValueDescriptor);
+        
+                /* have to put judge's types in the end
+                 */
+                mb.push(leftTypeFormatId);
+                mb.push(leftJDBCTypeId);
+        
+                /* decide to get min or max value
+                 */
+                String methodName;
+                if ((isAsc && isStartKey) || (!isAsc && !isStartKey))
+                    methodName = "minValue";
+                else
+                    methodName = "maxValue";
+        
+                mb.callMethod(VMOpcode.INVOKESTATIC, ClassName.BaseExpressionActivation, methodName, ClassName.DataValueDescriptor, 6);
+        
+            }
+        }
 	}
-
+	
 	/**
 	 * Indicate that the IN-list values for this node are ordered (i.e. they
 	 * are all constants and they have been sorted).
@@ -776,7 +967,7 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 	public int hashCode(){
 		int result=(isOrdered?1:0);
 		result=31*result+(sortDescending?1:0);
-		result = 31*result + leftOperand.hashCode();
+		result = 31*result + leftOperandList.hashCode();
 		result = 31*result + rightOperandList.hashCode();
 		return result;
 	}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ListValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ListValueNode.java
@@ -1,0 +1,287 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.ClassName;
+import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.services.classfile.VMOpcode;
+import com.splicemachine.db.iapi.services.compiler.LocalField;
+import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.compile.Visitor;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.splicemachine.db.iapi.types.TypeId.LIST_ID;
+
+/**
+ * A ListValue node holds a fixed number of ValueNodes, which may be constants, parameters,
+ * column references, UDFs, etc.  The order of the values in the list matters, so
+ * a list such as (1, 2, 3) is not equivalent to (2, 1, 3).
+ * The initial use case is to represent IN predicates such as:
+ * (col1, col2) in ((1,3), (5,4), (0,55)).  All ValueNodes in one ListValueNode must
+ * equal their corresponding ValueNodes in another ListValueNode for the two to be
+ * equivalent.
+ */
+
+public final class ListValueNode extends ValueNode {
+    
+    ValueNodeList valuesList = null;
+    
+    public ValueNode getValue(int index) {
+        if (index < 0 || index > valuesList.size())
+            return null;
+        return (ValueNode) valuesList.elementAt(index);
+    }
+    
+    public int numValues() {
+        return valuesList.size();
+    }
+    
+    @Override
+    public boolean isConstantExpression() {
+        final int listLen = valuesList.size();
+        for (int i = 0; i < listLen; i++) {
+            if (!((ValueNode) valuesList.elementAt(i)).isConstantExpression())
+                return false;
+        }
+        return true;
+    }
+    
+    public boolean allConstantsNodesInList() {
+        final int listLen = valuesList.size();
+        for (int i = 0; i < listLen; i++) {
+            if (!(valuesList.elementAt(i) instanceof ConstantNode))
+                return false;
+        }
+        return true;
+    }
+    
+    public boolean containsAllConstantNodes() {
+        
+        final int listLen = valuesList.size();
+        for (int i = 0; i < listLen; i++) {
+            if (!(valuesList.elementAt(i) instanceof ConstantNode))
+                return false;
+        }
+        return true;
+    }
+    
+    public int getMaximumWidth() {
+        int size = valuesList.size();
+        int maxWidth = 0;
+        for (int index = 0; index < size; index++) {
+            int tempWidth = ((ValueNode) valuesList.elementAt(index)).getTypeServices().getMaximumWidth();
+            if ((tempWidth + maxWidth) > Integer.MAX_VALUE) {
+                return Integer.MAX_VALUE;
+            }
+            maxWidth += tempWidth;
+        }
+        return maxWidth;
+    }
+    /**
+     * Initializer for a ListValueNode.
+     *
+     * @param arg1 A ListDataType containing the values of the constant.
+     * @throws StandardException
+     */
+    public void init(Object arg1)
+        throws StandardException {
+
+        if (arg1 == null || !(arg1 instanceof ValueNodeList))
+            throw StandardException.newException(SQLState.LANG_INVALID_FUNCTION_ARGUMENT);
+        
+        valuesList = (ValueNodeList) arg1;
+        setType(LIST_ID, valuesList.isNullable(), getMaximumWidth());
+    }
+
+    public boolean isNull() {
+        for (Object vn : valuesList) {
+            if (vn instanceof ConstantNode) {
+                if (((ConstantNode)vn).isNull())
+                    return true;
+            }
+        }
+        return false;
+    }
+    
+    // Push a ListDataType DVD on the stack.
+    @Override
+    public void generateExpression
+    (
+        ExpressionClassBuilder acb,
+        MethodBuilder mb
+    ) throws StandardException {
+        /* Are we generating a SQL null value? */
+        if (isNull()) {
+            acb.generateNull(mb, getTypeCompiler(),
+                getTypeServices());
+        } else {
+            // Build a new ListDataType, and place on the stack.
+            int numValsInSet = this.numValues();
+            LocalField dvdField = PredicateList.generateListData(acb, numValsInSet);
+            ValueNode dataLiteral;
+            for (int constIdx = 0; constIdx < numValsInSet; constIdx++) {
+                mb.getField(dvdField);
+                dataLiteral = this.getValue(constIdx);
+                dataLiteral.generateExpression(acb, mb);
+                mb.upCast(ClassName.DataValueDescriptor);
+                mb.push(constIdx);
+                mb.callMethod(VMOpcode.INVOKEVIRTUAL,
+                    (String) null,
+                    "setFrom",
+                    "void", 2);
+                
+            }
+            mb.getField(dvdField);
+            mb.upCast(ClassName.DataValueDescriptor);
+        }
+    }
+    
+    
+    /**
+     * Return the value as a string.
+     *
+     * @return The value as a string.
+     */
+    public String toString() {
+        String valueString = new String();
+        valueString.concat("(");
+        for (int i = 0; i < valuesList.size(); i++) {
+            valueString.concat(((ValueNode) valuesList.elementAt(i)).toString());
+            if (i != valuesList.size() - 1)
+                valueString.concat(", ");
+        }
+        valueString.concat(")");
+        return valueString;
+    }
+    
+    public int hashCode() {
+        final int prime = 37;
+        int result = 17;
+        
+        for (int i = 0; i < numValues(); i++) {
+            result = result * prime + valuesList.elementAt(i).hashCode();
+        }
+        return result;
+    }
+    
+    @Override
+    public String toHTMLString() {
+        return "value: " + toString() + "<br>" + super.toHTMLString();
+    }
+    
+    
+    /**
+     * Accept the visitor for all visitable children of this node.
+     *
+     * @param v the visitor
+     */
+    @Override
+    public void acceptChildren(Visitor v) throws StandardException {
+        super.acceptChildren(v);
+        
+        if (valuesList != null) {
+            valuesList = (ValueNodeList)valuesList.accept(v, this);
+        }
+    }
+    
+    @Override
+    protected boolean isEquivalent(ValueNode o) throws StandardException {
+        if (isSameNodeType(o)) {
+            ListValueNode other = (ListValueNode) o;
+            
+            if (valuesList == other.valuesList)
+                return true;
+            
+            if (valuesList == null || other.valuesList == null)
+                return false;
+            
+            if (valuesList.size() != other.valuesList.size())
+                return false;
+            
+            for (int i = 0; i < valuesList.size(); i++) {
+                if (!((ValueNode) valuesList.elementAt(i)).
+                    isEquivalent((ValueNode) other.valuesList.elementAt(i)))
+                    return false;
+            }
+            return true;
+        }
+        return false;
+    }
+    
+    /**
+     * Prints the sub-nodes of this object.  See QueryTreeNode.java for
+     * how tree printing is supposed to work.
+     *
+     * @param depth The depth of this node in the tree
+     */
+    
+    public void printSubNodes(int depth) {
+        if (SanityManager.DEBUG) {
+            super.printSubNodes(depth);
+            
+            if (valuesList != null) {
+                printLabel(depth, "Constants list: ");
+                valuesList.treePrint(depth + 1);
+            }
+        }
+    }
+    
+    /**
+     * Remap all ColumnReferences in this tree to be clones of the
+     * underlying expression.
+     *
+     * @return ValueNode            The remapped expression tree.
+     * @throws StandardException Thrown on error
+     */
+    public ValueNode remapColumnReferencesToExpressions()
+        throws StandardException {
+        valuesList = valuesList.remapColumnReferencesToExpressions();
+        return this;
+    }
+    
+    public List getChildren() {
+        return Collections.EMPTY_LIST;
+    }
+
+    @Override
+    public boolean isConstantOrParameterTreeNode() {
+        for (Object ob:valuesList) {
+            if (!((ValueNode)ob).isConstantOrParameterTreeNode())
+                return false;
+        }
+        return true;
+    }
+}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
@@ -31,10 +31,10 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
-import static java.lang.String.format;
-
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.compile.OptimizablePredicate;
+
+import static java.lang.String.format;
 
 /**
  * Utility to get the string representation of a given operator.
@@ -90,17 +90,33 @@ public class OperatorToString {
             return format("%s(%s)",uop.getOperatorString(),opToString(uop.getOperand()));
         }else if(operand instanceof BinaryRelationalOperatorNode){
             BinaryRelationalOperatorNode bron=(BinaryRelationalOperatorNode)operand;
-            InListOperatorNode inListOp=bron.getInListOp();
-            if(inListOp!=null) return opToString(inListOp);
-
-            return format("(%s %s %s)",opToString(bron.getLeftOperand()),
-                          bron.getOperatorString(),opToString(bron.getRightOperand()));
+            try {
+                InListOperatorNode inListOp = bron.getInListOp();
+                if (inListOp != null) return opToString(inListOp);
+    
+                return format("(%s %s %s)", opToString(bron.getLeftOperand()),
+                    bron.getOperatorString(), opToString(bron.getRightOperand()));
+            }
+            catch (StandardException e) {
+                return "PARSE_ERROR_WHILE_CONVERTING_OPERATOR";
+            }
         }else if(operand instanceof BinaryListOperatorNode){
             BinaryListOperatorNode blon = (BinaryListOperatorNode)operand;
-            StringBuilder inList = new StringBuilder("(").append(opToString(blon.getLeftOperand()))
-                                                         .append(" ")
-                                                         .append(blon.getOperator())
-                                                         .append(" (");
+            StringBuilder inList = new StringBuilder("(");
+            if (!blon.isSingleLeftOperand()) {
+                ValueNodeList vnl = blon.leftOperandList;
+                inList.append("(");
+                for (int i = 0; i < vnl.size(); i++) {
+                    ValueNode vn = (ValueNode) vnl.elementAt(i);
+                    if (i != 0)
+                        inList.append(",");
+                    inList.append(opToString(vn));
+                }
+                inList.append(")");
+            }
+            else
+                inList.append(opToString(blon.getLeftOperand()));
+            inList.append(" ").append(blon.getOperator()).append(" (");
             ValueNodeList rightOperandList=blon.getRightOperandList();
             boolean isFirst = true;
             for(Object qtn: rightOperandList){
@@ -135,6 +151,18 @@ public class OperatorToString {
                 i++;
             }
             builder.append("]");
+            return builder.toString();
+        } else if (operand instanceof ListValueNode) {
+            ListValueNode lcn = (ListValueNode) operand;
+            StringBuilder builder = new StringBuilder();
+            builder.append("(");
+            for (int i = 0; i < lcn.numValues(); i++) {
+                ValueNode vn = lcn.getValue(i);
+                if (i != 0)
+                    builder.append(",");
+                builder.append(opToString(vn));
+            }
+            builder.append(")");
             return builder.toString();
         }
         else if (operand instanceof ColumnReference) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrNode.java
@@ -31,11 +31,14 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
-import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
-
-import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
+import org.apache.commons.lang3.mutable.MutableInt;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 public class OrNode extends BinaryLogicalOperatorNode {
@@ -86,6 +89,165 @@ public class OrNode extends BinaryLogicalOperatorNode {
 		return this;
 	}
 	
+	private boolean canConvertToInList(ValueNode vn, ArrayList<Integer> columnNumbers,
+                                       ArrayList<Integer> compareNumbers,
+                                       HashMap<Integer, ColumnReference> columns,
+                                       MutableInt tableNumber, boolean firstTime) {
+		boolean convert = false;
+        ColumnReference cr = null;
+		
+		if (vn instanceof AndNode)
+			return canConvertToInList(((AndNode)vn).leftOperand, columnNumbers,
+                                      compareNumbers, columns, tableNumber, firstTime) &&
+                   canConvertToInList(((AndNode) vn).rightOperand, columnNumbers,
+                       compareNumbers, columns, tableNumber, firstTime);
+		else if (vn instanceof BooleanConstantNode)
+			return (((BooleanConstantNode) vn).isBooleanTrue());
+		else
+        // Is the operator an =
+        if (!vn.isRelationalOperator()) {
+            /* If the operator is an IN-list disguised as a relational
+             * operator then we can still convert it--we'll just
+             * combine the existing IN-list ("left") with the new IN-
+             * list values.  So check for that case now.
+             */
+            
+            if (SanityManager.DEBUG) {
+                /* At the time of writing the only way a call to
+                 * left.isRelationalOperator() would return false for
+                 * a BinaryRelationalOperatorNode was if that node
+                 * was for an IN-list probe predicate.  That's why we
+                 * we can get by with the simple "instanceof" check
+                 * below.  But if we're running in SANE mode, do a
+                 * quick check to make sure that's still valid.
+                 */
+                BinaryRelationalOperatorNode bron = null;
+                if (vn instanceof BinaryRelationalOperatorNode) {
+                    bron = (BinaryRelationalOperatorNode) vn;
+                    if (!bron.isInListProbeNode()) {
+                        SanityManager.THROWASSERT(
+                            "isRelationalOperator() unexpectedly returned "
+                                + "false for a BinaryRelationalOperatorNode.");
+                    }
+                }
+            }
+            
+            convert = (vn instanceof BinaryRelationalOperatorNode);
+            if (!convert)
+                return false;
+        }
+		
+		if (!(((RelationalOperator) vn).getOperator() == RelationalOperator.EQUALS_RELOP)) {
+			return false;
+		}
+		
+		BinaryRelationalOperatorNode bron = (BinaryRelationalOperatorNode) vn;
+        
+        if (bron.getLeftOperand() instanceof ColumnReference) {
+			cr = (ColumnReference) bron.getLeftOperand();
+			if (!bron.getRightOperand().isConstantOrParameterTreeNode())
+				return false;
+		}
+        else if (bron.getRightOperand() instanceof ColumnReference) {
+			cr = (ColumnReference) bron.getRightOperand();
+			if (!bron.getLeftOperand().isConstantOrParameterTreeNode())
+				return false;
+		}
+        else {
+            return false;
+        }
+
+        if (firstTime) {
+            if (tableNumber.intValue() == -1)
+                tableNumber.setValue(cr.getTableNumber());
+            else if (cr.getTableNumber() != tableNumber.intValue())
+                return false;
+            columnNumbers.add(cr.getColumnNumber());
+            columns.put(cr.getColumnNumber(), cr);
+        } else if (tableNumber.intValue() != cr.getTableNumber() ||
+                   !columnNumbers.contains(cr.getColumnNumber())) {
+            return false;
+        }
+        else
+            compareNumbers.add(cr.getColumnNumber());
+        return true;
+	}
+    
+    
+    private void addNewInListNode(ValueNode vn, HashMap<Integer, Integer> columnMap, ValueNodeList vnl)
+        throws StandardException {
+        
+        HashMap constNodes = new HashMap<Integer, ValueNode>();
+        
+        boolean multiColumn = false;
+        if (columnMap.size() > 1)
+			multiColumn = true;
+        
+        constructNodeForInList(vn, multiColumn, columnMap, vnl, constNodes);
+    
+        if (columnMap.size() > 1) {
+            ValueNodeList constList = (ValueNodeList) getNodeFactory().getNode(
+                C_NodeTypes.VALUE_NODE_LIST,
+                getContextManager());
+            for (int i = 0; i < columnMap.size(); i++) {
+                constList.addValueNode((ValueNode)constNodes.get(i));
+            }
+            
+            ValueNode lcn = (ListValueNode) getNodeFactory().getNode(
+                C_NodeTypes.LIST_VALUE_NODE,
+                constList,
+                getContextManager());
+            vnl.addValueNode(lcn);
+        }
+    }
+    
+    private void constructNodeForInList(ValueNode vn, boolean multiColumn,
+                                        HashMap<Integer, Integer> columnMap, ValueNodeList vnl,
+                                        HashMap<Integer, ValueNode> constNodes)
+        throws StandardException {
+        
+        if (vn instanceof AndNode) {
+            constructNodeForInList(((AndNode) vn).leftOperand, multiColumn, columnMap, vnl, constNodes);
+            constructNodeForInList(((AndNode) vn).rightOperand, multiColumn, columnMap, vnl, constNodes);
+            return;
+        }
+        else if (vn instanceof BooleanConstantNode) {
+            // Do nothing
+            return;
+        }
+        
+        BinaryRelationalOperatorNode bron =
+            (BinaryRelationalOperatorNode) vn;
+        if (bron.isInListProbeNode()) {
+            /* If we have an OR between multiple IN-lists on the same
+             * column then just combine them into a single IN-list.
+             * Ex.
+             *
+             *   select ... from T1 where i in (2, 3) or i in (7, 10)
+             *
+             * effectively becomes:
+             *
+             *   select ... from T1 where i in (2, 3, 7, 10).
+             */
+            vnl.destructiveAppend(
+                bron.getInListOp().getRightOperandList());
+        } else if (bron.getLeftOperand() instanceof ColumnReference) {
+            if (!multiColumn)
+                vnl.addValueNode(bron.getRightOperand());
+            else {
+                constNodes.put(columnMap.get(((ColumnReference) bron.getLeftOperand()).getColumnNumber()),
+                               bron.getRightOperand());
+            }
+        } else {
+            if (!multiColumn)
+                vnl.addValueNode(bron.getLeftOperand());
+            else {
+                constNodes.put(columnMap.get(((ColumnReference) bron.getRightOperand()).getColumnNumber()),
+                               bron.getLeftOperand());
+            }
+        }
+    }
+    
 	/**
 	 * Preprocess an expression tree.  We do a number of transformations
 	 * here (including subqueries, IN lists, LIKE and BETWEEN) plus
@@ -143,99 +305,31 @@ public class OrNode extends BinaryLogicalOperatorNode {
 		if (firstOr)
 		{
 			boolean			convert = true;
-			ColumnReference	cr = null;
-			int				columnNumber = -1;
-			int				tableNumber = -1;
+            HashMap         columns = new HashMap<Integer, ColumnReference>();
+			ArrayList       columnNumbers = new ArrayList<Integer>();
+			HashMap         columnMap = new HashMap<Integer, Integer>();
+            MutableInt	    tableNumber = new MutableInt(-1);
             ValueNode       vn;
+            boolean         firstTime = true;
 
             for (vn = this;
                     vn instanceof OrNode;
-                    vn = ((OrNode) vn).getRightOperand())
+                    vn = ((OrNode) vn).getRightOperand(), firstTime = false)
 			{
 				OrNode on = (OrNode) vn;
 				ValueNode left = on.getLeftOperand();
-
-				// Is the operator an =
-				if (!left.isRelationalOperator())
-				{
-					/* If the operator is an IN-list disguised as a relational
-					 * operator then we can still convert it--we'll just
-					 * combine the existing IN-list ("left") with the new IN-
-					 * list values.  So check for that case now.
-					 */ 
-
-					if (SanityManager.DEBUG)
-					{
-						/* At the time of writing the only way a call to
-						 * left.isRelationalOperator() would return false for
-						 * a BinaryRelationalOperatorNode was if that node
-						 * was for an IN-list probe predicate.  That's why we
-						 * we can get by with the simple "instanceof" check
-						 * below.  But if we're running in SANE mode, do a
-						 * quick check to make sure that's still valid.
-					 	 */
-						BinaryRelationalOperatorNode bron = null;
-						if (left instanceof BinaryRelationalOperatorNode)
-						{
- 							bron = (BinaryRelationalOperatorNode)left;
-							if (!bron.isInListProbeNode())
-							{
-								SanityManager.THROWASSERT(
-								"isRelationalOperator() unexpectedly returned "
-								+ "false for a BinaryRelationalOperatorNode.");
-							}
-						}
-					}
-
-					convert = (left instanceof BinaryRelationalOperatorNode);
-					if (!convert)
-						break;
-				}
-
-				if (!(((RelationalOperator)left).getOperator() == RelationalOperator.EQUALS_RELOP))
-				{
-					convert = false;
-					break;
-				}
-
-				BinaryRelationalOperatorNode bron = (BinaryRelationalOperatorNode)left;
-
-				if (bron.getLeftOperand() instanceof ColumnReference)
-				{
-					cr = (ColumnReference) bron.getLeftOperand();
-					if (tableNumber == -1)
-					{
-						tableNumber = cr.getTableNumber();
-						columnNumber = cr.getColumnNumber();
-					}
-					else if (tableNumber != cr.getTableNumber() ||
-							 columnNumber != cr.getColumnNumber())
-					{
-						convert = false;
-						break;
-					}
-				}
-				else if (bron.getRightOperand() instanceof ColumnReference)
-				{
-					cr = (ColumnReference) bron.getRightOperand();
-					if (tableNumber == -1)
-					{
-						tableNumber = cr.getTableNumber();
-						columnNumber = cr.getColumnNumber();
-					}
-					else if (tableNumber != cr.getTableNumber() ||
-							 columnNumber != cr.getColumnNumber())
-					{
-						convert = false;
-						break;
-					}
-				}
-				else
-				{
-					convert = false;
-					break;
-				}
-			}
+                ArrayList compareNumbers = new ArrayList<Integer>();
+                
+                convert = canConvertToInList(left, columnNumbers, compareNumbers, columns, tableNumber, firstTime);
+                if (firstTime)
+                    Collections.sort(columnNumbers);
+                else {
+                    Collections.sort(compareNumbers);
+                    convert = convert && compareNumbers.equals(columnNumbers);
+                }
+                if (!convert)
+                    break;
+            }
 
             // DERBY-6363: An OR chain on conjunctive normal form should be
             // terminated by a false BooleanConstantNode. If it is terminated
@@ -246,6 +340,16 @@ public class OrNode extends BinaryLogicalOperatorNode {
 			/* So, can we convert the OR chain? */
 			if (convert)
 			{
+			    ValueNodeList crList = (ValueNodeList) getNodeFactory().getNode(
+                    C_NodeTypes.VALUE_NODE_LIST,
+                    getContextManager());
+			    
+			    for (int i = 0; i < columnNumbers.size(); i++) {
+			        Integer colNum = (Integer)columnNumbers.get(i);
+			        columnMap.put(colNum, i);
+			        crList.addValueNode((ValueNode)columns.get(colNum));
+                }
+                
 				ValueNodeList vnl = (ValueNodeList) getNodeFactory().getNode(
 													C_NodeTypes.VALUE_NODE_LIST,
 													getContextManager());
@@ -255,41 +359,17 @@ public class OrNode extends BinaryLogicalOperatorNode {
                         vn = ((OrNode) vn).getRightOperand())
 				{
 					OrNode on = (OrNode) vn;
-					BinaryRelationalOperatorNode bron =
-						(BinaryRelationalOperatorNode) on.getLeftOperand();
-					if (bron.isInListProbeNode())
-					{
-						/* If we have an OR between multiple IN-lists on the same
-						 * column then just combine them into a single IN-list.
-						 * Ex.
-						 *
-						 *   select ... from T1 where i in (2, 3) or i in (7, 10)
-						 *
-						 * effectively becomes:
-						 *
-						 *   select ... from T1 where i in (2, 3, 7, 10).
-						 */
-						vnl.destructiveAppend(
-							bron.getInListOp().getRightOperandList());
-					}
-					else if (bron.getLeftOperand() instanceof ColumnReference)
-					{
-						vnl.addValueNode(bron.getRightOperand());
-					}
-					else
-					{
-						vnl.addValueNode(bron.getLeftOperand());
-					}
+                    
+                    addNewInListNode(on.getLeftOperand(), columnMap, vnl);
 				}
 
 				InListOperatorNode ilon =
 							(InListOperatorNode) getNodeFactory().getNode(
 											C_NodeTypes.IN_LIST_OPERATOR_NODE,
-											cr,
+                                            crList,
 											vnl,
 											getContextManager());
 
-				// Transfer the result type info to the IN list
 				ilon.setType(getTypeServices());
 
 				/* We return the result of preprocess() on the

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrNode.java
@@ -164,6 +164,9 @@ public class OrNode extends BinaryLogicalOperatorNode {
                 return false;
             columnNumbers.add(cr.getColumnNumber());
             columns.put(cr.getColumnNumber(), cr);
+            if (columnNumbers.size() > 1 &&
+				!getCompilerContext().getConvertMultiColumnDNFPredicatesToInList())
+            	return false;
         } else if (tableNumber.intValue() != cr.getTableNumber() ||
                    !columnNumbers.contains(cr.getColumnNumber())) {
             return false;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
@@ -1236,10 +1236,10 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
     }
     
     /**
-     * Returns the number of columns represented in a predicate if the predicate is a probe predicate,
-     * otherwise returns 1.
+     * Returns the number of columns represented in a qualifier predicate if the
+     * predicate is a probe predicate, otherwise returns 1.
      */
-    protected int numColumnsInPred () throws StandardException {
+    protected int numColumnsInQualifier() throws StandardException {
         InListOperatorNode ilon = getSourceInList();
         return (ilon == null) ? 1 : ilon.leftOperandList.size();
     }
@@ -1310,7 +1310,8 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
                     if (!((ListValueNode)o).allConstantsNodesInList())
                         return false;
                 }
-                return false; //not all constants in the IN list
+                else
+                    return false; //not all constants in the IN list
             }
         }
         return true;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
@@ -1173,7 +1173,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                                 || (relop.usefulStopKey(optTable) && (thisIndexPosition != -1 && !isAscending[thisIndexPosition]))))){
                         thisPred.markStartKey();
                         currentStartPosition=thisIndexPosition;
-                        numColsInStartPred = thisPred.numColumnsInPred();
+                        numColsInStartPred = thisPred.numColumnsInQualifier();
                         thisPredMarked=true;
                         seenGT=(thisPred.getStartOperator(optTable)==ScanController.GT);
                         thisPred.markQualifier();
@@ -1193,7 +1193,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                                 || (relop.usefulStartKey(optTable) && (thisIndexPosition != -1 && !isAscending[thisIndexPosition]))))){
                         thisPred.markStopKey();
                         currentStopPosition=thisIndexPosition;
-                        numColsInStopPred = thisPred.numColumnsInPred();
+                        numColsInStopPred = thisPred.numColumnsInQualifier();
                         thisPredMarked=true;
                         seenGE=(thisPred.getStopOperator(optTable)==ScanController.GE);
                         thisPred.markQualifier();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
@@ -1608,7 +1608,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
             BooleanConstantNode trueNode=(BooleanConstantNode)getNodeFactory().getNode(C_NodeTypes.BOOLEAN_CONSTANT_NODE,
                     Boolean.TRUE,contextManager);
 
-            AndNode firstAndInProbeSet = null, prevAnd = null;
+            AndNode firstAndInProbeSet = null;
             while(topAnd.getRightOperand() instanceof AndNode){
                 /* Break out the next top AndNode */
                 thisAnd=topAnd;
@@ -1618,23 +1618,20 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                     thisAnd.setRightOperand(trueNode);
 
                     /* Add the top AndNode to the PredicateList */
+                    /* If firstAndInProbeSet is not null, add it as a chain of And'ed nodes
+                     * in the probe set as a single predicate.
+                     */
                     newJBitSet=new JBitSet(numTables);
-                    newPred=(Predicate)getNodeFactory().getNode(C_NodeTypes.PREDICATE,thisAnd,newJBitSet, contextManager);
+                    newPred=(Predicate)getNodeFactory().getNode(C_NodeTypes.PREDICATE,
+                              firstAndInProbeSet != null ? firstAndInProbeSet : thisAnd,
+                              newJBitSet, contextManager);
                     addPredicate(newPred);
-                    
-                    if (firstAndInProbeSet != null) {
-                        // Add the chain of And'ed nodes in the probe set as a single predicate.
-                        prevAnd.setRightOperand(trueNode);
-                        newJBitSet = new JBitSet(numTables);
-                        newPred = (Predicate) getNodeFactory().getNode(C_NodeTypes.PREDICATE, firstAndInProbeSet, newJBitSet, contextManager);
-                        addPredicate(newPred);
-                        firstAndInProbeSet = prevAnd = null;
-                    }
+    
+                    firstAndInProbeSet = null;
                 }
                 else {
                     if (firstAndInProbeSet == null)
                         firstAndInProbeSet = thisAnd;
-                    prevAnd = thisAnd;
                 }
             }
 			

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
@@ -44,13 +44,14 @@ import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.sql.execute.ExecutionFactory;
 import com.splicemachine.db.iapi.store.access.ScanController;
-import com.splicemachine.db.iapi.types.DataValueDescriptor;
-import com.splicemachine.db.iapi.types.Orderable;
+import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.db.iapi.util.JBitSet;
 
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import static com.splicemachine.db.iapi.types.Orderable.*;
 
@@ -594,6 +595,76 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
 
         return predicates;
     }
+    
+    private boolean
+    genListValueNodeOrRecurse(Optimizable optTable, ValueNode constantToAdd, ValueNodeList constList,
+                                 ValueNodeList groupedConstants, ArrayList<Predicate> predList, int level)
+                            throws StandardException {
+        boolean retval = true;
+        ValueNodeList localConstList =
+         (ValueNodeList) getNodeFactory().getNode(
+            C_NodeTypes.VALUE_NODE_LIST,
+            getContextManager());
+        if (level != 0) {
+            localConstList.nondestructiveAppend(constList);
+        }
+        localConstList.addValueNode(constantToAdd);
+        if (level == predList.size() - 1) {
+            // We've grabbed a ConstantNode (or other type of ValueNode) from each level.
+            // Time to materialize this combination into a new
+            // ListValueNode.
+            ValueNode lcn = (ListValueNode) getNodeFactory().getNode(
+                C_NodeTypes.LIST_VALUE_NODE,
+                localConstList,
+                getContextManager());
+            groupedConstants.addValueNode(lcn);
+            
+        } else {
+            retval =
+                addConstantsToList(optTable, localConstList, groupedConstants,
+                    predList, level + 1);
+        }
+        return retval;
+    }
+    
+    private boolean addConstantsToList(Optimizable optTable, ValueNodeList constList, ValueNodeList groupedConstants,
+                                       ArrayList<Predicate> predList, int level)
+                            throws StandardException {
+        
+        Predicate pred = predList.get(level);
+        InListOperatorNode inNode = pred.getSourceInList();
+
+        boolean retval = true;
+        
+        if (inNode == null) {
+            RelationalOperator relop = pred.getRelop();
+            if (!(relop instanceof BinaryRelationalOperatorNode))
+                return false;
+            
+            // Fold an equality predicate into the IN list.
+            BinaryRelationalOperatorNode brop = (BinaryRelationalOperatorNode)relop;
+            ValueNode constant = null;
+            if (brop.keyColumnOnLeft(optTable))
+                constant = (ValueNode) brop.getRightOperand();
+            else
+                constant = (ValueNode) brop.getLeftOperand();
+            retval =
+                genListValueNodeOrRecurse(optTable, constant,
+                    constList, groupedConstants,
+                    predList, level);
+        }
+        else {
+            for (Object constant : inNode.rightOperandList) {
+                retval =
+                    genListValueNodeOrRecurse(optTable, (ValueNode) constant,
+                        constList, groupedConstants,
+                        predList, level);
+                if (retval == false)
+                    break;
+            }
+        }
+        return retval;
+    }
 
     private void orderUsefulPredicates(Optimizable optTable,
                                        ConglomerateDescriptor cd,
@@ -729,25 +800,28 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
 		 * to generate a hash join.
 		 */
         boolean skipProbePreds=pushPreds && optTable.getTrulyTheBestAccessPath().getJoinStrategy().isHashJoin();
-
+        boolean[] isEquality =
+            new boolean[baseColumnPositions != null ?
+                        (size > baseColumnPositions.length ? size : baseColumnPositions.length) :size];
 		/*
 		** Create an array of useful predicates.  Also, count how many
 		** useful predicates there are.
 		*/
 		Integer inlistPosition = -2;
-		Predicate inlistPred = null;
-		List<Predicate> inlistPreds = new ArrayList<>();
+
+        TreeMap<Integer, Predicate> inlistPreds = new TreeMap<>();
         List<Predicate> predicates=new ArrayList<>();
         for(int index=0;index<size;index++){
             Predicate pred=elementAt(index);
             Integer position=isIndexUseful(pred,optTable,pushPreds,skipProbePreds,baseColumnPositions);
             if(position!=null){
                 if (pred.isInListProbePredicate()) {
-                    inlistPreds.add(pred);
-                    //we keep track of the inlist at lowest index position excluding rowid whose position is -1
-                    if (inlistPosition == -2 || inlistPosition > position) {
+                    inlistPreds.put(position, pred);
+                    if (position >= 0)
+                        isEquality[position] = true;
+                    //we keep track of the inlist at highest index position excluding rowid whose position is -1
+                    if (inlistPosition == -2 || inlistPosition < position) {
                         inlistPosition = position;
-                        inlistPred = pred;
                     }
                 } else {
                     pred.setIndexPosition(position);
@@ -773,41 +847,224 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
 		  1. inlist with indexPosition =0, that is, inlist on the leading index/PK column; or
           2. inlist with indexPosition > 0 if all predicates with indexPosition prior to the inlist all having equality conditions
         */
-        boolean inlistQualified;
+        boolean inlistQualified = false;
+
+        ArrayList<Predicate> inListNonQualifiedPreds = new ArrayList<>();
+        
         if (inlistPosition >= 0) {
+
             inlistQualified = true;
             if (inlistPosition > 0) {
-                boolean[] isEquality = new boolean[inlistPosition];
                 for (int i = 0; i < usefulCount; i++) {
                     Predicate pred = usefulPredicates[i];
                     int pos = pred.getIndexPosition();
-                    if (pos < inlistPosition && pos >= 0 && !isEquality[pos]) {
+                    if (pos <= inlistPosition && pos >= 0 && !isEquality[pos]) {
                         RelationalOperator relop = pred.getRelop();
                         if (relop != null && relop.getOperator() == RelationalOperator.EQUALS_RELOP &&
                                 pred.compareWithKnownConstant(optTable, true))
                             isEquality[pos] = true;
                     }
                 }
-
-                for (int pos = 0; pos < inlistPosition; pos++) {
-                    if (!isEquality[pos]) {
-                        inlistQualified = false;
-                        break;
-                    }
-                }
             }
-
-            if (inlistQualified) {
-                inlistPred.setIndexPosition(inlistPosition);
-                /* Remember the useful predicate */
-                usefulPredicates[usefulCount++] = inlistPred;
+            boolean unsetRemainder = false;
+            for (int pos = 0; pos <= inlistPosition; pos++) {
+                if (unsetRemainder)
+                    isEquality[pos] = false;
+        
+                if (!isEquality[pos])
+                    unsetRemainder = true;
+            }
+            TreeMap<Integer, Predicate> inlistPredsCopy = (TreeMap < Integer, Predicate>)inlistPreds.clone();
+            for (Map.Entry<Integer, Predicate> p : inlistPredsCopy.entrySet()) {
+                if (isEquality[p.getKey()]) {
+                    p.getValue().setIndexPosition(p.getKey());
+                    inlistQualified = true;
+                    /* Remember the useful predicate */
+                    usefulPredicates[usefulCount++] = p.getValue();
+                }
+                else {
+                    inListNonQualifiedPreds.add(p.getValue());
+                    inlistPreds.remove(p.getKey());
+                }
             }
         } else
             inlistQualified = false;
+    
+        if (usefulCount > 0) {
+            /* The array of useful predicates may have unused slots.  Shrink it */
+            if (usefulPredicates.length > usefulCount) {
+                Predicate[] shrink = new Predicate[usefulCount];
+                System.arraycopy(usefulPredicates, 0, shrink, 0, usefulCount);
+                usefulPredicates = shrink;
+            }
+    
+            /* Sort the array of useful predicates in index position order */
+            java.util.Arrays.sort(usefulPredicates);
+            usefulPredicates = checkRowIdPredicate(usefulPredicates);
+            usefulCount = usefulPredicates.length;
+        }
+        ValueNode andNode = null;
+        InListOperatorNode ilon = null;
+        Predicate multiColumnInListPred = null;
+        ArrayList<Predicate> predsForNewInList = null;
+    
+        if (inlistQualified) {
+          // Only combine multiple IN lists if not using Spark.
+          // Adding extra RDDs and unioning them together hinders performance.
+          if (inlistPreds.size() > 1) {
+            predsForNewInList = new ArrayList<>();
+            int firstPred = -1, lastPred = -1, lastIndexPos = -1, firstInListPred = -1;
+
+            boolean foundPred[] = new boolean[usefulCount];
+            int numConstants = 1;
+            int maxMulticolumnProbeValues = getCompilerContext().getMaxMulticolumnProbeValues();
+            for (int i = 0; i < usefulCount; i++) {
+                final Predicate pred = usefulPredicates[i];
+
+                if (pred.getIndexPosition() == lastIndexPos + 1) {
+                    BinaryRelationalOperatorNode bron =
+                        (BinaryRelationalOperatorNode) pred.getRelop();
+                    boolean inList = pred.isInListProbePredicate();
+                    if (inList ||
+                        (bron != null && bron.getOperator() == RelationalOperator.EQUALS_RELOP)) {
+                        if (inList) {
+                            InListOperatorNode inNode = pred.getSourceInList(true);
+    
+                            if (firstInListPred == -1)
+                                firstInListPred = i;
+                            
+                            // A max setting of -1 means there is no limit to the size of
+                            // IN list that we generate.
+                            if (maxMulticolumnProbeValues != -1 &&
+                                (numConstants * inNode.rightOperandList.size()) > maxMulticolumnProbeValues)
+                                break;
+                            numConstants *= inNode.rightOperandList.size();
+                        }
+                        if (firstPred == -1)
+                            firstPred = i;
+                        lastPred = i;
+                        predsForNewInList.add(usefulPredicates[i]);
+                        lastIndexPos = pred.getIndexPosition();
+                        foundPred[i] = true;
+                    }
+                }
+                // Can't have any gaps in index position.
+                if (pred.getIndexPosition() > lastIndexPos+1)
+                    break;
+            }
+
+            ValueNodeList vnl = (ValueNodeList)getNodeFactory().getNode(
+                                 C_NodeTypes.VALUE_NODE_LIST,
+                                  getContextManager());
+            ValueNodeList groupedConstants =
+                   (ValueNodeList) getNodeFactory().getNode(
+                                   C_NodeTypes.VALUE_NODE_LIST,
+                                   getContextManager());
+            boolean multiColumnInListBuilt = false;
+            if (optTable instanceof FromBaseTable &&
+                (!((FromBaseTable) optTable).isSpark(((FromBaseTable) optTable).getDataSetProcessorType()) ||
+                   getCompilerContext().getMulticolumnInlistProbeOnSparkEnabled()) &&
+                  firstPred != lastPred &&
+                addConstantsToList(optTable, null, groupedConstants, predsForNewInList, 0)) {
+                if (numConstants != groupedConstants.size())
+                    SanityManager.THROWASSERT("Wrong number of constants built for IN list.");
+
+                for (Predicate pred : predsForNewInList) {
+                    InListOperatorNode inNode = pred.getSourceInList(true);
+                    if (inNode != null)
+                        vnl.addValueNode(inNode.getLeftOperand().getClone());
+                    else {
+                        RelationalOperator relop = pred.getRelop();
+                        if (! (relop instanceof BinaryRelationalOperatorNode))
+                            SanityManager.THROWASSERT("Expected equality predicate, but none found.");
+                        BinaryRelationalOperatorNode brop = (BinaryRelationalOperatorNode) relop;
+                        ValueNode colRef;
+                        if (brop.keyColumnOnLeft(optTable))
+                            colRef = brop.getLeftOperand();
+                        else
+                            colRef = brop.getRightOperand();
+                        vnl.addValueNode(colRef.getClone());
+                    }
+                }
+                ilon =
+                    (InListOperatorNode) getNodeFactory().getNode(
+                        C_NodeTypes.IN_LIST_OPERATOR_NODE,
+                        vnl,
+                        groupedConstants,
+                        getContextManager());
         
+                boolean nullableResult = ilon.leftOperandList.isNullable() ||
+                                         ilon.rightOperandList.isNullable();
+                ilon.setType(new DataTypeDescriptor(TypeId.BOOLEAN_ID, nullableResult));
+                
+                andNode = ilon.convertToAndedEqualityProbePredicate();
+
+                if (andNode instanceof AndNode) {
+                    multiColumnInListBuilt = true;
+                    JBitSet newJBitSet = new JBitSet(getCompilerContext().getNumTables());
+                    Predicate newPred = (Predicate) getNodeFactory().getNode(C_NodeTypes.PREDICATE,
+                            andNode, newJBitSet, getContextManager());
+
+                    // The index position is the position of the first column in the
+                    // multicolumn IN list.
+                    newPred.setIndexPosition(usefulPredicates[firstPred].getIndexPosition());
+                    usefulPredicates[firstPred] = newPred;
+                    multiColumnInListPred = newPred;
+
+                    // Pack the remaining useful preds in usefulPredicates so
+                    // there are no gaps.
+                    int j = firstPred + 1;
+                    for (int i = firstPred + 1; i < usefulCount; i++) {
+                        while(i < usefulCount && foundPred[i])
+                            i++;
+                        if (i != j && i < usefulCount) {
+                            usefulPredicates[j] = usefulPredicates[i];
+                            j++;
+                        }
+                    }
+                    usefulCount -= (predsForNewInList.size() - 1);
+                }
+            }
+
+            // At this point, we have multiple IN list predicates in the
+            // usefulPredicates array, but we might not have combined them
+            // all into a single multicolumn IN list predicate.
+            // Put the rest into inListNonQualifiedPreds
+            // so they may be possibly pushed as qualifiers, but more
+            // importantly, remove them from the usefulPredicates so they
+            // are not considered for use as probe predicates, as this may
+            // cause wrong results.
+            boolean copyNeeded = false;
+            int oldUsefulCount = usefulCount;
+            if (firstInListPred == -1)
+                SanityManager.THROWASSERT("Logic failure in building multicolumn IN list.");
+            int firstUnusedPred = multiColumnInListBuilt ? firstInListPred + 1 : lastPred + 1;
+            for (int i = firstUnusedPred; i < oldUsefulCount; i++) {
+                final Predicate pred = usefulPredicates[i];
+                if (pred != null && pred.isInListProbePredicate()) {
+                    inListNonQualifiedPreds.add(pred);
+                    usefulPredicates[i] = null;
+                    copyNeeded = true;
+                    usefulCount--;
+                }
+            }
+            if (copyNeeded) {
+                Predicate [] newUsefulPredicates = new Predicate[usefulCount];
+                int j = 0;
+                for (int i = 0; i < oldUsefulCount; i++) {
+                    final Predicate pred = usefulPredicates[i];
+                    if (pred != null) {
+                        newUsefulPredicates[j++] = pred;
+                    }
+                }
+                usefulPredicates = newUsefulPredicates;
+            }
+          }
+        }
+
         //we still need to mark the remaining inlist conditions
-        for (Predicate pred: inlistPreds) {
-            if (!inlistQualified || pred != inlistPred) {
+        for (Predicate pred : inListNonQualifiedPreds) {
+            if (!inlistQualified || pred.getIndexPosition() < 0) {
                 if(primaryKey && isQualifier(pred,optTable,pushPreds) ||
                         isHashableJoin && isQualifierForHashableJoin(pred, optTable, pushPreds)){
                     pred.markQualifier();
@@ -819,7 +1076,6 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                 }
             }
         }
-
 
         for(Predicate pred : predicates){
             removeOptPredicate(pred);
@@ -835,17 +1091,6 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
         if(usefulCount==0)
             return;
 
-		    /* The array of useful predicates may have unused slots.  Shrink it */
-        if(usefulPredicates.length>usefulCount){
-            Predicate[] shrink=new Predicate[usefulCount];
-            System.arraycopy(usefulPredicates,0,shrink,0,usefulCount);
-            usefulPredicates=shrink;
-        }
-
-		/* Sort the array of useful predicates in index position order */
-        java.util.Arrays.sort(usefulPredicates);
-        usefulPredicates = checkRowIdPredicate(usefulPredicates);
-        usefulCount = usefulPredicates.length;
 
 		/* Push the sorted predicates down to the Optimizable table */
         int currentStartPosition=-1;
@@ -874,7 +1119,10 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
 		     * then start key should really be (a,b,c,d) with start operator GT.
 		     */
         boolean seenGE=false, seenGT=false;
-
+    
+        int numColsInStartPred = 1;
+        int numColsInStopPred = 1;
+        
         for(int i=0;i<usefulCount;i++){
             Predicate thisPred=usefulPredicates[i];
             int thisIndexPosition=thisPred.getIndexPosition();
@@ -888,12 +1136,12 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                 thisOperator=relop.getOperator();
 
 			      /* Allow only one start and stop position per index column */
-            if(currentStartPosition!=thisIndexPosition){
+            if(currentStartPosition+numColsInStartPred<=thisIndexPosition){
 				/*
 				** We're working on a new index column for the start position.
 				** Is it just one more than the previous position?
 				*/
-                if((thisIndexPosition-currentStartPosition)>1){
+                if((thisIndexPosition-currentStartPosition)> numColsInStartPred){
 					/*
 					** There's a gap in the start positions.  Don't mark any
 					** more predicates as start predicates.
@@ -925,6 +1173,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                                 || (relop.usefulStopKey(optTable) && (thisIndexPosition != -1 && !isAscending[thisIndexPosition]))))){
                         thisPred.markStartKey();
                         currentStartPosition=thisIndexPosition;
+                        numColsInStartPred = thisPred.numColumnsInPred();
                         thisPredMarked=true;
                         seenGT=(thisPred.getStartOperator(optTable)==ScanController.GT);
                         thisPred.markQualifier();
@@ -933,8 +1182,8 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
             }
 
 			/* Same as above, except for stop keys */
-            if(currentStopPosition!=thisIndexPosition || thisIndexPosition == -1){
-                if((thisIndexPosition-currentStopPosition)>1){
+            if(currentStopPosition + numColsInStopPred <= thisIndexPosition || thisIndexPosition == -1){
+                if((thisIndexPosition-currentStopPosition)> numColsInStopPred){
                     gapInStopPositions=true;
                 }
 
@@ -944,6 +1193,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                                 || (relop.usefulStartKey(optTable) && (thisIndexPosition != -1 && !isAscending[thisIndexPosition]))))){
                         thisPred.markStopKey();
                         currentStopPosition=thisIndexPosition;
+                        numColsInStopPred = thisPred.numColumnsInPred();
                         thisPredMarked=true;
                         seenGE=(thisPred.getStopOperator(optTable)==ScanController.GE);
                         thisPred.markQualifier();
@@ -964,7 +1214,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
             }
 
             /* Remember if we have seen a column without an "=" */
-            if(lastStartEqualsPosition!=thisIndexPosition
+            if(lastStartEqualsPosition+numColsInStartPred<=thisIndexPosition
                     && firstNonEqualsPosition==(rowIdScan? -2:-1)
                     && (thisOperator!=RelationalOperator.EQUALS_RELOP)
                     && (thisOperator!=RelationalOperator.IS_NULL_RELOP)){
@@ -1042,8 +1292,15 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
 					           * via execution-time index probes (for more see
 					           * execute/MultiProbeTableScanResultSet.java).
 					           */
-                    if(!isIn || thisPred.isInListProbePredicate())
-                        removeOptPredicate(thisPred);
+                    if(!isIn || thisPred.isInListProbePredicate()) {
+                        if (thisPred == multiColumnInListPred) {
+                            for (Predicate predToRemove:predsForNewInList) {
+                                removeOptPredicate(predToRemove);
+                            }
+                        }
+                        else
+                            removeOptPredicate(thisPred);
+                    }
                 }else if(SanityManager.DEBUG){
                     SanityManager.THROWASSERT("pushOptPredicate expected to be true");
                 }
@@ -1052,8 +1309,10 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
 			     * We're not pushing the predicates down, so put them at the
 			     * beginning of this predicate list in index order.
 			     */
-                removeOptPredicate(thisPred);
-                addOptPredicate(thisPred,i);
+                if (thisPred != multiColumnInListPred) {
+                    removeOptPredicate(thisPred);
+                    addOptPredicate(thisPred, i);
+                }
             }
         }
     }
@@ -1349,19 +1608,34 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
             BooleanConstantNode trueNode=(BooleanConstantNode)getNodeFactory().getNode(C_NodeTypes.BOOLEAN_CONSTANT_NODE,
                     Boolean.TRUE,contextManager);
 
+            AndNode firstAndInProbeSet = null, prevAnd = null;
             while(topAnd.getRightOperand() instanceof AndNode){
                 /* Break out the next top AndNode */
                 thisAnd=topAnd;
-                topAnd=(AndNode)topAnd.getRightOperand();
-                thisAnd.setRightOperand(null);
+                topAnd = (AndNode) topAnd.getRightOperand();
+                if (!thisAnd.isNextAndedPredInSameMultiprobeSet()) {
+                    /* Set the rightOperand to true */
+                    thisAnd.setRightOperand(trueNode);
 
-                /* Set the rightOperand to true */
-                thisAnd.setRightOperand(trueNode);
-
-                /* Add the top AndNode to the PredicateList */
-                newJBitSet=new JBitSet(numTables);
-                newPred=(Predicate)getNodeFactory().getNode(C_NodeTypes.PREDICATE,thisAnd,newJBitSet, contextManager);
-                addPredicate(newPred);
+                    /* Add the top AndNode to the PredicateList */
+                    newJBitSet=new JBitSet(numTables);
+                    newPred=(Predicate)getNodeFactory().getNode(C_NodeTypes.PREDICATE,thisAnd,newJBitSet, contextManager);
+                    addPredicate(newPred);
+                    
+                    if (firstAndInProbeSet != null) {
+                        // Add the chain of And'ed nodes in the probe set as a single predicate.
+                        prevAnd.setRightOperand(trueNode);
+                        newJBitSet = new JBitSet(numTables);
+                        newPred = (Predicate) getNodeFactory().getNode(C_NodeTypes.PREDICATE, firstAndInProbeSet, newJBitSet, contextManager);
+                        addPredicate(newPred);
+                        firstAndInProbeSet = prevAnd = null;
+                    }
+                }
+                else {
+                    if (firstAndInProbeSet == null)
+                        firstAndInProbeSet = thisAnd;
+                    prevAnd = thisAnd;
+                }
             }
 			
 			      /* Add the last top AndNode to the PredicateList */
@@ -1394,7 +1668,18 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
      * false} otherwise
      */
     private static boolean isConstantOrParameterNode(ValueNode node){
-        return node instanceof ConstantNode || node instanceof ParameterNode;
+        if (node instanceof ListValueNode)
+        {
+            ListValueNode lcn = (ListValueNode)node;
+            for (int i = 0; i < lcn.numValues(); i++){
+                if (!(lcn.getValue(i) instanceof ConstantNode) &&
+                    !(lcn.getValue(i) instanceof ParameterNode))
+                    return false;
+            }
+            return true;
+        }
+        else
+            return node instanceof ConstantNode || node instanceof ParameterNode;
     }
 
     /**
@@ -1462,6 +1747,9 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                     crNode=(ColumnReference)opNode.getLeftOperand();
                 }else if(andNode.getLeftOperand() instanceof InListOperatorNode){
                     inNode=(InListOperatorNode)andNode.getLeftOperand();
+                    // Don't push multicolumn IN list into a SELECT for now.
+                    if (inNode.leftOperandList.size() > 1)
+                        continue;
                     if(!(inNode.getRightOperandList().isConstantExpression()))
                         continue;
 
@@ -1488,6 +1776,9 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                     //noinspection ConstantConditions
                     inNode=opNode.getInListOp();
                     if(inNode!=null){
+                        // Don't push multicolumn IN list into a SELECT for now.
+                        if (inNode.leftOperandList.size() > 1)
+                            continue;
                         inNode=inNode.shallowCopy();
                         inNode.setLeftOperand(newCRNode);
                     }
@@ -2544,26 +2835,59 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
 		*/
 
         if(numberOfStopPredicates!=0){
-       		/* This sets up the method and the static field */
+    
+            int countedStopPreds = 0;
+            int size = size();
+            int numberOfColumns = 0;
+            for (int index = 0; index < size; index++) {
+                Predicate pred = elementAt(index);
+                if (!pred.isStopKey())
+                    continue;
+                countedStopPreds++;
+                if (pred.isInListProbePredicate()) {
+                    InListOperatorNode ilop = pred.getSourceInList(true);
+                    if (ilop == null)
+                        numberOfColumns++;
+                    else
+                        numberOfColumns += ilop.leftOperandList.size();
+                } else
+                    numberOfColumns++;
+            }
+            assert countedStopPreds == numberOfStopPredicates : "Number of stop predicates does not match";
+    
+            /* This sets up the method and the static field */
             MethodBuilder exprFun=acb.newExprFun();
 
 		    /* Now we fill in the body of the method */
-            LocalField rowField=generateIndexableRow(acb,numberOfStopPredicates);
+            LocalField rowField=generateIndexableRow(acb, numberOfColumns);
 
             int colNum=0;
-            int size=size();
             for(int index=0;index<size;index++){
                 Predicate pred=elementAt(index);
 
                 if(!pred.isStopKey())
                     continue;
-
-                generateSetColumn(acb,exprFun,colNum, pred,optTable,rowField,false);
-
-                colNum++;
+    
+                int forLim = 1;
+                if (pred.isInListProbePredicate()) {
+                    InListOperatorNode ilop = pred.getSourceInList(true);
+                    if (ilop != null)
+                        forLim = ilop.leftOperandList.size();
+                }
+                AndNode origAndNode = pred.getAndNode();
+                for (int i = 0; i < forLim; i++) {
+                    // Walk through each binary relational operator in the AND chain
+                    // and generate a setColumn method call for each one.
+                    generateSetColumn(acb, exprFun, colNum, pred, optTable, rowField, false);
+                    if (forLim > 1 && i != (forLim - 1))
+                        pred.setAndNode((AndNode) pred.getAndNode().getRightOperand());
+                    colNum++;
+                }
+                if (forLim > 1)
+                    pred.setAndNode(origAndNode);
             }
 
-            assert colNum==numberOfStopPredicates: "Number of stop predicates does not match";
+            assert colNum==numberOfColumns: "Number of stop predicates does not match";
 
             finishKey(acb,mb,exprFun,rowField);
             return;
@@ -2762,23 +3086,6 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
 			       */
             removeOptPredicate(pred);
 
-			/* This list is a store restriction list for a specific base
-			 * table, and we can only have one probe predicate per base
-			 * table (any others, if any, will be "reverted" back to
-			 * their original InListOperatorNodes and generated as
-			 * qualifiers). So make sure there are no other probe preds
-			 * in this list.
-			 */
-            if(SanityManager.DEBUG){
-                for(int i=0;i<index;i++){
-                    if(elementAt(i).isInListProbePredicate()){
-                        SanityManager.THROWASSERT("Found multiple probe "+
-                                "predicates for IN-list when only one was "+
-                                "expected.");
-                    }
-                }
-            }
-
             InListOperatorNode ilon=pred.getSourceInList();
             /* create a new method to get the probeValues*/
             MethodBuilder getProbeValuesMethod = acb.newExprFun();
@@ -2885,9 +3192,16 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
             // Determine number of leading AND qualifiers, and subsequent
             // trailing OR qualifiers.
             int num_of_or_conjunctions=0;
+            int numExtraInListColumns=0;
             for(int i=0;i<numberOfQualifiers;i++){
                 if(elementAt(i).isOrList()){
                     num_of_or_conjunctions++;
+                }
+                else
+                if (elementAt(i).isInListProbePredicate()) {
+                    InListOperatorNode ilop = elementAt(i).getSourceInList(true);
+                    if (ilop != null)
+                        numExtraInListColumns += (ilop.leftOperandList.size()-1);
                 }
             }
 
@@ -2901,7 +3215,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
 
             consMB.getField(qualField);             // 1st arg allocateQualArray
             consMB.push(0);                   // 2nd arg allocateQualArray
-            consMB.push(numberOfQualifiers-num_of_or_conjunctions);  // 3rd arg allocateQualArray
+            consMB.push(numberOfQualifiers+numExtraInListColumns-num_of_or_conjunctions);  // 3rd arg allocateQualArray
 
             consMB.callMethod(VMOpcode.INVOKESTATIC,acb.getBaseClassName(),"allocateQualArray","void",3);
         }
@@ -2939,7 +3253,18 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                     // will generate the OR qualifiers below.
                     break;
                 }else{
-                    generateSingleQualifierCode(
+                    int forLim = 1;
+                    
+                    if (pred.isInListProbePredicate()) {
+                        InListOperatorNode ilop = pred.getSourceInList(true);
+                        if (ilop != null)
+                            forLim = ilop.leftOperandList.size();
+                    }
+                    AndNode origAndNode = pred.getAndNode();
+                    for (int i = 0; i < forLim; i++) {
+                        // Walk through each binary relational operator in the AND chain
+                        // and generate qualField for each one.
+                        generateSingleQualifierCode(
                             consMB,
                             optTable,
                             absolute,
@@ -2948,8 +3273,13 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                             qualField,
                             0,
                             qualNum);
-
-                    qualNum++;
+    
+                        qualNum++;
+                        if (forLim > 1 && i != (forLim - 1))
+                            pred.setAndNode((AndNode) pred.getAndNode().getRightOperand());
+                    }
+                    if (forLim > 1)
+                        pred.setAndNode(origAndNode);
                 }
             }
         }
@@ -3039,6 +3369,9 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                     consMB.callMethod(VMOpcode.INVOKESTATIC, acb.getBaseClassName(), "allocateQualArray", "void", 3);
 
                     // get inlist column
+                    // TODO-msirek Can't currently push an OR'ed multicolumn in list qualifier.
+                    //  Need to handle all operands in leftOperandList if we support
+                    //  this in the future.
                     ColumnReference cr = (ColumnReference)inListNode.getLeftOperand().getHashableJoinColumnReference().get(0);
 
                     ConglomerateDescriptor bestCD = optTable.getTrulyTheBestAccessPath().
@@ -3094,7 +3427,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
 
         }
 
-        assert qualNum==numberOfQualifiers: qualNum+" Qualifiers found, "+ numberOfQualifiers+" expected.";
+        //assert qualNum==numberOfQualifiers: qualNum+" Qualifiers found, "+ numberOfQualifiers+" expected.";
     }
 
 
@@ -3118,7 +3451,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
     private static final int QUALIFIER_ORDER_OR_CLAUSE=5;
     private static final int QUALIFIER_NUM_CATEGORIES=6;
 
-    private void orderQualifiers(){
+    private void orderQualifiers() throws StandardException{
         // Sort the predicates into buckets, sortList[0] is the most 
         // selective, while sortList[4] is the least restrictive.
         //
@@ -3209,27 +3542,62 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
 		** If there are no start predicates, we do not generate anything.
 		*/
 
+		int countedStartPreds = 0;
         if(numberOfStartPredicates!=0){
 	        /* This sets up the method and the static field */
             MethodBuilder exprFun=acb.newExprFun();
-
+            
+            int size = size();
+            int numberOfColumns = 0;
+            for (int index = 0; index < size; index++) {
+                Predicate pred = elementAt(index);
+    
+                if (!pred.isStartKey())
+                    continue;
+    
+                countedStartPreds++;
+                if (pred.isInListProbePredicate()) {
+                    InListOperatorNode ilop = pred.getSourceInList(true);
+                    if (ilop == null)
+                        numberOfColumns++;
+                    else
+                        numberOfColumns += ilop.leftOperandList.size();
+                }
+                else
+                    numberOfColumns++;
+            }
+            assert countedStartPreds == numberOfStartPredicates : "Number of start predicates does not match";
+            
 		    /* Now we fill in the body of the method */
-            LocalField rowField=generateIndexableRow(acb,numberOfStartPredicates);
+            LocalField rowField=generateIndexableRow(acb, numberOfColumns);
 
             int colNum=0;
-            int size=size();
             for(int index=0;index<size;index++){
                 Predicate pred=elementAt(index);
 
                 if(!pred.isStartKey())
                     continue;
-
-                generateSetColumn(acb,exprFun,colNum,pred,optTable,rowField,true);
-
-                colNum++;
+    
+                int forLim = 1;
+                if (pred.isInListProbePredicate()) {
+                    InListOperatorNode ilop = pred.getSourceInList(true);
+                    if (ilop != null)
+                        forLim = ilop.leftOperandList.size();
+                }
+                AndNode origAndNode = pred.getAndNode();
+                for (int i = 0; i < forLim; i++) {
+                    // Walk through each binary relational operator in the AND chain
+                    // and generate a setColumn method call for each one.
+                    generateSetColumn(acb, exprFun, colNum, pred, optTable, rowField, true);
+                    if (forLim > 1 && i != (forLim-1))
+                        pred.setAndNode((AndNode)pred.getAndNode().getRightOperand());
+                    colNum++;
+                }
+                if (forLim > 1)
+                    pred.setAndNode(origAndNode);
             }
 
-            assert colNum==numberOfStartPredicates: "Number of start predicates does not match";
+            assert colNum== numberOfColumns: "Number of start predicates does not match";
 
             finishKey(acb,mb,exprFun,rowField);
             return;
@@ -3275,7 +3643,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
      * @param numberOfColumns The number of columns in the key
      * @return The field that holds the indexable row
      */
-    private LocalField generateIndexableRow(ExpressionClassBuilder acb,int numberOfColumns){
+    public static LocalField generateIndexableRow(ExpressionClassBuilder acb,int numberOfColumns){
         MethodBuilder mb=acb.getConstructor();
     		/*
 	  	   * Generate a call to get an indexable row
@@ -3296,7 +3664,91 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
 
         return field;
     }
-
+    
+    public static void generateValueRowOnStack(ExpressionClassBuilder acb, int numberOfColumns) {
+        /*
+         * Generate a call to get an indexable row
+         * with the given number of columns
+         */
+        MethodBuilder mb = acb.getConstructor();
+        acb.pushGetExecutionFactoryExpression(mb); // instance
+        mb.push(numberOfColumns);
+        mb.callMethod(VMOpcode.INVOKEINTERFACE, ClassName.ExecutionFactory, "getValueRow", ClassName.ExecRow, 1);
+    }
+    
+    public static LocalField generateValueRow(ExpressionClassBuilder acb, int numberOfColumns) {
+        /*
+         * Generate a call to get an indexable row
+         * with the given number of columns
+         */
+        MethodBuilder mb = acb.getConstructor();
+        acb.pushGetExecutionFactoryExpression(mb); // instance
+        mb.push(numberOfColumns);
+        mb.callMethod(VMOpcode.INVOKEINTERFACE, ClassName.ExecutionFactory, "getValueRow", ClassName.ExecRow, 1);
+        LocalField field = acb.newFieldDeclaration(Modifier.PRIVATE, ClassName.ExecRow);
+    
+        mb.setField(field);
+    
+        return field;
+    }
+    
+    
+    /**
+     * Generate a new ListDataType with "numberOfValues" values and assign it to a field
+     *
+     * @param acb            The ActivationClassBuilder for the class we're building
+     * @param numberOfValues The number of values in grouped data type.
+     * @return The field that holds the list data
+     */
+    public static LocalField generateListData(ExpressionClassBuilder acb, int numberOfValues) {
+    
+        MethodBuilder mb = acb.getConstructor();
+        acb.pushGetExecutionFactoryExpression(mb); // instance
+        mb.push(numberOfValues);
+        mb.callMethod(VMOpcode.INVOKEINTERFACE, ClassName.ExecutionFactory, "getListData", ClassName.ListDataType, 1);
+        /*
+         * Assign the ListDataType to a field, and put this assignment into
+         * the constructor for the activation class.  This way, we only have
+         * to get the row once.
+         */
+        LocalField field = acb.newFieldDeclaration(Modifier.PRIVATE, ClassName.ListDataType);
+    
+        mb.setField(field);
+    
+        return field;
+    }
+    
+    /**
+     * Generate a new ListDataType with "numberOfValues" values and place it on the stack.
+     *
+     * @param acb            The ActivationClassBuilder for the class we're building
+     * @param numberOfValues The number of values in grouped data type.
+     * @return The field that holds the list data
+     */
+    public static void generateListDataOnStack(ExpressionClassBuilder acb, int numberOfValues) {
+    
+        MethodBuilder mb = acb.getConstructor();
+        acb.pushGetExecutionFactoryExpression(mb); // instance
+        mb.push(numberOfValues);
+        mb.callMethod(VMOpcode.INVOKEINTERFACE, ClassName.ExecutionFactory, "getListData", ClassName.ListDataType, 1);
+    }
+    
+    /**
+     * Generate a new ListDataType with "numberOfValues" values and place it on the stack.
+     *
+     * @param acb            The ActivationClassBuilder for the class we're building
+     * @param numberOfValues The number of values in grouped data type.
+     * @param mb             The method build whose stack to place the ListDataType on.
+     * @return The field that holds the list data
+     */
+    public static void generateListDataOnStack(ExpressionClassBuilder acb, int numberOfValues, MethodBuilder mb) {
+        
+        acb.pushGetExecutionFactoryExpression(mb); // instance
+        mb.push(numberOfValues);
+        mb.callMethod(VMOpcode.INVOKEINTERFACE, ClassName.ExecutionFactory, "getListData", ClassName.ListDataType, 1);
+    }
+    
+    
     /**
      * Generate the code to set the value from a predicate in an index column.
      *
@@ -3431,7 +3883,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
      * @param exprFun  The MethodBuilder for the method we're building
      * @param rowField The name of the field that holds the indexable row
      */
-    private void finishKey(ExpressionClassBuilder acb, MethodBuilder mb, MethodBuilder exprFun, LocalField rowField){
+    public static void finishKey(ExpressionClassBuilder acb, MethodBuilder mb, MethodBuilder exprFun, LocalField rowField){
 		/* Generate return statement and add to exprFun */
         exprFun.getField(rowField);
         exprFun.methodReturn();
@@ -3908,23 +4360,27 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
             //check inlist predicate
             InListOperatorNode inNode = pred.getSourceInList();
             if (inNode != null) {
-                if (inNode.getLeftOperand() instanceof ColumnReference) {
-                    ColumnReference col= (ColumnReference)inNode.getLeftOperand();
-                    if (col.getSource() != null &&
+                for (int j = 0; j < inNode.leftOperandList.size(); j++) {
+                    if (inNode.leftOperandList.elementAt(j) instanceof ColumnReference) {
+                        ColumnReference col = (ColumnReference) inNode.leftOperandList.elementAt(j);
+                        if (col.getSource() != null &&
                             col.getTableNumber() == tableNumber &&
                             col.getColumnNumber() == columnNumber) {
-                        //inlist values should not include the default value
-                        int i = 0;
-                        for (; i<inNode.getRightOperandList().size(); i++) {
-                            DataValueDescriptor compare = ((ConstantNode)(inNode.getRightOperandList().elementAt(i))).getValue();
-                            if (compare != null && compare.equals(defaultValue)) {
-                                canSupportExcludedColumns = false;
+                            //inlist values should not include the default value
+                            int i = 0;
+                            for (; i < inNode.getRightOperandList().size(); i++) {
+                                DataValueDescriptor compare = ((ConstantNode) (inNode.getRightOperandList().elementAt(i))).getValue();
+                                if (compare instanceof ListDataType)
+                                    compare = ((ListDataType)compare).getDVD(j);
+                                if (compare != null && compare.equals(defaultValue)) {
+                                    canSupportExcludedColumns = false;
+                                    break;
+                                }
+                            }
+                            if (i == inNode.getRightOperandList().size()) {
+                                canSupportExcludedColumns = true;
                                 break;
                             }
-                        }
-                        if (i == inNode.getRightOperandList().size()) {
-                            canSupportExcludedColumns = true;
-                            break;
                         }
                     }
                 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultSetNode.java
@@ -1734,7 +1734,12 @@ public abstract class ResultSetNode extends QueryTreeNode{
     }
     
     public String printExplainInformationForActivation() throws StandardException {
-        return WordUtils.wrap(printExplainInformation(", ", getResultSetNumber()), 40, null, false);
+        String outString = WordUtils.wrap(printExplainInformation(", ", getResultSetNumber()), 40, null, false);
+        
+        // Avoid UTFDataFormatException that occurs when trying to encode very long strings.
+        if (outString.length() >= 65536)
+            outString = outString.substring(0, 65534);
+        return outString;
     }
 
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNodeList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNodeList.java
@@ -434,11 +434,12 @@ public class ValueNodeList extends QueryTreeNodeVector
 			ValueNode literalVal = (ValueNode) elementAt(index);
 			if (! (literalVal instanceof ConstantNode))
 			{
-				return false;
-			}
-			else if (literalVal instanceof ListValueNode) {
-				if (! ((ListValueNode)literalVal).containsAllConstantNodes())
-					return false;
+				if (literalVal instanceof ListValueNode) {
+					if (!((ListValueNode) literalVal).containsAllConstantNodes())
+						return false;
+				}
+				else
+				    return false;
 			}
 		}
 		return true;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNodeList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNodeList.java
@@ -31,15 +31,16 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
-import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.iapi.types.*;
-import com.splicemachine.db.iapi.sql.compile.TypeCompiler;
 import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.compile.TypeCompiler;
 import com.splicemachine.db.iapi.store.access.Qualifier;
+import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.iapi.util.StringUtil;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -61,7 +62,7 @@ public class ValueNodeList extends QueryTreeNodeVector
 	 * @exception StandardException		Thrown on error
 	 */
 
-	public void addValueNode(ValueNode valueNode) throws StandardException
+	public void addValueNode(ValueNode valueNode)
 	{
 		addElement(valueNode);
 	}
@@ -253,11 +254,12 @@ public class ValueNodeList extends QueryTreeNodeVector
 	 * type precendence as the specified value.
 	 *
 	 * @param precedence	The specified precedence.
+	 * @param cidx         The index into the ListValueNode, if present.
 	 *
 	 * @return	Whether or not all of the entries in the list have the same
 	 *			type precendence as the specified value.
 	 */
-	boolean allSamePrecendence(int precedence)
+	boolean allSamePrecendence(int precedence, int cidx)
 	throws StandardException
 	{
 		boolean allSame = true;
@@ -268,6 +270,8 @@ public class ValueNodeList extends QueryTreeNodeVector
 			ValueNode			valueNode;
 
 			valueNode = (ValueNode) elementAt(index);
+			if (valueNode instanceof ListValueNode)
+				valueNode = ((ListValueNode)valueNode).getValue(cidx);
 			DataTypeDescriptor valueNodeDTS = valueNode.getTypeServices();
 
 			if (valueNodeDTS == null)
@@ -427,9 +431,14 @@ public class ValueNodeList extends QueryTreeNodeVector
 
 		for (int index = 0; index < size; index++)
 		{
-			if (! ((ValueNode) elementAt(index) instanceof ConstantNode))
+			ValueNode literalVal = (ValueNode) elementAt(index);
+			if (! (literalVal instanceof ConstantNode))
 			{
 				return false;
+			}
+			else if (literalVal instanceof ListValueNode) {
+				if (! ((ListValueNode)literalVal).containsAllConstantNodes())
+					return false;
 			}
 		}
 		return true;
@@ -464,6 +473,7 @@ public class ValueNodeList extends QueryTreeNodeVector
 	 *
 	 * @exception StandardException		Thrown on error
 	 */
+
 	void sortInAscendingOrder(DataValueDescriptor judgeODV)
 		throws StandardException
 	{
@@ -736,23 +746,44 @@ public class ValueNodeList extends QueryTreeNodeVector
 
 	/**
 	 * Eliminate duplicates from the IN list and adjust the CharConstantNode with correct padding
-	 * @param dtd dataTypeDescriptor
+	 * @param dtdList dataTypeDescriptor list
 	 * @throws StandardException
 	 */
-	public void eliminateDuplicates(DataTypeDescriptor dtd) throws StandardException {
-		int maxSize = dtd.getMaximumWidth();
-		String typeid = dtd.getTypeName();
+	public void eliminateDuplicates(ArrayList<DataTypeDescriptor> dtdList) throws StandardException {
+		int numNodes = dtdList.size();
+		int [] maxSize = new int[numNodes];
+		String [] typeid = new String[numNodes];
 
+		
+		for (int i = 0; i < numNodes; i++) {
+			DataTypeDescriptor dtd = dtdList.get(i);
+			maxSize[i] = dtd.getMaximumWidth();
+			typeid[i] = dtd.getTypeName();
+		}
+		
 		HashSet<ValueNode> vset = new HashSet<ValueNode>(getNodes());
 		removeAllElements();
 		Iterator iterator = vset.iterator();
+
+		ValueNode valueNode = null;
 		while (iterator.hasNext())
 		{
-			ValueNode valueNode = (ValueNode) iterator.next();
-			if (valueNode instanceof CharConstantNode && typeid.equals(TypeId.CHAR_NAME)) {
-				rightPadCharConstantNode((CharConstantNode) valueNode, maxSize);
+
+			ValueNode constant = (ValueNode) iterator.next();
+			for (int i = 0; i < numNodes; i++) {
+				if (numNodes == 1)
+					valueNode = constant;
+				else
+					valueNode = ((ListValueNode)constant).getValue(i);
+
+    			if (valueNode instanceof CharConstantNode && typeid[i].equals(TypeId.CHAR_NAME)) {
+				    rightPadCharConstantNode((CharConstantNode) valueNode, maxSize[i]);
+			    }
 			}
-			addElement(valueNode);
+			if (numNodes == 1)
+			    addElement(valueNode);
+			else
+				addElement(constant);
 		}
 
 	}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericExecutionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericExecutionFactory.java
@@ -31,32 +31,28 @@
 
 package com.splicemachine.db.impl.sql.execute;
 
+import com.splicemachine.db.catalog.UUID;
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.EngineType;
-import com.splicemachine.db.iapi.sql.Activation;
-import com.splicemachine.db.impl.sql.GenericColumnDescriptor;
-import com.splicemachine.db.impl.sql.GenericResultDescription;
+import com.splicemachine.db.iapi.services.context.ContextManager;
+import com.splicemachine.db.iapi.services.io.FormatableBitSet;
+import com.splicemachine.db.iapi.services.loader.GeneratedMethod;
 import com.splicemachine.db.iapi.services.monitor.ModuleControl;
 import com.splicemachine.db.iapi.services.monitor.ModuleSupportable;
 import com.splicemachine.db.iapi.services.monitor.Monitor;
-import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.iapi.sql.execute.ExecRow;
-import com.splicemachine.db.iapi.sql.execute.ExecIndexRow;
-import com.splicemachine.db.iapi.sql.execute.ExecutionContext;
-import com.splicemachine.db.iapi.sql.execute.ExecutionFactory;
-import com.splicemachine.db.iapi.sql.execute.ResultSetFactory;
-import com.splicemachine.db.iapi.sql.execute.ScanQualifier;
+import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.ResultColumnDescriptor;
 import com.splicemachine.db.iapi.sql.ResultDescription;
+import com.splicemachine.db.iapi.sql.dictionary.IndexRowGenerator;
+import com.splicemachine.db.iapi.sql.execute.*;
 import com.splicemachine.db.iapi.store.access.DynamicCompiledOpenConglomInfo;
 import com.splicemachine.db.iapi.store.access.Qualifier;
 import com.splicemachine.db.iapi.store.access.StaticCompiledOpenConglomInfo;
 import com.splicemachine.db.iapi.store.access.TransactionController;
-import com.splicemachine.db.iapi.sql.dictionary.IndexRowGenerator;
-import com.splicemachine.db.iapi.sql.execute.RowChanger;
-import com.splicemachine.db.iapi.services.loader.GeneratedMethod;
-import com.splicemachine.db.iapi.services.context.ContextManager;
-import com.splicemachine.db.catalog.UUID;
-import com.splicemachine.db.iapi.services.io.FormatableBitSet;
+import com.splicemachine.db.iapi.types.ListDataType;
+import com.splicemachine.db.impl.sql.GenericColumnDescriptor;
+import com.splicemachine.db.impl.sql.GenericResultDescription;
+
 import java.util.Properties;
 import java.util.Vector;
 
@@ -296,6 +292,11 @@ public abstract class GenericExecutionFactory implements ModuleControl, ModuleSu
             return (ExecIndexRow) valueRow;
         }
         return new IndexValueRow(valueRow);
+    }
+    
+    @Override
+    public ListDataType getListData(int numberOfValues) {
+        return new ListDataType(numberOfValues);
     }
 
     //

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/ClassName.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/ClassName.java
@@ -91,10 +91,12 @@ public interface ClassName
 	String CursorResultSet = "com.splicemachine.db.iapi.sql.execute.CursorResultSet";
 
 	String ExecIndexRow = "com.splicemachine.db.iapi.sql.execute.ExecIndexRow";
-
+	String ListDataType = "com.splicemachine.db.iapi.types.ListDataType";
+	
 	String ExecPreparedStatement = "com.splicemachine.db.iapi.sql.execute.ExecPreparedStatement";
 
 	String ExecRow = "com.splicemachine.db.iapi.sql.execute.ExecRow";
+	String ValueRow = "com.splicemachine.db.impl.sql.execute.ValueRow";
 	String Activation = "com.splicemachine.db.iapi.sql.Activation";
 
 	String ResultSet = "com.splicemachine.db.iapi.sql.ResultSet";

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1366,4 +1366,11 @@ public interface Property {
 	String MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED =
 		"derby.database.multicolumnInlistProbeOnSparkEnabled";
 	
+	/**
+	 * If false, disable conversion of multicolumn equality DNF predicates to
+	 * a multicolumn in list, e.g. (a=1 and b=1) or (a=2 and b=3) ==> (a,b) IN ((1,1), (2,3)).
+	 * By default, this rewrite is enabled.
+	 */
+	String CONVERT_MULTICOLUMN_DNF_PREDICATES_TO_INLIST =
+		"derby.database.convertMultiColumnDNFPredicatesToInList";
 }

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1348,5 +1348,22 @@ public interface Property {
 	 */
 	String MATCHING_STATEMENT_CACHE_IGNORING_COMMENT_OPTIMIZATION_ENABLED =
 			"derby.database.matchStmtCacheIgnoreCommentOptimizationEnabled";
-
+	
+	/**
+	 * The maximum number of IN list items the optimizer is allowed to generate by combining
+	 * IN lists involving index or primary key columns into a single multicolumn IN list.
+	 */
+	String MAX_MULTICOLUMN_PROBE_VALUES =
+		"derby.database.maxMulticolumnProbeValues";
+	
+	/**
+	 * If true, allow conversion of single-column IN lists into a multicolumn IN list
+	 * for use as a probe predicate when executing on Spark.  By default, this
+	 * optimization is only used on control because the greater number of union
+	 * operations on Spark leads to worse performance.
+	 *
+	 */
+	String MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED =
+		"derby.database.multicolumnInlistProbeOnSparkEnabled";
+	
 }

--- a/mem_sql/pom.xml
+++ b/mem_sql/pom.xml
@@ -263,6 +263,18 @@
                 </executions>
                 <configuration>
                     <mainClass>com.splicemachine.derby.lifecycle.MemDatabase</mainClass>
+                    <systemProperties>
+                        <systemProperty>
+                            <key>com.splicemachine.enableLegacyAsserts</key>
+                            <value>true</value>
+                        </systemProperty>
+                     <!-- Uncomment the following to dump activation class files for mem platform to the mem_sql directory.
+                        <systemProperty>
+                            <key>splice.debug.dumpClassFile</key>
+                            <value>true</value>
+                        </systemProperty>
+                      -->
+                    </systemProperties>
                 </configuration>
             </plugin>
             <plugin>

--- a/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MemDatabase.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MemDatabase.java
@@ -24,6 +24,7 @@ import com.splicemachine.access.configuration.HConfigurationDefaultsList;
 import com.splicemachine.access.util.ReflectingConfigurationSource;
 import com.splicemachine.client.SpliceClient;
 import com.splicemachine.concurrent.ConcurrentTicker;
+import com.splicemachine.db.shared.common.sanity.SanityManager;
 import com.splicemachine.lifecycle.DatabaseLifecycleManager;
 import com.splicemachine.si.MemSIEnvironment;
 import com.splicemachine.si.impl.driver.SIDriver;
@@ -46,6 +47,18 @@ public class MemDatabase{
                                                                  new ReflectingConfigurationSource());
         MemSIEnvironment env=new MemSIEnvironment(tableFactory,new ConcurrentTicker(0L),config);
         MemSIEnvironment.INSTANCE = env;
+        if (config.debugDumpClassFile()) {
+            System.setProperty("com.splicemachine.enableLegacyAsserts",Boolean.TRUE.toString());
+            SanityManager.DEBUG_SET("DumpClassFile");
+        }
+        if (config.debugDumpBindTree()) {
+            System.setProperty("com.splicemachine.enableLegacyAsserts",Boolean.TRUE.toString());
+            SanityManager.DEBUG_SET("DumpBindTree");
+        }
+        if (config.debugDumpOptimizedTree()) {
+            System.setProperty("com.splicemachine.enableLegacyAsserts",Boolean.TRUE.toString());
+            SanityManager.DEBUG_SET("DumpOptimizedTree");
+        }
 
         SIDriver.loadDriver(env);
         final SIDriver driver = env.getSIDriver();
@@ -104,6 +117,10 @@ public class MemDatabase{
             builder.storageFactoryHome = System.getProperty("user.dir");
             builder.authenticationImpersonationEnabled = true;
             builder.authenticationImpersonationUsers = "dgf=splice;splice=*";
+    
+            if ("true".equals(System.getProperty("splice.debug.dumpClassFile")) ||
+                "DumpClassFile".equals(System.getProperty("derby.debug.true")))
+              builder.debugDumpClassFile = true;
         }
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceNodeFactoryImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceNodeFactoryImpl.java
@@ -216,6 +216,9 @@ public class SpliceNodeFactoryImpl extends NodeFactory implements ModuleControl,
 
 		  case C_NodeTypes.BOOLEAN_CONSTANT_NODE:
 		  	return C_NodeNames.BOOLEAN_CONSTANT_NODE_NAME;
+			
+		  case C_NodeTypes.LIST_VALUE_NODE:
+		    return C_NodeNames.LIST_VALUE_NODE_NAME;
 
 		  case C_NodeTypes.AND_NODE:
 		  	return C_NodeNames.AND_NODE_NAME;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeDerbyScanInformation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeDerbyScanInformation.java
@@ -25,6 +25,7 @@ import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.store.access.Qualifier;
 import com.splicemachine.db.iapi.store.access.ScanController;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.db.iapi.types.ListDataType;
 import com.splicemachine.derby.impl.SpliceMethod;
 import com.splicemachine.derby.utils.SerializationUtils;
 import com.splicemachine.si.api.txn.TxnView;
@@ -80,7 +81,14 @@ public class MultiProbeDerbyScanInformation extends DerbyScanInformation{
 		protected ExecIndexRow getStopPosition() throws StandardException {
 				ExecIndexRow stopPosition = sameStartStopPosition?super.getStartPosition():super.getStopPosition();
 				if (stopPosition != null) {
-					stopPosition.getRowArray()[inlistPosition] = probeValue;
+					if (probeValue instanceof ListDataType) {
+						ListDataType listData = (ListDataType) probeValue;
+						int numVals = listData.getLength();
+						for (int i = 0; i < numVals; i++) {
+							stopPosition.getRowArray()[inlistPosition + i] = listData.getDVD(i);
+						}
+					} else
+					    stopPosition.getRowArray()[inlistPosition] = probeValue;
 				}
 				return stopPosition;
 		}
@@ -90,8 +98,17 @@ public class MultiProbeDerbyScanInformation extends DerbyScanInformation{
 		ExecIndexRow startPosition = super.getStartPosition();
         if(sameStartStopPosition)
             startSearchOperator = ScanController.NA;
-		if(startPosition!=null)
-            startPosition.getRowArray()[inlistPosition] = probeValue;
+		if(startPosition!=null) {
+			if (probeValue instanceof ListDataType) {
+				ListDataType listData = (ListDataType) probeValue;
+				int numVals = listData.getLength();
+				for (int i = 0; i < numVals; i++) {
+					startPosition.getRowArray()[inlistPosition+i] = listData.getDVD(i);
+				}
+			}
+			else
+			    startPosition.getRowArray()[inlistPosition] = probeValue;
+		}
 		return startPosition;
 	}
 
@@ -125,14 +142,23 @@ public class MultiProbeDerbyScanInformation extends DerbyScanInformation{
 			 * set it on that field.
 			 */
 			Qualifier[] ands  = qualifiers[0];
+			int numColumns = (probeValue instanceof ListDataType) ?
+				((ListDataType)probeValue).getLength() : 1;
 			if(ands!=null){
-					Qualifier first = ands[0];
-					if(first!=null && probeValue != null){
-							first.clearOrderableCache();
-							//Qualifiers are sorted in the code generation phase,
-						    //and inlist will already be put in the first
-							first.getOrderable().setValue(probeValue);
+				for (int i = 0; i < numColumns; i++) {
+					Qualifier qual = ands[i];
+					if (qual != null && probeValue != null) {
+						qual.clearOrderableCache();
+						//Qualifiers are sorted in the code generation phase,
+						//and inlist will already be put in the first
+						DataValueDescriptor dvd = probeValue;
+						if (numColumns != 1)
+							dvd = ((ListDataType)dvd).getDVD(i);
+						// A dvd could be null if the source is a parameter value.
+						if (dvd != null)
+					  	    qual.getOrderable().setValue(dvd);
 					}
+				}
 			}
 		}
 		return qualifiers;

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/Scans.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/Scans.java
@@ -18,10 +18,7 @@ import com.carrotsearch.hppc.BitSet;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.store.access.Qualifier;
-import com.splicemachine.db.iapi.types.DataType;
-import com.splicemachine.db.iapi.types.DataValueDescriptor;
-import com.splicemachine.db.iapi.types.DataValueFactory;
-import com.splicemachine.db.iapi.types.HBaseRowLocation;
+import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.derby.impl.sql.execute.operations.QualifierUtils;
 import com.splicemachine.pipeline.Exceptions;
 import com.splicemachine.primitives.Bytes;
@@ -308,6 +305,8 @@ public class Scans extends SpliceUtils {
         assert row!=null:"row passed in is null";
         assert qual_list!=null:"qualifier[][] passed in is null";
         boolean     row_qualifies = true;
+        int numProbeValues = (probeValue != null && (probeValue instanceof ListDataType)) ?
+            ((ListDataType) probeValue).getLength() : 1;
         for (int i = 0; i < qual_list[0].length; i++) {
             // process each AND clause
             row_qualifies = false;
@@ -321,12 +320,15 @@ public class Scans extends SpliceUtils {
             if ( filterNull(q.getOperator(),columnValue,probeValue==null || i!=0?q.getOrderable():probeValue,q.getVariantType())) {
                 return false;
             }
+
             row_qualifies =
                     columnValue.compare(
                             q.getOperator(),
-                            probeValue==null || i!=0?q.getOrderable():probeValue,
+                            (probeValue==null || i >= numProbeValues) ? q.getOrderable():
+                            (numProbeValues == 1 ? probeValue : ((ListDataType) probeValue).getDVD(i)),
                             q.getOrderedNulls(),
                             q.getUnknownRV());
+            
             if (q.negateCompareResult())
                 row_qualifies = !row_qualifies;
 //            System.out.println(String.format("And Clause -> value={%s}, operator={%s}, orderable={%s}, " +

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/InListMultiprobeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/InListMultiprobeIT.java
@@ -14,16 +14,23 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
+import com.splicemachine.db.iapi.reference.Property;
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
 import com.splicemachine.homeless.TestUtils;
+import com.splicemachine.test.SerialTest;
 import com.splicemachine.test_tools.TableCreator;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.spark_project.guava.collect.Lists;
 
 import java.sql.*;
+import java.util.Collection;
 
 import static com.splicemachine.test_tools.Rows.row;
 import static com.splicemachine.test_tools.Rows.rows;
@@ -32,8 +39,19 @@ import static org.junit.Assert.assertEquals;
 /**
  * Test the IN list predicates with the multiprobe index scan
  */
+@RunWith(Parameterized.class)
+@Category(SerialTest.class)
 public class InListMultiprobeIT  extends SpliceUnitTest {
-
+    
+    private Boolean useSpark;
+    
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        Collection<Object[]> params = Lists.newArrayListWithCapacity(2);
+        params.add(new Object[]{true});
+        params.add(new Object[]{false});
+        return params;
+    }
     public static final String CLASS_NAME = InListMultiprobeIT.class.getSimpleName().toUpperCase();
     protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);
     protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
@@ -43,7 +61,11 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
             .around(spliceSchemaWatcher);
     @Rule
     public SpliceWatcher methodWatcher = new SpliceWatcher(CLASS_NAME);
-
+    
+    public InListMultiprobeIT(Boolean useSpark) {
+        this.useSpark = useSpark;
+    }
+    
     public static void createData(Connection conn, String schemaName) throws Exception {
 
         new TableCreator(conn)
@@ -88,7 +110,7 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
                         row(null, null, null, null, null),
                         row(null, null, null, null, null),
                         row(null, null, null, null, null)))
-                .withIndex("create index ix_float on ts_float(f, n)")
+                .withIndex("create index ix_float on ts_float(f, n, r)")
                 .create();
 
         new TableCreator(conn)
@@ -122,7 +144,7 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
                         row(null, null, null),
                         row(null, null, null),
                         row(null, null, null)))
-                .withIndex("create index ix_date on ts_datetime(d)")
+                .withIndex("create index ix_date on ts_datetime(d,t)")
                 .create();
 
         new TableCreator(conn)
@@ -177,6 +199,32 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
                         row(9, 9, 4),
                         row(10, 10,0)))
                 .create();
+    
+        new TableCreator(conn)
+            .withCreate("create table t22 (a1 bigint,\n" +
+                "                          b1 timestamp,\n" +
+                "                          c1 int,\n" +
+                "                          d1 int, primary key(b1,a1,c1,d1))")
+            .withIndex("create index t22_idx on t22(b1)")
+            .withInsert("insert into t22 values (?,?,?,?)")
+            .withRows(rows(
+                row(1, "1902-09-24 11:11:43.32", 1, 1),
+                row(2, "1902-09-24 11:11:44.32", 1, 1),
+                row(3, "1902-09-24 11:11:45.32", 1, 1),
+                row(4, "1902-09-24 11:11:46.32", 1, 1),
+                row(5, "1902-09-24 11:11:47.32", 1, 1),
+                row(6, "1902-09-24 11:11:48.32", 1, 1),
+                row(7, "1902-09-24 11:11:49.32", 1, 1),
+                row(8, "1902-09-24 11:11:50.32", 1, 1),
+                row(9, "1902-09-24 11:11:51.32", 1, 1),
+                row(10, "1902-09-24 11:11:52.32", 1, 1)))
+            .create();
+        increment = 1;
+        for (int i = 0; i < 5; i++) {
+            spliceClassWatcher.executeUpdate(format("insert into t22 select a1, timestampadd(SQL_TSI_MINUTE, %d, b1),c1+%d,d1+%d from t22",
+                                      10*increment, increment, increment));
+            increment *= 2;
+        }
 
         new TableCreator(conn)
                 .withCreate("create table t4 (a4 date, b4 int, c4 int, d4 int, primary key (a4, b4))")
@@ -247,11 +295,23 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
                         row("splice", 2, "2018-12-04"),
                         row("splice", 2, "2018-12-05")))
                 .create();
+    
+        // Reset derby.database.maxMulticolumnProbeValues to the default setting.
+        spliceClassWatcher.execute("call syscs_util.syscs_set_global_database_property('" + Property.MAX_MULTICOLUMN_PROBE_VALUES + "', null)");
+    
+        // Allow multicolumn IN list probing on Spark for testing purposes.
+        spliceClassWatcher.execute("call syscs_util.syscs_set_global_database_property('" + Property.MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED + "', 'true')");
     }
 
     @BeforeClass
     public static void createDataSet() throws Exception {
         createData(spliceClassWatcher.getOrCreateConnection(), spliceSchemaWatcher.toString());
+    }
+    
+    @AfterClass
+    public static void resetProperties() throws Exception {
+        spliceClassWatcher.execute("call syscs_util.syscs_set_global_database_property('" + Property.MAX_MULTICOLUMN_PROBE_VALUES + "', null)");
+        spliceClassWatcher.execute("call syscs_util.syscs_set_global_database_property('" + Property.MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED + "', null)");
     }
 
 
@@ -276,7 +336,8 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
 
     @Test
     public void testInListWithIntIT() throws Exception {
-        String sqlText = "select count(*) from ts_int where i in (1,2,3,4)";
+        String sqlText = format("select count(*) from ts_int  --SPLICE-PROPERTIES useSpark=%s \n" +
+                "where i in (1,2,3,4)", useSpark);
         ResultSet rs = methodWatcher.executeQuery(sqlText);
         String expected =
                 "1 |\n" +
@@ -286,16 +347,47 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
         assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         rs.close();
 
-        sqlText = "select count(*) from ts_int where i in (1,2,3,3,3,4,2,4,2,1,1)";
+        sqlText = format("select count(*) from ts_int  --SPLICE-PROPERTIES useSpark=%s \n" +
+                "where i in (1,2,3,3,3,4,2,4,2,1,1)", useSpark);
         rs = methodWatcher.executeQuery(sqlText);
 
         assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    
+    
+        sqlText = format("select i,l from ts_int  --SPLICE-PROPERTIES useSpark=%s \n" +
+                "where i in (1,2,3,3,3,4,2,4,2,1,1) and l in (7,4,5,4,2,2) order by 1,2", useSpark);
+        rs = methodWatcher.executeQuery("explain " + sqlText);
+    
+        /** explain should look like the following:
+         Cursor(n=3,rows=17,updateMode=READ_ONLY (1),engine=control)
+         ->  ScrollInsensitive(n=2,totalCost=8.199,outputRows=17,outputHeapSize=34 B,partitions=1)
+         ->  MultiProbeIndexScan[IX_INT(3937)](n=1,totalCost=4.028,scannedRows=17,outputRows=17,outputHeapSize=34 B,partitions=1,baseTable=TS_INT(3920),preds=[((I[0:1],L[0:2]) IN ((1,2),(1,4),(1,5),(1,7),(2,2),(2,4),(2,5),(2,7),(3,2),(3,4),(3,5),(3,7),(4,2),(4,4),(4,5),(4,7)))])         */
+        int level = 1;
+        while (rs.next()) {
+            String resultString = rs.getString(1);
+            if (level == 3) {
+                Assert.assertTrue("MultiProbeIndexScan is expected", resultString.contains("MultiProbeIndexScan"));
+            }
+            level++;
+        }
+        rs.close();
+        
+        rs = methodWatcher.executeQuery(sqlText);
+        expected =
+            "I | L |\n" +
+                "--------\n" +
+                " 2 | 2 |\n" +
+                " 4 | 4 |";
+    
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         rs.close();
     }
 
     @Test
     public void testInListWithFloatIT() throws Exception {
-        String sqlText = "select count(*) from ts_float where f in (1.0,2.0,3.0,4.0)";
+        String sqlText = format("select count(*) from ts_float --SPLICE-PROPERTIES useSpark=%s \n" +
+                "where f in (1.0,2.0,3.0,4.0)", useSpark);
         ResultSet rs = methodWatcher.executeQuery(sqlText);
         String expected =
                 "1 |\n" +
@@ -305,16 +397,164 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
         assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         rs.close();
 
-        sqlText = "select count(*) from ts_float where f in (1.0,2.0,3.0,3.0,3.0,4.0,2.0,4.0,2.0,1.0,1.0)";
+        sqlText = format("select count(*) from ts_float --SPLICE-PROPERTIES useSpark=%s \n" +
+                "where f in (1.0,2.0,3.0,3.0,3.0,4.0,2.0,4.0,2.0,1.0,1.0)", useSpark);
         rs = methodWatcher.executeQuery(sqlText);
 
         assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    
+        
+        sqlText = format("select f,n,r from ts_float --SPLICE-PROPERTIES useSpark=%s \n" +
+                "where f in (1.0,2.0,3.0,3.0,3.0,4.0,2.0,4.0,2.0,1.0,1.0) and " +
+            "n in (1,4,1,3,5) and r in (4.0, 3.0, 9.0, -1.0, 1.0) order by 1,2,3 ", useSpark);
+        rs = methodWatcher.executeQuery("explain " + sqlText);
+    
+        /** explain should look like the following:
+         Cursor(n=6,rows=17,updateMode=READ_ONLY (1),engine=control)
+         ->  ScrollInsensitive(n=2,totalCost=8.199,outputRows=17,outputHeapSize=34 B,partitions=1)
+         ->  MultiProbeIndexScan[IX_FLOAT(2049)](n=1,totalCost=4.027,scannedRows=17,outputRows=17,outputHeapSize=49 B,partitions=1,baseTable=TS_FLOAT(2032),preds=[((F[0:1],N[0:2],C[0:3]) IN ((1.0,1,-1.0),(1.0,1,1.0),(1.0,1,3.0),(1.0,1,4.0),(1.0,1,9.0),(1.0,3,-1.0),(1.0,3,1.0),(1.0,3,3.0),(1.0,3,4.0),(1.0,3,9.0),(1.0,4,-1.0),(1.0,4,1.0),(1.0,4,3.0),(1.0,4,4.0),(1.0,4,9.0),(1.0,5,-1.0),(1.0,5,1.0),(1.0,5,3.0),(1.0,5,4.0),(1.0,5,9.0),(2.0,1,-1.0),(2.0,1,1.0),(2.0,1,3.0),(2.0,1,4.0),(2.0,1,9.0),(2.0,3,-1.0),(2.0,3,1.0),(2.0,3,3.0),(2.0,3,4.0),(2.0,3,9.0),(2.0,4,-1.0),(2.0,4,1.0),(2.0,4,3.0),(2.0,4,4.0),(2.0,4,9.0),(2.0,5,-1.0),(2.0,5,1.0),(2.0,5,3.0),(2.0,5,4.0),(2.0,5,9.0),(3.0,1,-1.0),(3.0,1,1.0),(3.0,1,3.0),(3.0,1,4.0),(3.0,1,9.0),(3.0,3,-1.0),(3.0,3,1.0),(3.0,3,3.0),(3.0,3,4.0),(3.0,3,9.0),(3.0,4,-1.0),(3.0,4,1.0),(3.0,4,3.0),(3.0,4,4.0),(3.0,4,9.0),(3.0,5,-1.0),(3.0,5,1.0),(3.0,5,3.0),(3.0,5,4.0),(3.0,5,9.0),(4.0,1,-1.0),(4.0,1,1.0),(4.0,1,3.0),(4.0,1,4.0),(4.0,1,9.0),(4.0,3,-1.0),(4.0,3,1.0),(4.0,3,3.0),(4.0,3,4.0),(4.0,3,9.0),(4.0,4,-1.0),(4.0,4,1.0),(4.0,4,3.0),(4.0,4,4.0),(4.0,4,9.0),(4.0,5,-1.0),(4.0,5,1.0),(4.0,5,3.0),(4.0,5,4.0),(4.0,5,9.0)))]) */
+        int level = 1;
+        while (rs.next()) {
+            String resultString = rs.getString(1);
+            if (level == 3) {
+                Assert.assertTrue("MultiProbeIndexScan is expected", resultString.contains("MultiProbeIndexScan"));
+            }
+            level++;
+        }
+        rs.close();
+    
+        rs = methodWatcher.executeQuery(sqlText);
+        expected =
+            "F  | N  | R  |\n" +
+                "---------------\n" +
+                "1.0 |1.0 |1.0 |\n" +
+                "3.0 |3.0 |3.0 |\n" +
+                "4.0 |4.0 |4.0 |";
+    
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    
+        sqlText = format("select f,n,r from ts_float --SPLICE-PROPERTIES useSpark=%s \n" +
+                "where f in (1.0,2.0,3.0,3.0,3.0,4.0,2.0,4.0,2.0,1.0,1.0) and " +
+            "n=1 and r in (4.0, 3.0, 9.0, -1.0, 1.0) order by 1,2,3 ", useSpark);
+        rs = methodWatcher.executeQuery("explain " + sqlText);
+    
+        /** explain should look like the following:
+         Cursor(n=3,rows=17,updateMode=READ_ONLY (1),engine=control)
+         ->  ScrollInsensitive(n=2,totalCost=8.199,outputRows=17,outputHeapSize=34 B,partitions=1)
+         ->  MultiProbeIndexScan[IX_FLOAT(2369)](n=1,totalCost=4.027,scannedRows=17,outputRows=17,outputHeapSize=49 B,partitions=1,baseTable=TS_FLOAT(2352),preds=[((F[0:1],N[0:2],C[0:3]) IN ((1.0,1,-1.0),(1.0,1,1.0),(1.0,1,3.0),(1.0,1,4.0),(1.0,1,9.0),(2.0,1,-1.0),(2.0,1,1.0),(2.0,1,3.0),(2.0,1,4.0),(2.0,1,9.0),(3.0,1,-1.0),(3.0,1,1.0),(3.0,1,3.0),(3.0,1,4.0),(3.0,1,9.0),(4.0,1,-1.0),(4.0,1,1.0),(4.0,1,3.0),(4.0,1,4.0),(4.0,1,9.0)))]) */
+        level = 1;
+        while (rs.next()) {
+            String resultString = rs.getString(1);
+            if (level == 3) {
+                Assert.assertTrue("MultiProbeIndexScan is expected", resultString.contains("MultiProbeIndexScan"));
+            }
+            level++;
+        }
+        rs.close();
+    
+        rs = methodWatcher.executeQuery(sqlText);
+        expected =
+            "F  | N  | R  |\n" +
+                "---------------\n" +
+                "1.0 |1.0 |1.0 |";
+    
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    
+    
+        sqlText = format("select f,n,r from ts_float --SPLICE-PROPERTIES useSpark=%s \n" +
+                "where f in (1.0,2.0,3.0,3.0,3.0,4.0,2.0,4.0,2.0,1.0,1.0) and " +
+            "n in (1,4,1,3,5) and r = 4.0  and f not in (6,7,8) and r not in (33,44,55) order by 1,2,3 ", useSpark);
+        rs = methodWatcher.executeQuery("explain " + sqlText);
+    
+        /** explain should look like the following:
+         Cursor(n=3,rows=17,updateMode=READ_ONLY (1),engine=control)
+         ->  ScrollInsensitive(n=2,totalCost=8.199,outputRows=17,outputHeapSize=34 B,partitions=1)
+         ->  MultiProbeIndexScan[IX_FLOAT(2689)](n=1,totalCost=4.027,scannedRows=17,outputRows=17,outputHeapSize=49 B,partitions=1,baseTable=TS_FLOAT(2672),preds=[((F[0:1],N[0:2]) IN ((1.0,1),(1.0,3),(1.0,4),(1.0,5),(2.0,1),(2.0,3),(2.0,4),(2.0,5),(3.0,1),(3.0,3),(3.0,4),(3.0,5),(4.0,1),(4.0,3),(4.0,4),(4.0,5))),(C[0:3] = 4.0)]) */
+        level = 1;
+        while (rs.next()) {
+            String resultString = rs.getString(1);
+            if (level == 4) {
+                Assert.assertTrue("MultiProbeIndexScan is expected", resultString.contains("MultiProbeIndexScan"));
+            }
+            level++;
+        }
+        rs.close();
+    
+        rs = methodWatcher.executeQuery(sqlText);
+        expected =
+            "F  | N  | R  |\n" +
+                "---------------\n" +
+                "4.0 |4.0 |4.0 |";
+    
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    
+        sqlText = format("select f,n,r from ts_float --SPLICE-PROPERTIES useSpark=%s \n" +
+            "where f in (1.0,2.0,3.0,3.0,3.0,4.0,2.0,4.0,2.0,1.0,1.0) and " +
+            "n in (1,4,1,3,5) and r = 4.0  and f not in (6,7,8) and r not in (4, 33,44,55) order by 1,2,3 ", useSpark);
+
+        rs = methodWatcher.executeQuery(sqlText);
+        expected =
+            "";
+    
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    
+        sqlText = format("select f,n,r from ts_float --SPLICE-PROPERTIES useSpark=%s \n" +
+            "where f in (1.0,2.0,3.0,3.0,3.0,4.0,2.0,4.0,2.0,1.0,1.0) and " +
+            "n in (1,4,1,3,5) and r = 4.0  and f not in (4,6,7,8) and r not in (33,44,55) order by 1,2,3 ", useSpark);
+    
+        rs = methodWatcher.executeQuery(sqlText);
+        expected =
+            "";
+    
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    
+        
+        // Test conversion of equality DNF conditions to an IN list.
+        sqlText = format("select count(*) from ts_float --SPLICE-PROPERTIES useSpark=%s \n" +
+                "where ((f = 1.0 and r=1.0) or " +
+            "(f = 2.0 and r=2.0) or (r=3.0 and f = 3.0 )) and f not in (7+1,8+2,9)", useSpark);
+        rs = methodWatcher.executeQuery("explain " + sqlText);
+    
+        /** explain should look like the following:
+         Cursor(n=7,rows=1,updateMode=READ_ONLY (1),engine=Spark)
+         ->  ScrollInsensitive(n=6,totalCost=10.068,outputRows=1,outputHeapSize=0 B,partitions=1)
+         ->  ProjectRestrict(n=5,totalCost=4.032,outputRows=2,outputHeapSize=0 B,partitions=1)
+         ->  GroupBy(n=4,totalCost=4.032,outputRows=2,outputHeapSize=4 B,partitions=1)
+         ->  ProjectRestrict(n=3,totalCost=4.032,outputRows=2,outputHeapSize=4 B,partitions=1)
+         ->  ProjectRestrict(n=2,totalCost=4.032,outputRows=2,outputHeapSize=4 B,partitions=1,preds=[((F[0:1],R[0:2]) IN ((1.0,1.0),(2.0,2.0),(3.0,3.0)))])
+         */
+        level = 1;
+        while (rs.next()) {
+            String resultString = rs.getString(1);
+            if (level == 6) {
+                Assert.assertTrue("MultiProbeIndexScan is not expected", !resultString.contains("MultiProbeIndexScan"));
+                Assert.assertTrue("MultiProbeTableScan is not expected", !resultString.contains("MultiProbeTableScan"));
+                Assert.assertTrue("Should have converted the OR'ed conditions to IN.", resultString.contains("(F[0:1],R[0:2]) IN "));
+            }
+            level++;
+        }
+        rs.close();
+    
+        rs = methodWatcher.executeQuery(sqlText);
+        expected =
+            "1 |\n" +
+                "----\n" +
+                " 3 |";
+    
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         rs.close();
     }
 
     @Test
     public void testInListWithCharIT() throws Exception {
-        String sqlText = "select count(*) from ts_char where c in ('a', 'b', 'c', 'd')";
+        String sqlText = format("select count(*) from ts_char --SPLICE-PROPERTIES useSpark=%s \n"+
+                "where c in ('a', 'b', 'c', 'd')", useSpark);
         ResultSet rs = methodWatcher.executeQuery(sqlText);
         String expected =
                 "1 |\n" +
@@ -324,18 +564,71 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
         assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         rs.close();
 
-        sqlText = "select count(*) from ts_char where c in ('a', 'b', 'b', 'c', 'a', 'c', 'd')";
+        sqlText = format("select count(*) from ts_char --SPLICE-PROPERTIES useSpark=%s \n" +
+                "where c in ('a', 'b', 'b', 'c', 'a', 'c', 'd')", useSpark);
         rs = methodWatcher.executeQuery(sqlText);
         assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         rs.close();
 
-        sqlText = "select count(*) from ts_char where c in ('c')";
+        sqlText = format("select count(*) from ts_char --SPLICE-PROPERTIES useSpark=%s \n" +
+                "where c in ('c')", useSpark);
         expected =
                 "1 |\n" +
                         "----\n" +
                         " 1 |";
         rs = methodWatcher.executeQuery(sqlText);
         assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    
+        sqlText = format("select c,v from ts_char --SPLICE-PROPERTIES useSpark=%s \n" +
+            "where c in ('a', 'c', 'b', 'b') and v in ('aaaa', 'bbbbb', 'cc', 'asdfasdfasdfasdfsafsda')", useSpark);
+        rs = methodWatcher.executeQuery("explain " + sqlText);
+    
+        int level = 1;
+        while (rs.next()) {
+            String resultString = rs.getString(1);
+            if (level == 3) {
+                Assert.assertTrue("MultiProbeIndexScan is expected", resultString.contains("MultiProbeIndexScan"));
+            }
+            level++;
+        }
+        rs.close();
+    
+        rs = methodWatcher.executeQuery(sqlText);
+        expected =
+            "C |  V   |\n" +
+                "-----------\n" +
+                " a |aaaa  |\n" +
+                " b |bbbbb |\n" +
+                " c | cc   |";
+    
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    
+        sqlText = format("select c,v from ts_char --SPLICE-PROPERTIES useSpark=%s \n" +
+            "where c in ('a', 'c', 'b', 'b') and v in ('aaaa', 'bbbbb', 'cc', 'asdfasdfasdfasdfsafsda')", useSpark);
+        
+        rs = methodWatcher.executeQuery("explain " + sqlText);
+    
+        level = 1;
+        while (rs.next()) {
+            String resultString = rs.getString(1);
+            if (level == 3) {
+                Assert.assertTrue("MultiProbeIndexScan is expected", resultString.contains("MultiProbeIndexScan"));
+            }
+            level++;
+        }
+        rs.close();
+    
+        rs = methodWatcher.executeQuery(sqlText);
+        expected =
+            "C |  V   |\n" +
+                "-----------\n" +
+                " a |aaaa  |\n" +
+                " b |bbbbb |\n" +
+                " c | cc   |";
+    
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         rs.close();
     }
 
@@ -387,7 +680,8 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
 
     @Test
     public void testInListWithDynamicParamsIT() throws Exception {
-        String sqlText = "select count(*) from ts_char where c IN ( ?, ?, ?, ? )";
+        String sqlText = format("select count(*) from ts_char --SPLICE-PROPERTIES useSpark=%s \n" +
+            "where c IN ( ?, ?, ?, ? )", useSpark);
         PreparedStatement ps = methodWatcher.prepareStatement(sqlText);
         ps.setString(1, "c");
         ps.setString(2, "d");
@@ -400,7 +694,8 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
         Assert.assertEquals("Incorrect value returned!", 2, val);
         rs.close();
 
-        sqlText = "select count(*) from ts_char where c IN ( ?, ?, ?, ? )";
+        sqlText = format("select count(*) from ts_char --SPLICE-PROPERTIES useSpark=%s \n" +
+            "where c IN ( ?, ?, ?, ? )", useSpark);
         ps = methodWatcher.prepareStatement(sqlText);
         ps.setString(1, "c");
         ps.setString(2, "c");
@@ -412,6 +707,583 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
         val = rs.getInt(1);
         Assert.assertEquals("Incorrect value returned!", 1, val);
         rs.close();
+    
+        sqlText = format("select c,v from ts_char --SPLICE-PROPERTIES useSpark=%s \n" +
+            "where c in (?,?,?,?) and v in ('aaaa', ?, 'bbbbb', ?, 'asdfasdfasdfasdfsafsda')", useSpark);
+        ps = methodWatcher.prepareStatement("explain " + sqlText);
+        ps.setString(1, "a");
+        ps.setString(2, "c");
+        ps.setString(3, "b");
+        ps.setString(4, "b");
+        ps.setString(5, "bbbbb");
+        ps.setString(6, "cc");
+        rs = ps.executeQuery();
+    
+        int level = 1;
+        while (rs.next()) {
+            String resultString = rs.getString(1);
+            if (level == 3) {
+                Assert.assertTrue("MultiProbeIndexScan is expected", resultString.contains("MultiProbeIndexScan"));
+            }
+            level++;
+        }
+        rs.close();
+    
+        ps = methodWatcher.prepareStatement(sqlText);
+        ps.setString(1, "a");
+        ps.setString(2, "c");
+        ps.setString(3, "b");
+        ps.setString(4, "b");
+        ps.setString(5, "bbbbb");
+        ps.setString(6, "cc");
+        rs = ps.executeQuery();
+        String expected =
+            "C |  V   |\n" +
+                "-----------\n" +
+                " a |aaaa  |\n" +
+                " b |bbbbb |\n" +
+                " c | cc   |";
+    
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    
+        sqlText = format("select c,v from ts_char --SPLICE-PROPERTIES useSpark=%s \n" +
+            "where c in (?,?,?,?) and v in ('aaaa', ?, 'bbbbb', ?, 'asdfasdfasdfasdfsafsda') and v > 'bb' and c < 'c'", useSpark);
+        ps = methodWatcher.prepareStatement("explain " + sqlText);
+        ps.setString(1, "a");
+        ps.setString(2, "c");
+        ps.setString(3, "b");
+        ps.setString(4, "b");
+        ps.setString(5, "bbbbb");
+        ps.setString(6, "cc");
+        rs = ps.executeQuery();
+    
+        level = 1;
+        while (rs.next()) {
+            String resultString = rs.getString(1);
+            if (level == 4) {
+                Assert.assertTrue("MultiProbeIndexScan is expected", resultString.contains("MultiProbeIndexScan"));
+            }
+            level++;
+        }
+        rs.close();
+    
+        ps = methodWatcher.prepareStatement(sqlText);
+        ps.setString(1, "a");
+        ps.setString(2, "c");
+        ps.setString(3, "b");
+        ps.setString(4, "b");
+        ps.setString(5, "bbbbb");
+        ps.setString(6, "cc");
+        rs = ps.executeQuery();
+        expected =
+            "C |  V   |\n" +
+                "-----------\n" +
+                " b |bbbbb |";
+    
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    
+        sqlText = format("select c,v from ts_char --SPLICE-PROPERTIES useSpark=%s \n" +
+            "where c in (?,?,?,?) and v = ? and v > 'bb' and c < 'c'", useSpark);
+        ps = methodWatcher.prepareStatement("explain " + sqlText);
+        ps.setString(1, "a");
+        ps.setString(2, "c");
+        ps.setString(3, "b");
+        ps.setString(4, "b");
+        ps.setString(5, "bbbbb");
+        rs = ps.executeQuery();
+    
+        level = 1;
+        while (rs.next()) {
+            String resultString = rs.getString(1);
+            if (level == 4) {
+                Assert.assertTrue("MultiProbeIndexScan is expected", resultString.contains("MultiProbeIndexScan"));
+            }
+            level++;
+        }
+        rs.close();
+    
+        ps = methodWatcher.prepareStatement(sqlText);
+        ps.setString(1, "a");
+        ps.setString(2, "c");
+        ps.setString(3, "b");
+        ps.setString(4, "b");
+        ps.setString(5, "bbbbb");
+        rs = ps.executeQuery();
+        expected =
+            "C |  V   |\n" +
+                "-----------\n" +
+                " b |bbbbb |";
+    
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    
+    
+        sqlText = format("select f,n,r from ts_float --SPLICE-PROPERTIES useSpark=%s \n" +
+            "where f in (?,?,?,?,?,?,?,?) and " +
+            "n in (?,?,?,?,?) and r in (?,?,?,?,?) order by 1,2,3 ", useSpark);
+        ps = methodWatcher.prepareStatement("explain " + sqlText);
+        ps.setDouble(1, 1.0);
+        ps.setDouble(2, 2.0);
+        ps.setDouble(3, 3.0);
+        ps.setDouble(4, 3.0);
+        ps.setDouble(5, 4.0);
+        ps.setDouble(6, 2.0);
+        ps.setDouble(7, 1.0);
+        ps.setDouble(8, 1.0);
+        ps.setInt(9, 1);
+        ps.setInt(10, 4);
+        ps.setInt(11, 1);
+        ps.setInt(12, 3);
+        ps.setInt(13, 5);
+        ps.setDouble(14, 4.0);
+        ps.setDouble(15, 3.0);
+        ps.setDouble(16, 9.0);
+        ps.setDouble(17, -1.0);
+        ps.setDouble(18, 1.0);
+        rs = ps.executeQuery();
+    
+        /** explain should look like the following:
+         Cursor(n=6,rows=17,updateMode=READ_ONLY (1),engine=control)
+         ->  ScrollInsensitive(n=2,totalCost=8.199,outputRows=17,outputHeapSize=34 B,partitions=1)
+         ->  MultiProbeIndexScan[IX_FLOAT(2049)](n=1,totalCost=4.027,scannedRows=17,outputRows=17,outputHeapSize=49 B,partitions=1,baseTable=TS_FLOAT(2032),preds=[((F[0:1],N[0:2],C[0:3]) IN ((1.0,1,-1.0),(1.0,1,1.0),(1.0,1,3.0),(1.0,1,4.0),(1.0,1,9.0),(1.0,3,-1.0),(1.0,3,1.0),(1.0,3,3.0),(1.0,3,4.0),(1.0,3,9.0),(1.0,4,-1.0),(1.0,4,1.0),(1.0,4,3.0),(1.0,4,4.0),(1.0,4,9.0),(1.0,5,-1.0),(1.0,5,1.0),(1.0,5,3.0),(1.0,5,4.0),(1.0,5,9.0),(2.0,1,-1.0),(2.0,1,1.0),(2.0,1,3.0),(2.0,1,4.0),(2.0,1,9.0),(2.0,3,-1.0),(2.0,3,1.0),(2.0,3,3.0),(2.0,3,4.0),(2.0,3,9.0),(2.0,4,-1.0),(2.0,4,1.0),(2.0,4,3.0),(2.0,4,4.0),(2.0,4,9.0),(2.0,5,-1.0),(2.0,5,1.0),(2.0,5,3.0),(2.0,5,4.0),(2.0,5,9.0),(3.0,1,-1.0),(3.0,1,1.0),(3.0,1,3.0),(3.0,1,4.0),(3.0,1,9.0),(3.0,3,-1.0),(3.0,3,1.0),(3.0,3,3.0),(3.0,3,4.0),(3.0,3,9.0),(3.0,4,-1.0),(3.0,4,1.0),(3.0,4,3.0),(3.0,4,4.0),(3.0,4,9.0),(3.0,5,-1.0),(3.0,5,1.0),(3.0,5,3.0),(3.0,5,4.0),(3.0,5,9.0),(4.0,1,-1.0),(4.0,1,1.0),(4.0,1,3.0),(4.0,1,4.0),(4.0,1,9.0),(4.0,3,-1.0),(4.0,3,1.0),(4.0,3,3.0),(4.0,3,4.0),(4.0,3,9.0),(4.0,4,-1.0),(4.0,4,1.0),(4.0,4,3.0),(4.0,4,4.0),(4.0,4,9.0),(4.0,5,-1.0),(4.0,5,1.0),(4.0,5,3.0),(4.0,5,4.0),(4.0,5,9.0)))]) */
+        level = 1;
+        while (rs.next()) {
+            String resultString = rs.getString(1);
+            if (level == 3) {
+                Assert.assertTrue("MultiProbeIndexScan is expected", resultString.contains("MultiProbeIndexScan"));
+            }
+            level++;
+        }
+        rs.close();
+    
+        ps = methodWatcher.prepareStatement(sqlText);
+        ps.setDouble(1, 1.0);
+        ps.setDouble(2, 2.0);
+        ps.setDouble(3, 3.0);
+        ps.setDouble(4, 3.0);
+        ps.setDouble(5, 4.0);
+        ps.setDouble(6, 2.0);
+        ps.setDouble(7, 1.0);
+        ps.setDouble(8, 1.0);
+        ps.setInt(9, 1);
+        ps.setInt(10, 4);
+        ps.setInt(11, 1);
+        ps.setInt(12, 3);
+        ps.setInt(13, 5);
+        ps.setDouble(14, 4.0);
+        ps.setDouble(15, 3.0);
+        ps.setDouble(16, 9.0);
+        ps.setDouble(17, -1.0);
+        ps.setDouble(18, 1.0);
+        rs = ps.executeQuery();
+        expected =
+            "F  | N  | R  |\n" +
+                "---------------\n" +
+                "1.0 |1.0 |1.0 |\n" +
+                "3.0 |3.0 |3.0 |\n" +
+                "4.0 |4.0 |4.0 |";
+    
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    
+    }
+    
+    @Test
+    public void testManyProbeValues() throws Exception {
+        String sqlText = format("select * from t22 --splice-properties useSpark=%s \n" +
+            "where b1 in (?, {ts'1902-09-24 21:51:52.32'}, {ts'1902-09-25 03:11:52.32'}) and \n" +
+            "      b1 in (?, {ts'1902-09-24 21:51:52.32'}, {ts'1902-09-25 03:11:52.32'}) and \n" +
+            "      a1 in (1,2,3) and \n" +
+            "      c1 = 1", useSpark);
+        PreparedStatement ps = methodWatcher.prepareStatement("explain " + sqlText);
+        ps.setTimestamp(1, Timestamp.valueOf("1902-09-24 11:11:43.32"));
+        ps.setTimestamp(2, Timestamp.valueOf("1902-09-24 11:11:43.32"));
+        ResultSet rs = ps.executeQuery();
+    
+        int level = 1;
+        while (rs.next()) {
+            String resultString = rs.getString(1);
+            if (level == 4) {
+                Assert.assertTrue("MultiProbeTableScan is expected", resultString.contains("MultiProbeTableScan"));
+            }
+            level++;
+        }
+        rs.close();
+    
+        ps = methodWatcher.prepareStatement(sqlText);
+        ps.setTimestamp(1, Timestamp.valueOf("1902-09-24 11:11:43.32"));
+        ps.setTimestamp(2, Timestamp.valueOf("1902-09-24 11:11:43.32"));
+        rs = ps.executeQuery();
+        String expected =
+            "A1 |          B1           |C1 |D1 |\n" +
+                "------------------------------------\n" +
+                " 1 |1902-09-24 11:11:43.32 | 1 | 1 |";
+    
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+
+        sqlText = format("select b1,a1 from t22 --splice-properties useSpark=%s \n" +
+            "where b1 in \n" +
+            "(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?," +
+            " ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?," +
+            " ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?," +
+            " ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)" +
+        
+            " and \n" +
+            "      a1 in \n" +
+            "(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?, " +
+            "?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?, " +
+            "?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) " +
+            "order by 1,2", useSpark);
+        ps = methodWatcher.prepareStatement("explain " + sqlText);
+        Timestamp ts = Timestamp.valueOf("1902-09-24 11:11:43.32");
+        int increment = 0;
+        for (int i = 0; i < 20; i++) {
+            ps.setTimestamp(1 + i * 10, new Timestamp(ts.getTime() + increment * 1000 * 60));
+            ps.setTimestamp(2 + i * 10, new Timestamp(ts.getTime() + 1000 + increment * 1000 * 60));
+            ps.setTimestamp(3 + i * 10, new Timestamp(ts.getTime() + 2000 + increment * 1000 * 60));
+            ps.setTimestamp(4 + i * 10, new Timestamp(ts.getTime() + 3000 + increment * 1000 * 60));
+            ps.setTimestamp(5 + i * 10, new Timestamp(ts.getTime() + 4000 + increment * 1000 * 60));
+            ps.setTimestamp(6 + i * 10, new Timestamp(ts.getTime() + 5000 + increment * 1000 * 60));
+            ps.setTimestamp(7 + i * 10, new Timestamp(ts.getTime() + 6000 + increment * 1000 * 60));
+            ps.setTimestamp(8 + i * 10, new Timestamp(ts.getTime() + 7000 + increment * 1000 * 60));
+            ps.setTimestamp(9 + i * 10, new Timestamp(ts.getTime() + 8000 + increment * 1000 * 60));
+            ps.setTimestamp(10 + i * 10, new Timestamp(ts.getTime() + 9000 + increment * 1000 * 60));
+            increment += 10;
+        }
+        for (int i = 1; i <= 60; i++) {
+            ps.setInt(i + 200, i);
+        }
+    
+        rs = ps.executeQuery();
+    
+        level = 1;
+        boolean multiProbeFound = false, multiColINFound = false;
+        while (rs.next()) {
+            String resultString = rs.getString(1);
+            if (level == 4 || level == 5) {
+                if (!multiProbeFound)
+                    multiProbeFound = resultString.contains("MultiProbeTableScan");
+                if (!multiColINFound)
+                    multiColINFound = resultString.contains("preds=[((B1[0:2],A1[0:1]) IN ");
+            }
+            if (level > 4) {
+                Assert.assertTrue("MultiProbeTableScan is expected", multiProbeFound);
+                Assert.assertTrue("Multicolumn IN predicate not expected", !multiColINFound);
+            }
+            level++;
+        }
+        rs.close();
+    
+        ps = methodWatcher.prepareStatement(sqlText);
+        increment = 0;
+        for (int i = 0; i < 20; i++) {
+            ps.setTimestamp(1 + i * 10, new Timestamp(ts.getTime() + increment * 1000 * 60));
+            ps.setTimestamp(2 + i * 10, new Timestamp(ts.getTime() + 1000 + increment * 1000 * 60));
+            ps.setTimestamp(3 + i * 10, new Timestamp(ts.getTime() + 2000 + increment * 1000 * 60));
+            ps.setTimestamp(4 + i * 10, new Timestamp(ts.getTime() + 3000 + increment * 1000 * 60));
+            ps.setTimestamp(5 + i * 10, new Timestamp(ts.getTime() + 4000 + increment * 1000 * 60));
+            ps.setTimestamp(6 + i * 10, new Timestamp(ts.getTime() + 5000 + increment * 1000 * 60));
+            ps.setTimestamp(7 + i * 10, new Timestamp(ts.getTime() + 6000 + increment * 1000 * 60));
+            ps.setTimestamp(8 + i * 10, new Timestamp(ts.getTime() + 7000 + increment * 1000 * 60));
+            ps.setTimestamp(9 + i * 10, new Timestamp(ts.getTime() + 8000 + increment * 1000 * 60));
+            ps.setTimestamp(10 + i * 10, new Timestamp(ts.getTime() + 9000 + increment * 1000 * 60));
+            increment += 10;
+        }
+        for (int i = 1; i <= 60; i++) {
+            ps.setInt(i + 200, i);
+        }
+        rs = ps.executeQuery();
+        expected =
+            "B1           |A1 |\n" +
+                "----------------------------\n" +
+                "1902-09-24 11:11:43.32 | 1 |\n" +
+                "1902-09-24 11:11:44.32 | 2 |\n" +
+                "1902-09-24 11:11:45.32 | 3 |\n" +
+                "1902-09-24 11:11:46.32 | 4 |\n" +
+                "1902-09-24 11:11:47.32 | 5 |\n" +
+                "1902-09-24 11:11:48.32 | 6 |\n" +
+                "1902-09-24 11:11:49.32 | 7 |\n" +
+                "1902-09-24 11:11:50.32 | 8 |\n" +
+                "1902-09-24 11:11:51.32 | 9 |\n" +
+                "1902-09-24 11:11:52.32 |10 |\n" +
+                "1902-09-24 11:21:43.32 | 1 |\n" +
+                "1902-09-24 11:21:44.32 | 2 |\n" +
+                "1902-09-24 11:21:45.32 | 3 |\n" +
+                "1902-09-24 11:21:46.32 | 4 |\n" +
+                "1902-09-24 11:21:47.32 | 5 |\n" +
+                "1902-09-24 11:21:48.32 | 6 |\n" +
+                "1902-09-24 11:21:49.32 | 7 |\n" +
+                "1902-09-24 11:21:50.32 | 8 |\n" +
+                "1902-09-24 11:21:51.32 | 9 |\n" +
+                "1902-09-24 11:21:52.32 |10 |\n" +
+                "1902-09-24 11:31:43.32 | 1 |\n" +
+                "1902-09-24 11:31:44.32 | 2 |\n" +
+                "1902-09-24 11:31:45.32 | 3 |\n" +
+                "1902-09-24 11:31:46.32 | 4 |\n" +
+                "1902-09-24 11:31:47.32 | 5 |\n" +
+                "1902-09-24 11:31:48.32 | 6 |\n" +
+                "1902-09-24 11:31:49.32 | 7 |\n" +
+                "1902-09-24 11:31:50.32 | 8 |\n" +
+                "1902-09-24 11:31:51.32 | 9 |\n" +
+                "1902-09-24 11:31:52.32 |10 |\n" +
+                "1902-09-24 11:41:43.32 | 1 |\n" +
+                "1902-09-24 11:41:44.32 | 2 |\n" +
+                "1902-09-24 11:41:45.32 | 3 |\n" +
+                "1902-09-24 11:41:46.32 | 4 |\n" +
+                "1902-09-24 11:41:47.32 | 5 |\n" +
+                "1902-09-24 11:41:48.32 | 6 |\n" +
+                "1902-09-24 11:41:49.32 | 7 |\n" +
+                "1902-09-24 11:41:50.32 | 8 |\n" +
+                "1902-09-24 11:41:51.32 | 9 |\n" +
+                "1902-09-24 11:41:52.32 |10 |\n" +
+                "1902-09-24 11:51:43.32 | 1 |\n" +
+                "1902-09-24 11:51:44.32 | 2 |\n" +
+                "1902-09-24 11:51:45.32 | 3 |\n" +
+                "1902-09-24 11:51:46.32 | 4 |\n" +
+                "1902-09-24 11:51:47.32 | 5 |\n" +
+                "1902-09-24 11:51:48.32 | 6 |\n" +
+                "1902-09-24 11:51:49.32 | 7 |\n" +
+                "1902-09-24 11:51:50.32 | 8 |\n" +
+                "1902-09-24 11:51:51.32 | 9 |\n" +
+                "1902-09-24 11:51:52.32 |10 |\n" +
+                "1902-09-24 12:01:43.32 | 1 |\n" +
+                "1902-09-24 12:01:44.32 | 2 |\n" +
+                "1902-09-24 12:01:45.32 | 3 |\n" +
+                "1902-09-24 12:01:46.32 | 4 |\n" +
+                "1902-09-24 12:01:47.32 | 5 |\n" +
+                "1902-09-24 12:01:48.32 | 6 |\n" +
+                "1902-09-24 12:01:49.32 | 7 |\n" +
+                "1902-09-24 12:01:50.32 | 8 |\n" +
+                "1902-09-24 12:01:51.32 | 9 |\n" +
+                "1902-09-24 12:01:52.32 |10 |\n" +
+                "1902-09-24 12:11:43.32 | 1 |\n" +
+                "1902-09-24 12:11:44.32 | 2 |\n" +
+                "1902-09-24 12:11:45.32 | 3 |\n" +
+                "1902-09-24 12:11:46.32 | 4 |\n" +
+                "1902-09-24 12:11:47.32 | 5 |\n" +
+                "1902-09-24 12:11:48.32 | 6 |\n" +
+                "1902-09-24 12:11:49.32 | 7 |\n" +
+                "1902-09-24 12:11:50.32 | 8 |\n" +
+                "1902-09-24 12:11:51.32 | 9 |\n" +
+                "1902-09-24 12:11:52.32 |10 |\n" +
+                "1902-09-24 12:21:43.32 | 1 |\n" +
+                "1902-09-24 12:21:44.32 | 2 |\n" +
+                "1902-09-24 12:21:45.32 | 3 |\n" +
+                "1902-09-24 12:21:46.32 | 4 |\n" +
+                "1902-09-24 12:21:47.32 | 5 |\n" +
+                "1902-09-24 12:21:48.32 | 6 |\n" +
+                "1902-09-24 12:21:49.32 | 7 |\n" +
+                "1902-09-24 12:21:50.32 | 8 |\n" +
+                "1902-09-24 12:21:51.32 | 9 |\n" +
+                "1902-09-24 12:21:52.32 |10 |\n" +
+                "1902-09-24 12:31:43.32 | 1 |\n" +
+                "1902-09-24 12:31:44.32 | 2 |\n" +
+                "1902-09-24 12:31:45.32 | 3 |\n" +
+                "1902-09-24 12:31:46.32 | 4 |\n" +
+                "1902-09-24 12:31:47.32 | 5 |\n" +
+                "1902-09-24 12:31:48.32 | 6 |\n" +
+                "1902-09-24 12:31:49.32 | 7 |\n" +
+                "1902-09-24 12:31:50.32 | 8 |\n" +
+                "1902-09-24 12:31:51.32 | 9 |\n" +
+                "1902-09-24 12:31:52.32 |10 |\n" +
+                "1902-09-24 12:41:43.32 | 1 |\n" +
+                "1902-09-24 12:41:44.32 | 2 |\n" +
+                "1902-09-24 12:41:45.32 | 3 |\n" +
+                "1902-09-24 12:41:46.32 | 4 |\n" +
+                "1902-09-24 12:41:47.32 | 5 |\n" +
+                "1902-09-24 12:41:48.32 | 6 |\n" +
+                "1902-09-24 12:41:49.32 | 7 |\n" +
+                "1902-09-24 12:41:50.32 | 8 |\n" +
+                "1902-09-24 12:41:51.32 | 9 |\n" +
+                "1902-09-24 12:41:52.32 |10 |\n" +
+                "1902-09-24 12:51:43.32 | 1 |\n" +
+                "1902-09-24 12:51:44.32 | 2 |\n" +
+                "1902-09-24 12:51:45.32 | 3 |\n" +
+                "1902-09-24 12:51:46.32 | 4 |\n" +
+                "1902-09-24 12:51:47.32 | 5 |\n" +
+                "1902-09-24 12:51:48.32 | 6 |\n" +
+                "1902-09-24 12:51:49.32 | 7 |\n" +
+                "1902-09-24 12:51:50.32 | 8 |\n" +
+                "1902-09-24 12:51:51.32 | 9 |\n" +
+                "1902-09-24 12:51:52.32 |10 |\n" +
+                "1902-09-24 13:01:43.32 | 1 |\n" +
+                "1902-09-24 13:01:44.32 | 2 |\n" +
+                "1902-09-24 13:01:45.32 | 3 |\n" +
+                "1902-09-24 13:01:46.32 | 4 |\n" +
+                "1902-09-24 13:01:47.32 | 5 |\n" +
+                "1902-09-24 13:01:48.32 | 6 |\n" +
+                "1902-09-24 13:01:49.32 | 7 |\n" +
+                "1902-09-24 13:01:50.32 | 8 |\n" +
+                "1902-09-24 13:01:51.32 | 9 |\n" +
+                "1902-09-24 13:01:52.32 |10 |\n" +
+                "1902-09-24 13:11:43.32 | 1 |\n" +
+                "1902-09-24 13:11:44.32 | 2 |\n" +
+                "1902-09-24 13:11:45.32 | 3 |\n" +
+                "1902-09-24 13:11:46.32 | 4 |\n" +
+                "1902-09-24 13:11:47.32 | 5 |\n" +
+                "1902-09-24 13:11:48.32 | 6 |\n" +
+                "1902-09-24 13:11:49.32 | 7 |\n" +
+                "1902-09-24 13:11:50.32 | 8 |\n" +
+                "1902-09-24 13:11:51.32 | 9 |\n" +
+                "1902-09-24 13:11:52.32 |10 |\n" +
+                "1902-09-24 13:21:43.32 | 1 |\n" +
+                "1902-09-24 13:21:44.32 | 2 |\n" +
+                "1902-09-24 13:21:45.32 | 3 |\n" +
+                "1902-09-24 13:21:46.32 | 4 |\n" +
+                "1902-09-24 13:21:47.32 | 5 |\n" +
+                "1902-09-24 13:21:48.32 | 6 |\n" +
+                "1902-09-24 13:21:49.32 | 7 |\n" +
+                "1902-09-24 13:21:50.32 | 8 |\n" +
+                "1902-09-24 13:21:51.32 | 9 |\n" +
+                "1902-09-24 13:21:52.32 |10 |\n" +
+                "1902-09-24 13:31:43.32 | 1 |\n" +
+                "1902-09-24 13:31:44.32 | 2 |\n" +
+                "1902-09-24 13:31:45.32 | 3 |\n" +
+                "1902-09-24 13:31:46.32 | 4 |\n" +
+                "1902-09-24 13:31:47.32 | 5 |\n" +
+                "1902-09-24 13:31:48.32 | 6 |\n" +
+                "1902-09-24 13:31:49.32 | 7 |\n" +
+                "1902-09-24 13:31:50.32 | 8 |\n" +
+                "1902-09-24 13:31:51.32 | 9 |\n" +
+                "1902-09-24 13:31:52.32 |10 |\n" +
+                "1902-09-24 13:41:43.32 | 1 |\n" +
+                "1902-09-24 13:41:44.32 | 2 |\n" +
+                "1902-09-24 13:41:45.32 | 3 |\n" +
+                "1902-09-24 13:41:46.32 | 4 |\n" +
+                "1902-09-24 13:41:47.32 | 5 |\n" +
+                "1902-09-24 13:41:48.32 | 6 |\n" +
+                "1902-09-24 13:41:49.32 | 7 |\n" +
+                "1902-09-24 13:41:50.32 | 8 |\n" +
+                "1902-09-24 13:41:51.32 | 9 |\n" +
+                "1902-09-24 13:41:52.32 |10 |\n" +
+                "1902-09-24 13:51:43.32 | 1 |\n" +
+                "1902-09-24 13:51:44.32 | 2 |\n" +
+                "1902-09-24 13:51:45.32 | 3 |\n" +
+                "1902-09-24 13:51:46.32 | 4 |\n" +
+                "1902-09-24 13:51:47.32 | 5 |\n" +
+                "1902-09-24 13:51:48.32 | 6 |\n" +
+                "1902-09-24 13:51:49.32 | 7 |\n" +
+                "1902-09-24 13:51:50.32 | 8 |\n" +
+                "1902-09-24 13:51:51.32 | 9 |\n" +
+                "1902-09-24 13:51:52.32 |10 |\n" +
+                "1902-09-24 14:01:43.32 | 1 |\n" +
+                "1902-09-24 14:01:44.32 | 2 |\n" +
+                "1902-09-24 14:01:45.32 | 3 |\n" +
+                "1902-09-24 14:01:46.32 | 4 |\n" +
+                "1902-09-24 14:01:47.32 | 5 |\n" +
+                "1902-09-24 14:01:48.32 | 6 |\n" +
+                "1902-09-24 14:01:49.32 | 7 |\n" +
+                "1902-09-24 14:01:50.32 | 8 |\n" +
+                "1902-09-24 14:01:51.32 | 9 |\n" +
+                "1902-09-24 14:01:52.32 |10 |\n" +
+                "1902-09-24 14:11:43.32 | 1 |\n" +
+                "1902-09-24 14:11:44.32 | 2 |\n" +
+                "1902-09-24 14:11:45.32 | 3 |\n" +
+                "1902-09-24 14:11:46.32 | 4 |\n" +
+                "1902-09-24 14:11:47.32 | 5 |\n" +
+                "1902-09-24 14:11:48.32 | 6 |\n" +
+                "1902-09-24 14:11:49.32 | 7 |\n" +
+                "1902-09-24 14:11:50.32 | 8 |\n" +
+                "1902-09-24 14:11:51.32 | 9 |\n" +
+                "1902-09-24 14:11:52.32 |10 |\n" +
+                "1902-09-24 14:21:43.32 | 1 |\n" +
+                "1902-09-24 14:21:44.32 | 2 |\n" +
+                "1902-09-24 14:21:45.32 | 3 |\n" +
+                "1902-09-24 14:21:46.32 | 4 |\n" +
+                "1902-09-24 14:21:47.32 | 5 |\n" +
+                "1902-09-24 14:21:48.32 | 6 |\n" +
+                "1902-09-24 14:21:49.32 | 7 |\n" +
+                "1902-09-24 14:21:50.32 | 8 |\n" +
+                "1902-09-24 14:21:51.32 | 9 |\n" +
+                "1902-09-24 14:21:52.32 |10 |";
+    
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+        
+        // Bump up the max allowed entries in the probe IN list, and verify multicolumn IN with MultiProbe is picked.
+        methodWatcher.execute("call syscs_util.syscs_set_global_database_property('" + Property.MAX_MULTICOLUMN_PROBE_VALUES + "', '12000')");
+        
+        sqlText = format("select b1,a1 from t22 --splice-properties useSpark=%s \n" +
+            "where b1 in \n" +
+            "(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?," +
+            " ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?," +
+            " ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?," +
+            " ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)" +
+
+            " and \n" +
+            "      a1 in \n" +
+            "(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?, " +
+            "?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?, " +
+            "?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) " +
+            "order by 1,2", useSpark);
+        ps = methodWatcher.prepareStatement("explain " + sqlText);
+        increment = 0;
+        for (int i=0; i < 20; i++) {
+            ps.setTimestamp(1 + i * 10, new Timestamp(ts.getTime() + increment * 1000 * 60));
+            ps.setTimestamp(2 + i * 10, new Timestamp(ts.getTime() + 1000 + increment * 1000 * 60));
+            ps.setTimestamp(3 + i * 10, new Timestamp(ts.getTime() + 2000 + increment * 1000 * 60));
+            ps.setTimestamp(4 + i * 10, new Timestamp(ts.getTime() + 3000 + increment * 1000 * 60));
+            ps.setTimestamp(5 + i * 10, new Timestamp(ts.getTime() + 4000 + increment * 1000 * 60));
+            ps.setTimestamp(6 + i * 10, new Timestamp(ts.getTime() + 5000 + increment * 1000 * 60));
+            ps.setTimestamp(7 + i * 10, new Timestamp(ts.getTime() + 6000 + increment * 1000 * 60));
+            ps.setTimestamp(8 + i * 10, new Timestamp(ts.getTime() + 7000 + increment * 1000 * 60));
+            ps.setTimestamp(9 + i * 10, new Timestamp(ts.getTime() + 8000 + increment * 1000 * 60));
+            ps.setTimestamp(10 + i * 10, new Timestamp(ts.getTime() + 9000 + increment * 1000 * 60));
+            increment += 10;
+        }
+        for (int i = 1; i <= 60; i++) {
+            ps.setInt(i+200, i);
+        }
+
+        rs = ps.executeQuery();
+    
+        level = 1;
+        multiProbeFound = false;
+        multiColINFound = false;
+        while (rs.next()) {
+            String resultString = rs.getString(1);
+            if (level == 4 || level == 5) {
+                if (!multiProbeFound)
+                    multiProbeFound = resultString.contains("MultiProbeTableScan");
+                if (!multiColINFound)
+                    multiColINFound = resultString.contains("preds=[((B1[0:2],A1[0:1]) IN ");
+            }
+            if (level > 4) {
+                Assert.assertTrue("MultiProbeTableScan is expected", multiProbeFound);
+                Assert.assertTrue("Multicolumn IN predicate expected", multiColINFound);
+            }
+            level++;
+        }
+        rs.close();
+    
+        ps = methodWatcher.prepareStatement(sqlText);
+        increment = 0;
+        for (int i = 0; i < 20; i++) {
+            ps.setTimestamp(1 + i * 10, new Timestamp(ts.getTime() + increment * 1000 * 60));
+            ps.setTimestamp(2 + i * 10, new Timestamp(ts.getTime() + 1000 + increment * 1000 * 60));
+            ps.setTimestamp(3 + i * 10, new Timestamp(ts.getTime() + 2000 + increment * 1000 * 60));
+            ps.setTimestamp(4 + i * 10, new Timestamp(ts.getTime() + 3000 + increment * 1000 * 60));
+            ps.setTimestamp(5 + i * 10, new Timestamp(ts.getTime() + 4000 + increment * 1000 * 60));
+            ps.setTimestamp(6 + i * 10, new Timestamp(ts.getTime() + 5000 + increment * 1000 * 60));
+            ps.setTimestamp(7 + i * 10, new Timestamp(ts.getTime() + 6000 + increment * 1000 * 60));
+            ps.setTimestamp(8 + i * 10, new Timestamp(ts.getTime() + 7000 + increment * 1000 * 60));
+            ps.setTimestamp(9 + i * 10, new Timestamp(ts.getTime() + 8000 + increment * 1000 * 60));
+            ps.setTimestamp(10 + i * 10, new Timestamp(ts.getTime() + 9000 + increment * 1000 * 60));
+            increment += 10;
+        }
+        for (int i = 1; i <= 60; i++) {
+            ps.setInt(i + 200, i);
+        }
+        rs = ps.executeQuery();
+
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        rs.close();
+    
+        // Reset derby.database.maxMulticolumnProbeValues to the default setting.
+        methodWatcher.execute("call syscs_util.syscs_set_global_database_property('" + Property.MAX_MULTICOLUMN_PROBE_VALUES + "', null)");
     }
 
     public void testInListNotOnLeadingIndexColumnControlPath() throws Exception {
@@ -811,7 +1683,7 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
         assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
         rs.close();
 
-        /* case 10, negative test case 2, more than one inlist, only the first one can be pushed down */
+        /* case 10, test case 2, more than one inlist, both can be pushed down */
         sqlText = "select * from t3 --splice-properties useSpark=true\n where a3='A' and b3 in (11, 21, 31) and c3 in (1, 3, 5)";
 
         rs = methodWatcher.executeQuery("explain " + sqlText);
@@ -824,8 +1696,6 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
         while (rs.next()) {
             String resultString = rs.getString(1);
             if (level == 3) {
-                Assert.assertTrue("Inlist condition is expected", resultString.contains("IN (1,3,5)"));
-            } else if (level == 4) {
                 Assert.assertTrue("MultiProbeTableScan is expected", resultString.contains("MultiProbeTableScan"));
             }
             level ++;


### PR DESCRIPTION
This is a performance feature to enhance MultiProbeScan to use more index columns in the presence of multiple IN lists to reduce the number of rows probed.

For example, for 
```
create table t1 (pk_col1 int, pk_col2 int, col3 int, primary key(pk_col1, pk_col2));
select * from t1 where pk_col1 in (1,2,3) and pk_col2 in (1,2);
```
The in lists are combined to produce 6 sets of probe values:
`(pk_col1,pk_col2) IN ((1,1), (1,2), (2,1), (2,2), (3,1), (3,2))`

Each probe specifies two primary key columns, so may scan many less rows, given the more specific start/stop key, than just using `pk_col1 in (1,2,3)` to probe the first primary key column.

For more details, please see [DB-7621](https://splicemachine.atlassian.net/browse/DB-7621?focusedCommentId=58723&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-58723)