### PR TITLE
SPLICE-2288 IndexOutOfBoundsException while loading a resource from a jar file

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/AccessibleByteArrayOutputStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/AccessibleByteArrayOutputStream.java
@@ -79,7 +79,7 @@ public class AccessibleByteArrayOutputStream extends ByteArrayOutputStream {
         
         for(;;)
         {
-            int read = in.read(buffer, 0, buf.length);
+            int read = in.read(buffer, 0, buffer.length);
             if (read == -1)
                 break;
             write(buffer, 0, read);


### PR DESCRIPTION
A bug in the original Derby code.