### PR TITLE
DB-7684 fix costing issue when JoinNode is served as the inner table of another join

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/LimitOffsetVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/LimitOffsetVisitor.java
@@ -290,7 +290,7 @@ public class LimitOffsetVisitor extends AbstractSpliceVisitor {
     public void adjustCost(ResultSetNode rsn) throws StandardException {
         if (fetchFirst==-1 && offset ==-1) // No Limit Adjustment
             return;
-        CostEstimate costEstimate = rsn.getFinalCostEstimate();
+        CostEstimate costEstimate = rsn.getFinalCostEstimate(false);
         long totalRowCount = costEstimate.getEstimatedRowCount();
         long currentOffset = offset==-1?0:offset;
         long currentFetchFirst = fetchFirst==-1?totalRowCount:fetchFirst;
@@ -316,7 +316,7 @@ public class LimitOffsetVisitor extends AbstractSpliceVisitor {
     public void adjustBaseTableCost(ResultSetNode rsn) throws StandardException {
         if (fetchFirst==-1 && offset ==-1) // No Limit Adjustment
             return;
-        CostEstimate costEstimate = rsn.getFinalCostEstimate();
+        CostEstimate costEstimate = rsn.getFinalCostEstimate(false);
         long totalRowCount = costEstimate.getEstimatedRowCount();
         long currentOffset = offset==-1?0:offset;
         long currentFetchFirst = fetchFirst==-1?totalRowCount:fetchFirst;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/PlanPrinter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/PlanPrinter.java
@@ -218,7 +218,7 @@ public class PlanPrinter extends AbstractSpliceVisitor {
 
     public static Map<String,Object> nodeInfo(final ResultSetNode rsn, final int level) throws StandardException {
         Map<String,Object> info = new HashMap<>();
-        CostEstimate co = rsn.getFinalCostEstimate().getBase();
+        CostEstimate co = rsn.getFinalCostEstimate(false).getBase();
         info.put("class", JoinInfo.className.apply(rsn));
         info.put("n", rsn.getResultSetNumber());
         info.put("level", level);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BatchOnceNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BatchOnceNode.java
@@ -133,7 +133,7 @@ public class BatchOnceNode extends SingleChildResultSetNode {
         return spaceToLevel() +
                 "BatchOnce" + "(" +
                 "n=" + order +
-                attrDelim + getFinalCostEstimate().prettyProcessingString(attrDelim) +
+                attrDelim + getFinalCostEstimate(false).prettyProcessingString(attrDelim) +
                 ")";
     }
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
@@ -1432,7 +1432,7 @@ public class BinaryRelationalOperatorNode
             double sel = factor * ((ColumnReference) leftOperand).columnReferenceEqualityPredicateSelectivity();
             // avoid the estimation to go over 1, in case it happens, round down to 0.9 to be consistent with the logic in
             // InListSelectivity.getSelectivity()
-            if (sel > 1.0d)
+            if (sel > 0.9d)
                 sel = 0.9d;;
             return sel;
         } else if (rightOperand instanceof ColumnReference && leftOperand instanceof ParameterNode) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CursorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CursorNode.java
@@ -819,7 +819,7 @@ public class CursorNode extends DMLStatementNode{
                     sb.append(attrDelim).append("name=").append(name);
                 }
                 if (this.resultSet!=null) {
-                    sb.append(",rows=").append(this.resultSet.getFinalCostEstimate().getEstimatedRowCount());
+                    sb.append(",rows=").append(this.resultSet.getFinalCostEstimate(false).getEstimatedRowCount());
                 }
                 sb.append(attrDelim).append("updateMode=").append(updateModeString(updateMode))
                 .append(")");

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DeleteNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DeleteNode.java
@@ -31,53 +31,35 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
-import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.error.StandardException;
-
-import com.splicemachine.db.iapi.sql.compile.CompilerContext;
-import com.splicemachine.db.iapi.sql.conn.Authorizer;
-import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
-import com.splicemachine.db.iapi.sql.dictionary.ColumnDescriptor;
-import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
-import com.splicemachine.db.iapi.sql.dictionary.GenericDescriptorList;
-import com.splicemachine.db.iapi.sql.dictionary.ColumnDescriptorList;
-import com.splicemachine.db.iapi.sql.dictionary.TriggerDescriptor;
-
-
-import com.splicemachine.db.iapi.sql.StatementType;
-
-import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.reference.ClassName;
-
+import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.services.classfile.VMOpcode;
+import com.splicemachine.db.iapi.services.compiler.LocalField;
+import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.io.FormatableBitSet;
+import com.splicemachine.db.iapi.services.io.FormatableProperties;
+import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.ResultDescription;
+import com.splicemachine.db.iapi.sql.StatementType;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
+import com.splicemachine.db.iapi.sql.compile.NodeFactory;
+import com.splicemachine.db.iapi.sql.conn.Authorizer;
+import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ConstantAction;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
-
-import com.splicemachine.db.iapi.services.sanity.SanityManager;
-
-import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
-
 import com.splicemachine.db.iapi.store.access.StaticCompiledOpenConglomInfo;
 import com.splicemachine.db.iapi.store.access.TransactionController;
-
+import com.splicemachine.db.iapi.util.ReuseFactory;
+import com.splicemachine.db.impl.sql.execute.FKInfo;
 import com.splicemachine.db.vti.DeferModification;
 
-import com.splicemachine.db.catalog.UUID;
-import com.splicemachine.db.iapi.services.io.FormatableBitSet;
-
-import com.splicemachine.db.impl.sql.execute.FKInfo;
-
 import java.lang.reflect.Modifier;
-import com.splicemachine.db.iapi.services.classfile.VMOpcode;
-import com.splicemachine.db.iapi.services.io.FormatableProperties;
-
-import java.util.Vector;
 import java.util.Hashtable;
-import java.util.Iterator;
 import java.util.Properties;
-import com.splicemachine.db.iapi.sql.compile.NodeFactory;
-import com.splicemachine.db.iapi.util.ReuseFactory;
-import com.splicemachine.db.iapi.sql.ResultDescription;
-import com.splicemachine.db.iapi.services.compiler.LocalField;
+import java.util.Vector;
 
 
 /**
@@ -680,8 +662,8 @@ public class DeleteNode extends DMLModStatementNode
 
 		}
 
-        mb.push((double)this.resultSet.getFinalCostEstimate().getEstimatedRowCount());
-        mb.push(this.resultSet.getFinalCostEstimate().getEstimatedCost());
+        mb.push((double)this.resultSet.getFinalCostEstimate(false).getEstimatedRowCount());
+        mb.push(this.resultSet.getFinalCostEstimate(false).getEstimatedCost());
         mb.push(targetTableDescriptor.getVersion());
         if ("getDeleteResultSet".equals(resultSetGetter)) {
 			mb.push(this.printExplainInformationForActivation());
@@ -1097,7 +1079,7 @@ public class DeleteNode extends DMLModStatementNode
 			.append("Delete").append("(")
 			.append("n=").append(order).append(attrDelim);
 		if (this.resultSet!=null) {
-			sb.append(this.resultSet.getFinalCostEstimate().prettyDmlStmtString("deletedRows"));
+			sb.append(this.resultSet.getFinalCostEstimate(false).prettyDmlStmtString("deletedRows"));
 		}
 		sb.append(attrDelim).append("targetTable=").append(targetTableName).append(")");
         return sb.toString();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DistinctNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DistinctNode.java
@@ -174,7 +174,7 @@ public class DistinctNode extends SingleChildResultSetNode
 			throws StandardException
 	{
         costEstimate = getNewCostEstimate();
-        CostEstimate baseCost = childResult.getFinalCostEstimate();
+        CostEstimate baseCost = childResult.getFinalCostEstimate(true);
 		double rc = baseCost.rowCount() > 1? baseCost.rowCount():1;
         double outputHeapSizePerRow = baseCost.getEstimatedHeapSize()/rc;
         double remoteCostPerRow=baseCost.remoteCost()/rc;
@@ -303,7 +303,7 @@ public class DistinctNode extends SingleChildResultSetNode
 		assignResultSetNumber();
 
 		// Get the final cost estimate based on the child's cost.
-		costEstimate = getFinalCostEstimate();
+		costEstimate = getFinalCostEstimate(false);
 
 		/*
 			create the orderItem and stuff it in.
@@ -341,13 +341,13 @@ public class DistinctNode extends SingleChildResultSetNode
 
 
     @Override
-    public CostEstimate getFinalCostEstimate() throws StandardException {
+    public CostEstimate getFinalCostEstimate(boolean useSelf) throws StandardException {
 
         if (costEstimate != null) {
             finalCostEstimate = costEstimate;
         }
         else {
-            finalCostEstimate = childResult.getFinalCostEstimate();
+            finalCostEstimate = childResult.getFinalCostEstimate(true);
         }
         return finalCostEstimate;
     }
@@ -358,7 +358,7 @@ public class DistinctNode extends SingleChildResultSetNode
         sb = sb.append(spaceToLevel())
                 .append("Distinct").append("(")
                 .append("n=").append(order);
-        sb.append(attrDelim).append(getFinalCostEstimate().prettyProcessingString(attrDelim));
+        sb.append(attrDelim).append(getFinalCostEstimate(false).prettyProcessingString(attrDelim));
         sb = sb.append(")");
         return sb.toString();
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -2070,7 +2070,7 @@ public class FromBaseTable extends FromTable {
      *
      * @return The final CostEstimate for this ResultSetNode.
      */
-    public CostEstimate getFinalCostEstimate(){
+    public CostEstimate getFinalCostEstimate(boolean useSelf){
         return getTrulyTheBestAccessPath().getCostEstimate();
     }
 
@@ -2117,7 +2117,7 @@ public class FromBaseTable extends FromTable {
 		*/
     private void generateMaxSpecialResultSet ( ExpressionClassBuilder acb, MethodBuilder mb ) throws StandardException{
         ConglomerateDescriptor cd=getTrulyTheBestAccessPath().getConglomerateDescriptor();
-        CostEstimate costEstimate=getFinalCostEstimate();
+        CostEstimate costEstimate=getFinalCostEstimate(false);
         int colRefItem=(referencedCols==null)?
                 -1:
                 acb.addItem(referencedCols);
@@ -2153,7 +2153,7 @@ public class FromBaseTable extends FromTable {
 
     private void generateDistinctScan ( ExpressionClassBuilder acb, MethodBuilder mb ) throws StandardException{
         ConglomerateDescriptor cd=getTrulyTheBestAccessPath().getConglomerateDescriptor();
-        CostEstimate costEstimate=getFinalCostEstimate();
+        CostEstimate costEstimate=getFinalCostEstimate(false);
         int colRefItem=(referencedCols==null)? -1: acb.addItem(referencedCols);
         boolean tableLockGranularity=tableDescriptor.getLockGranularity()==TableDescriptor.TABLE_LOCK_GRANULARITY;
 
@@ -2943,7 +2943,7 @@ public class FromBaseTable extends FromTable {
     @Override
     void markForDistinctScan() throws StandardException {
         distinctScan=true;
-        resultColumns.computeDistinctCardinality(getFinalCostEstimate());
+        resultColumns.computeDistinctCardinality(getFinalCostEstimate(false));
     }
 
 
@@ -3336,7 +3336,7 @@ public class FromBaseTable extends FromTable {
         StringBuilder sb = new StringBuilder();
         String indexName = getIndexName();
         sb.append(getClassName(indexName)).append("(")
-                .append(",").append(getFinalCostEstimate().prettyFromBaseTableString());
+                .append(",").append(getFinalCostEstimate(false).prettyFromBaseTableString());
         if (indexName != null)
             sb.append(",baseTable=").append(getPrettyTableName());
         List<String> qualifiers =  Lists.transform(PredicateUtils.PLtoList(RSUtils.getPreds(this)), PredicateUtils.predToString);
@@ -3353,7 +3353,7 @@ public class FromBaseTable extends FromTable {
         sb.append(spaceToLevel());
         sb.append(getClassName(indexName)).append("(");
         sb.append("n=").append(order).append(attrDelim);
-        sb.append(getFinalCostEstimate().prettyFromBaseTableString(attrDelim));
+        sb.append(getFinalCostEstimate(false).prettyFromBaseTableString(attrDelim));
         if (indexName != null)
             sb.append(attrDelim).append("baseTable=").append(getPrettyTableName());
         List<String> qualifiers = Lists.transform(PredicateUtils.PLtoList(RSUtils.getPreds(this)), PredicateUtils.predToString);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
@@ -573,7 +573,7 @@ public abstract class FromTable extends ResultSetNode implements Optimizable{
      * we just return the value stored in costEstimate as a default.
      */
     @Override
-    public CostEstimate getFinalCostEstimate() throws StandardException{
+    public CostEstimate getFinalCostEstimate(boolean useSelf) throws StandardException{
         // If we already found it, just return it.
         if(finalCostEstimate!=null)
             return finalCostEstimate;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
@@ -1355,7 +1355,7 @@ public class FromVTI extends FromTable implements VTIEnvironment {
         int				numSet = 0;
 
         // Get our final cost estimate.
-        costEstimate = getFinalCostEstimate();
+        costEstimate = getFinalCostEstimate(false);
 
         for (int index = 0; index < rclSize; index++)
         {
@@ -1770,7 +1770,7 @@ public class FromVTI extends FromTable implements VTIEnvironment {
         return spaceToLevel() +
                 "VTI:" + getName() + "(" +
                 "n=" + order +
-                attrDelim + getFinalCostEstimate().prettyProcessingString(attrDelim) +
+                attrDelim + getFinalCostEstimate(false).prettyProcessingString(attrDelim) +
                 ")";
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GroupByNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GroupByNode.java
@@ -257,7 +257,7 @@ public class GroupByNode extends SingleChildResultSetNode{
     }
 
     @Override
-    public CostEstimate getFinalCostEstimate() throws StandardException{
+    public CostEstimate getFinalCostEstimate(boolean useSelf) throws StandardException{
         if(costEstimate==null){
             throw new RuntimeException("Should not be null");
         }
@@ -419,7 +419,7 @@ public class GroupByNode extends SingleChildResultSetNode{
         assignResultSetNumber();
 
         // Get the final cost estimate from the child.
-        costEstimate=childResult.getFinalCostEstimate();
+        childResult.getFinalCostEstimate(true);
 
 		/*
 		** Get the column ordering for the sort.  Note that
@@ -1247,7 +1247,7 @@ public class GroupByNode extends SingleChildResultSetNode{
         sb = sb.append(spaceToLevel())
                 .append("GroupBy").append("(")
                 .append("n=").append(order);
-        sb.append(attrDelim).append(getFinalCostEstimate().prettyProcessingString(attrDelim));
+        sb.append(attrDelim).append(getFinalCostEstimate(false).prettyProcessingString(attrDelim));
         sb = sb.append(")");
         return sb.toString();
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HalfOuterJoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HalfOuterJoinNode.java
@@ -820,7 +820,7 @@ public class HalfOuterJoinNode extends JoinNode{
         sb.append(spaceToLevel())
                 .append(joinStrategy.getJoinStrategyType().niceName()).append(isRightOuterJoin()?"RightOuter":"LeftOuter").append("Join(")
                 .append("n=").append(order)
-                .append(attrDelim).append(getFinalCostEstimate().prettyProcessingString(attrDelim));
+                .append(attrDelim).append(getFinalCostEstimate(false).prettyProcessingString(attrDelim));
         if (joinPredicates !=null) {
             List<String> joinPreds = Lists.transform(PredicateUtils.PLtoList(joinPredicates), PredicateUtils.predToString);
             if (!joinPreds.isEmpty()) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashTableNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashTableNode.java
@@ -299,7 +299,7 @@ public class HashTableNode extends SingleChildResultSetNode
 		assignResultSetNumber();
 
 		// Get the final cost estimate based on child's cost.
-		costEstimate = childResult.getFinalCostEstimate();
+		costEstimate = childResult.getFinalCostEstimate(true);
 
 		// if there is no searchClause, we just want to pass null.
 		if (searchClause == null)

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListSelectivity.java
@@ -69,7 +69,7 @@ public class InListSelectivity extends AbstractSelectivityHolder {
             if (selectivityFactor > 0)
                 selectivity *= selectivityFactor;
 
-            if (selectivity > 1.0d)
+            if (selectivity > 0.9d)
                 selectivity = 0.9d;
         }
         return selectivity;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IndexToBaseRowNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IndexToBaseRowNode.java
@@ -116,8 +116,8 @@ public class IndexToBaseRowNode extends FromTable{
     }
 
     @Override
-    public CostEstimate getFinalCostEstimate(){
-        return source.getFinalCostEstimate();
+    public CostEstimate getFinalCostEstimate(boolean useSelf){
+        return source.getFinalCostEstimate(true);
     }
 
     /**
@@ -158,7 +158,7 @@ public class IndexToBaseRowNode extends FromTable{
         assignResultSetNumber();
 
         // Get the CostEstimate info for the underlying scan
-        costEstimate=getFinalCostEstimate();
+        costEstimate=getFinalCostEstimate(false);
 
 		/* Put the predicates back into the tree */
         if(restrictionList!=null){
@@ -407,7 +407,7 @@ public class IndexToBaseRowNode extends FromTable{
         return spaceToLevel() +
                 "IndexLookup" + "(" +
                 "n=" + order +
-                attrDelim + getFinalCostEstimate().prettyIndexLookupString(attrDelim) +
+                attrDelim + getFinalCostEstimate(false).prettyIndexLookupString(attrDelim) +
                 ")";
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InsertNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InsertNode.java
@@ -1018,8 +1018,8 @@ public final class InsertNode extends DMLModStatementNode {
 			mb.push(badRecordsAllowed);
 			mb.push(skipConflictDetection);
 			mb.push(skipWAL);
-            mb.push((double) this.resultSet.getFinalCostEstimate().getEstimatedRowCount());
-            mb.push(this.resultSet.getFinalCostEstimate().getEstimatedCost());
+            mb.push((double) this.resultSet.getFinalCostEstimate(false).getEstimatedRowCount());
+            mb.push(this.resultSet.getFinalCostEstimate(false).getEstimatedCost());
             mb.push(targetTableDescriptor.getVersion());
             mb.push(this.printExplainInformationForActivation());
 			BaseJoinStrategy.pushNullableString(mb,targetTableDescriptor.getDelimited());
@@ -1058,8 +1058,8 @@ public final class InsertNode extends DMLModStatementNode {
 
 			// arg 2
 			targetVTI.generate(acb, mb);
-            mb.push((double)this.resultSet.getFinalCostEstimate().getEstimatedRowCount());
-            mb.push(this.resultSet.getFinalCostEstimate().getEstimatedCost());
+            mb.push((double)this.resultSet.getFinalCostEstimate(false).getEstimatedRowCount());
+            mb.push(this.resultSet.getFinalCostEstimate(false).getEstimatedCost());
             mb.callMethod(VMOpcode.INVOKEINTERFACE, (String) null, "getInsertVTIResultSet", ClassName.ResultSet, 4);
 		}
 	}
@@ -1152,7 +1152,7 @@ public final class InsertNode extends DMLModStatementNode {
 			.append("Insert").append("(")
 			.append("n=").append(order).append(attrDelim);
 		if (this.resultSet!=null) {
-			sb.append(this.resultSet.getFinalCostEstimate().prettyDmlStmtString("insertedRows"));
+			sb.append(this.resultSet.getFinalCostEstimate(false).prettyDmlStmtString("insertedRows"));
 		}
 		sb.append(attrDelim).append("targetTable=").append(targetTableName).append(")");
         return sb.toString();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IntersectOrExceptNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IntersectOrExceptNode.java
@@ -363,7 +363,7 @@ public class IntersectOrExceptNode extends SetOperatorNode
 		assignResultSetNumber();
 
 		// Get our final cost estimate based on the child estimates.
-		costEstimate = getFinalCostEstimate();
+		costEstimate = getFinalCostEstimate(false);
 
 		// build up the tree.
 
@@ -412,14 +412,14 @@ public class IntersectOrExceptNode extends SetOperatorNode
 	 *  rows depends on whether this is an INTERSECT or EXCEPT (see
 	 *  getRowCountEstimate() in this class for more).
 	 */
-	public CostEstimate getFinalCostEstimate()
+	public CostEstimate getFinalCostEstimate(boolean useSelf)
 		throws StandardException
 	{
 		if (finalCostEstimate != null)
 			return finalCostEstimate;
 
-		CostEstimate leftCE = leftResultSet.getFinalCostEstimate();
-		CostEstimate rightCE = rightResultSet.getFinalCostEstimate();
+		CostEstimate leftCE = leftResultSet.getFinalCostEstimate(true);
+		CostEstimate rightCE = rightResultSet.getFinalCostEstimate(true);
 
 		finalCostEstimate = getNewCostEstimate();
 		finalCostEstimate.setCost(
@@ -478,7 +478,7 @@ public class IntersectOrExceptNode extends SetOperatorNode
         sb = sb.append(spaceToLevel())
                 .append(getExplainDisplay()).append("(")
                 .append("n=").append(order);
-        sb.append(attrDelim).append(getFinalCostEstimate().prettyProcessingString(attrDelim));
+        sb.append(attrDelim).append(getFinalCostEstimate(false).prettyProcessingString(attrDelim));
         sb = sb.append(")");
         return sb.toString();
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
@@ -214,7 +214,7 @@ public class JoinNode extends TableOperatorNode{
         // RESOLVE: NEED TO SET ROW ORDERING OF SOURCES IN THE ROW ORDERING
         // THAT WAS PASSED IN.
 
-        leftResultSet=optimizeSource(optimizer,leftResultSet,getLeftPredicateList(),outerCost);
+        leftResultSet=optimizeSource(optimizer,leftResultSet,getLeftPredicateList(),null);
 
 		/* Move all joinPredicates down to the right.
 		 * RESOLVE - When we consider the reverse join order then

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
@@ -980,13 +980,16 @@ public class JoinNode extends TableOperatorNode{
      * Get the final CostEstimate for this JoinNode.
      */
     @Override
-    public CostEstimate getFinalCostEstimate() throws StandardException{
+    public CostEstimate getFinalCostEstimate(boolean useSelf) throws StandardException{
+        if (useSelf && trulyTheBestAccessPath != null) {
+            return getTrulyTheBestAccessPath().getCostEstimate();
+        }
         // If we already found it, just return it.
         if(finalCostEstimate!=null)
             return finalCostEstimate;
 
 //        CostEstimate leftCE=leftResultSet.getFinalCostEstimate();
-        CostEstimate rightCE=rightResultSet.getFinalCostEstimate();
+        CostEstimate rightCE=rightResultSet.getFinalCostEstimate(true);
         finalCostEstimate=getNewCostEstimate();
         finalCostEstimate.setCost(rightCE);
         finalCostEstimate.setBase(null);
@@ -1839,7 +1842,7 @@ public class JoinNode extends TableOperatorNode{
 
         }
         // Get our final cost estimate based on child estimates.
-        costEstimate=getFinalCostEstimate();
+        costEstimate=getFinalCostEstimate(false);
 
         // for the join clause, we generate an exprFun
         // that evaluates the expression of the clause
@@ -1961,7 +1964,7 @@ public class JoinNode extends TableOperatorNode{
         sb.append(spaceToLevel())
                 .append(joinStrategy.getJoinStrategyType().niceName()).append(rightResultSet.isNotExists()?"Anti":"").append("Join(")
                 .append("n=").append(order)
-                .append(attrDelim).append(getFinalCostEstimate().prettyProcessingString(attrDelim));
+                .append(attrDelim).append(getFinalCostEstimate(false).prettyProcessingString(attrDelim));
         if (joinPredicates != null) {
             List<String> joinPreds = Lists.transform(PredicateUtils.PLtoList(joinPredicates), PredicateUtils.predToString);
             if (joinPreds != null && !joinPreds.isEmpty())

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MaterializeResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MaterializeResultSetNode.java
@@ -97,7 +97,7 @@ public class MaterializeResultSetNode extends SingleChildResultSetNode
 		assignResultSetNumber();
 
 		// Get the cost estimate from the child if we don't have one yet
-		costEstimate = childResult.getFinalCostEstimate();
+		costEstimate = childResult.getFinalCostEstimate(true);
 
 		// build up the tree.
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NormalizeResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NormalizeResultSetNode.java
@@ -644,7 +644,7 @@ public class NormalizeResultSetNode extends SingleChildResultSetNode
 		// Generate the child ResultSet
 
 		// Get the cost estimate for the child
-		costEstimate = childResult.getFinalCostEstimate();
+		costEstimate = childResult.getFinalCostEstimate(true);
 
 		erdNumber = acb.addItem(makeResultDescription());
 
@@ -708,7 +708,7 @@ public class NormalizeResultSetNode extends SingleChildResultSetNode
         sb = sb.append(spaceToLevel())
                 .append("NormalizeResult").append("(")
                 .append("n=").append(order);
-        sb.append(attrDelim).append(getFinalCostEstimate().prettyScrollInsensitiveString(attrDelim));
+        sb.append(attrDelim).append(getFinalCostEstimate(false).prettyScrollInsensitiveString(attrDelim));
         sb = sb.append(")");
         return sb.toString();
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderByNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderByNode.java
@@ -120,9 +120,9 @@ public class OrderByNode extends SingleChildResultSetNode {
     }
 
     @Override
-    public CostEstimate getFinalCostEstimate() throws StandardException{
+    public CostEstimate getFinalCostEstimate(boolean useSelf) throws StandardException{
         if(costEstimate==null) {
-            costEstimate = childResult.getFinalCostEstimate().cloneMe();
+            costEstimate = childResult.getFinalCostEstimate(true).cloneMe();
             orderByList.estimateCost(optimizer, null, costEstimate);
         }
         return costEstimate;
@@ -132,7 +132,7 @@ public class OrderByNode extends SingleChildResultSetNode {
     public void generate(ActivationClassBuilder acb, MethodBuilder mb) throws StandardException {
         // Get the cost estimate for the child
         if (costEstimate == null) {
-            costEstimate = getFinalCostEstimate();
+            costEstimate = getFinalCostEstimate(false);
         }
 
         orderByList.generate(acb, mb, this, childResult,costEstimate);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultSetNode.java
@@ -193,7 +193,7 @@ public abstract class ResultSetNode extends QueryTreeNode{
      *
      * @return The final CostEstimate for this ResultSetNode.
      */
-    public CostEstimate getFinalCostEstimate()
+    public CostEstimate getFinalCostEstimate(boolean useSelf)
             throws StandardException{
         if(SanityManager.DEBUG){
             if(finalCostEstimate==null){

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowCountNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowCountNode.java
@@ -131,7 +131,7 @@ public final class RowCountNode extends SingleChildResultSetNode{
      * the final cost estimate for the child node.
      */
     @Override
-    public CostEstimate getFinalCostEstimate() throws StandardException{
+    public CostEstimate getFinalCostEstimate(boolean useSelf) throws StandardException{
 		/*
 		** The cost estimate will be set here if either optimize() or
 		** optimizeIt() was called on this node.  It's also possible
@@ -139,7 +139,7 @@ public final class RowCountNode extends SingleChildResultSetNode{
 		** in which case the cost estimate will be null here.
 		*/
         if(costEstimate==null) {
-            costEstimate = childResult.getFinalCostEstimate().cloneMe();
+            costEstimate = childResult.getFinalCostEstimate(true).cloneMe();
             fixCost();
             return costEstimate;
         }
@@ -164,7 +164,8 @@ public final class RowCountNode extends SingleChildResultSetNode{
          */
         assignResultSetNumber();
 
-        costEstimate=getFinalCostEstimate();childResult.getFinalCostEstimate();
+        costEstimate=getFinalCostEstimate(false);
+        childResult.getFinalCostEstimate(true);
 
         acb.pushGetResultSetFactoryExpression(mb);
 
@@ -242,7 +243,7 @@ public final class RowCountNode extends SingleChildResultSetNode{
         sb.append(spaceToLevel())
                 .append("Limit(")
                 .append("n=").append(order)
-                .append(attrDelim).append(getFinalCostEstimate().prettyProcessingString(attrDelim));
+                .append(attrDelim).append(getFinalCostEstimate(false).prettyProcessingString(attrDelim));
                 if (offset != null && offset instanceof NumericConstantNode) {
                     sb.append(attrDelim).append("offset=").append( ((NumericConstantNode)offset).getValue());
                 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowResultSetNode.java
@@ -133,9 +133,9 @@ public class RowResultSetNode extends FromTable {
 
 
     @Override
-    public CostEstimate getFinalCostEstimate() throws StandardException{
+    public CostEstimate getFinalCostEstimate(boolean useSelf) throws StandardException{
         if(costEstimate==null){
-            costEstimate = super.getFinalCostEstimate();
+            costEstimate = super.getFinalCostEstimate(false);
         }
         return costEstimate;
     }
@@ -780,7 +780,7 @@ public class RowResultSetNode extends FromTable {
 			SanityManager.ASSERT(resultColumns != null, "Tree structure bad");
 
 		// Get our final cost estimate.
-		costEstimate = getFinalCostEstimate();
+		costEstimate = getFinalCostEstimate(false);
 
 		/*
 		** Check and see if everything below us is a constant or not.
@@ -877,7 +877,7 @@ public class RowResultSetNode extends FromTable {
         return spaceToLevel() +
                 "Values" + "(" +
                 "n=" + order +
-                attrDelim + getFinalCostEstimate().prettyProcessingString(attrDelim) +
+                attrDelim + getFinalCostEstimate(false).prettyProcessingString(attrDelim) +
                 ")";
     }
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ScrollInsensitiveResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ScrollInsensitiveResultSetNode.java
@@ -88,7 +88,7 @@ public class ScrollInsensitiveResultSetNode  extends SingleChildResultSetNode
 		// Generate the child ResultSet
 
 		// Get the cost estimate for the child
-		costEstimate = childResult.getFinalCostEstimate();
+		costEstimate = childResult.getFinalCostEstimate(true);
 
 		int erdNumber = acb.addItem(makeResultDescription());
 
@@ -117,7 +117,7 @@ public class ScrollInsensitiveResultSetNode  extends SingleChildResultSetNode
         sb = sb.append(spaceToLevel())
                 .append("ScrollInsensitive").append("(")
                 .append("n=").append(order);
-            sb.append(attrDelim).append(getFinalCostEstimate().prettyScrollInsensitiveString(attrDelim));
+            sb.append(attrDelim).append(getFinalCostEstimate(false).prettyScrollInsensitiveString(attrDelim));
         sb = sb.append(")");
         return sb.toString();
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
@@ -1805,7 +1805,7 @@ public class SelectNode extends ResultSetNode{
      * this SelectNode's optimizer.
      */
     @Override
-    public CostEstimate getFinalCostEstimate() throws StandardException{
+    public CostEstimate getFinalCostEstimate(boolean useSelf) throws StandardException{
         return optimizer.getFinalCost();
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetOperatorNode.java
@@ -173,7 +173,7 @@ abstract class SetOperatorNode extends TableOperatorNode
 
 		// Get the cost estimate for this node so that we can put it in
 		// the new ProjectRestrictNode, if one is needed.
-		CostEstimate ce = getFinalCostEstimate();
+		CostEstimate ce = getFinalCostEstimate(false);
 
 		// Modify this node's access paths.
 		ResultSetNode topNode = (ResultSetNode)modifyAccessPath(outerTables);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SingleChildResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SingleChildResultSetNode.java
@@ -500,7 +500,7 @@ public abstract class SingleChildResultSetNode extends FromTable{
      * the final cost estimate for the child node.
      */
     @Override
-    public CostEstimate getFinalCostEstimate() throws StandardException{
+    public CostEstimate getFinalCostEstimate(boolean useSelf) throws StandardException{
 		/*
 		** The cost estimate will be set here if either optimize() or
 		** optimizeIt() was called on this node.  It's also possible
@@ -508,7 +508,7 @@ public abstract class SingleChildResultSetNode extends FromTable{
 		** in which case the cost estimate will be null here.
 		*/
         if(costEstimate==null)
-            return childResult.getFinalCostEstimate();
+            return childResult.getFinalCostEstimate(true);
         else{
             return costEstimate;
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
@@ -1068,7 +1068,7 @@ public class SubqueryNode extends ValueNode{
         }
 
         // Get cost estimate for underlying subquery
-        CostEstimate costEstimate=resultSet.getFinalCostEstimate();
+        CostEstimate costEstimate=resultSet.getFinalCostEstimate(false);
 
 		/* Generate a new method.  It's only used within the other
 		 * exprFuns, so it could be private. but since we don't
@@ -1109,7 +1109,7 @@ public class SubqueryNode extends ValueNode{
                 ResultSetNode materialSubNode=new MaterializeSubqueryNode(subRS);
 
                 // Propagate the resultSet's cost estimate to the new node.
-                materialSubNode.costEstimate=resultSet.getFinalCostEstimate();
+                materialSubNode.costEstimate=resultSet.getFinalCostEstimate(false);
 
                 ((ProjectRestrictNode)resultSet).setChildResult(materialSubNode);
 
@@ -2450,7 +2450,7 @@ public class SubqueryNode extends ValueNode{
                 .append("Subquery(")
                 .append("n=").append(order);
                 if (resultSet!=null) {
-                    sb.append(attrDelim).append(resultSet.getFinalCostEstimate().prettyScrollInsensitiveString(attrDelim));
+                    sb.append(attrDelim).append(resultSet.getFinalCostEstimate(false).prettyScrollInsensitiveString(attrDelim));
                 }
                 sb.append(attrDelim).append(String.format("correlated=%b%sexpression=%b%sinvariant=%b",
                         hasCorrelatedCRs(),attrDelim,getSubqueryType()==SubqueryNode.EXPRESSION_SUBQUERY,attrDelim,isInvariant()))

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableOperatorNode.java
@@ -728,7 +728,8 @@ public abstract class TableOperatorNode extends FromTable{
 			*/
 
             // Encapsulate this transfer logic.
-            optimizer.transferOuterCost(outerCost);
+            if (outerCost != null)
+                optimizer.transferOuterCost(outerCost);
 
 			/* Optimize the underlying result set */
             while(optimizer.nextJoinOrder()){
@@ -743,7 +744,7 @@ public abstract class TableOperatorNode extends FromTable{
             retval=sourceResultSet.optimize(
                     optimizer.getDataDictionary(),
                     predList,
-                    outerCost.rowCount());
+                    outerCost == null? 1.0 : outerCost.rowCount());
         }
 
         return retval;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnionNode.java
@@ -584,7 +584,7 @@ public class UnionNode extends SetOperatorNode{
         assignResultSetNumber();
 
         // Get our final cost estimate based on the child estimates.
-        costEstimate=getFinalCostEstimate();
+        costEstimate=getFinalCostEstimate(false);
 
         // build up the tree.
 
@@ -637,13 +637,13 @@ public class UnionNode extends SetOperatorNode{
      * Get the final CostEstimate for this UnionNode.
      */
     @Override
-    public CostEstimate getFinalCostEstimate() throws StandardException{
+    public CostEstimate getFinalCostEstimate(boolean useSelf) throws StandardException{
         // If we already found it, just return it.
         if(finalCostEstimate!=null)
             return finalCostEstimate;
 
-        CostEstimate leftCE=leftResultSet.getFinalCostEstimate();
-        CostEstimate rightCE=rightResultSet.getFinalCostEstimate();
+        CostEstimate leftCE=leftResultSet.getFinalCostEstimate(true);
+        CostEstimate rightCE=rightResultSet.getFinalCostEstimate(true);
 
         finalCostEstimate=getNewCostEstimate();
         finalCostEstimate.setCost(leftCE.getEstimatedCost(), leftCE.rowCount(),

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UpdateNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UpdateNode.java
@@ -867,8 +867,8 @@ public final class UpdateNode extends DMLModStatementNode
         if( null != targetVTI)
         {
 			targetVTI.assignCostEstimate(resultSet.getNewCostEstimate());
-            mb.push((double)this.resultSet.getFinalCostEstimate().getEstimatedRowCount());
-            mb.push(this.resultSet.getFinalCostEstimate().getEstimatedCost());
+            mb.push((double)this.resultSet.getFinalCostEstimate(false).getEstimatedRowCount());
+            mb.push(this.resultSet.getFinalCostEstimate(false).getEstimatedCost());
             mb.callMethod(VMOpcode.INVOKEINTERFACE, (String) null, "getUpdateVTIResultSet", ClassName.ResultSet, 3);
 		}
         else
@@ -887,8 +887,8 @@ public final class UpdateNode extends DMLModStatementNode
                               ClassName.ResultSet, 5);
             }else
             {
-                mb.push((double)this.resultSet.getFinalCostEstimate().getEstimatedRowCount());
-                mb.push(this.resultSet.getFinalCostEstimate().getEstimatedCost());
+                mb.push((double)this.resultSet.getFinalCostEstimate(false).getEstimatedRowCount());
+                mb.push(this.resultSet.getFinalCostEstimate(false).getEstimatedCost());
                 mb.push(targetTableDescriptor.getVersion());
                 mb.push(this.printExplainInformationForActivation());
                 mb.callMethod(VMOpcode.INVOKEINTERFACE, (String) null, "getUpdateResultSet",
@@ -1535,7 +1535,7 @@ public final class UpdateNode extends DMLModStatementNode
 			.append("Update").append("(")
 			.append("n=").append(order).append(attrDelim);
 		if (this.resultSet!=null) {
-			sb.append(this.resultSet.getFinalCostEstimate().prettyDmlStmtString("updatedRows"));
+			sb.append(this.resultSet.getFinalCostEstimate(false).prettyDmlStmtString("updatedRows"));
 		}
 		sb.append(attrDelim).append("targetTable=").append(targetTableName).append(")");
         return sb.toString();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowResultSetNode.java
@@ -1051,7 +1051,7 @@ public class WindowResultSetNode extends SingleChildResultSetNode {
         assignResultSetNumber();
 
         // Get the final cost estimate from the child.
-        costEstimate = childResult.getFinalCostEstimate();
+        costEstimate = childResult.getFinalCostEstimate(true);
 
 		/*
 		** We have aggregates, so save the windowInfoList
@@ -1543,7 +1543,7 @@ public class WindowResultSetNode extends SingleChildResultSetNode {
     @Override
     public String printExplainInformation(String attrDelim, int order) throws StandardException {
         return spaceToLevel() + "WindowFunction" + "(" + "n=" + order + attrDelim +
-            getFinalCostEstimate().prettyProjectionString(attrDelim) + ")";
+            getFinalCostEstimate(false).prettyProjectionString(attrDelim) + ")";
     }
 
     @Override

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/CostEstimationIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/CostEstimationIT.java
@@ -103,6 +103,17 @@ public class CostEstimationIT extends SpliceUnitTest {
             ps.execute();
         }
 
+        // create more tables that use dummy stats
+        new TableCreator(conn)
+                .withCreate("create table t11 (a1 int, b1 int, c1 int)")
+                .create();
+        new TableCreator(conn)
+                .withCreate("create table t22 (a2 int, b2 int, c2 int)")
+                .create();
+        new TableCreator(conn)
+                .withCreate("create table t33 (a3 int, b3 int, c3 int)")
+                .create();
+
         conn.commit();
     }
 
@@ -152,5 +163,31 @@ public class CostEstimationIT extends SpliceUnitTest {
                 Assert.assertTrue(format("OutputRows is expected to be greater than 1, actual is %s", outputRows), outputRows > 1);
             }
         }
+    }
+
+    @Test
+    public void testOuterJoinRowCount() throws Exception {
+        /*  t11 is hinted to have a total rowcount of 300, t22 and t33 have the default rowcount of 20.
+            The plan is similar to the following:
+            --------------------------------------------------------------------
+            Cursor(n=10,rows=1,updateMode=READ_ONLY (1),engine=control)
+              ->  ScrollInsensitive(n=9,totalCost=131.717,outputRows=1,outputHeapSize=0 B,partitions=1)
+                ->  ProjectRestrict(n=8,totalCost=29.575,outputRows=1,outputHeapSize=0 B,partitions=1)
+                  ->  GroupBy(n=7,totalCost=29.575,outputRows=1,outputHeapSize=0 B,partitions=1)
+                    ->  ProjectRestrict(n=6,totalCost=24.84,outputRows=219,outputHeapSize=296 B,partitions=1)
+                      ->  BroadcastJoin(n=5,totalCost=24.84,outputRows=219,outputHeapSize=296 B,partitions=1,preds=[(A1[8:1] = A2[8:2])])
+                        ->  BroadcastLeftOuterJoin(n=4,totalCost=12.28,outputRows=18,outputHeapSize=78 B,partitions=1,preds=[(A2[6:1] = A3[6:2])])
+                          ->  TableScan[T33(1920)](n=3,totalCost=4.04,scannedRows=20,outputRows=20,outputHeapSize=78 B,partitions=1)
+                          ->  TableScan[T22(1904)](n=2,totalCost=4.04,scannedRows=20,outputRows=18,outputHeapSize=18 B,partitions=1,preds=[(A2[2:1] = 90)])
+                        ->  TableScan[T11(1888)](n=1,totalCost=4.6,scannedRows=300,outputRows=270,outputHeapSize=270 B,partitions=1,preds=[(A1[0:1] = 90)])
+
+            10 rows selected
+         */
+        rowContainsQuery(new int[]{2,3,4,5,6,7,8,9,10},"explain select count(*) from --splice-properties joinOrder=fixed\n" +
+                        "t11  --splice-properties useDefaultRowCount=300\n" +
+                        ", t22 left join t33 --splice-properties joinStrategy=broadcast\n" +
+                        "on a2=a3 where a1=a2 and a1=90", methodWatcher,
+                "outputRows=1", "outputRows=1", "outputRows=1", "outputRows=219", "outputRows=219", "outputRows=18", "outputRows=20", "outputRows=18", "outputRows=270");
+
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/ast/LimitOffsetVisitorIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/ast/LimitOffsetVisitorIT.java
@@ -80,7 +80,7 @@ public class LimitOffsetVisitorIT extends SpliceUnitTest {
     @Test
     public void limitOverGroupBy() throws Exception {
         rowContainsQuery(new int[]{1,2,3,4,5,6,7},"explain select top 10 col1,max(col2) from A group by col1",methodWatcher,
-                "rows=10,","outputRows=10,","outputRows=10,","outputRows=20,","outputRows=20,",
+                "rows=10,","outputRows=10,","outputRows=10,","outputRows=10,","outputRows=10,",
                 "outputRows=20,","outputRows=20,");
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/JoinSelectionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/JoinSelectionIT.java
@@ -441,29 +441,29 @@ public class JoinSelectionIT extends SpliceUnitTest  {
     public void testRepetivePredicate() throws Exception {
 
         // predicates that repeat in all sub-clauses are all extracted as hashable join predicates
-        thirdRowContainsQuery(
+        rowContainsQuery(4,
                 "explain select * from a, b where (a.i = b.i and a.j=1) or (a.i = b.i and a.j=2)",
                 BROADCAST_JOIN, methodWatcher);
 
-        thirdRowContainsQuery(
+        rowContainsQuery(4,
                 "explain select * from a, b where (a.i = b.i and a.j=1) or (a.i = b.i and a.j=2)",
-                "preds=[(A.I[4:1] = B.I[4:3])]", methodWatcher);
+                "preds=[(A.I[4:3] = B.I[4:1])]", methodWatcher);
 
         rowContainsQuery(5,
                 "explain select * from a, b where (a.i = b.i and a.j=1) or (a.i = b.i and a.j=2)",
-                "preds=[(A.J[0:2] IN (1,2))]", methodWatcher);
+                "preds=[(A.J[2:2] IN (1,2))]", methodWatcher);
 
-        thirdRowContainsQuery(
+        rowContainsQuery(4,
                 "explain select * from a, b where (a.i = b.i and a.j=1 and a.j=b.j) or (a.i = b.i and a.j=2 and a.j=b.j)",
                 BROADCAST_JOIN, methodWatcher);
 
-        thirdRowContainsQuery(
+        rowContainsQuery(4,
                 "explain select * from a, b where (a.i = b.i and a.j=1 and a.j=b.j) or (a.i = b.i and a.j=2 and a.j=b.j)",
-                "preds=[(A.J[4:2] = B.J[4:4]),(A.I[4:1] = B.I[4:3])]", methodWatcher);
+                "preds=[(A.J[4:4] = B.J[4:2]),(A.I[4:3] = B.I[4:1])]", methodWatcher);
 
         rowContainsQuery(5,
                 "explain select * from a, b where (a.i = b.i and a.j=1 and a.j=b.j) or (a.i = b.i and a.j=2 and a.j=b.j)",
-                "preds=[(A.J[0:2] IN (1,2))]", methodWatcher);
+                "preds=[(A.J[2:2] IN (1,2))]", methodWatcher);
 
         // Negative test: predicate does not repeat in all clauses
         thirdRowContainsQuery(


### PR DESCRIPTION
The PR fixes a costing issue and some explain display issue(details please see [DB-7684](https://splicemachine.atlassian.net/browse/DB-7684). I separate the code into two commits. The first one is the fix for the costing issue. The second one contains the fix for the explain display issue,most files changes are just interface change. I also incorporated review comment for inlist selectivity from #2548 .