### PR TITLE
DB-6830:Enable ldap server in distributed standalone 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,4 @@ tramp
 # cask packages
 .cask/
 
+/platform_it/src/test/resources/ee.txt


### PR DESCRIPTION
usage: ./start-splice-cluster -pcdh5.12.2,ee -f to start the cluster.
when starting a full distributed standalone cluster, the ee key will be read from /platform_it/src/test/resources/ee.txt ,which has been added to git ignore file.
if the ee key doesn't exists ,the cluster will start without the ldap server and use native auth.
if the ee key has been setup correctly ,a full kerberos + ldap full standalone cluster will start