### PR TITLE
DB-7812 Update Copyright Date

### DIFF
--- a/assembly/cdh5.12.0/src/main/resources/conf/olap-log4j.properties
+++ b/assembly/cdh5.12.0/src/main/resources/conf/olap-log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/assembly/cdh5.12.2/src/main/resources/conf/olap-log4j.properties
+++ b/assembly/cdh5.12.2/src/main/resources/conf/olap-log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/assembly/cdh5.13.0/src/main/resources/conf/olap-log4j.properties
+++ b/assembly/cdh5.13.0/src/main/resources/conf/olap-log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/assembly/cdh5.13.2/src/main/resources/conf/olap-log4j.properties
+++ b/assembly/cdh5.13.2/src/main/resources/conf/olap-log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/assembly/cdh5.13.3/src/main/resources/conf/olap-log4j.properties
+++ b/assembly/cdh5.13.3/src/main/resources/conf/olap-log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/assembly/cdh5.14.0/src/main/resources/conf/olap-log4j.properties
+++ b/assembly/cdh5.14.0/src/main/resources/conf/olap-log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/assembly/cdh5.14.2/src/main/resources/conf/olap-log4j.properties
+++ b/assembly/cdh5.14.2/src/main/resources/conf/olap-log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/assembly/cdh5.8.3/src/main/resources/conf/olap-log4j.properties
+++ b/assembly/cdh5.8.3/src/main/resources/conf/olap-log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/assembly/cdh5.8.5/src/main/resources/conf/olap-log4j.properties
+++ b/assembly/cdh5.8.5/src/main/resources/conf/olap-log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/assembly/cdh5.9.0/src/main/resources/conf/olap-log4j.properties
+++ b/assembly/cdh5.9.0/src/main/resources/conf/olap-log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/assembly/hdp2.5.5/src/main/resources/conf/olap-log4j.properties
+++ b/assembly/hdp2.5.5/src/main/resources/conf/olap-log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/assembly/mapr5.2.0/src/main/resources/examples/conf/hbase-site.xml
+++ b/assembly/mapr5.2.0/src/main/resources/examples/conf/hbase-site.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/assembly/mapr6.0.0/src/main/resources/examples/conf/hbase-site.xml
+++ b/assembly/mapr6.0.0/src/main/resources/examples/conf/hbase-site.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-build/pom.xml
+++ b/db-build/pom.xml
@@ -26,7 +26,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/db-build/src/main/java/com/splicemachine/derbyBuild/MessageVetter.java
+++ b/db-build/src/main/java/com/splicemachine/derbyBuild/MessageVetter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-build/src/main/java/com/splicemachine/derbyBuild/ODBCMetadataGenerator.java
+++ b/db-build/src/main/java/com/splicemachine/derbyBuild/ODBCMetadataGenerator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-build/src/main/java/com/splicemachine/derbyBuild/classlister.java
+++ b/db-build/src/main/java/com/splicemachine/derbyBuild/classlister.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-build/src/main/java/com/splicemachine/derbyBuild/maintversion2props.java
+++ b/db-build/src/main/java/com/splicemachine/derbyBuild/maintversion2props.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-build/src/main/java/com/splicemachine/derbyBuild/messages/MessageBuilder.java
+++ b/db-build/src/main/java/com/splicemachine/derbyBuild/messages/MessageBuilder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-build/src/main/java/com/splicemachine/derbyBuild/messages/MessageBundleTest.java
+++ b/db-build/src/main/java/com/splicemachine/derbyBuild/messages/MessageBundleTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-build/src/main/java/com/splicemachine/derbyBuild/messages/SplitMessages.java
+++ b/db-build/src/main/java/com/splicemachine/derbyBuild/messages/SplitMessages.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-build/src/main/java/com/splicemachine/derbyBuild/propertyconfig.java
+++ b/db-build/src/main/java/com/splicemachine/derbyBuild/propertyconfig.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-build/src/main/resources/com/splicemachine/derbyBuild/odbcgen_fragments.properties
+++ b/db-build/src/main/resources/com/splicemachine/derbyBuild/odbcgen_fragments.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-client/pom.xml
+++ b/db-client/pom.xml
@@ -13,7 +13,7 @@
   ~
   ~ Splice Machine, Inc. has modified this file.
   ~
-  ~ All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the License; you may not use this file except in
   ~ compliance with the License.
   ~

--- a/db-client/src/main/java/com/splicemachine/db/client/ClientDataSourceFactory.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/ClientDataSourceFactory.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/ClientPooledConnection.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/ClientPooledConnection.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/ClientPooledConnection40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/ClientPooledConnection40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/ClientXAConnection.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/ClientXAConnection.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/ClientXAConnection40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/ClientXAConnection40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/ClientXid.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/ClientXid.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Agent.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Agent.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/AsciiStream.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/AsciiStream.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/BatchUpdateException.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/BatchUpdateException.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Blob.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Blob.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/BlobLocatorInputStream.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/BlobLocatorInputStream.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/BlobLocatorOutputStream.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/BlobLocatorOutputStream.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/BlobOutputStream.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/BlobOutputStream.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ByteArrayCombinerStream.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ByteArrayCombinerStream.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/CachingLogicalConnection.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/CachingLogicalConnection.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/CachingLogicalConnection40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/CachingLogicalConnection40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/CallableLocatorProcedures.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/CallableLocatorProcedures.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/CallableStatement.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/CallableStatement.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/CallableStatement40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/CallableStatement40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ClientJDBCObjectFactory.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ClientJDBCObjectFactory.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ClientMessageId.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ClientMessageId.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Clob.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Clob.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ClobLocatorInputStream.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ClobLocatorInputStream.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ClobLocatorOutputStream.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ClobLocatorOutputStream.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ClobLocatorReader.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ClobLocatorReader.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ClobLocatorWriter.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ClobLocatorWriter.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ClobOutputStream.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ClobOutputStream.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ClobWriter.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ClobWriter.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/CloseFilterInputStream.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/CloseFilterInputStream.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ColumnMetaData.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ColumnMetaData.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ColumnMetaData40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ColumnMetaData40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Configuration.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Configuration.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Connection.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Connection.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ConnectionCallbackInterface.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ConnectionCallbackInterface.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/CrossConverters.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/CrossConverters.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Cursor.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Cursor.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/DatabaseMetaData.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/DatabaseMetaData.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/DateTime.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/DateTime.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/DateTimeValue.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/DateTimeValue.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Decimal.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Decimal.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Diagnosable.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Diagnosable.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/DisconnectException.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/DisconnectException.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/EncryptionManager.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/EncryptionManager.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ErrorKey.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ErrorKey.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ExceptionFormatter.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ExceptionFormatter.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/FailedProperties40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/FailedProperties40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/FloatingPoint.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/FloatingPoint.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/GetFileInputStreamAction.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/GetFileInputStreamAction.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/GetResourceBundleAction.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/GetResourceBundleAction.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/GetResourceInputStreamAction.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/GetResourceInputStreamAction.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/GetSystemPropertiesAction.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/GetSystemPropertiesAction.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/LOBStateTracker.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/LOBStateTracker.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Lob.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Lob.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/LogWriter.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/LogWriter.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/LogicalCallableStatement.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/LogicalCallableStatement.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/LogicalCallableStatement40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/LogicalCallableStatement40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/LogicalConnection.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/LogicalConnection.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/LogicalConnection40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/LogicalConnection40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/LogicalDatabaseMetaData.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/LogicalDatabaseMetaData.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/LogicalDatabaseMetaData40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/LogicalDatabaseMetaData40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/LogicalPreparedStatement.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/LogicalPreparedStatement.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/LogicalPreparedStatement40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/LogicalPreparedStatement40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/LogicalStatementEntity.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/LogicalStatementEntity.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/MaterialPreparedStatement.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/MaterialPreparedStatement.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/MaterialStatement.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/MaterialStatement.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ParameterMetaData.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ParameterMetaData.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ParameterMetaData40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ParameterMetaData40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/PreparedStatement.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/PreparedStatement.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/PreparedStatement40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/PreparedStatement40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/PreparedStatementCallbackInterface.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/PreparedStatementCallbackInterface.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ProductLevel.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ProductLevel.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ResultSet.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ResultSet.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ResultSetCallbackInterface.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ResultSetCallbackInterface.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/RowId.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/RowId.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/SQLExceptionFactory.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/SQLExceptionFactory.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/SQLExceptionFactory40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/SQLExceptionFactory40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Savepoint.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Savepoint.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Section.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Section.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/SectionManager.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/SectionManager.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/SetAccessibleAction.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/SetAccessibleAction.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/SignedBinary.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/SignedBinary.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/SqlCode.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/SqlCode.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/SqlException.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/SqlException.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/SqlState.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/SqlState.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/SqlWarning.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/SqlWarning.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Sqlca.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Sqlca.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Statement.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Statement.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Statement40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Statement40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/StatementCacheInteractor.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/StatementCacheInteractor.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/StatementCallbackInterface.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/StatementCallbackInterface.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Types.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Types.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/UnitOfWorkListener.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/UnitOfWorkListener.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/UpdateSensitiveBlobLocatorInputStream.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/UpdateSensitiveBlobLocatorInputStream.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/UpdateSensitiveClobLocatorInputStream.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/UpdateSensitiveClobLocatorInputStream.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/UpdateSensitiveClobLocatorReader.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/UpdateSensitiveClobLocatorReader.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/UpdateSensitiveLOBLocatorInputStream.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/UpdateSensitiveLOBLocatorInputStream.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Utils.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Utils.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Version.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Version.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/XaException.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/XaException.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/stmtcache/JDBCStatementCache.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/stmtcache/JDBCStatementCache.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/stmtcache/StatementKey.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/stmtcache/StatementKey.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/stmtcache/StatementKeyFactory.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/stmtcache/StatementKeyFactory.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/am/stmtcache/package.html
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/stmtcache/package.html
@@ -12,7 +12,7 @@
   ~
   ~ Splice Machine, Inc. has modified this file.
   ~
-  ~ All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the License; you may not use this file except in
   ~ compliance with the License.
   ~

--- a/db-client/src/main/java/com/splicemachine/db/client/net/CcsidManager.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/CcsidManager.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/ClientJDBCObjectFactoryImpl.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/ClientJDBCObjectFactoryImpl.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/ClientJDBCObjectFactoryImpl40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/ClientJDBCObjectFactoryImpl40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/CodePoint.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/CodePoint.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/CodePointNameTable.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/CodePointNameTable.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/ConnectionReply.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/ConnectionReply.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/ConnectionReplyInterface.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/ConnectionReplyInterface.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/ConnectionRequestInterface.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/ConnectionRequestInterface.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/DssConstants.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/DssConstants.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/DynamicByteArrayOutputStream.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/DynamicByteArrayOutputStream.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/EbcdicCcsidManager.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/EbcdicCcsidManager.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/EncodedInputStream.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/EncodedInputStream.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/FdocaConstants.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/FdocaConstants.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/FdocaSimpleDataArray.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/FdocaSimpleDataArray.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/InputStreamUtil.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/InputStreamUtil.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/JaasConfiguration.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/JaasConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-client/src/main/java/com/splicemachine/db/client/net/KerberosUtil.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/KerberosUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NaiveTrustManager.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NaiveTrustManager.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetAgent.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetAgent.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetCallableStatement.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetCallableStatement.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetConfiguration.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetConfiguration.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetConnection.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetConnection.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetConnection40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetConnection40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetConnectionReply.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetConnectionReply.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetConnectionRequest.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetConnectionRequest.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetCursor.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetCursor.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetDatabaseMetaData.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetDatabaseMetaData.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetDatabaseMetaData40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetDatabaseMetaData40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetIndoubtTransaction.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetIndoubtTransaction.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetLogWriter.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetLogWriter.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetPackageReply.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetPackageReply.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetPackageRequest.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetPackageRequest.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetPreparedStatement.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetPreparedStatement.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetResultSet.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetResultSet.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetResultSet40.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetResultSet40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetResultSetReply.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetResultSetReply.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetResultSetRequest.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetResultSetRequest.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetSqlca.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetSqlca.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetSqldta.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetSqldta.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetStatement.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetStatement.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetStatementReply.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetStatementReply.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetStatementRequest.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetStatementRequest.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetXACallInfo.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetXACallInfo.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetXAConnection.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetXAConnection.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetXAConnectionReply.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetXAConnectionReply.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetXAConnectionRequest.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetXAConnectionRequest.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetXAResource.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetXAResource.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/OpenSocketAction.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/OpenSocketAction.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/Reply.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/Reply.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/Request.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/Request.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/ResourceLocalizer.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/ResourceLocalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-client/src/main/java/com/splicemachine/db/client/net/ResourceLocalizerService.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/ResourceLocalizerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-client/src/main/java/com/splicemachine/db/client/net/ResultSetReply.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/ResultSetReply.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/ResultSetReplyInterface.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/ResultSetReplyInterface.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/ResultSetRequestInterface.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/ResultSetRequestInterface.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/StatementReply.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/StatementReply.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/StatementReplyInterface.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/StatementReplyInterface.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/StatementRequestInterface.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/StatementRequestInterface.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/Typdef.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/Typdef.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/client/net/Utf8CcsidManager.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/Utf8CcsidManager.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/jdbc/ClientBaseDataSource.java
+++ b/db-client/src/main/java/com/splicemachine/db/jdbc/ClientBaseDataSource.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/jdbc/ClientConnectionPoolDataSource.java
+++ b/db-client/src/main/java/com/splicemachine/db/jdbc/ClientConnectionPoolDataSource.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/jdbc/ClientConnectionPoolDataSource40.java
+++ b/db-client/src/main/java/com/splicemachine/db/jdbc/ClientConnectionPoolDataSource40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/jdbc/ClientDataSource.java
+++ b/db-client/src/main/java/com/splicemachine/db/jdbc/ClientDataSource.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/jdbc/ClientDataSource40.java
+++ b/db-client/src/main/java/com/splicemachine/db/jdbc/ClientDataSource40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/jdbc/ClientDriver.java
+++ b/db-client/src/main/java/com/splicemachine/db/jdbc/ClientDriver.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/jdbc/ClientDriver40.java
+++ b/db-client/src/main/java/com/splicemachine/db/jdbc/ClientDriver40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/jdbc/ClientXADataSource.java
+++ b/db-client/src/main/java/com/splicemachine/db/jdbc/ClientXADataSource.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/java/com/splicemachine/db/jdbc/ClientXADataSource40.java
+++ b/db-client/src/main/java/com/splicemachine/db/jdbc/ClientXADataSource40.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/main/resources/META-INF/services/java.sql.Driver
+++ b/db-client/src/main/resources/META-INF/services/java.sql.Driver
@@ -12,7 +12,7 @@
 #
 # Splice Machine, Inc. has modified this file.
 #
-# All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the License; you may not use this file except in
 # compliance with the License.
 #

--- a/db-client/src/test/java/com/splicemachine/db/client/am/LogicalStatementEntityTest.java
+++ b/db-client/src/test/java/com/splicemachine/db/client/am/LogicalStatementEntityTest.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/test/java/com/splicemachine/db/client/am/stmtcache/JDBCStatementCacheTest.java
+++ b/db-client/src/test/java/com/splicemachine/db/client/am/stmtcache/JDBCStatementCacheTest.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-client/src/test/java/com/splicemachine/db/client/am/stmtcache/StatementKeyFactoryTest.java
+++ b/db-client/src/test/java/com/splicemachine/db/client/am/stmtcache/StatementKeyFactoryTest.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-drda/pom.xml
+++ b/db-drda/pom.xml
@@ -26,7 +26,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/db-drda/src/main/java/com/splicemachine/db/drda/NetworkServerControl.java
+++ b/db-drda/src/main/java/com/splicemachine/db/drda/NetworkServerControl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/AppRequester.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/AppRequester.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/CcsidManager.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/CcsidManager.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.drda;

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/CharacterEncodings.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/CharacterEncodings.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/ClientThread.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/ClientThread.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/CodePoint.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/CodePoint.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.drda;

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/CodePointNameTable.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/CodePointNameTable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.drda;

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/ConsistencyToken.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/ConsistencyToken.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DDMReader.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DDMReader.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DDMWriter.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DDMWriter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAConnThread.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAConnThread.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAProtocolException.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAProtocolException.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAProtocolExceptionInfo.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAProtocolExceptionInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAResultSet.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAResultSet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAStatement.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAStatement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAString.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAString.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAXAProtocol.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAXAProtocol.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAXid.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAXid.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/Database.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/Database.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DecryptionManager.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DecryptionManager.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DssConstants.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DssConstants.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DssTrace.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DssTrace.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.drda;

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/EXTDTAInputStream.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/EXTDTAInputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.drda;

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/EXTDTAReaderInputStream.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/EXTDTAReaderInputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.drda;

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/EbcdicCcsidManager.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/EbcdicCcsidManager.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/FailingEXTDTAInputStream.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/FailingEXTDTAInputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.drda;

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/FdocaConstants.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/FdocaConstants.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.drda;

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/LayerBStreamedEXTDTAReaderInputStream.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/LayerBStreamedEXTDTAReaderInputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.drda;

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/NaiveTrustManager.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/NaiveTrustManager.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/NetworkServerControlImpl.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/NetworkServerControlImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/NetworkServerMBeanImpl.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/NetworkServerMBeanImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/PiggyBackedSessionData.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/PiggyBackedSessionData.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/Pkgnamcsn.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/Pkgnamcsn.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/ProtocolTestAdapter.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/ProtocolTestAdapter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.drda;

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/ReEncodedInputStream.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/ReEncodedInputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.drda;

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/RemoteUser.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/RemoteUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/RemoteUserKerberos.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/RemoteUserKerberos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/RemoteUserPassword.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/RemoteUserPassword.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/SQLTypes.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/SQLTypes.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/Session.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/Session.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/SignedBinary.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/SignedBinary.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.drda;

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/StandardEXTDTAReaderInputStream.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/StandardEXTDTAReaderInputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.drda;

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/User.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/UserManager.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/UserManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/UserManagerService.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/UserManagerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/Utf8CcsidManager.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/Utf8CcsidManager.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.drda;

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/XADatabase.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/XADatabase.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/memCheck.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/memCheck.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/package.html
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/package.html
@@ -25,7 +25,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">

--- a/db-drda/src/main/java/com/splicemachine/db/impl/tools/sysinfo/Main.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/tools/sysinfo/Main.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/impl/tools/sysinfo/ZipInfoProperties.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/tools/sysinfo/ZipInfoProperties.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/mbeans/drda/NetworkServerMBean.java
+++ b/db-drda/src/main/java/com/splicemachine/db/mbeans/drda/NetworkServerMBean.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/java/com/splicemachine/db/mbeans/drda/package.html
+++ b/db-drda/src/main/java/com/splicemachine/db/mbeans/drda/package.html
@@ -25,7 +25,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <body>

--- a/db-drda/src/main/java/com/splicemachine/db/tools/sysinfo.java
+++ b/db-drda/src/main/java/com/splicemachine/db/tools/sysinfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-drda/src/main/properties/metadata.properties
+++ b/db-drda/src/main/properties/metadata.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 getProcedures=\

--- a/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_cs.properties
+++ b/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_cs.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_de_DE.properties
+++ b/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_de_DE.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_en.properties
+++ b/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_en.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_es.properties
+++ b/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_es.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_fr.properties
+++ b/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_fr.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_hu.properties
+++ b/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_hu.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_it.properties
+++ b/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_it.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_ja_JP.properties
+++ b/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_ja_JP.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_ko_KR.properties
+++ b/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_ko_KR.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_pl.properties
+++ b/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_pl.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_pt_BR.properties
+++ b/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_pt_BR.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_ru.properties
+++ b/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_ru.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_zh_CN.properties
+++ b/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_zh_CN.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_zh_TW.properties
+++ b/db-drda/src/main/resources/com/splicemachine/db/loc/drda/messages_zh_TW.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-engine/pom.xml
+++ b/db-engine/pom.xml
@@ -26,7 +26,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/db-engine/src/main/java/com/splicemachine/access/util/ByteComparisons.java
+++ b/db-engine/src/main/java/com/splicemachine/access/util/ByteComparisons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/java/com/splicemachine/db/agg/Aggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/agg/Aggregator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.agg;

--- a/db-engine/src/main/java/com/splicemachine/db/authentication/SystemPrincipal.java
+++ b/db-engine/src/main/java/com/splicemachine/db/authentication/SystemPrincipal.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/authentication/UserAuthenticator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/authentication/UserAuthenticator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/AliasInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/AliasInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/DefaultInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/DefaultInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/Dependable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/Dependable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/DependableFinder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/DependableFinder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/GetProcedureColumns.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/GetProcedureColumns.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/IndexDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/IndexDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/ReferencedColumns.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/ReferencedColumns.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/SequencePreallocator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/SequencePreallocator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/Statistics.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/Statistics.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/SystemProcedures.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/SystemProcedures.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/TriggerNewTransitionRows.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/TriggerNewTransitionRows.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/TypeDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/TypeDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/UUID.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/UUID.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/AggregateAliasInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/AggregateAliasInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/BaseTypeIdImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/BaseTypeIdImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/DecimalTypeIdImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/DecimalTypeIdImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/DefaultInfoImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/DefaultInfoImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/IndexDescriptorImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/IndexDescriptorImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/MethodAliasInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/MethodAliasInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/OldRoutineType.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/OldRoutineType.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.catalog.types;

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/ReferencedColumnsDescriptorImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/ReferencedColumnsDescriptorImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/RoutineAliasInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/RoutineAliasInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/RowMultiSetImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/RowMultiSetImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/StatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/StatisticsImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/SynonymAliasInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/SynonymAliasInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/TypeDescriptorImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/TypeDescriptorImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/TypesImplInstanceGetter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/TypesImplInstanceGetter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/UDTAliasInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/UDTAliasInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/UserDefinedTypeIdImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/UserDefinedTypeIdImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/database/Database.java
+++ b/db-engine/src/main/java/com/splicemachine/db/database/Database.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/ast/ISpliceVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/ast/ISpliceVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/db/ConnectionInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/db/ConnectionInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/db/ConsistencyChecker.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/db/ConsistencyChecker.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/db/Database.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/db/Database.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/db/DatabaseContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/db/DatabaseContext.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/db/Factory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/db/Factory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/db/PropertyInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/db/PropertyInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/error/DerbySQLException.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/error/DerbySQLException.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.error;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/error/ErrorStringBuilder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/error/ErrorStringBuilder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/error/ExceptionSeverity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/error/ExceptionSeverity.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/error/ExceptionUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/error/ExceptionUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.error;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/error/PassThroughException.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/error/PassThroughException.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/error/PublicAPI.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/error/PublicAPI.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/error/SQLWarningFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/error/SQLWarningFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/error/ShutdownException.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/error/ShutdownException.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/error/StandardException.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/error/StandardException.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/error/ThreadDump.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/error/ThreadDump.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/AuthenticationService.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/AuthenticationService.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredCallableStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredCallableStatement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredCallableStatement30.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredCallableStatement30.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredCallableStatement40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredCallableStatement40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredConnection.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredConnection.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredConnection30.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredConnection30.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredConnection40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredConnection40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredConnectionControl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredConnectionControl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredPreparedStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredPreparedStatement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredPreparedStatement30.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredPreparedStatement30.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredPreparedStatement40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredPreparedStatement40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredStatement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredStatement40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredStatement40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredStatementControl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/BrokeredStatementControl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/CharacterStreamDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/CharacterStreamDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/ConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/ConnectionContext.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/DRDAServerStarter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/DRDAServerStarter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/EngineCallableStatement40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/EngineCallableStatement40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/EngineConnection.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/EngineConnection.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/EngineConnection40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/EngineConnection40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/EngineLOB.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/EngineLOB.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/EngineParameterMetaData.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/EngineParameterMetaData.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/EnginePreparedStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/EnginePreparedStatement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/EngineResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/EngineResultSet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/EngineStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/EngineStatement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/ExceptionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/ExceptionFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/FailedProperties40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/FailedProperties40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/JDBCBoot.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/JDBCBoot.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/ResourceAdapter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/jdbc/ResourceAdapter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/security/SecurityUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/security/SecurityUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/authorization/AuthorizationFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/authorization/AuthorizationFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.services.authorization;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/cache/CacheFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/cache/CacheFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/cache/CacheManager.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/cache/CacheManager.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/cache/Cacheable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/cache/Cacheable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/cache/CacheableFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/cache/CacheableFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/cache/ClassSize.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/cache/ClassSize.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/cache/ClassSizeCrawler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/cache/ClassSizeCrawler.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/cache/SizedCacheable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/cache/SizedCacheable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/AttributeEntry.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/AttributeEntry.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/Attributes.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/Attributes.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/CONSTANT_Double_info.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/CONSTANT_Double_info.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/CONSTANT_Float_info.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/CONSTANT_Float_info.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/CONSTANT_Index_info.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/CONSTANT_Index_info.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/CONSTANT_Integer_info.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/CONSTANT_Integer_info.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/CONSTANT_Long_info.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/CONSTANT_Long_info.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/CONSTANT_Utf8_info.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/CONSTANT_Utf8_info.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/ClassEnumeration.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/ClassEnumeration.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/ClassFormatOutput.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/ClassFormatOutput.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/ClassHolder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/ClassHolder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/ClassInput.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/ClassInput.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/ClassInvestigator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/ClassInvestigator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/ClassMember.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/ClassMember.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/ConstantPoolEntry.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/ConstantPoolEntry.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/MemberTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/MemberTable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/VMDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/VMDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/VMOpcode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/classfile/VMOpcode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/compiler/ClassBuilder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/compiler/ClassBuilder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/compiler/JavaFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/compiler/JavaFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/compiler/LocalField.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/compiler/LocalField.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/compiler/MethodBuilder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/compiler/MethodBuilder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/Context.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/Context.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextManager.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextManager.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextService.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextService.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/SystemContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/SystemContext.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/crypto/CipherFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/crypto/CipherFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/crypto/CipherFactoryBuilder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/crypto/CipherFactoryBuilder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/crypto/CipherProvider.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/crypto/CipherProvider.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/daemon/DaemonFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/daemon/DaemonFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/daemon/DaemonService.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/daemon/DaemonService.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/daemon/Serviceable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/daemon/Serviceable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/diag/DiagnosticUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/diag/DiagnosticUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/diag/Diagnosticable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/diag/Diagnosticable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/diag/DiagnosticableGeneric.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/diag/DiagnosticableGeneric.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/diag/Performance.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/diag/Performance.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/i18n/BundleFinder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/i18n/BundleFinder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/i18n/LocaleFinder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/i18n/LocaleFinder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/i18n/MessageService.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/i18n/MessageService.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/info/JVMInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/info/JVMInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/info/Version.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/info/Version.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/AccessibleByteArrayOutputStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/AccessibleByteArrayOutputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/ApplicationObjectInputStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/ApplicationObjectInputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/ArrayInputStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/ArrayInputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/ArrayOutputStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/ArrayOutputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/ArrayUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/ArrayUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/CloneableStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/CloneableStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/CloseFilterInputStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/CloseFilterInputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.services.io;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/CompressedNumber.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/CompressedNumber.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/CounterOutputStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/CounterOutputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/DataInputUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/DataInputUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/DebugByteTeeOutputStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/DebugByteTeeOutputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.services.io;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/DerbyIOException.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/DerbyIOException.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/DynamicByteArrayOutputStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/DynamicByteArrayOutputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/ErrorInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/ErrorInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/ErrorObjectInput.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/ErrorObjectInput.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FileUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FileUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatIdInputStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatIdInputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatIdOutputStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatIdOutputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatIdUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatIdUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/Formatable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/Formatable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatableArrayHolder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatableArrayHolder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatableBitSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatableBitSet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatableHashtable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatableHashtable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatableInstanceGetter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatableInstanceGetter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatableIntHolder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatableIntHolder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatableLongHolder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatableLongHolder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatableProperties.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/FormatableProperties.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/InputStreamUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/InputStreamUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/Limit.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/Limit.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/LimitInputStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/LimitInputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/LimitObjectInput.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/LimitObjectInput.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/LimitReader.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/LimitReader.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/NullOutputStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/NullOutputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/RegisteredFormatIds.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/RegisteredFormatIds.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/SQLExceptionWrapper.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/SQLExceptionWrapper.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/Storable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/Storable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/StoredFormatIds.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/StoredFormatIds.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/StreamStorable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/StreamStorable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/TypedFormat.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/TypedFormat.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/jmx/ManagementService.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/jmx/ManagementService.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/ClassFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/ClassFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/ClassFactoryContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/ClassFactoryContext.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/ClassInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/ClassInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.services.loader;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/ClassInspector.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/ClassInspector.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/GeneratedByteCode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/GeneratedByteCode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/GeneratedClass.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/GeneratedClass.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/GeneratedMethod.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/GeneratedMethod.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/InstanceGetter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/InstanceGetter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/JarReader.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/loader/JarReader.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/C_LockFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/C_LockFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/CompatibilitySpace.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/CompatibilitySpace.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/Latch.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/Latch.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/Limit.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/Limit.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/LockFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/LockFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/LockOwner.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/LockOwner.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/Lockable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/Lockable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/ShExLockable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/ShExLockable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/ShExQual.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/ShExQual.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/VirtualLockTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/locks/VirtualLockTable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/memory/LowMemory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/memory/LowMemory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/metadata/MetadataFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/metadata/MetadataFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.services.metadata;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/metadata/MetadataFactoryService.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/metadata/MetadataFactoryService.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.services.metadata;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/metadata/NoOpMetadataFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/metadata/NoOpMetadataFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.services.metadata;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/monitor/ModuleControl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/monitor/ModuleControl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/monitor/ModuleFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/monitor/ModuleFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/monitor/ModuleSupportable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/monitor/ModuleSupportable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/monitor/Monitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/monitor/Monitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/monitor/PersistentService.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/monitor/PersistentService.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/property/PersistentSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/property/PersistentSet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/property/PropertyFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/property/PropertyFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/property/PropertySetCallback.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/property/PropertySetCallback.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/property/PropertyUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/property/PropertyUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/property/PropertyValidation.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/property/PropertyValidation.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/sanity/SanityManager.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/sanity/SanityManager.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/stream/HeaderPrintWriter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/stream/HeaderPrintWriter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/stream/InfoStreams.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/stream/InfoStreams.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/stream/PrintWriterGetHeader.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/stream/PrintWriterGetHeader.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/timer/TimerFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/timer/TimerFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/uuid/UUIDFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/uuid/UUIDFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/Activation.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/Activation.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/LanguageFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/LanguageFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/LanguageProperties.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/LanguageProperties.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ParameterValueSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ParameterValueSet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/PreparedStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/PreparedStatement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ResultColumnDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ResultColumnDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ResultDescription.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ResultDescription.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ResultSet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/Row.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/Row.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/Statement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/Statement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/StatementType.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/StatementType.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/StatementUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/StatementUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/StorablePreparedStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/StorablePreparedStatement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/ASTVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/ASTVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/AccessPath.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/AccessPath.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/AggregateDefinition.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/AggregateDefinition.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/C_NodeTypes.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/C_NodeTypes.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CodeGeneration.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CodeGeneration.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilationPhase.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilationPhase.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CostEstimate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CostEstimate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/ExpressionClassBuilderInterface.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/ExpressionClassBuilderInterface.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/JoinCostEstimate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/JoinCostEstimate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/JoinStrategy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/JoinStrategy.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Node.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Node.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/NodeFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/NodeFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizableList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizableList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizablePredicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizablePredicate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizablePredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizablePredicateList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizer.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizer.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizerFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizerFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizerFlag.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizerFlag.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizerTrace.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizerTrace.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Parser.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Parser.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/RequiredRowOrdering.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/RequiredRowOrdering.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/RowOrdering.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/RowOrdering.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/TypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/TypeCompiler.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/TypeCompilerFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/TypeCompilerFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Visitable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Visitable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Visitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Visitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/Authorizer.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/Authorizer.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/ConnectionUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/ConnectionUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/ControlExecutionLimiter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/ControlExecutionLimiter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/ControlExecutionLimiterImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/ControlExecutionLimiterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/ResubmitDistributedException.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/ResubmitDistributedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/SQLSessionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/SQLSessionContext.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/SessionProperties.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/SessionProperties.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.sql.conn;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/StatementContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/StatementContext.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/depend/Dependency.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/depend/Dependency.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/depend/DependencyManager.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/depend/DependencyManager.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/depend/Dependent.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/depend/Dependent.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/depend/Provider.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/depend/Provider.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/depend/ProviderInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/depend/ProviderInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/depend/ProviderList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/depend/ProviderList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/AliasDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/AliasDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/BackupDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/BackupDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/BackupFileSetDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/BackupFileSetDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/BackupItemsDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/BackupItemsDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/BackupJobsDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/BackupJobsDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/CatalogRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/CatalogRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/CheckConstraintDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/CheckConstraintDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ColPermsDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ColPermsDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ColumnDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ColumnDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ColumnDescriptorList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ColumnDescriptorList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ColumnStatisticsDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ColumnStatisticsDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ConglomerateDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ConglomerateDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ConglomerateDescriptorList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ConglomerateDescriptorList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ConsInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ConsInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ConstraintDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ConstraintDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ConstraintDescriptorList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ConstraintDescriptorList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DDUtils.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DDUtils.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDescriptorGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDescriptorGenerator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DefaultDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DefaultDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DependencyDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DependencyDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/FileInfoDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/FileInfoDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ForeignKeyConstraintDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ForeignKeyConstraintDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/GenericDescriptorList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/GenericDescriptorList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/IndexLister.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/IndexLister.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/IndexRowGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/IndexRowGenerator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/KeyConstraintDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/KeyConstraintDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/PartitionStatisticsDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/PartitionStatisticsDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/PasswordHasher.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/PasswordHasher.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.sql.dictionary;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/PermDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/PermDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/PermissionsDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/PermissionsDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/PhysicalStatsDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/PhysicalStatsDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/PrivilegedSQLObject.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/PrivilegedSQLObject.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ReferencedKeyConstraintDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ReferencedKeyConstraintDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/RoleClosureIterator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/RoleClosureIterator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.sql.dictionary;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/RoleGrantDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/RoleGrantDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/RoutinePermsDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/RoutinePermsDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SPSDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SPSDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SchemaDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SchemaDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SchemaPermsDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SchemaPermsDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SequenceDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SequenceDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SnapshotDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SnapshotDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SourceCodeDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SourceCodeDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementColumnPermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementColumnPermission.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementGenericPermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementGenericPermission.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementPermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementPermission.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementRolePermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementRolePermission.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementRoutinePermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementRoutinePermission.java
@@ -26,7 +26,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementSchemaPermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementSchemaPermission.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementTablePermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementTablePermission.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SubCheckConstraintDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SubCheckConstraintDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SubConstraintDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SubConstraintDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SubKeyConstraintDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SubKeyConstraintDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SystemColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SystemColumn.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TablePermsDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TablePermsDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableStatisticsDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableStatisticsDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TokenDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TokenDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TriggerDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TriggerDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TupleDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TupleDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/UniqueSQLObjectDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/UniqueSQLObjectDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/UniqueTupleDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/UniqueTupleDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/UserDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/UserDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ViewDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ViewDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ConstantAction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ConstantAction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/CursorActivation.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/CursorActivation.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/CursorResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/CursorResultSet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecAggregator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecCursorTableReference.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecCursorTableReference.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecIndexRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecIndexRow.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecPreparedStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecPreparedStatement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecRow.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecutionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecutionContext.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecutionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecutionFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecutionStmtValidator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ExecutionStmtValidator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/Expirable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/Expirable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/HasIncrement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/HasIncrement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.sql.execute;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/KeyableRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/KeyableRow.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/NoPutResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/NoPutResultSet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/RowChanger.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/RowChanger.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ScanQualifier.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ScanQualifier.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/TargetResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/TargetResultSet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/TemporaryRowHolder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/TemporaryRowHolder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/TupleFilter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/TupleFilter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/WindowFunction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/WindowFunction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/ColumnStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/ColumnStatisticsImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.stats;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/ColumnStatisticsMerge.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/ColumnStatisticsMerge.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.stats;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/DVDArrayOfItemsSerDe.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/DVDArrayOfItemsSerDe.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.stats;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/EffectivePartitionStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/EffectivePartitionStatisticsImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/FakePartitionStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/FakePartitionStatisticsImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/ItemStatistics.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/ItemStatistics.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.stats;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/NonUniqueKeyStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/NonUniqueKeyStatisticsImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/PartitionStatistics.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/PartitionStatistics.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.stats;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/PartitionStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/PartitionStatisticsImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.stats;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/PrimaryKeyStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/PrimaryKeyStatisticsImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/StatsBoundaryDataValueDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/StatsBoundaryDataValueDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.stats;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/StatsExcludeStartDVD.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/StatsExcludeStartDVD.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.stats;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/StatsIncludeEndDVD.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/StatsIncludeEndDVD.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.stats;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/TableStatistics.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/TableStatistics.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/TableStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/TableStatisticsImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.stats;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/UniqueKeyStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/UniqueKeyStatisticsImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/AccessFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/AccessFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/AccessFactoryGlobals.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/AccessFactoryGlobals.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/AggregateCostController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/AggregateCostController.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/ColumnOrdering.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/ColumnOrdering.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/ConglomPropertyQueryable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/ConglomPropertyQueryable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/ConglomerateController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/ConglomerateController.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/DynamicCompiledOpenConglomInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/DynamicCompiledOpenConglomInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/FileResource.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/FileResource.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/GenericScanController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/GenericScanController.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/GlobalXact.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/GlobalXact.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/GroupFetchScanController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/GroupFetchScanController.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/Qualifier.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/Qualifier.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/RowCountable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/RowCountable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/RowLocationRetRowSource.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/RowLocationRetRowSource.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/RowSource.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/RowSource.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/RowUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/RowUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/ScanController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/ScanController.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/SortCostController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/SortCostController.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/StaticCompiledOpenConglomInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/StaticCompiledOpenConglomInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/StoreCostController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/StoreCostController.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/StoreCostResult.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/StoreCostResult.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/TransactionController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/TransactionController.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/TransactionInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/TransactionInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/XATransactionController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/XATransactionController.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/conglomerate/Conglomerate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/conglomerate/Conglomerate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/conglomerate/ConglomerateFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/conglomerate/ConglomerateFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/conglomerate/MethodFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/conglomerate/MethodFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/conglomerate/ScanManager.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/conglomerate/ScanManager.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/conglomerate/SortFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/conglomerate/SortFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/conglomerate/TransactionManager.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/conglomerate/TransactionManager.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/xa/XAResourceManager.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/xa/XAResourceManager.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/xa/XAXactId.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/xa/XAXactId.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/raw/GlobalTransactionId.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/raw/GlobalTransactionId.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/raw/RawStoreFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/raw/RawStoreFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/raw/Transaction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/raw/Transaction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/raw/data/DataFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/raw/data/DataFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/ArrayDataValue.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/ArrayDataValue.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2016 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/BinaryDecimal.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/BinaryDecimal.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/BitDataValue.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/BitDataValue.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/BooleanDataValue.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/BooleanDataValue.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/CharStreamHeaderGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/CharStreamHeaderGenerator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/ClobStreamHeaderGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/ClobStreamHeaderGenerator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollationElementsInterface.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollationElementsInterface.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLChar.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLChar.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLClob.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLClob.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLLongvarchar.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLLongvarchar.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLVarchar.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLVarchar.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/ConcatableDataValue.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/ConcatableDataValue.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DTSClassInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DTSClassInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataType.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataType.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataTypeDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataTypeDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataTypeUtilities.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataTypeUtilities.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueFactoryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueFactoryImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DateTimeDataValue.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DateTimeDataValue.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DateTimeParser.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DateTimeParser.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DoubleParser.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DoubleParser.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/HBaseRowLocation.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/HBaseRowLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/HarmonySerialBlob.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/HarmonySerialBlob.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/HarmonySerialClob.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/HarmonySerialClob.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/J2SEDataValueFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/J2SEDataValueFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/JSQLType.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/JSQLType.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/Like.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/Like.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/ListDataType.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/ListDataType.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/NullValueData.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/NullValueData.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/NumberDataType.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/NumberDataType.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/NumberDataValue.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/NumberDataValue.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/Orderable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/Orderable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/PositionedStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/PositionedStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/RawToBinaryFormatStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/RawToBinaryFormatStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/ReaderToUTF8Stream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/ReaderToUTF8Stream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/RefDataValue.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/RefDataValue.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/Resetable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/Resetable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/RowLocation.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/RowLocation.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLArray.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLArray.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2016 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLBinary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLBinary.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLBit.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLBit.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLBlob.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLBlob.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLBoolean.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLBoolean.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLChar.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLChar.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLClob.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLClob.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLDate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLDate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLDecimal.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLDecimal.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLDouble.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLDouble.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLInteger.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLInteger.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLLongVarbit.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLLongVarbit.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLLongint.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLLongint.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLLongvarchar.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLLongvarchar.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLReal.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLReal.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLRef.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLRef.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLRowId.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLRowId.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLSmallint.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLSmallint.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTime.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTime.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTimestamp.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTimestamp.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTinyint.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTinyint.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLVarbit.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLVarbit.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLVarchar.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLVarchar.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SqlXmlUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SqlXmlUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/StreamHeaderGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/StreamHeaderGenerator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/StringDataValue.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/StringDataValue.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/TruncateFunctionUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/TruncateFunctionUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/TypeId.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/TypeId.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/UserDataValue.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/UserDataValue.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/UserType.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/UserType.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/VariableSizeDataValue.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/VariableSizeDataValue.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/WorkHorseForCollatorDatatypes.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/WorkHorseForCollatorDatatypes.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/XML.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/XML.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/XMLDataValue.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/XMLDataValue.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/package.html
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/package.html
@@ -25,7 +25,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/util/ByteArray.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/util/ByteArray.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/util/DoubleProperties.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/util/DoubleProperties.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/util/IdUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/util/IdUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/util/InterruptDetectedException.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/util/InterruptDetectedException.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/util/InterruptStatus.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/util/InterruptStatus.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/util/JBitSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/util/JBitSet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/util/Matchable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/util/Matchable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/util/Operator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/util/Operator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/util/PropertyUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/util/PropertyUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/util/ReuseFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/util/ReuseFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/util/StringUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/util/StringUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/util/UTF8Util.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/util/UTF8Util.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.util;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/AbstractSpliceVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/AbstractSpliceVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/AndOrReplacementVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/AndOrReplacementVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/AssignRSNVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/AssignRSNVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/AxisVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/AxisVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/CollectChildrenVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/CollectChildrenVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/CollectingVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/CollectingVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/CollectingVisitorBuilder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/CollectingVisitorBuilder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/ColumnUtils.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/ColumnUtils.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/CorrelatedPushDown.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/CorrelatedPushDown.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/FixSubqueryColRefs.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/FixSubqueryColRefs.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/JoinConditionVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/JoinConditionVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/JoinInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/JoinInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/JsonTreeBuilderVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/JsonTreeBuilderVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/LimitOffsetVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/LimitOffsetVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/PlanPrinter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/PlanPrinter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/PredicateUtils.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/PredicateUtils.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/RSUtils.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/RSUtils.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/RepeatedPredicateVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/RepeatedPredicateVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/RowLocationColumnVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/RowLocationColumnVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/SkippingVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/SkippingVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/SpliceASTWalker.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/SpliceASTWalker.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/SpliceDerbyVisitorAdapter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/SpliceDerbyVisitorAdapter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/StringUtils.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/StringUtils.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/UnsupportedFormsDetector.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/UnsupportedFormsDetector.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/VisitUntilVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/VisitUntilVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/db/BasicDatabase.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/db/BasicDatabase.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/db/DatabaseContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/db/DatabaseContextImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/db/StoreClassFactoryContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/db/StoreClassFactoryContext.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/io/BaseStorageFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/io/BaseStorageFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/io/CPFile.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/io/CPFile.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/io/CPStorageFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/io/CPStorageFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/io/DirFile.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/io/DirFile.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/io/DirFile4.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/io/DirFile4.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/io/DirRandomAccessFile.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/io/DirRandomAccessFile.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/io/DirStorageFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/io/DirStorageFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/io/DirStorageFactory4.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/io/DirStorageFactory4.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/io/InputStreamFile.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/io/InputStreamFile.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/io/JarDBFile.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/io/JarDBFile.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/io/JarStorageFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/io/JarStorageFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/io/URLFile.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/io/URLFile.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/io/URLStorageFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/io/URLStorageFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/AutoPositioningStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/AutoPositioningStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/BinaryToRawStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/BinaryToRawStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/ClobAsciiStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/ClobAsciiStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/ClobUpdatableReader.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/ClobUpdatableReader.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/ClobUtf8Writer.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/ClobUtf8Writer.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/ConnectionChild.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/ConnectionChild.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedBlob.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedBlob.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedCallableStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedCallableStatement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedCallableStatement20.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedCallableStatement20.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedCallableStatement30.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedCallableStatement30.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedCallableStatement40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedCallableStatement40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedClob.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedClob.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection30.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection30.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnectionContext.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedDatabaseMetaData.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedDatabaseMetaData.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedDatabaseMetaData40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedDatabaseMetaData40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedParameterMetaData30.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedParameterMetaData30.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedParameterMetaData40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedParameterMetaData40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedParameterSetMetaData.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedParameterSetMetaData.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedPreparedStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedPreparedStatement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedPreparedStatement20.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedPreparedStatement20.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedPreparedStatement30.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedPreparedStatement30.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedPreparedStatement40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedPreparedStatement40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedResultSet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedResultSet20.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedResultSet20.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedResultSet40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedResultSet40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedResultSetMetaData.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedResultSetMetaData.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedResultSetMetaData40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedResultSetMetaData40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedSQLException.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedSQLException.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedSavepoint30.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedSavepoint30.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedStatement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedStatement40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedStatement40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EncryptedLOBFile.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EncryptedLOBFile.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/InternalClob.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/InternalClob.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/LOBFile.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/LOBFile.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/LOBInputStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/LOBInputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/LOBOutputStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/LOBOutputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/LOBStoredProcedure.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/LOBStoredProcedure.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/LOBStreamControl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/LOBStreamControl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/PositionedStoreStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/PositionedStoreStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/ReaderToAscii.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/ReaderToAscii.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/ResultSetBuilder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/ResultSetBuilder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/SQLExceptionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/SQLExceptionFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/SQLExceptionFactory40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/SQLExceptionFactory40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/StoreStreamClob.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/StoreStreamClob.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/TemporaryClob.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/TemporaryClob.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/TransactionResourceImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/TransactionResourceImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/UTF8Reader.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/UTF8Reader.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/UpdatableBlobStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/UpdatableBlobStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/Util.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/Util.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/AuthenticationServiceBase.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/AuthenticationServiceBase.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/BasicAuthenticationServiceImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/BasicAuthenticationServiceImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/NativeAuthenticationServiceImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/NativeAuthenticationServiceImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/NoneAuthenticationServiceImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/NoneAuthenticationServiceImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/SpecificAuthenticationServiceImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/SpecificAuthenticationServiceImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/load/ColumnInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/load/ColumnInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/load/ControlInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/load/ControlInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/load/Import.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/load/Import.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/load/ImportAbstract.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/load/ImportAbstract.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/load/ImportBlob.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/load/ImportBlob.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/load/ImportClob.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/load/ImportClob.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/load/ImportLobFile.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/load/ImportLobFile.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/load/ImportReadData.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/load/ImportReadData.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/load/ImportResultSetMetaData.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/load/ImportResultSetMetaData.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/load/LoadError.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/load/LoadError.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/BCClass.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/BCClass.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/BCExpr.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/BCExpr.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/BCJava.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/BCJava.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/BCLocalField.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/BCLocalField.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/BCMethod.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/BCMethod.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/BCMethodCaller.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/BCMethodCaller.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/BCMethodDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/BCMethodDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/CodeChunk.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/CodeChunk.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/Conditional.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/Conditional.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/GClass.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/GClass.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/OpcodeDebug.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/OpcodeDebug.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/Type.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/Type.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/VMTypeIdCacheable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/VMTypeIdCacheable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/d_BCValidate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/bytecode/d_BCValidate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/BackgroundCleaner.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/BackgroundCleaner.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/CacheEntry.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/CacheEntry.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/CacheStat.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/CacheStat.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/CachedItem.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/CachedItem.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/Clock.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/Clock.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/ClockFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/ClockFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/ClockPolicy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/ClockPolicy.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/ConcurrentCache.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/ConcurrentCache.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/ConcurrentCacheFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/ConcurrentCacheFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/ReplacementPolicy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/cache/ReplacementPolicy.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/daemon/BasicDaemon.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/daemon/BasicDaemon.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/daemon/ServiceRecord.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/daemon/ServiceRecord.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/daemon/SingleThreadDaemonFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/daemon/SingleThreadDaemonFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/jce/JCECipherFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/jce/JCECipherFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/jce/JCECipherFactoryBuilder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/jce/JCECipherFactoryBuilder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/jce/JCECipherProvider.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/jce/JCECipherProvider.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/jmx/JMXManagementService.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/jmx/JMXManagementService.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/jmxnone/NoManagementService.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/jmxnone/NoManagementService.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/AbstractPool.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/AbstractPool.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/ActiveLock.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/ActiveLock.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/ConcurrentLockSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/ConcurrentLockSet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/ConcurrentPool.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/ConcurrentPool.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/Constants.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/Constants.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/Control.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/Control.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/D_ActiveLock.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/D_ActiveLock.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/D_Lock.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/D_Lock.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/D_LockControl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/D_LockControl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/Deadlock.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/Deadlock.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/Lock.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/Lock.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/LockControl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/LockControl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/LockSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/LockSet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/LockSpace.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/LockSpace.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/LockTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/LockTable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/LockTableVTI.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/LockTableVTI.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/SinglePool.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/SinglePool.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/TableNameInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/TableNameInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/Timeout.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/locks/Timeout.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/BaseMonitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/BaseMonitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/FileMonitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/FileMonitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/ModuleInstance.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/ModuleInstance.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/ProtocolKey.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/ProtocolKey.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/ServiceBootContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/ServiceBootContext.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/StorageFactoryService.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/StorageFactoryService.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/TopService.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/TopService.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/UpdateServiceProperties.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/monitor/UpdateServiceProperties.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/DatabaseClasses.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/DatabaseClasses.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/GCInstanceFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/GCInstanceFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/JarLoader.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/JarLoader.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/LoadedGeneratedClass.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/LoadedGeneratedClass.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/ReflectClassesJava2.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/ReflectClassesJava2.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/ReflectGeneratedClass.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/ReflectGeneratedClass.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/ReflectLoaderJava2.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/ReflectLoaderJava2.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/ReflectMethod.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/ReflectMethod.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/UpdateLoader.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/reflect/UpdateLoader.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/stream/BasicGetLogHeader.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/stream/BasicGetLogHeader.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/stream/BasicHeaderPrintWriter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/stream/BasicHeaderPrintWriter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/stream/SingleStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/stream/SingleStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/timer/SingletonTimerFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/timer/SingletonTimerFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/uuid/BasicUUID.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/uuid/BasicUUID.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/uuid/BasicUUIDFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/uuid/BasicUUIDFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/services/uuid/BasicUUIDGetter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/services/uuid/BasicUUIDGetter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/CursorInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/CursorInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/CursorTableReference.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/CursorTableReference.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericActivationHolder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericActivationHolder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericClassInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericClassInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericColumnDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericColumnDescriptor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericLanguageFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericLanguageFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericParameter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericParameter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericParameterValueSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericParameterValueSet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericPreparedStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericPreparedStatement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericResultDescription.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericResultDescription.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStorablePreparedStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStorablePreparedStatement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/LanguageDbPropertySetter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/LanguageDbPropertySetter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/Aggregate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/Aggregate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/BaseDataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/BaseDataDictionary.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/CoreDDFinderClassInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/CoreDDFinderClassInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DDColumnDependableFinder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DDColumnDependableFinder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DD_Version.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DD_Version.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DDdependableFinder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DDdependableFinder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DefaultSystemAggregateGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DefaultSystemAggregateGenerator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DefaultSystemProcedureGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DefaultSystemProcedureGenerator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DropDependencyFilter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DropDependencyFilter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/GenericManagedCacheIFace.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/GenericManagedCacheIFace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/IndexInfoImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/IndexInfoImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/ManagedCache.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/ManagedCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/ManagedCacheMBean.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/ManagedCacheMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/PermissionsCatalogRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/PermissionsCatalogRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/Procedure.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/Procedure.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/RoleClosureIteratorImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/RoleClosureIteratorImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSALIASESRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSALIASESRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSBACKUPFILESETRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSBACKUPFILESETRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSBACKUPITEMSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSBACKUPITEMSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSBACKUPJOBSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSBACKUPJOBSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSBACKUPRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSBACKUPRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSCHECKSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSCHECKSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSCOLPERMSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSCOLPERMSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSCOLUMNSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSCOLUMNSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSCOLUMNSTATISTICSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSCOLUMNSTATISTICSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSCONGLOMERATESRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSCONGLOMERATESRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSCONSTRAINTSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSCONSTRAINTSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSDEPENDSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSDEPENDSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSDUMMY1RowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSDUMMY1RowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSFILESRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSFILESRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSFOREIGNKEYSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSFOREIGNKEYSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSKEYSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSKEYSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSPERMSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSPERMSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSPHYSICALSTATISTICSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSPHYSICALSTATISTICSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSPRIMARYKEYSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSPRIMARYKEYSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSROLESRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSROLESRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSROUTINEPERMSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSROUTINEPERMSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSSCHEMAPERMSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSSCHEMAPERMSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSSCHEMASRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSSCHEMASRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSSEQUENCESRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSSEQUENCESRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSSNAPSHOTSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSSNAPSHOTSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSSOURCECODERowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSSOURCECODERowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSSTATEMENTSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSSTATEMENTSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTABLEPERMSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTABLEPERMSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTABLESRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTABLESRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTABLESTATISTICSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTABLESTATISTICSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTOKENSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTOKENSRowFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTRIGGERSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTRIGGERSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSUSERSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSUSERSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSVIEWSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSVIEWSRowFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SequenceGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SequenceGenerator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.sql.catalog;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SequenceRange.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SequenceRange.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SequenceUpdater.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SequenceUpdater.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.sql.catalog;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SystemAggregateGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SystemAggregateGenerator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SystemColumnImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SystemColumnImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SystemProcedureGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SystemProcedureGenerator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/TabInfoImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/TabInfoImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/TableKey.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/TableKey.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/TotalManagedCache.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/TotalManagedCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AbstractSelectivityHolder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AbstractSelectivityHolder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AccessPathImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AccessPathImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ActivationClassBuilder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ActivationClassBuilder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AggregateNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AggregateNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AllResultColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AllResultColumn.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AlterTableNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AlterTableNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AndNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AndNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayConstantNode.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2016 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayOperatorNode.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2016 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayTypeCompiler.java
@@ -12,7 +12,7 @@
  *
  * Splice Machine, Inc. has modified this file.
  *
- * All Splice Machine modifications are Copyright 2012 - 2016 Splice Machine, Inc.,
+ * All Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the License; you may not use this file except in
  * compliance with the License.
  *

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseColumnNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseColumnNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseJoinStrategy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseJoinStrategy.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseTableNumbersVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseTableNumbersVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseTypeCompiler.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BasicPrivilegesNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BasicPrivilegesNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BatchOnceNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BatchOnceNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BetweenOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BetweenOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryArithmeticOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryArithmeticOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryComparisonOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryComparisonOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryExportNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryExportNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
@@ -27,7 +27,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryListOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryListOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryLogicalOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryLogicalOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNodeUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNodeUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BitConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BitConstantNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BitTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BitTypeCompiler.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BooleanConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BooleanConstantNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BooleanTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BooleanTypeCompiler.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CLOBTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CLOBTypeCompiler.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/C_NodeNames.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/C_NodeNames.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CallStatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CallStatementNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CastNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CastNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CharConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CharConstantNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CharStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CharStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CharTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CharTypeCompiler.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CheckCorrelatedSubqueryVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CheckCorrelatedSubqueryVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CoalesceFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CoalesceFunctionNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CollectNodesVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CollectNodesVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnDefinitionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnDefinitionNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnMappingUtils.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnMappingUtils.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnOrdering.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnOrdering.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnPullupVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnPullupVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnReference.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnReference.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConcatenationOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConcatenationOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConditionalNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConditionalNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstantExpressionVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstantExpressionVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstantNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstantSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstantSelectivity.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstraintDefinitionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstraintDefinitionNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CostEstimateImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CostEstimateImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CountAggregateDefinition.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CountAggregateDefinition.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CountWhereSubqueryVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CountWhereSubqueryVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateAliasNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateAliasNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateIndexNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateIndexNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreatePinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreatePinNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateRoleNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateRoleNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateSchemaNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateSchemaNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateSequenceNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateSequenceNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateTableNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateTableNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateTriggerNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateTriggerNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateViewNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateViewNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CurrentDatetimeOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CurrentDatetimeOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CurrentOfNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CurrentOfNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CurrentRowLocationNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CurrentRowLocationNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CursorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CursorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DB2LengthOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DB2LengthOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DDLStatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DDLStatementNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLModStatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLModStatementNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLStatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLStatementNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DateTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DateTypeCompiler.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DefaultNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DefaultNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DefaultVTIModDeferPolicy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DefaultVTIModDeferPolicy.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DeleteNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DeleteNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DenseRankFunctionDefinition.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DenseRankFunctionDefinition.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DenseRankFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DenseRankFunctionNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DistinctNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DistinctNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropAliasNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropAliasNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropIndexNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropIndexNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropPinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropPinNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropRoleNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropRoleNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropSchemaNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropSchemaNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropSequenceNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropSequenceNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropTableNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropTableNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropTriggerNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropTriggerNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropViewNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropViewNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExcludedNullIndexColumnVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExcludedNullIndexColumnVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExecSPSNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExecSPSNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExplainNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExplainNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExportNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExportNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExpressionClassBuilder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExpressionClassBuilder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExtractOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExtractOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FKConstraintDefinitionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FKConstraintDefinitionNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FindNonConstantsVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FindNonConstantsVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FirstLastValueFunctionDefinition.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FirstLastValueFunctionDefinition.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FirstLastValueFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FirstLastValueFunctionNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromSubquery.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromSubquery.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GenerationClauseNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GenerationClauseNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GetCurrentConnectionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GetCurrentConnectionNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GrantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GrantNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GrantRoleNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GrantRoleNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GroupByColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GroupByColumn.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GroupByList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GroupByList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GroupByNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GroupByNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HalfOuterJoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HalfOuterJoinNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HasCorrelatedCRsVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HasCorrelatedCRsVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HasNodeVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HasNodeVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HasTableFunctionVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HasTableFunctionVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HasVariantValueNodeVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HasVariantValueNodeVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashTableNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashTableNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListSelectivity.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IndexToBaseRowNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IndexToBaseRowNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InsertNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InsertNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IntersectOrExceptNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IntersectOrExceptNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IsNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IsNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IsNullNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IsNullNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JavaToSQLValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JavaToSQLValueNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JavaValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JavaValueNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LOBTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LOBTypeCompiler.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LeadLagFunctionDefinition.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LeadLagFunctionDefinition.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LeadLagFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LeadLagFunctionNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LengthOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LengthOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Level2CostEstimateImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Level2CostEstimateImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Level2OptimizerFactoryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Level2OptimizerFactoryImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Level2OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Level2OptimizerImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Level2OptimizerTrace.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Level2OptimizerTrace.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LikeEscapeOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LikeEscapeOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ListValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ListValueNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LockTableNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LockTableNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MaterializeResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MaterializeResultSetNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MaterializeSubqueryNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MaterializeSubqueryNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MaxMinAggregateDefinition.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MaxMinAggregateDefinition.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MethodCallNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MethodCallNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MiscellaneousStatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MiscellaneousStatementNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ModifyColumnNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ModifyColumnNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NOPStatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NOPStatementNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NewInvocationNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NewInvocationNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NextSequenceNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NextSequenceNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.sql.compile;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NoOpOptimizerTrace.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NoOpOptimizerTrace.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NonLocalColumnReferenceVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NonLocalColumnReferenceVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NonStaticMethodCallNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NonStaticMethodCallNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NormalizeResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NormalizeResultSetNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NotEqualsSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NotEqualsSelectivity.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NotNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NotNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NotNullSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NotNullSelectivity.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NullSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NullSelectivity.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NumericConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NumericConstantNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NumericTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NumericTypeCompiler.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerFactoryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerFactoryImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderByColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderByColumn.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderByList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderByList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderByNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderByNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderedColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderedColumn.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderedColumnList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderedColumnList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OverClause.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OverClause.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParameterNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParameterNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParseException.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParseException.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParserImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParserImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Partition.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Partition.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateSelectivity.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PrivilegeNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PrivilegeNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectionPruningVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectionPruningVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QualifierPhase.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QualifierPhase.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QueryTreeNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QueryTreeNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QueryTreeNodeVector.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QueryTreeNodeVector.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RangePredicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RangePredicate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RangeSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RangeSelectivity.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RankFunctionDefinition.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RankFunctionDefinition.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RankFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RankFunctionNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RefTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RefTypeCompiler.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ReferencedTablesVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ReferencedTablesVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RelationalOperator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RelationalOperator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RemapCRsVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RemapCRsVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RenameNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RenameNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ReplaceAggregatesWithCRVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ReplaceAggregatesWithCRVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumnList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumnList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultSetNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RevokeNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RevokeNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RevokeRoleNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RevokeRoleNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RoutineDesignator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RoutineDesignator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowCountNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowCountNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowNumberFunctionDefinition.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowNumberFunctionDefinition.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowNumberFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowNumberFunctionNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowOrderingImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowOrderingImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowResultSetNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLBooleanConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLBooleanConstantNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLToJavaValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLToJavaValueNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SavepointNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SavepointNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ScanCostFunction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ScanCostFunction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ScrollInsensitiveResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ScrollInsensitiveResultSetNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityHolder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityHolder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetRoleNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetRoleNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetSchemaNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetSchemaNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetSessionPropertyNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetSessionPropertyNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.sql.compile;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetTransactionIsolationNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetTransactionIsolationNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SimpleStringOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SimpleStringOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SingleChildResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SingleChildResultSetNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SpecialFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SpecialFunctionNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StatementNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StaticClassFieldReferenceNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StaticClassFieldReferenceNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StaticMethodCallNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StaticMethodCallNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubstituteExpressionVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubstituteExpressionVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.sql.compile;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SumAvgAggregateDefinition.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SumAvgAggregateDefinition.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableElementList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableElementList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableElementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableElementNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableName.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableName.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TestConstraintNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TestConstraintNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TimeTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TimeTypeCompiler.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TimestampOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TimestampOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TimestampTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TimestampTypeCompiler.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Token.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Token.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TransactionStatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TransactionStatementNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TreePruningVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TreePruningVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TreeStitchingVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TreeStitchingVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TriggerReferencingStruct.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TriggerReferencingStruct.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TruncateOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TruncateOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TypeCompilerFactoryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TypeCompilerFactoryImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UCode_CharStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UCode_CharStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryArithmeticOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryArithmeticOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryComparisonOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryComparisonOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryDateTimestampOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryDateTimestampOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryLogicalOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryLogicalOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryOperatorNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnionNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UntypedNullConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UntypedNullConstantNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UpdateNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UpdateNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UserAggregateDefinition.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UserAggregateDefinition.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UserDefinedTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UserDefinedTypeCompiler.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UserTypeConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UserTypeConstantNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/VTIDeferModPolicy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/VTIDeferModPolicy.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNodeList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNodeList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/VarbitConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/VarbitConstantNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/VerifyAggregateExpressionsVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/VerifyAggregateExpressionsVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/VirtualColumnNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/VirtualColumnNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WinSubstituteExpressionVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WinSubstituteExpressionVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowDefinitionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowDefinitionNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowFrameDefinition.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowFrameDefinition.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowFunctionNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowFunctionReplacementVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowFunctionReplacementVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowReferenceNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowReferenceNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowResultSetNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WrappedAggregateFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WrappedAggregateFunctionNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/XMLConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/XMLConstantNode.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/XMLTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/XMLTypeCompiler.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/CorrelatedBronPredicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/CorrelatedBronPredicate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/CorrelatedEqualityBronPredicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/CorrelatedEqualityBronPredicate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/CorrelationLevelPredicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/CorrelationLevelPredicate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/FlatteningUtils.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/FlatteningUtils.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/FromSubqueryColRefFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/FromSubqueryColRefFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/GroupByUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/GroupByUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/SubqueryComparator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/SubqueryComparator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/SubqueryFlattening.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/SubqueryFlattening.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/SubqueryNodeFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/SubqueryNodeFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/SubqueryReplacement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/SubqueryReplacement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/aggregate/AggregateSubqueryFlatteningVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/aggregate/AggregateSubqueryFlatteningVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/aggregate/AggregateSubqueryPredicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/aggregate/AggregateSubqueryPredicate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/aggregate/AggregateSubqueryWhereVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/aggregate/AggregateSubqueryWhereVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/exists/ExistsSubqueryFlatteningVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/exists/ExistsSubqueryFlatteningVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/exists/ExistsSubqueryPredicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/exists/ExistsSubqueryPredicate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/exists/ExistsSubqueryWhereVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/exists/ExistsSubqueryWhereVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/exists/package-info.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/exists/package-info.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/package-info.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/package-info.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/ssq/ReplaceSubqueryWithColRefVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/ssq/ReplaceSubqueryWithColRefVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.sql.compile.subquery.ssq;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/ssq/ScalarSubqueryCorrelatedPredicateVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/ssq/ScalarSubqueryCorrelatedPredicateVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.sql.compile.subquery.ssq;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/ssq/ScalarSubqueryFlatteningVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/ssq/ScalarSubqueryFlatteningVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.sql.compile.subquery.ssq;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/ssq/ScalarSubqueryPredicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/ssq/ScalarSubqueryPredicate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.sql.compile.subquery.ssq;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/ssq/ScalarSubqueryWhereVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/ssq/ScalarSubqueryWhereVisitor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.sql.compile.subquery.ssq;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/CachedStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/CachedStatement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericAuthorizer.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericAuthorizer.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericStatementContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericStatementContext.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/SQLSessionContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/SQLSessionContextImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/SessionPropertiesImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/SessionPropertiesImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.sql.conn;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/TempTableInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/TempTableInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicDependency.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicDependency.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicDependencyManager.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicDependencyManager.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicProviderInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicProviderInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/DepClassInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/DepClassInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/AggregatorInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/AggregatorInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/AggregatorInfoList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/AggregatorInfoList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/AutoincrementCounter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/AutoincrementCounter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/AvgAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/AvgAggregator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BaseActivation.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BaseActivation.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BaseExpressionActivation.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BaseExpressionActivation.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BasicNoPutResultSetImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BasicNoPutResultSetImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BasicPrivilegeInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BasicPrivilegeInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ColumnInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ColumnInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ConstantActionActivation.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ConstantActionActivation.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ConstraintConstantAction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ConstraintConstantAction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ConstraintInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ConstraintInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CountAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CountAggregator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CreateConstraintConstantAction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CreateConstraintConstantAction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CreateIndexConstantAction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CreateIndexConstantAction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CreateSchemaConstantAction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CreateSchemaConstantAction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CurrentDatetime.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CurrentDatetime.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CursorActivation.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CursorActivation.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DDLConstantAction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DDLConstantAction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DDLSingleTableConstantAction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DDLSingleTableConstantAction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DecimalBufferedSumAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DecimalBufferedSumAggregator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DenseRankFunction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DenseRankFunction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DoubleBufferedSumAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DoubleBufferedSumAggregator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/FKInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/FKInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/FirstLastValueFunction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/FirstLastValueFunction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/FloatBufferedSumAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/FloatBufferedSumAggregator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericAggregator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericConstantActionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericConstantActionFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericExecutionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericExecutionContext.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericExecutionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericExecutionFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericPrivilegeInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericPrivilegeInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericQualifier.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericQualifier.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericScanQualifier.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericScanQualifier.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericTriggerExecutor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericTriggerExecutor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexChanger.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexChanger.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexColumnOrder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexColumnOrder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexConstantAction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexConstantAction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexRow.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexSetChanger.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexSetChanger.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexValueRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexValueRow.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IteratorNoPutResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IteratorNoPutResultSet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/JarUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/JarUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/LeadLagFunction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/LeadLagFunction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/LongBufferedSumAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/LongBufferedSumAggregator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/MaxMinAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/MaxMinAggregator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/NoPutResultSetImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/NoPutResultSetImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/OnceResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/OnceResultSet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/OrderableAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/OrderableAggregator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/PrivilegeInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/PrivilegeInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/RIBulkChecker.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/RIBulkChecker.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/RankFunction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/RankFunction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/RoutinePrivilegeInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/RoutinePrivilegeInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/RowChangerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/RowChangerImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/RowNumberFunction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/RowNumberFunction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/RowTriggerExecutor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/RowTriggerExecutor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/RowUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/RowUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/SchemaPrivilegeInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/SchemaPrivilegeInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/StatementTriggerExecutor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/StatementTriggerExecutor.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/StatisticsRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/StatisticsRow.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/SumAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/SumAggregator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/SystemAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/SystemAggregator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TablePrivilegeInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TablePrivilegeInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TemporaryRowHolderImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TemporaryRowHolderImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TemporaryRowHolderResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TemporaryRowHolderResultSet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerEvent.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerEvent.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerEventActivator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerEventActivator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerEventDML.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerEventDML.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerEventWhen.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerEventWhen.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerExecutionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerExecutionContext.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerExecutionStack.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerExecutionStack.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/UpdatableVTIConstantAction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/UpdatableVTIConstantAction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/UserDefinedAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/UserDefinedAggregator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/WindowFunctionBase.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/WindowFunctionBase.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/WindowFunctionInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/WindowFunctionInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/WindowFunctionInfoList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/WindowFunctionInfoList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/WriteCursorConstantAction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/WriteCursorConstantAction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/misc/CharStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/misc/CharStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/misc/CommentStripper.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/misc/CommentStripper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/misc/CommentStripperImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/misc/CommentStripperImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/misc/UCode_CharStream.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/misc/UCode_CharStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/store/access/CacheableConglomerate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/store/access/CacheableConglomerate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/store/access/PC_XenaVersion.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/store/access/PC_XenaVersion.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/store/access/UTF.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/store/access/UTF.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/store/access/conglomerate/ConglomerateUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/store/access/conglomerate/ConglomerateUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/store/access/conglomerate/GenericConglomerate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/store/access/conglomerate/GenericConglomerate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/io/StorageFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/io/StorageFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/io/StorageFile.java
+++ b/db-engine/src/main/java/com/splicemachine/db/io/StorageFile.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/io/StorageRandomAccessFile.java
+++ b/db-engine/src/main/java/com/splicemachine/db/io/StorageRandomAccessFile.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/io/WritableStorageFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/io/WritableStorageFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/AutoloadedDriver.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/AutoloadedDriver.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/AutoloadedDriver40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/AutoloadedDriver40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/Driver20.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/Driver20.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/Driver30.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/Driver30.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/Driver40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/Driver40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbedPooledConnection.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbedPooledConnection.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbedPooledConnection40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbedPooledConnection40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbedXAConnection.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbedXAConnection.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbedXAConnection40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbedXAConnection40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbedXAResource.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbedXAResource.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbeddedConnectionPoolDataSource.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbeddedConnectionPoolDataSource.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbeddedConnectionPoolDataSource40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbeddedConnectionPoolDataSource40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbeddedDataSource.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbeddedDataSource.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbeddedDataSource40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbeddedDataSource40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbeddedDriver.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbeddedDriver.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbeddedXADataSource.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbeddedXADataSource.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbeddedXADataSource40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/EmbeddedXADataSource40.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/InternalDriver.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/InternalDriver.java
@@ -26,7 +26,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/JDBC.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/JDBC.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/ReferenceableDataSource.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/ReferenceableDataSource.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.jdbc;

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/ResourceAdapterImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/ResourceAdapterImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/XAStatementControl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/XAStatementControl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/XATransactionState.java
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/XATransactionState.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/jdbc/package.html
+++ b/db-engine/src/main/java/com/splicemachine/db/jdbc/package.html
@@ -25,7 +25,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <body>

--- a/db-engine/src/main/java/com/splicemachine/db/mbeans/JDBCMBean.java
+++ b/db-engine/src/main/java/com/splicemachine/db/mbeans/JDBCMBean.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/mbeans/Management.java
+++ b/db-engine/src/main/java/com/splicemachine/db/mbeans/Management.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/mbeans/ManagementMBean.java
+++ b/db-engine/src/main/java/com/splicemachine/db/mbeans/ManagementMBean.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/mbeans/VersionMBean.java
+++ b/db-engine/src/main/java/com/splicemachine/db/mbeans/VersionMBean.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/mbeans/package.html
+++ b/db-engine/src/main/java/com/splicemachine/db/mbeans/package.html
@@ -25,7 +25,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <body>

--- a/db-engine/src/main/java/com/splicemachine/db/security/DatabasePermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/security/DatabasePermission.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/security/SystemPermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/security/SystemPermission.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/vti/DeferModification.java
+++ b/db-engine/src/main/java/com/splicemachine/db/vti/DeferModification.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/vti/IFastPath.java
+++ b/db-engine/src/main/java/com/splicemachine/db/vti/IFastPath.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/vti/IQualifyable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/vti/IQualifyable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/vti/Pushable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/vti/Pushable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/vti/RestrictedVTI.java
+++ b/db-engine/src/main/java/com/splicemachine/db/vti/RestrictedVTI.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.vti;

--- a/db-engine/src/main/java/com/splicemachine/db/vti/Restriction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/vti/Restriction.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.vti;

--- a/db-engine/src/main/java/com/splicemachine/db/vti/StringColumnVTI.java
+++ b/db-engine/src/main/java/com/splicemachine/db/vti/StringColumnVTI.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/vti/UpdatableVTITemplate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/vti/UpdatableVTITemplate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/vti/VTICosting.java
+++ b/db-engine/src/main/java/com/splicemachine/db/vti/VTICosting.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/vti/VTIEnvironment.java
+++ b/db-engine/src/main/java/com/splicemachine/db/vti/VTIEnvironment.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/vti/VTIMetaDataTemplate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/vti/VTIMetaDataTemplate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/vti/VTITemplate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/vti/VTITemplate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/vti/VTITemplateBase.java
+++ b/db-engine/src/main/java/com/splicemachine/db/vti/VTITemplateBase.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/main/java/com/splicemachine/db/vti/package.html
+++ b/db-engine/src/main/java/com/splicemachine/db/vti/package.html
@@ -25,7 +25,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <BODY>

--- a/db-engine/src/main/java/com/splicemachine/utils/ByteSlice.java
+++ b/db-engine/src/main/java/com/splicemachine/utils/ByteSlice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/java/com/splicemachine/utils/CachedByteSlice.java
+++ b/db-engine/src/main/java/com/splicemachine/utils/CachedByteSlice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/resources/META-INF/services/com.splicemachine.db.iapi.services.authorization.AuthorizationFactory
+++ b/db-engine/src/main/resources/META-INF/services/com.splicemachine.db.iapi.services.authorization.AuthorizationFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2018 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/resources/META-INF/services/com.splicemachine.db.iapi.services.metadata.MetadataFactory
+++ b/db-engine/src/main/resources/META-INF/services/com.splicemachine.db.iapi.services.metadata.MetadataFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2018 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/db-engine/src/main/resources/com/splicemachine/db/impl/sql/catalog/metadata_net.properties
+++ b/db-engine/src/main/resources/com/splicemachine/db/impl/sql/catalog/metadata_net.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-engine/src/test/java/com/splicemachine/db/DerbyVersionTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/DerbyVersionTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/jdbc/CharacterStreamDescriptorTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/jdbc/CharacterStreamDescriptorTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.jdbc;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/services/io/ArrayInputStreamTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/services/io/ArrayInputStreamTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/services/io/CompressedNumberTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/services/io/CompressedNumberTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/services/io/DataInputUtilTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/services/io/DataInputUtilTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.services.io;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/services/io/FormatableBitSetTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/services/io/FormatableBitSetTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/services/io/InputStreamUtilTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/services/io/InputStreamUtilTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.services.io;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/stats/AbstractKeyStatisticsImplTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/stats/AbstractKeyStatisticsImplTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.stats;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/stats/NonUniqueKeyStatisticsImplTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/stats/NonUniqueKeyStatisticsImplTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.stats;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/stats/PartitionStatisticsImplTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/stats/PartitionStatisticsImplTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.stats;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/stats/PrimaryKeyStatisticsImplTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/stats/PrimaryKeyStatisticsImplTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.stats;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/stats/TableStatisticsImplTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/stats/TableStatisticsImplTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.stats;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/stats/UniqueKeyStatisticsImplTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/stats/UniqueKeyStatisticsImplTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.stats;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/ReaderToUTF8StreamTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/ReaderToUTF8StreamTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLArrayTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 - 2016 Splice Machine, Inc.
+ * Copyright 2012 - 2019 Splice Machine, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy of the

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLBlobTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLBlobTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLBooleanTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLBooleanTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLCharTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLCharTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLDataValueDescriptorTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLDataValueDescriptorTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLDateTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLDateTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLDecimalTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLDecimalTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLDoubleTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLDoubleTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLIntegerTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLIntegerTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLLongIntTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLLongIntTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLRealTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLRealTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLRefTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLRefTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLSmallIntTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLSmallIntTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLTimeTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLTimeTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLTimestampTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLTimestampTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLTinyIntTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLTinyIntTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLVarcharTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/types/SQLVarcharTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.types;

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/util/UTF8UtilTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/util/UTF8UtilTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.util;

--- a/db-engine/src/test/java/com/splicemachine/db/security/SystemPrivilegesPermissionTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/security/SystemPrivilegesPermissionTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/pom.xml
+++ b/db-shared/pom.xml
@@ -26,7 +26,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Attribute.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Attribute.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/ClassName.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/ClassName.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/ContextId.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/ContextId.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/DRDAConstants.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/DRDAConstants.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 /**

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/EngineType.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/EngineType.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/JDBC30Translation.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/JDBC30Translation.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/JDBC40Translation.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/JDBC40Translation.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Limits.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Limits.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/MessageId.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/MessageId.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Module.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Module.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/SQLState.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/services/info/ProductGenusNames.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/services/info/ProductGenusNames.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/services/info/ProductVersionHolder.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/services/info/ProductVersionHolder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/services/info/PropertyNames.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/services/info/PropertyNames.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/error/ExceptionSeverity.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/error/ExceptionSeverity.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/error/ExceptionUtil.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/error/ExceptionUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.shared.common.error;

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/i18n/MessageUtil.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/i18n/MessageUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.shared.common.i18n;

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/Attribute.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/Attribute.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/JDBC30Translation.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/JDBC30Translation.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/JDBC40Translation.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/JDBC40Translation.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/MessageId.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/MessageId.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/package.html
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/package.html
@@ -25,7 +25,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <body>

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/sanity/SanityManager.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/sanity/SanityManager.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/udt/UDTBase.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/udt/UDTBase.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-shared/src/main/java/com/splicemachine/db/shared/package.html
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/package.html
@@ -25,7 +25,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">

--- a/db-shared/src/main/resources/com/splicemachine/db/info/DBMS.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/DBMS.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-shared/src/main/resources/com/splicemachine/db/info/dnc.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/dnc.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-shared/src/main/resources/com/splicemachine/db/info/locale_cs.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/locale_cs.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-shared/src/main/resources/com/splicemachine/db/info/locale_de_DE.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/locale_de_DE.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-shared/src/main/resources/com/splicemachine/db/info/locale_es.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/locale_es.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-shared/src/main/resources/com/splicemachine/db/info/locale_fr.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/locale_fr.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-shared/src/main/resources/com/splicemachine/db/info/locale_hu.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/locale_hu.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-shared/src/main/resources/com/splicemachine/db/info/locale_it.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/locale_it.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-shared/src/main/resources/com/splicemachine/db/info/locale_ja_JP.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/locale_ja_JP.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-shared/src/main/resources/com/splicemachine/db/info/locale_ko_KR.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/locale_ko_KR.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-shared/src/main/resources/com/splicemachine/db/info/locale_pl.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/locale_pl.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-shared/src/main/resources/com/splicemachine/db/info/locale_pt_BR.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/locale_pt_BR.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-shared/src/main/resources/com/splicemachine/db/info/locale_ru.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/locale_ru.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-shared/src/main/resources/com/splicemachine/db/info/locale_zh_CN.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/locale_zh_CN.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-shared/src/main/resources/com/splicemachine/db/info/locale_zh_TW.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/locale_zh_TW.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-shared/src/main/resources/com/splicemachine/db/info/net.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/net.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-shared/src/main/resources/com/splicemachine/db/info/tools.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/tools.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/pom.xml
+++ b/db-testing/pom.xml
@@ -26,7 +26,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/db-testing/src/test/java/com/splicemachine/db/impl/jdbc/BiggerStoreStreamClobTest.java
+++ b/db-testing/src/test/java/com/splicemachine/db/impl/jdbc/BiggerStoreStreamClobTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-testing/src/test/java/com/splicemachine/db/impl/jdbc/BiggerTemporaryClobTest.java
+++ b/db-testing/src/test/java/com/splicemachine/db/impl/jdbc/BiggerTemporaryClobTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-testing/src/test/java/com/splicemachine/db/impl/jdbc/InternalClobTest.java
+++ b/db-testing/src/test/java/com/splicemachine/db/impl/jdbc/InternalClobTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-testing/src/test/java/com/splicemachine/db/impl/jdbc/SmallStoreStreamClobTest.java
+++ b/db-testing/src/test/java/com/splicemachine/db/impl/jdbc/SmallStoreStreamClobTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-testing/src/test/java/com/splicemachine/db/impl/jdbc/SmallTemporaryClobTest.java
+++ b/db-testing/src/test/java/com/splicemachine/db/impl/jdbc/SmallTemporaryClobTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-testing/src/test/java/com/splicemachine/db/impl/jdbc/UTF8ReaderTest.java
+++ b/db-testing/src/test/java/com/splicemachine/db/impl/jdbc/UTF8ReaderTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.jdbc;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/multi/stress/copyfiles.ant
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/multi/stress/copyfiles.ant
@@ -48,7 +48,7 @@ stress_sed.properties
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/multi/stress/init.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/multi/stress/init.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/multi/stress/init_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/multi/stress/init_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/multi/stress/run.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/multi/stress/run.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/multi/stress/run_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/multi/stress/run_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/multi/stress/stress50x59_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/multi/stress/stress50x59_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/multi/stress/stress_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/multi/stress/stress_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/multi/stress/stress_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/multi/stress/stress_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/EncryptionSuite.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/EncryptionSuite.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.suites;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/XMLSuite.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/XMLSuite.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.suites;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/derbyall.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/derbyall.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/derbynetautostart.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/derbynetautostart.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/derbynetclientmats.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/derbynetclientmats.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/encodingTests.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/encodingTests.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/encryption.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/encryption.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/encryptionAll.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/encryptionAll.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/encryptionBlowfish.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/encryptionBlowfish.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/encryptionCFB.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/encryptionCFB.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/encryptionDES.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/encryptionDES.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/encryptionECB.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/encryptionECB.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/encryptionOFB.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/encryptionOFB.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 runwithj9dee15=false

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/j9derbynetclientmats.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/j9derbynetclientmats.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/j9derbynetmats.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/j9derbynetmats.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/jdbc20.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/jdbc20.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/multi.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/multi.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/simpledemo.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/simpledemo.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/storeCollationDBrecovery.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/storeCollationDBrecovery.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/storeall.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/storeall.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/storemats.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/storemats.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/storerecovery.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/storerecovery.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/storetests.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/storetests.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/storeunit.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/storeunit.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/unit.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/unit.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/xa.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/suites/xa.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/testData/serializedDataSources/SerializeDataSources.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/testData/serializedDataSources/SerializeDataSources.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.testData.serializedDataSources;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/testData/v1/copyfiles.ant
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/testData/v1/copyfiles.ant
@@ -26,7 +26,7 @@ j1v1.jar
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/testData/v2/copyfiles.ant
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/testData/v2/copyfiles.ant
@@ -26,7 +26,7 @@ j1v2.jar
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/BadConnectionTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/BadConnectionTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.derbynet;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/ByteArrayCombinerStreamTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/ByteArrayCombinerStreamTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.derbynet;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/CheckSecurityManager.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/CheckSecurityManager.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/ClientSideSystemPropertiesTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/ClientSideSystemPropertiesTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/DRDAProtocolTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/DRDAProtocolTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/DerbyNetAutoStart.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/DerbyNetAutoStart.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/DerbyNetAutoStart_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/DerbyNetAutoStart_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/LOBLocatorReleaseTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/LOBLocatorReleaseTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/NetHarnessJavaTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/NetHarnessJavaTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.derbynet;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/NetIjTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/NetIjTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/NetworkServerControlClientCommandTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/NetworkServerControlClientCommandTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/OutBufferedStreamTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/OutBufferedStreamTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/PrepareStatementTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/PrepareStatementTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/ProtocolTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/ProtocolTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.derbynet;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/SecureServerTest.derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/SecureServerTest.derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/SqlExceptionTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/SqlExceptionTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.derbynet;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/SuicideOfStreamingTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/SuicideOfStreamingTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/SwitchablePrintStream.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/SwitchablePrintStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/TestEnc.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/TestEnc.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.derbynet;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/Utf8CcsidManagerClientTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/Utf8CcsidManagerClientTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/Utf8CcsidManagerTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/Utf8CcsidManagerTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.derbynet;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/dblook_test_net.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/dblook_test_net.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/dblook_test_net_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/dblook_test_net_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/dblook_test_net_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/dblook_test_net_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/dblook_test_net_territory.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/dblook_test_net_territory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/dblook_test_net_territory_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/dblook_test_net_territory_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/dblook_test_net_territory_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/dblook_test_net_territory_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/default_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/default_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/default_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/default_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/executeUpdate.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/executeUpdate.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/maxthreads_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/derbynet/maxthreads_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/engine/ErrorStreamTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/engine/ErrorStreamTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/engine/LockInterruptTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/engine/LockInterruptTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/engine/ModuleLoadingTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/engine/ModuleLoadingTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/DefaultLocale.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/DefaultLocale.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/I18NImportExport_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/I18NImportExport_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/JapanCodeConversion_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/JapanCodeConversion_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/LocalizedAttributeScriptTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/LocalizedAttributeScriptTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/LocalizedDisplayScriptTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/LocalizedDisplayScriptTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/caseI_tr_TR_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/caseI_tr_TR_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/copyfiles.ant
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/copyfiles.ant
@@ -44,7 +44,7 @@ urlLocale_app.properties
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/data/copyfiles.ant
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/data/copyfiles.ant
@@ -31,7 +31,7 @@ jap_SJIS.ctrl
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/default_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/default_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/default_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/default_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/iepnegativetests_ES_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/iepnegativetests_ES_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/iepnegativetests_ES_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/iepnegativetests_ES_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/messageLocale_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/messageLocale_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/urlLocale_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/i18n/urlLocale_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/AbortTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/AbortTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/BlobClobTestSetup.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/BlobClobTestSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/BlobSetMethodsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/BlobSetMethodsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbc4;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/BlobTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/BlobTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/CallableStatementTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/CallableStatementTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/CallableStatementTestSetup.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/CallableStatementTestSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/ClobTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/ClobTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/ConnectionMethodsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/ConnectionMethodsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/ConnectionTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/ConnectionTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbc4;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/DataSourceTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/DataSourceTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Derby2017LayerBTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Derby2017LayerBTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Derby3650Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Derby3650Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Driver40Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Driver40Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Driver40UnbootedTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Driver40UnbootedTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/JDBC40TranslationTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/JDBC40TranslationTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/JDBC4FromJDBC3DataSourceTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/JDBC4FromJDBC3DataSourceTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/LobSortTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/LobSortTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/LobStreamTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/LobStreamTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbc4;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/ParameterMetaDataWrapperTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/ParameterMetaDataWrapperTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbc4;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/PreparedStatementTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/PreparedStatementTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/README.html
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/README.html
@@ -25,7 +25,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <html>

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/ResultSetMetaDataTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/ResultSetMetaDataTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbc4;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/ResultSetTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/ResultSetTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/RowIdNotImplementedTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/RowIdNotImplementedTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/SetObjectUnsupportedTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/SetObjectUnsupportedTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/StatementEventsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/StatementEventsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/StatementTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/StatementTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/StatementTestSetup.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/StatementTestSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/StreamTruncationTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/StreamTruncationTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbc4;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/TestDbMetaData.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/TestDbMetaData.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/TestJDBC40Exception.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/TestJDBC40Exception.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/UnsupportedVetter.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/UnsupportedVetter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/VerifySignatures.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/VerifySignatures.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Wrapper41.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Wrapper41.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Wrapper41Conn.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Wrapper41Conn.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Wrapper41DataSource.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Wrapper41DataSource.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Wrapper41Driver.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Wrapper41Driver.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Wrapper41Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/Wrapper41Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/XA40Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/XA40Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/copyfiles.ant
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/copyfiles.ant
@@ -28,7 +28,7 @@ noAbortPermission.policy
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/default_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbc4/default_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/AIjdbcTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/AIjdbcTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/AssertEventCatcher.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/AssertEventCatcher.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/AuthenticationTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/AuthenticationTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/AutoGenJDBC30Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/AutoGenJDBC30Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/AutoloadTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/AutoloadTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/BLOBDataModelSetup.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/BLOBDataModelSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/BLOBTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/BLOBTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/BLOBTest_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/BLOBTest_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/BatchUpdateTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/BatchUpdateTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/BlobClob4BlobTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/BlobClob4BlobTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/BlobSetBytesBoundaryTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/BlobSetBytesBoundaryTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/BlobStoredProcedureTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/BlobStoredProcedureTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/BlobUpdatableStreamTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/BlobUpdatableStreamTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/CacheSessionDataTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/CacheSessionDataTest.java
@@ -26,7 +26,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/CallableTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/CallableTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/CharacterStreamsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/CharacterStreamsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ClientConnectionPoolDataSourceTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ClientConnectionPoolDataSourceTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ClobStoredProcedureTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ClobStoredProcedureTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ClobTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ClobTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ClobTruncateTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ClobTruncateTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ClobUpdatableReaderTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ClobUpdatableReaderTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ClosedObjectTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ClosedObjectTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/Compat_BlobClob4BlobTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/Compat_BlobClob4BlobTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ConcurrencyTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ConcurrencyTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DMDBugsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DMDBugsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DSCreateShutdownDBTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DSCreateShutdownDBTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DataSourcePropertiesTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DataSourcePropertiesTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DataSourceReferenceTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DataSourceReferenceTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DataSourceSerializationTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DataSourceSerializationTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DataSourceTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DataSourceTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DatabaseMetaDataTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DatabaseMetaDataTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DaylightSavingTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DaylightSavingTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DboPowersTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DboPowersTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/Derby2017LayerATest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/Derby2017LayerATest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/Derby5158Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/Derby5158Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DriverMgrAuthenticationTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DriverMgrAuthenticationTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DriverTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DriverTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DummyReader.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/DummyReader.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/HoldabilityTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/HoldabilityTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/InternationalConnectSimpleDSTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/InternationalConnectSimpleDSTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/InternationalConnectTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/InternationalConnectTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/InvalidLDAPServerAuthenticationTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/InvalidLDAPServerAuthenticationTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/J2EEDataSourceTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/J2EEDataSourceTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/JDBCDriversAllTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/JDBCDriversAllTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/JDBCDriversClientTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/JDBCDriversClientTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/JDBCDriversEmbeddedTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/JDBCDriversEmbeddedTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/JDBCDriversPropertyTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/JDBCDriversPropertyTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/JDBCHarnessJavaTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/JDBCHarnessJavaTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/LDAPAuthenticationTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/LDAPAuthenticationTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/LargeDataLocksTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/LargeDataLocksTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/LobLengthTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/LobLengthTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/LobRsGetterTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/LobRsGetterTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/LobStreamsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/LobStreamsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/NullSQLTextTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/NullSQLTextTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ParameterMappingTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ParameterMappingTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ParameterMetaDataJdbc30Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ParameterMetaDataJdbc30Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/PoolDSAuthenticationTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/PoolDSAuthenticationTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/PoolXADSCreateShutdownDBTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/PoolXADSCreateShutdownDBTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/PrepStmtMetaDataTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/PrepStmtMetaDataTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/PrepStmtNullTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/PrepStmtNullTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ProcedureTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ProcedureTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/RelativeTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/RelativeTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ResultSetCloseTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ResultSetCloseTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ResultSetJDBC30Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ResultSetJDBC30Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ResultSetMiscTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ResultSetMiscTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ResultSetStreamTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ResultSetStreamTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/SURBaseTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/SURBaseTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/SURDataModelSetup.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/SURDataModelSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/SURQueryMixTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/SURQueryMixTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/SURTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/SURTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/SURijTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/SURijTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/SavepointJdbc30Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/SavepointJdbc30Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ScrollResultSetTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/ScrollResultSetTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/SetQueryTimeoutTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/SetQueryTimeoutTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/SetTransactionIsolationTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/SetTransactionIsolationTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/StatementJdbc20Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/StatementJdbc20Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/StatementJdbc30Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/StatementJdbc30Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/StatementPoolingTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/StatementPoolingTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/StreamTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/StreamTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/URCoveringIndexTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/URCoveringIndexTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/UpdatableResultSetTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/UpdatableResultSetTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/UpdateXXXTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/UpdateXXXTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/Wrapper41DBMD.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/Wrapper41DBMD.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/Wrapper41Statement.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/Wrapper41Statement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/XADSAuthenticationTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/XADSAuthenticationTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/XAJNDITest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/XAJNDITest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
     

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/XATest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/XATest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/XATransactionTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/XATransactionTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/connectionJdbc20.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/connectionJdbc20.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/default_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/default_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/default_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/default_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/getCurConnJdbc20_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/getCurConnJdbc20_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/maxfieldsize.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/maxfieldsize.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/metadataMultiConnTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/metadataMultiConnTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/resultsetJdbc20.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/resultsetJdbc20.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/rsgetXXXcolumnNames.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/rsgetXXXcolumnNames.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.jdbcapi;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/setTransactionIsolation_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/setTransactionIsolation_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/setTransactionIsolation_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/setTransactionIsolation_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/xaAnotherTest_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/xaAnotherTest_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/xaAnotherTest_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/xaAnotherTest_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/xaAnotherTest_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/xaAnotherTest_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/xaSimpleNegative_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/xaSimpleNegative_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/xaSimpleNegative_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/jdbcapi/xaSimpleNegative_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/compatibility/CompatibilityCombinations.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/compatibility/CompatibilityCombinations.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/compatibility/CompatibilitySuite.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/compatibility/CompatibilitySuite.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 /**

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/compatibility/JDBCDriverTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/compatibility/JDBCDriverTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 /**

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/compatibility/Pinger.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/compatibility/Pinger.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 /**

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/compatibility/README.html
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/compatibility/README.html
@@ -25,7 +25,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <html>

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/compatibility/oneCombo.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/compatibility/oneCombo.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/compatibility/testScript.xml
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/compatibility/testScript.xml
@@ -27,7 +27,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/derbyNet/CompatibilityTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/derbyNet/CompatibilityTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/derbyNet/CompatibilityTest_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/derbyNet/CompatibilityTest_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/derbyNet/copyfiles.ant
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/junitTests/derbyNet/copyfiles.ant
@@ -26,7 +26,7 @@ CompatibilityTest_app.properties
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/AggregateClassLoadingTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/AggregateClassLoadingTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/AlterColumnTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/AlterColumnTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/AlterTableTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/AlterTableTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/AnsiSignatures.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/AnsiSignatures.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/AnsiSignaturesTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/AnsiSignaturesTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/AnsiTrimTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/AnsiTrimTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ArithmeticTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ArithmeticTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/AutoIncrementTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/AutoIncrementTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/BigDataTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/BigDataTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/BooleanValuesTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/BooleanValuesTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/Bug4356Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/Bug4356Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/Bug5052rtsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/Bug5052rtsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/Bug5054Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/Bug5054Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CaseExpressionTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CaseExpressionTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CastingTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CastingTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CharUTF8Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CharUTF8Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CheckConstraintTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CheckConstraintTest.java
@@ -26,7 +26,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CoalesceTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CoalesceTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CollationTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CollationTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CollationTest2.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CollationTest2.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ColumnDefaultsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ColumnDefaultsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CommentTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CommentTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CompressTableTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CompressTableTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ConcurrentImplicitCreateSchema.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ConcurrentImplicitCreateSchema.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ConglomerateSharingTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ConglomerateSharingTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ConnectTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ConnectTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ConstantExpressionTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ConstantExpressionTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CreateTableFromQueryTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CreateTableFromQueryTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CurrentOfTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CurrentOfTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CursorTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/CursorTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DBInJarTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DBInJarTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DBOAccessTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DBOAccessTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DBOperations.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DBOperations.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DatabaseClassLoadingTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DatabaseClassLoadingTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DateTimeTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DateTimeTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DeadlockDetectionTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DeadlockDetectionTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DeadlockModeTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DeadlockModeTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DeclareGlobalTempTableJavaJDBC30Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DeclareGlobalTempTableJavaJDBC30Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DeclareGlobalTempTableJavaTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DeclareGlobalTempTableJavaTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/Derby5005Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/Derby5005Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/Derby5652.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/Derby5652.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DistinctTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DistinctTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DropTableTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DropTableTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DynamicLikeOptimizationTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/DynamicLikeOptimizationTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ErrorCodeTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ErrorCodeTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ErrorMessageTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ErrorMessageTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ExistsWithSubqueriesTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ExistsWithSubqueriesTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/FakeByteArray.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/FakeByteArray.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/FloatTypesTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/FloatTypesTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ForBitDataTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ForBitDataTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ForUpdateTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ForUpdateTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GeneratedColumnsHelper.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GeneratedColumnsHelper.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GeneratedColumnsPermsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GeneratedColumnsPermsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GeneratedColumnsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GeneratedColumnsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GetPropertyInfoTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GetPropertyInfoTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GetPropertyInfoTest_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GetPropertyInfoTest_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GrantRevokeDDLTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GrantRevokeDDLTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GrantRevokeTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GrantRevokeTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GroupByExpressionTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GroupByExpressionTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GroupByTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/GroupByTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/HalfCreatedDatabaseTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/HalfCreatedDatabaseTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/HoldCursorTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/HoldCursorTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/InListMultiProbeTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/InListMultiProbeTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/InbetweenTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/InbetweenTest.java
@@ -26,7 +26,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/InsertTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/InsertTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/IntArray.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/IntArray.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/IntegerArrayVTI.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/IntegerArrayVTI.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/JitTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/JitTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/JoinTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/JoinTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/LangHarnessJavaTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/LangHarnessJavaTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/LangProcedureTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/LangProcedureTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/LangScripts.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/LangScripts.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/LazyDefaultSchemaCreationTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/LazyDefaultSchemaCreationTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/LikeTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/LikeTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/LojReorderTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/LojReorderTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/MathTrigFunctionsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/MathTrigFunctionsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/MiscErrorsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/MiscErrorsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/MixedCaseExpressionTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/MixedCaseExpressionTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/NativeAuthenticationServiceTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/NativeAuthenticationServiceTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/NestedWhereSubqueryTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/NestedWhereSubqueryTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/NullIfTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/NullIfTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/NullableUniqueConstraintTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/NullableUniqueConstraintTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/NullsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/NullsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/OLAPTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/OLAPTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/OffsetFetchNextTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/OffsetFetchNextTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/OptimizerOverridesTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/OptimizerOverridesTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/OrderByAndOffsetFetchInSubqueries.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/OrderByAndOffsetFetchInSubqueries.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/OrderByAndSortAvoidance.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/OrderByAndSortAvoidance.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/OuterJoinTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/OuterJoinTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/PrecedenceTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/PrecedenceTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/PredicatePushdownTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/PredicatePushdownTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/PredicateTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/PredicateTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/PrepareExecuteDDL.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/PrepareExecuteDDL.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/Price.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/Price.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/PrimaryKeyTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/PrimaryKeyTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ProcedureInTriggerTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ProcedureInTriggerTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ReferentialActionsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ReferentialActionsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ReleaseCompileLocksTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ReleaseCompileLocksTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RenameIndexTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RenameIndexTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RenameTableTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RenameTableTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RestrictedTableVTI.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RestrictedTableVTI.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RestrictedVTITest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RestrictedVTITest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ResultSetsFromPreparedStatementTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ResultSetsFromPreparedStatementTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RolesConferredPrivilegesTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RolesConferredPrivilegesTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RolesTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RolesTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RoutineSecurityTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RoutineSecurityTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RoutineTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RoutineTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RoutinesDefinersRightsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/RoutinesDefinersRightsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SGVetter.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SGVetter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SQLAuthorizationPropTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SQLAuthorizationPropTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SQLSessionContextTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SQLSessionContextTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SampleSQLData.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SampleSQLData.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ScrollCursors1Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ScrollCursors1Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ScrollCursors2Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ScrollCursors2Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SecurityPolicyReloadingTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SecurityPolicyReloadingTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SelectivityTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SelectivityTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SequenceGeneratorTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SequenceGeneratorTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SequencePermsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SequencePermsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SequenceTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SequenceTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ShutdownDatabaseTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ShutdownDatabaseTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SimpleTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SimpleTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SpillHashTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SpillHashTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/StalePlansTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/StalePlansTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/StatementPlanCacheTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/StatementPlanCacheTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/StreamsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/StreamsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/StringArrayVTI.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/StringArrayVTI.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SubqueryFlatteningTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SubqueryFlatteningTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SubqueryTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SubqueryTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SynonymTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SynonymTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SysDiagVTIMappingTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SysDiagVTIMappingTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SystemCatalogTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/SystemCatalogTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/TableFunctionTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/TableFunctionTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/TableVTI.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/TableVTI.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/TimeHandlingTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/TimeHandlingTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/TimestampArithTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/TimestampArithTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/TriggerTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/TriggerTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/TruncateTableTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/TruncateTableTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UDAPermsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UDAPermsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UDTPermsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UDTPermsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UDTTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UDTTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UnaryArithmeticParameterTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UnaryArithmeticParameterTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UngroupedAggregatesNegativeTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UngroupedAggregatesNegativeTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UniqueConstraintMultiThreadedTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UniqueConstraintMultiThreadedTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UniqueConstraintSetNullTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UniqueConstraintSetNullTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UpdatableResultSetTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UpdatableResultSetTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UpdateCursorTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UpdateCursorTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UpdateStatisticsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UpdateStatisticsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UserDefinedAggregatesTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UserDefinedAggregatesTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UserLobTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/UserLobTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/VTITest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/VTITest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ViewsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ViewsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/WISCInsert.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/WISCInsert.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/WarehouseVTI.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/WarehouseVTI.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/XMLBindingTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/XMLBindingTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/XMLConcurrencyTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/XMLConcurrencyTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/XMLMissingClassesTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/XMLMissingClassesTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/XMLTypeAndOpsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/XMLTypeAndOpsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/aggregateOptimization_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/aggregateOptimization_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/aggregateOptimization_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/aggregateOptimization_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/compressTable_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/compressTable_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/compressTable_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/compressTable_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/concateTests.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/concateTests.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/currentSchema_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/currentSchema_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/cursorerrors_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/cursorerrors_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/db2Compatibility_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/db2Compatibility_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/dbManagerLimits.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/dbManagerLimits.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/dbManagerLimits_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/dbManagerLimits_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/dbjarUtil.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/dbjarUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ddlTableLockMode_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/ddlTableLockMode_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/default_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/default_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/default_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/default_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/desc_index_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/desc_index_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/emptyStatistics_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/emptyStatistics_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/errorCode_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/errorCode_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/fk_nonSPS_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/fk_nonSPS_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/functions_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/functions_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/implicitConversions_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/implicitConversions_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/implicitConversions_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/implicitConversions_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/infostreams_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/infostreams_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/insert_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/insert_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/joinDeadlock_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/joinDeadlock_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/joinDeadlock_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/joinDeadlock_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/langUnitTests_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/langUnitTests_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/largeCodeGen.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/largeCodeGen.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/lockTable_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/lockTable_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/lockTable_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/lockTable_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/longStringColumn_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/longStringColumn_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/maxMemPerTab.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/maxMemPerTab.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/maxMemPerTab_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/maxMemPerTab_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/maxMemPerTab_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/maxMemPerTab_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/nestedCommit_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/nestedCommit_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/openScans_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/openScans_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/orderbyElimination_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/orderbyElimination_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/outparams.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/outparams.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/outparams30.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/outparams30.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/outparams_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/outparams_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/partdml_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/partdml_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/predicatesIntoViews_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/predicatesIntoViews_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/refActions_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/refActions_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/scrollCursors1_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/scrollCursors1_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/selectivity_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/selectivity_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/simpleThread.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/simpleThread.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/simpleThreadWrapper.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/simpleThreadWrapper.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/specjPlans_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/specjPlans_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/subquery2_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/subquery2_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/subqueryFlattening_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/subqueryFlattening_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/supersimple_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/supersimple_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/supersimple_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/supersimple_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/triggerGeneral_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/triggerGeneral_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/triggerGeneral_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/triggerGeneral_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/triggerRecursion_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/triggerRecursion_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/triggerRefClause_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/triggerRefClause_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/userDefMethods.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/userDefMethods.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/wisconsin.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/wisconsin.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.lang;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/wisconsin_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/wisconsin_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/wisconsin_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/wisconsin_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/wisconsin_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/wisconsin_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/xmlTestFiles/deep40k.xml
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/xmlTestFiles/deep40k.xml
@@ -27,7 +27,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/xmlTestFiles/dtdDoc.xml
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/xmlTestFiles/dtdDoc.xml
@@ -27,7 +27,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/xmlTestFiles/dtdDoc_invalid.xml
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/xmlTestFiles/dtdDoc_invalid.xml
@@ -27,7 +27,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/xmlTestFiles/personal.dtd
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/xmlTestFiles/personal.dtd
@@ -27,7 +27,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/xmlTestFiles/personal.xsd
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/xmlTestFiles/personal.xsd
@@ -27,7 +27,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/xmlTestFiles/wide40k.xml
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/xmlTestFiles/wide40k.xml
@@ -27,7 +27,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/xmlTestFiles/xsdDoc.xml
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/xmlTestFiles/xsdDoc.xml
@@ -27,7 +27,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/xmlTestFiles/xsdDoc_invalid.xml
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/lang/xmlTestFiles/xsdDoc_invalid.xml
@@ -27,7 +27,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/largedata/Derby5624Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/largedata/Derby5624Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/largedata/LobLimitsClientTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/largedata/LobLimitsClientTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.largedata;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/largedata/LobLimitsLiteTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/largedata/LobLimitsLiteTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/largedata/LobLimitsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/largedata/LobLimitsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/AccessTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/AccessTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/AutomaticIndexStatisticsMultiTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/AutomaticIndexStatisticsMultiTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/AutomaticIndexStatisticsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/AutomaticIndexStatisticsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/BTreeMaxScanTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/BTreeMaxScanTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/BackupPathTests.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/BackupPathTests.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/BackupPathTests_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/BackupPathTests_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/BackupRestoreTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/BackupRestoreTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/BaseTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/BaseTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Beetle6038.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Beetle6038.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Beetle6038_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Beetle6038_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/BootAllTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/BootAllTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/BootLockTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/BootLockTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/ClassLoaderBootTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/ClassLoaderBootTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/ClobReclamationTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/ClobReclamationTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Derby3980DeadlockTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Derby3980DeadlockTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Derby4676Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Derby4676Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Derby5234Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Derby5234Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Derby5582AutomaticIndexStatisticsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Derby5582AutomaticIndexStatisticsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/EncryptDatabaseTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/EncryptDatabaseTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/EncryptionAESTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/EncryptionAESTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/EncryptionKeyAESTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/EncryptionKeyAESTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/EncryptionKeyBlowfishTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/EncryptionKeyBlowfishTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/EncryptionKeyDESTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/EncryptionKeyDESTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/EncryptionKeyTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/EncryptionKeyTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/EncryptionTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/EncryptionTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/EscalateLock_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/EscalateLock_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/HoldCursorExternalSortJDBC30Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/HoldCursorExternalSortJDBC30Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/HoldCursorJDBC30Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/HoldCursorJDBC30Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/IndexSplitDeadlockTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/IndexSplitDeadlockTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/InterruptResilienceTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/InterruptResilienceTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/KeepDisposableStatsPropertyTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/KeepDisposableStatsPropertyTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LiveLockTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LiveLockTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumRecovery.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumRecovery.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumRecovery1.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumRecovery1.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumRecovery1_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumRecovery1_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumRecovery1_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumRecovery1_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumRecovery1_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumRecovery1_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumRecovery_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumRecovery_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumRecovery_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumRecovery_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumRecovery_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumRecovery_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumSetup.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumSetup_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumSetup_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumSetup_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogChecksumSetup_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogDeviceTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogDeviceTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogDeviceTest_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LogDeviceTest_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LongColumnTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/LongColumnTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/MadhareTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/MadhareTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/MaxLogNumber.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/MaxLogNumber.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/MaxLogNumberRecovery.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/MaxLogNumberRecovery.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/MaxLogNumberRecovery_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/MaxLogNumberRecovery_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/MaxLogNumberRecovery_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/MaxLogNumberRecovery_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/MaxLogNumberRecovery_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/MaxLogNumberRecovery_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/MaxLogNumber_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/MaxLogNumber_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/MaxLogNumber_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/MaxLogNumber_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OCRecoveryTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OCRecoveryTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OSReadOnlyTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OSReadOnlyTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OfflineBackupTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OfflineBackupTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineBackup.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineBackup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineBackupTest1.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineBackupTest1.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineBackupTest1_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineBackupTest1_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineBackupTest3.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineBackupTest3.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineBackupTest3_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineBackupTest3_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineBackupTest5_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineBackupTest5_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineCompressTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineCompressTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineCompressTest_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineCompressTest_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineCompressTest_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/OnlineCompressTest_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/PositionedStoreStreamTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/PositionedStoreStreamTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/ReEncryptCrashRecovery.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/ReEncryptCrashRecovery.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RecoveryAfterBackup.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RecoveryAfterBackup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RecoveryAfterBackupSetup.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RecoveryAfterBackupSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RecoveryAfterBackupSetup_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RecoveryAfterBackupSetup_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RecoveryAfterBackup_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RecoveryAfterBackup_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RecoveryAfterBackup_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RecoveryAfterBackup_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RecoveryTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RecoveryTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Rllmodule1_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Rllmodule1_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Rllmodule2_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Rllmodule2_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Rllmodule3_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Rllmodule3_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Rllmodule4_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/Rllmodule4_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RowLockBasicTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RowLockBasicTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RowLockIso_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RowLockIso_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RowLockIso_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/RowLockIso_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/ServicePropertiesFileTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/ServicePropertiesFileTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/StreamingColumnTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/StreamingColumnTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/TableLockBasicTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/TableLockBasicTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/TestDurabilityProperty.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/TestDurabilityProperty.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/TestDurabilityProperty_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/TestDurabilityProperty_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/TransactionTable_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/TransactionTable_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/TransactionTable_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/TransactionTable_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/TurnsReadOnly.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/TurnsReadOnly.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/TurnsReadOnly_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/TurnsReadOnly_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/UpdateLocksTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/UpdateLocksTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.store;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/backupRestore1.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/backupRestore1.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/backupRestore1_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/backupRestore1_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/backupRestore_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/backupRestore_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/bug3498_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/bug3498_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/checkPoint.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/checkPoint.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/checkPoint_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/checkPoint_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/cisco_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/cisco_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/cisco_default.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/cisco_default.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/cisco_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/cisco_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/col_rec1.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/col_rec1.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/col_rec1_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/col_rec1_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/col_rec2.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/col_rec2.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/col_rec2_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/col_rec2_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/connectDisconnect_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/connectDisconnect_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/connectDisconnect_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/connectDisconnect_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/databaseProperties_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/databaseProperties_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/default_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/default_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/default_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/default_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/dropcrash.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/dropcrash.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/dropcrash2.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/dropcrash2.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/dropcrash2_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/dropcrash2_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/dropcrash_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/dropcrash_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/encryptDatabaseTest1_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/encryptDatabaseTest1_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/encryptDatabaseTest2_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/encryptDatabaseTest2_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/encryptDatabaseTest3_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/encryptDatabaseTest3_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/encryptParams_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/encryptParams_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/encryptionKey_jar_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/encryptionKey_jar_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/heapscan_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/heapscan_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/heapscan_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/heapscan_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/lockTableVti_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/lockTableVti_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/logDevice_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/logDevice_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/onlineBackupTest2_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/onlineBackupTest2_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/onlineBackupTest4_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/onlineBackupTest4_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/readUncommitted_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/readUncommitted_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/removeStubs_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/removeStubs_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rlliso1multi_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rlliso1multi_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rlliso1multi_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rlliso1multi_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rlliso2multi_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rlliso2multi_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rlliso2multi_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rlliso2multi_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rlliso3multi_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rlliso3multi_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rlliso3multi_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rlliso3multi_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rollForwardBackup_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rollForwardBackup_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rollForwardBackup_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rollForwardBackup_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rollForwardRecovery_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rollForwardRecovery_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rollForwardRecovery_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/rollForwardRecovery_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/testsqldecimal_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/testsqldecimal_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/testsqldecimal_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/testsqldecimal_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/updatelocksJDBC30_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/updatelocksJDBC30_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/xaOffline1_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/xaOffline1_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/xaOffline1_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/xaOffline1_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/xab2354_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/store/xab2354_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ConnectWrongSubprotocolTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ConnectWrongSubprotocolTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.tools;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/IJRunScriptTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/IJRunScriptTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/IjConnNameTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/IjConnNameTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.tools;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/IjSecurityManagerTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/IjSecurityManagerTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ImportExportBaseTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ImportExportBaseTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.tools;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ImportExportBinaryDataTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ImportExportBinaryDataTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.tools;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ImportExportIJTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ImportExportIJTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ImportExportLobTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ImportExportLobTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.tools;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ImportExportProcedureTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ImportExportProcedureTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.tools;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ImportExportTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ImportExportTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/RollBackWrappingWhenFailOnImportTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/RollBackWrappingWhenFailOnImportTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.tools;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/SysinfoAPITest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/SysinfoAPITest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/SysinfoCPCheckTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/SysinfoCPCheckTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/SysinfoLocaleTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/SysinfoLocaleTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ToolScripts.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ToolScripts.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.tools;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/dblook_test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/dblook_test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/dblook_test_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/dblook_test_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 ij.user=app

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/dblook_test_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/dblook_test_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/dblook_test_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/dblook_test_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/dblook_test_territory_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/dblook_test_territory_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/dblook_test_territory_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/dblook_test_territory_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/dblook_test_territory_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/dblook_test_territory_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/default_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/default_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/default_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/default_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/derbyrunjartest_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/derbyrunjartest_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/derbyrunjartest_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/derbyrunjartest_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ij2Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ij2Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ij3Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ij3Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ij5Test.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ij5Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ij_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/tools/ij_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/TLockFactory_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/TLockFactory_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/TUUIDFactory_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/TUUIDFactory_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_AccessFactory_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_AccessFactory_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherBlowfish_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherBlowfish_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherBlowfish_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherBlowfish_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherCFB_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherCFB_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherCFB_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherCFB_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherDES_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherDES_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherDES_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherDES_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherECB_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherECB_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherECB_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherECB_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherOFB_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherOFB_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherOFB_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_CipherOFB_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_Cipher_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_Cipher_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_Cipher_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_Cipher_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_Diagnosticable_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_Diagnosticable_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_FileSystemData_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_FileSystemData_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_Heap_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_Heap_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_MarkedLimitInputStream_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_MarkedLimitInputStream_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_RawStoreFactory_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_RawStoreFactory_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_RawStoreFactory_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_RawStoreFactory_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_SortController_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_SortController_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_SortController_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_SortController_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_StreamFile_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_StreamFile_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_XA_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_XA_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_b2i_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/T_b2i_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/cacheService_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/cacheService_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/cacheService_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/cacheService_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/daemonService_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/daemonService_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/default_app.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/default_app.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/fillLog_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/fillLog_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/fullRecoveryFail_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/fullRecoveryFail_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/fullRecovery_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/fullRecovery_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/logSwitchFail_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/logSwitchFail_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadChecksumLog1_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadChecksumLog1_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadChecksumLog2_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadChecksumLog2_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadChecksumLog3_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadChecksumLog3_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadChecksumLog4_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadChecksumLog4_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadChecksumLog5_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadChecksumLog5_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadChecksumLog6_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadChecksumLog6_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadChecksumLog7_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadChecksumLog7_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadChecksumLogSetup_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadChecksumLogSetup_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadLog1_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadLog1_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadLog2_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadLog2_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadLog3_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadLog3_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadLog4_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadLog4_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadLog5_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadLog5_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadLog6_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadLog6_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadLog7_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadLog7_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadLogSetup_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverBadLogSetup_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverySetup_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoverySetup_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoveryTest_derby.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoveryTest_derby.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoveryTest_sed.properties
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/unit/recoveryTest_sed.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/upgradeTests/Version.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/functionTests/tests/upgradeTests/Version.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.tests.upgradeTests;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/NsTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/NsTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.nstest;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/init/DbSetup.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/init/DbSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/init/Initializer.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/init/Initializer.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/init/NWServerThread.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/init/NWServerThread.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.nstest.init;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/tester/BackupRestoreReEncryptTester.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/tester/BackupRestoreReEncryptTester.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/tester/Tester1.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/tester/Tester1.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/tester/Tester2.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/tester/Tester2.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/tester/Tester3.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/tester/Tester3.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/tester/TesterObject.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/tester/TesterObject.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/utils/DbUtil.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/utils/DbUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/utils/MemCheck.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/nstest/utils/MemCheck.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/client/Display.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/client/Display.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.client;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/client/Load.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/client/Load.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.client;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/client/MultiThreadSubmitter.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/client/MultiThreadSubmitter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.client;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/client/Operations.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/client/Operations.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.client;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/client/Submitter.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/client/Submitter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.client;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/direct/SimpleNonStandardOperations.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/direct/SimpleNonStandardOperations.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.direct;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/direct/Standard.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/direct/Standard.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.direct;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/direct/StatementHelper.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/direct/StatementHelper.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.direct;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/load/SimpleInsert.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/load/SimpleInsert.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.load;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/load/ThreadInsert.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/load/ThreadInsert.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.load;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/model/Address.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/model/Address.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.model;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/model/Customer.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/model/Customer.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.model;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/model/District.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/model/District.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.model;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/model/Order.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/model/Order.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.model;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/model/OrderLine.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/model/OrderLine.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.model;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/model/Warehouse.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/model/Warehouse.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.model;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/routines/Data.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/routines/Data.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.routines;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/run/DriverUtility.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/run/DriverUtility.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.run;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/test/OperationsTester.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/test/OperationsTester.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.test;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/util/HandleCheckError.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/util/HandleCheckError.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.util;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/util/OEChecks.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/util/OEChecks.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.util;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/util/OERandom.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/oe/util/OERandom.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.oe.util;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/RunOptimizerTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/RunOptimizerTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.optimizer;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/StaticValues.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/StaticValues.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.optimizer;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/query/GenericQuery.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/query/GenericQuery.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.optimizer.query;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/query/Query1.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/query/Query1.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.optimizer.query;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/query/Query2.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/query/Query2.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.optimizer.query;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/query/Query3.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/query/Query3.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.optimizer.query;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/query/Query4.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/query/Query4.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.optimizer.query;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/query/Query5.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/query/Query5.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.optimizer.query;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/query/Query6.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/query/Query6.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.optimizer.query;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/query/QueryList.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/query/QueryList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.optimizer.query;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/utils/DataUtils.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/utils/DataUtils.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.optimizer.utils;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/utils/TestUtils.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/utils/TestUtils.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.optimizer.utils;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/utils/TestViews.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/optimizer/utils/TestViews.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.optimizer.utils;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/sttest/Sttest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/sttest/Sttest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/sttest/tools/MemCheck.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/sttest/tools/MemCheck.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.sttest.tools;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/sttest/utils/CompressTable.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/sttest/utils/CompressTable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.sttest.utils;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/sttest/utils/Datatypes.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/sttest/utils/Datatypes.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/sttest/utils/Setup.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/sttest/utils/Setup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.sttest.utils;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/system/sttest/utils/StStatus.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/system/sttest/utils/StStatus.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.system.sttest.utils;

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/crypto/T_Cipher.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/crypto/T_Cipher.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/crypto/T_CipherBlowfish.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/crypto/T_CipherBlowfish.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/crypto/T_CipherCFB.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/crypto/T_CipherCFB.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/crypto/T_CipherDES.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/crypto/T_CipherDES.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/crypto/T_CipherECB.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/crypto/T_CipherECB.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/crypto/T_CipherOFB.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/crypto/T_CipherOFB.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/BasicUnitTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/BasicUnitTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/BasicUnitTestManager.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/BasicUnitTestManager.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/T_Bomb.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/T_Bomb.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/T_Bombable.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/T_Bombable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/T_Fail.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/T_Fail.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/T_Generic.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/T_Generic.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/T_MultiIterations.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/T_MultiIterations.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/T_MultiThreadedIterations.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/T_MultiThreadedIterations.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/UnitTest.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/UnitTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/UnitTestConstants.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/UnitTestConstants.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/UnitTestMain.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/UnitTestMain.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/UnitTestManager.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/harness/UnitTestManager.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/lang/T_Like.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/lang/T_Like.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/D_T_DiagTestClass1.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/D_T_DiagTestClass1.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/MarkedLimitInputStream.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/MarkedLimitInputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_CacheException.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_CacheException.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_CacheService.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_CacheService.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_CacheUser.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_CacheUser.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_Cacheable.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_Cacheable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_CachedInteger.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_CachedInteger.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_DaemonService.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_DaemonService.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_DiagTestClass1.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_DiagTestClass1.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_DiagTestClass1Sub.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_DiagTestClass1Sub.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_Diagnosticable.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_Diagnosticable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_Key.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_Key.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_L1.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_L1.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_L2.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_L2.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_LockFactory.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_LockFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_MarkedLimitInputStream.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_MarkedLimitInputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_Serviceable.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_Serviceable.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_StandardException.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_StandardException.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_UUIDFactory.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_UUIDFactory.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_User.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/services/T_User.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/store/QualifierUtil.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/store/QualifierUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/store/T_AccessRow.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/store/T_AccessRow.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/store/T_ColumnOrderingImpl.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/store/T_ColumnOrderingImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/store/T_SecondaryIndexRow.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/store/T_SecondaryIndexRow.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/store/T_StoreCostResult.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/store/T_StoreCostResult.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/store/T_XA.java
+++ b/db-testing/src/test/java/com/splicemachine/dbTesting/unitTests/store/T_XA.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-i18n/pom.xml
+++ b/db-tools-i18n/pom.xml
@@ -26,7 +26,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/db-tools-i18n/src/main/java/com/splicemachine/db/iapi/tools/i18n/LocalizedInput.java
+++ b/db-tools-i18n/src/main/java/com/splicemachine/db/iapi/tools/i18n/LocalizedInput.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.tools.i18n;

--- a/db-tools-i18n/src/main/java/com/splicemachine/db/iapi/tools/i18n/LocalizedOutput.java
+++ b/db-tools-i18n/src/main/java/com/splicemachine/db/iapi/tools/i18n/LocalizedOutput.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.tools.i18n;

--- a/db-tools-i18n/src/main/java/com/splicemachine/db/iapi/tools/i18n/LocalizedResource.java
+++ b/db-tools-i18n/src/main/java/com/splicemachine/db/iapi/tools/i18n/LocalizedResource.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.iapi.tools.i18n;

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.dtd
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.dtd
@@ -27,7 +27,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.properties
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -26,7 +26,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_cs.properties
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_cs.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_de_DE.properties
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_de_DE.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_es.properties
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_es.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_fr.properties
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_fr.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_hu.properties
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_hu.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_it.properties
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_it.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_ja_JP.properties
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_ja_JP.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_ko_KR.properties
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_ko_KR.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_pl.properties
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_pl.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_pt_BR.properties
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_pt_BR.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_qq_PP_testOnly.properties
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_qq_PP_testOnly.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_ru.properties
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_ru.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_zh_CN.properties
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_zh_CN.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_zh_TW.properties
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages_zh_TW.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/pom.xml
+++ b/db-tools-ij/pom.xml
@@ -26,7 +26,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Alias.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Alias.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Check.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Check.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_GrantRevoke.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_GrantRevoke.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Index.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Index.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Jar.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Jar.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Key.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Key.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Roles.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Roles.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Schema.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Schema.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Sequence.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Sequence.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Table.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Table.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Trigger.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_Trigger.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_View.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/DB_View.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/Logs.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/dblook/Logs.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/AsyncStatement.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/AsyncStatement.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/AttributeHolder.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/AttributeHolder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ConnectionEnv.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ConnectionEnv.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/Main.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/Main.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ParseException.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ParseException.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/QualifiedIdentifier.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/QualifiedIdentifier.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/Session.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/Session.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/StatementFinder.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/StatementFinder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/UCode_CharStream.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/UCode_CharStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/URLCheck.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/URLCheck.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijConnectionResult.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijConnectionResult.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijException.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijException.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijExceptionResult.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijExceptionResult.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijFatalException.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijFatalException.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijMultiResult.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijMultiResult.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijMultipleResultSetResult.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijMultipleResultSetResult.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijResult.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijResult.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijResultImpl.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijResultImpl.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijResultSetResult.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijResultSetResult.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijRowResult.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijRowResult.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijStatementResult.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijStatementResult.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijTokenException.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijTokenException.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijUnsupportedCommandResult.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijUnsupportedCommandResult.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijVectorResult.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijVectorResult.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijWarningResult.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijWarningResult.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/mtTestCase.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/mtTestCase.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/mtTestSuite.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/mtTestSuite.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/mtTester.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/mtTester.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/mtTime.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/mtTime.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/util.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/util.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/utilMain.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/utilMain.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/xaAbstractHelper.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/xaAbstractHelper.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/xaHelper.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/xaHelper.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/tools/JDBCDisplayUtil.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/tools/JDBCDisplayUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/tools/dblook.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/tools/dblook.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/tools/ij.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/tools/ij.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_cs.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_cs.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_de_DE.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_de_DE.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_es.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_es.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_fr.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_fr.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_hu.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_hu.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_it.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_it.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_ja_JP.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_ja_JP.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_ko_KR.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_ko_KR.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_pt_BR.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_pt_BR.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_ru.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_ru.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_zh_CN.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_zh_CN.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_zh_TW.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfoMessages_zh_TW.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfomessages_pl.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/sysinfomessages_pl.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_cs.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_cs.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_de_DE.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_de_DE.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_es.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_es.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_fr.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_fr.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_hu.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_hu.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_it.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_it.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_ja_JP.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_ja_JP.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_ko_KR.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_ko_KR.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_pl.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_pl.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_pt_BR.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_pt_BR.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_ru.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_ru.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_zh_CN.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_zh_CN.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_zh_TW.properties
+++ b/db-tools-ij/src/main/resources/com/splicemachine/db/loc/toolsmessages_zh_TW.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-testing/pom.xml
+++ b/db-tools-testing/pom.xml
@@ -26,7 +26,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/BackgroundStreamDrainer.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/BackgroundStreamDrainer.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/BackgroundStreamSaver.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/BackgroundStreamSaver.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/CopySuppFiles.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/CopySuppFiles.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/CurrentTime.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/CurrentTime.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/FileCompare.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/FileCompare.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/GRFileFilter.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/GRFileFilter.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/GenerateReport.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/GenerateReport.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/HandleResult.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/HandleResult.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/JavaVersionHolder.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/JavaVersionHolder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ManageSysProps.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ManageSysProps.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/NetServer.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/NetServer.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ProcessStreamDrainer.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ProcessStreamDrainer.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ProcessStreamResult.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ProcessStreamResult.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/PropertyUtil.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/PropertyUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/RunClass.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/RunClass.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/RunIJ.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/RunIJ.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/RunList.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/RunList.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/RunSuite.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/RunSuite.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/RunTest.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/RunTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/Sed.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/Sed.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/SimpleDiff.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/SimpleDiff.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/SkipTest.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/SkipTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/SpecialFlags.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/SpecialFlags.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/SysInfoLog.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/SysInfoLog.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/TimedProcess.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/TimedProcess.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/UnJar.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/UnJar.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/currentjvm.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/currentjvm.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/dbcleanup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/dbcleanup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ibm13.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ibm13.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ibm14.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ibm14.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ibm15.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ibm15.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ibm16.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ibm16.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ibm17.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ibm17.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ibm18.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/ibm18.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/j9_13.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/j9_13.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/j9_22.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/j9_22.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/j9_foundation.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/j9_foundation.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/j9_foundation11.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/j9_foundation11.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/j9dee15.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/j9dee15.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/jdk13.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/jdk13.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/jdk14.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/jdk14.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/jdk15.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/jdk15.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/jdk16.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/jdk16.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/jdk17.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/jdk17.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/jdk18.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/jdk18.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/jvm.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/jvm.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/shutdown.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/shutdown.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/testtypes.properties
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/harness/testtypes.properties
@@ -25,7 +25,7 @@
 #
 # Splice Machine, Inc. has modified the Apache Derby code in this file.
 #
-# All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+# All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
 # and are licensed to you under the GNU Affero General Public License.
 #
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/BigDecimalHandler.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/BigDecimalHandler.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/CanonTestCase.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/CanonTestCase.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.util;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/DbFile.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/DbFile.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/DerbyJUnitTest.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/DerbyJUnitTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/ExecProcUtil.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/ExecProcUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.util;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/ExtendingInterface.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/ExtendingInterface.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/FTFileUtil.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/FTFileUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/Formatters.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/Formatters.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/HarnessJavaTest.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/HarnessJavaTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.util;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/IjTestCase.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/IjTestCase.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/JDBCTestDisplayUtil.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/JDBCTestDisplayUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/JarUtil.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/JarUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/Jdbc20Test.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/Jdbc20Test.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/ManyMethods.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/ManyMethods.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/NoMethodInterface.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/NoMethodInterface.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/PrivilegedFileOpsForTests.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/PrivilegedFileOpsForTests.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.util;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/ProcedureTest.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/ProcedureTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/PropertyUtil.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/PropertyUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/ProtocolTestGrammar.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/ProtocolTestGrammar.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.util;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/SQLStateConstants.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/SQLStateConstants.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.util;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/SQLToJUnit.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/SQLToJUnit.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.util;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/SampleVTI.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/SampleVTI.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.util;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/ScriptTestCase.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/ScriptTestCase.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.util;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/SecurityCheck.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/SecurityCheck.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/ShortHolder.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/ShortHolder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/SimpleProcedureTest.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/SimpleProcedureTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.util;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/StatParser.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/StatParser.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/StaticInitializers/DMLInStaticInitializer.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/StaticInitializers/DMLInStaticInitializer.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/StaticInitializers/InsertInStaticInitializer.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/StaticInitializers/InsertInStaticInitializer.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/SubClass.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/SubClass.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/SubInterfaceClass.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/SubInterfaceClass.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/SubSubClass.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/SubSubClass.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/T_Authorize.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/T_Authorize.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/TestInputStream.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/TestInputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.util;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/TestNullOutputStream.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/TestNullOutputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/TestPropertyInfo.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/TestPropertyInfo.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/TestRoutines.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/TestRoutines.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/TestUtil.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/TestUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/ThreadDump.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/ThreadDump.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/Triggers.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/Triggers.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/UniqueRandomSequence.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/UniqueRandomSequence.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/metadataHelperProcs.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/metadataHelperProcs.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/streams/ByteAlphabet.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/streams/ByteAlphabet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/streams/CharAlphabet.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/streams/CharAlphabet.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/streams/LoopingAlphabetReader.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/streams/LoopingAlphabetReader.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/streams/LoopingAlphabetStream.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/streams/LoopingAlphabetStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/streams/ReadOnceByteArrayInputStream.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/streams/ReadOnceByteArrayInputStream.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.util.streams;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/streams/StringReaderWithLength.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/functionTests/util/streams/StringReaderWithLength.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.functionTests.util.streams;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/BaseJDBCTestCase.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/BaseJDBCTestCase.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/BaseJDBCTestSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/BaseJDBCTestSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/BaseTestCase.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/BaseTestCase.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/BaseTestSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/BaseTestSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/BigDecimalHandler.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/BigDecimalHandler.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/ChangeConfigurationSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/ChangeConfigurationSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/ChangeSSLSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/ChangeSSLSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/ChangeUserSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/ChangeUserSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/ClasspathSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/ClasspathSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/CleanDatabaseTestSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/CleanDatabaseTestSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/ConnectionPoolDataSourceConnector.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/ConnectionPoolDataSourceConnector.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/Connector.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/Connector.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/ConnectorSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/ConnectorSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/DataSourceConnector.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/DataSourceConnector.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/DatabaseChangeSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/DatabaseChangeSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/DatabasePropertyTestSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/DatabasePropertyTestSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/Decorator.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/Decorator.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/Derby.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/Derby.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/DerbyConstants.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/DerbyConstants.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/DerbyDistribution.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/DerbyDistribution.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/DerbyVersion.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/DerbyVersion.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/DriverManagerConnector.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/DriverManagerConnector.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/DropDatabaseSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/DropDatabaseSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/EnvTest.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/EnvTest.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/IndexStatsUtil.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/IndexStatsUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/J2EEDataSource.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/J2EEDataSource.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/JAXPFinder.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/JAXPFinder.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/JDBC.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/JDBC.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/JDBCClient.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/JDBCClient.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/JDBCClientSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/JDBCClientSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/JDBCDataSource.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/JDBCDataSource.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/LocaleTestSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/LocaleTestSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/NetworkServerControlWrapper.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/NetworkServerControlWrapper.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/OsName.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/OsName.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/ReleaseRepository.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/ReleaseRepository.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/RuntimeStatisticsParser.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/RuntimeStatisticsParser.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/SQLUtilities.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/SQLUtilities.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/SecurityManagerSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/SecurityManagerSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/ServerSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/ServerSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/SpawnedProcess.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/SpawnedProcess.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/SupportFilesSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/SupportFilesSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/SystemPropertyTestSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/SystemPropertyTestSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/TestConfiguration.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/TestConfiguration.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/TimeZoneTestSetup.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/TimeZoneTestSetup.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/Utilities.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/Utilities.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/Version.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/Version.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/XADataSourceConnector.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/XADataSourceConnector.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/XATestUtil.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/XATestUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/XML.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/junit/XML.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.dbTesting.junit;

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/unitTests/util/BitUtil.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/unitTests/util/BitUtil.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/java/com/splicemachine/dbTesting/unitTests/util/MsgTrace.java
+++ b/db-tools-testing/src/main/java/com/splicemachine/dbTesting/unitTests/util/MsgTrace.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/resources/ast-visualization/ast-visualization.html
+++ b/db-tools-testing/src/main/resources/ast-visualization/ast-visualization.html
@@ -26,7 +26,7 @@
   ~
   ~ Splice Machine, Inc. has modified the Apache Derby code in this file.
   ~
-  ~ All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+  ~ All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
   ~ and are licensed to you under the GNU Affero General Public License.
   -->
 

--- a/db-tools-testing/src/main/resources/ast-visualization/css/ast-visualization.css
+++ b/db-tools-testing/src/main/resources/ast-visualization/css/ast-visualization.css
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/resources/ast-visualization/js/FileControl.js
+++ b/db-tools-testing/src/main/resources/ast-visualization/js/FileControl.js
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/resources/ast-visualization/js/GraphControls.js
+++ b/db-tools-testing/src/main/resources/ast-visualization/js/GraphControls.js
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/db-tools-testing/src/main/resources/ast-visualization/js/Startup.js
+++ b/db-tools-testing/src/main/resources/ast-visualization/js/Startup.js
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2018 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -1,6 +1,6 @@
 <?xml version="1.1"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.1.1/src/main/java/com/splicemachine/derby/hbase/ShutdownRegionServerObserver.java
+++ b/hbase_pipeline/hbase1.1.1/src/main/java/com/splicemachine/derby/hbase/ShutdownRegionServerObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.1.1/src/main/java/com/splicemachine/pipeline/client/Hbase10RpcChannelFactory.java
+++ b/hbase_pipeline/hbase1.1.1/src/main/java/com/splicemachine/pipeline/client/Hbase10RpcChannelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.1.1/src/main/java/org/apache/hadoop/hbase/ipc/SpliceRetryingCaller.java
+++ b/hbase_pipeline/hbase1.1.1/src/main/java/org/apache/hadoop/hbase/ipc/SpliceRetryingCaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.1.1/src/main/resources/META-INF/services/com.splicemachine.pipeline.client.RpcChannelFactory
+++ b/hbase_pipeline/hbase1.1.1/src/main/resources/META-INF/services/com.splicemachine.pipeline.client.RpcChannelFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2018 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.1.2.2.5/src/main/java/com/splicemachine/derby/hbase/ShutdownRegionServerObserver.java
+++ b/hbase_pipeline/hbase1.1.2.2.5/src/main/java/com/splicemachine/derby/hbase/ShutdownRegionServerObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.1.2.2.5/src/main/java/com/splicemachine/pipeline/client/Hbase10RpcChannelFactory.java
+++ b/hbase_pipeline/hbase1.1.2.2.5/src/main/java/com/splicemachine/pipeline/client/Hbase10RpcChannelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.1.2.2.5/src/main/java/org/apache/hadoop/hbase/ipc/SpliceRetryingCaller.java
+++ b/hbase_pipeline/hbase1.1.2.2.5/src/main/java/org/apache/hadoop/hbase/ipc/SpliceRetryingCaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.1.2.2.5/src/main/resources/META-INF/services/com.splicemachine.pipeline.client.RpcChannelFactory
+++ b/hbase_pipeline/hbase1.1.2.2.5/src/main/resources/META-INF/services/com.splicemachine.pipeline.client.RpcChannelFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2018 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.1.2.2.6/src/main/java/com/splicemachine/derby/hbase/ShutdownRegionServerObserver.java
+++ b/hbase_pipeline/hbase1.1.2.2.6/src/main/java/com/splicemachine/derby/hbase/ShutdownRegionServerObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.1.2.2.6/src/main/java/com/splicemachine/pipeline/client/Hbase10RpcChannelFactory.java
+++ b/hbase_pipeline/hbase1.1.2.2.6/src/main/java/com/splicemachine/pipeline/client/Hbase10RpcChannelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.1.2.2.6/src/main/java/org/apache/hadoop/hbase/ipc/SpliceRetryingCaller.java
+++ b/hbase_pipeline/hbase1.1.2.2.6/src/main/java/org/apache/hadoop/hbase/ipc/SpliceRetryingCaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.1.2.2.6/src/main/resources/META-INF/services/com.splicemachine.pipeline.client.RpcChannelFactory
+++ b/hbase_pipeline/hbase1.1.2.2.6/src/main/resources/META-INF/services/com.splicemachine.pipeline.client.RpcChannelFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2018 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.1.8/src/main/java/com/splicemachine/derby/hbase/ShutdownRegionServerObserver.java
+++ b/hbase_pipeline/hbase1.1.8/src/main/java/com/splicemachine/derby/hbase/ShutdownRegionServerObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.1.8/src/main/java/com/splicemachine/pipeline/client/Hbase10RpcChannelFactory.java
+++ b/hbase_pipeline/hbase1.1.8/src/main/java/com/splicemachine/pipeline/client/Hbase10RpcChannelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.1.8/src/main/java/org/apache/hadoop/hbase/ipc/SpliceRetryingCaller.java
+++ b/hbase_pipeline/hbase1.1.8/src/main/java/org/apache/hadoop/hbase/ipc/SpliceRetryingCaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.1.8/src/main/resources/META-INF/services/com.splicemachine.pipeline.client.RpcChannelFactory
+++ b/hbase_pipeline/hbase1.1.8/src/main/resources/META-INF/services/com.splicemachine.pipeline.client.RpcChannelFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2018 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.2.0/src/main/java/com/splicemachine/derby/hbase/ShutdownRegionServerObserver.java
+++ b/hbase_pipeline/hbase1.2.0/src/main/java/com/splicemachine/derby/hbase/ShutdownRegionServerObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.2.0/src/main/java/com/splicemachine/pipeline/client/Hbase10RpcChannelFactory.java
+++ b/hbase_pipeline/hbase1.2.0/src/main/java/com/splicemachine/pipeline/client/Hbase10RpcChannelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.2.0/src/main/java/org/apache/hadoop/hbase/ipc/SpliceRetryingCaller.java
+++ b/hbase_pipeline/hbase1.2.0/src/main/java/org/apache/hadoop/hbase/ipc/SpliceRetryingCaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/hbase1.2.0/src/main/resources/META-INF/services/com.splicemachine.pipeline.client.RpcChannelFactory
+++ b/hbase_pipeline/hbase1.2.0/src/main/resources/META-INF/services/com.splicemachine.pipeline.client.RpcChannelFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2018 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/pom.xml
+++ b/hbase_pipeline/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2018 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/AdapterPipelineEnvironment.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/AdapterPipelineEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/BatchProtocol.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/BatchProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/ChannelFactoryService.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/ChannelFactoryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/CompactionObserver.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/CompactionObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/CoprocessorWriterFactory.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/CoprocessorWriterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/CountingPipelineMeter.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/CountingPipelineMeter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/FlushObserver.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/FlushObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/HBasePipelineEnvironment.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/HBasePipelineEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/HPipelineExceptionFactory.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/HPipelineExceptionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/IndexEndpoint.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/IndexEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/PipelineKryoRegistry.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/PipelineKryoRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/SpliceIndexEndpoint.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/SpliceIndexEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/SpliceIndexObserver.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/SpliceIndexObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/SplitObserver.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/SplitObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/StoreScannerObserver.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/StoreScannerObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/pipeline/ConstraintViolation.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/pipeline/ConstraintViolation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/pipeline/HTooBusy.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/pipeline/HTooBusy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/pipeline/InitializationCompleted.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/pipeline/InitializationCompleted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/pipeline/SnappyPipelineCompressor.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/pipeline/SnappyPipelineCompressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/pipeline/client/BulkWriteChannelInvoker.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/pipeline/client/BulkWriteChannelInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/pipeline/client/BulkWritesRPCInvoker.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/pipeline/client/BulkWritesRPCInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/pipeline/client/RpcChannelFactory.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/pipeline/client/RpcChannelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/main/java/com/splicemachine/pipeline/client/SpliceRetryingCall.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/pipeline/client/SpliceRetryingCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/test/java/com/splicemachine/pipeline/testsetup/HPipelineTestDataEnv.java
+++ b/hbase_pipeline/src/test/java/com/splicemachine/pipeline/testsetup/HPipelineTestDataEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/test/java/com/splicemachine/pipeline/testsetup/HPipelineTestEnv.java
+++ b/hbase_pipeline/src/test/java/com/splicemachine/pipeline/testsetup/HPipelineTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/test/resources/META-INF/services/com.splicemachine.pipeline.testsetup.PipelineTestDataEnv
+++ b/hbase_pipeline/src/test/resources/META-INF/services/com.splicemachine.pipeline.testsetup.PipelineTestDataEnv
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2018 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_pipeline/src/test/resources/META-INF/services/com.splicemachine.pipeline.testsetup.PipelineTestEnv
+++ b/hbase_pipeline/src/test/resources/META-INF/services/com.splicemachine.pipeline.testsetup.PipelineTestEnv
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2018 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.0.0.x/src/test/java/com/splicemachine/test/SpliceZoo.java
+++ b/hbase_sql/hbase1.0.0.x/src/test/java/com/splicemachine/test/SpliceZoo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.1.0/src/test/java/com/splicemachine/test/SpliceZoo.java
+++ b/hbase_sql/hbase1.1.0/src/test/java/com/splicemachine/test/SpliceZoo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.1.1/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
+++ b/hbase_sql/hbase1.1.1/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.1.1/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.1/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.1.1/src/test/java/com/splicemachine/hbase/StubInternalScanner.java
+++ b/hbase_sql/hbase1.1.1/src/test/java/com/splicemachine/hbase/StubInternalScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.1.1/src/test/java/com/splicemachine/test/SpliceZoo.java
+++ b/hbase_sql/hbase1.1.1/src/test/java/com/splicemachine/test/SpliceZoo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
+++ b/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.1.2.2.5/src/test/java/com/splicemachine/hbase/StubInternalScanner.java
+++ b/hbase_sql/hbase1.1.2.2.5/src/test/java/com/splicemachine/hbase/StubInternalScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.1.2.2.5/src/test/java/com/splicemachine/test/SpliceZoo.java
+++ b/hbase_sql/hbase1.1.2.2.5/src/test/java/com/splicemachine/test/SpliceZoo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.1.2.2.6/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
+++ b/hbase_sql/hbase1.1.2.2.6/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.1.2.2.6/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.2.2.6/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.1.2.2.6/src/test/java/com/splicemachine/hbase/StubInternalScanner.java
+++ b/hbase_sql/hbase1.1.2.2.6/src/test/java/com/splicemachine/hbase/StubInternalScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.1.2.2.6/src/test/java/com/splicemachine/test/SpliceZoo.java
+++ b/hbase_sql/hbase1.1.2.2.6/src/test/java/com/splicemachine/test/SpliceZoo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.1.8/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
+++ b/hbase_sql/hbase1.1.8/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.1.8/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.1.8/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.1.8/src/test/java/com/splicemachine/hbase/StubInternalScanner.java
+++ b/hbase_sql/hbase1.1.8/src/test/java/com/splicemachine/hbase/StubInternalScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.1.8/src/test/java/com/splicemachine/test/SpliceZoo.java
+++ b/hbase_sql/hbase1.1.8/src/test/java/com/splicemachine/test/SpliceZoo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
+++ b/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
+++ b/hbase_sql/hbase1.2.0/src/main/java/com/splicemachine/hbase/BackupEndpointObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.2.0/src/test/java/com/splicemachine/hbase/StubInternalScanner.java
+++ b/hbase_sql/hbase1.2.0/src/test/java/com/splicemachine/hbase/StubInternalScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/hbase1.2.0/src/test/java/com/splicemachine/test/SpliceZoo.java
+++ b/hbase_sql/hbase1.2.0/src/test/java/com/splicemachine/test/SpliceZoo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/orc-cds-2.3/src/main/java/com/splicemachine/orc/reader/SliceDictionary.java
+++ b/hbase_sql/orc-cds-2.3/src/main/java/com/splicemachine/orc/reader/SliceDictionary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/orc-cds-2.3/src/main/java/com/splicemachine/stream/output/ParquetWriterFactoryImpl.java
+++ b/hbase_sql/orc-cds-2.3/src/main/java/com/splicemachine/stream/output/ParquetWriterFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/orc-cds-2.3/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/hbase_sql/orc-cds-2.3/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/orc-cds-2.3/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatch.java
+++ b/hbase_sql/orc-cds-2.3/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/orc-spark-2.3/src/main/java/com/splicemachine/orc/reader/SliceDictionary.java
+++ b/hbase_sql/orc-spark-2.3/src/main/java/com/splicemachine/orc/reader/SliceDictionary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/orc-spark-2.3/src/main/java/com/splicemachine/stream/output/ParquetWriterFactoryImpl.java
+++ b/hbase_sql/orc-spark-2.3/src/main/java/com/splicemachine/stream/output/ParquetWriterFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/orc-spark-2.3/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/hbase_sql/orc-spark-2.3/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/orc-spark-2.3/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatch.java
+++ b/hbase_sql/orc-spark-2.3/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/parquet-cloudera/src/main/java/com/splicemachine/orc/reader/SliceDictionary.java
+++ b/hbase_sql/parquet-cloudera/src/main/java/com/splicemachine/orc/reader/SliceDictionary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/parquet-cloudera/src/main/java/com/splicemachine/stream/output/ParquetWriterFactoryImpl.java
+++ b/hbase_sql/parquet-cloudera/src/main/java/com/splicemachine/stream/output/ParquetWriterFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/parquet-spark2/src/main/java/com/splicemachine/orc/reader/SliceDictionary.java
+++ b/hbase_sql/parquet-spark2/src/main/java/com/splicemachine/orc/reader/SliceDictionary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/parquet-spark2/src/main/java/com/splicemachine/stream/output/ParquetWriterFactoryImpl.java
+++ b/hbase_sql/parquet-spark2/src/main/java/com/splicemachine/stream/output/ParquetWriterFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/assembly/assembly.xml
+++ b/hbase_sql/src/main/assembly/assembly.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/assembly/standalone_assembly.xml
+++ b/hbase_sql/src/main/assembly/standalone_assembly.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/SpliceDoNotRetryIOException.java
+++ b/hbase_sql/src/main/java/com/splicemachine/SpliceDoNotRetryIOException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/SpliceDoNotRetryIOExceptionWrapping.java
+++ b/hbase_sql/src/main/java/com/splicemachine/SpliceDoNotRetryIOExceptionWrapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/compactions/CompactionInputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/compactions/CompactionInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/compactions/CompactionRecordReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/compactions/CompactionRecordReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/compactions/CompactionResult.java
+++ b/hbase_sql/src/main/java/com/splicemachine/compactions/CompactionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/compactions/CompactionSplit.java
+++ b/hbase_sql/src/main/java/com/splicemachine/compactions/CompactionSplit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/compactions/SpliceCompactionRequest.java
+++ b/hbase_sql/src/main/java/com/splicemachine/compactions/SpliceCompactionRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactionPolicy.java
+++ b/hbase_sql/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/ddl/DDLZookeeperClient.java
+++ b/hbase_sql/src/main/java/com/splicemachine/ddl/DDLZookeeperClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/ddl/HBaseDDLEnvironment.java
+++ b/hbase_sql/src/main/java/com/splicemachine/ddl/HBaseDDLEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/ddl/ZooKeeperDDLCommunicator.java
+++ b/hbase_sql/src/main/java/com/splicemachine/ddl/ZooKeeperDDLCommunicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/ddl/ZooKeeperDDLWatchChecker.java
+++ b/hbase_sql/src/main/java/com/splicemachine/ddl/ZooKeeperDDLWatchChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/UGIUser.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/UGIUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/UGIUserManager.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/UGIUserManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/io/HdfsDirFile.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/io/HdfsDirFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/io/HdfsDirStorageFactory.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/io/HdfsDirStorageFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/kryo/SparkValueRowSerializer.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/kryo/SparkValueRowSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/spark/WholeTextInputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/spark/WholeTextInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/sql/HSqlExceptionFactory.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/sql/HSqlExceptionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/sql/ZkPropertyManager.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/sql/ZkPropertyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/sql/execute/HBaseDropIndexConstantOperation.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/sql/execute/HBaseDropIndexConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/sql/execute/HExecutionFactory.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/sql/execute/HExecutionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/sql/execute/HbaseGenericConstantActionFactory.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/sql/execute/HbaseGenericConstantActionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/store/access/HBaseFileResourceFactory.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/store/access/HBaseFileResourceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/store/access/HdfsResourceLocalizer.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/store/access/HdfsResourceLocalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceHdfsFileResource.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceHdfsFileResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/lifecycle/CostChoosingDataSetProcessorFactory.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/lifecycle/CostChoosingDataSetProcessorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/lifecycle/HEngineSqlEnv.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/lifecycle/HEngineSqlEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/compaction/SparkCompactionFunction.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/compaction/SparkCompactionFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkDeleteHFileGenerationFunction.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkDeleteHFileGenerationFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkImportFunction.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkImportFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkImportPartition.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkImportPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkImportPartitioner.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkImportPartitioner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkImportUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkImportUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkInsertHFileGenerationFunction.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkInsertHFileGenerationFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkLoadKVPairFunction.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkLoadKVPairFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/HBaseBulkImportRowToSparkRowFunction.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/HBaseBulkImportRowToSparkRowFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/HFileGenerationFunction.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/HFileGenerationFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/RowKeyGenerator.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/RowKeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/SerializableComparator.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/SerializableComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BroadcastedActivation.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BroadcastedActivation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BulkDataSetWriter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BulkDataSetWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BulkDeleteDataSetWriter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BulkDeleteDataSetWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BulkInsertDataSetWriter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BulkInsertDataSetWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BulkLoadIndexDataSetWriter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BulkLoadIndexDataSetWriter.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/DeleteDataSetWriter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/DeleteDataSetWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/ExceptionWrapperFunction.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/ExceptionWrapperFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/HBasePartitioner.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/HBasePartitioner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/HregionDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/HregionDataSetProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/InsertDataSetWriter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/InsertDataSetWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/PartialKeyPartitioner.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/PartialKeyPartitioner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/RDDName.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/RDDName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/RowPartition.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/RowPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkBulkDeleteTableWriterBuilder.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkBulkDeleteTableWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkBulkInsertTableWriterBuilder.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkBulkInsertTableWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkBulkLoadIndexDataSetWriterBuilder.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkBulkLoadIndexDataSetWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDeleteTableWriterBuilder.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDeleteTableWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDirectDataSetWriter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDirectDataSetWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDirectWriterBuilder.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDirectWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkExportDataSetWriter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkExportDataSetWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkFlatMapFunction.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkInsertTableWriterBuilder.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkInsertTableWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkOperationContext.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkOperationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkPairDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkPairDataSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkScanSetBuilder.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkScanSetBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkSpliceFunctionWrapper.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkSpliceFunctionWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkSpliceFunctionWrapper2.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkSpliceFunctionWrapper2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkSplittingFunction.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkSplittingFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkTableSampler.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkTableSampler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkTableSamplerBuilder.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkTableSamplerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkUpdateDataSetWriter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkUpdateDataSetWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkUpdateTableWriterBuilder.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkUpdateTableWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkWindow.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/utils/BulkLoadUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/utils/BulkLoadUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/utils/TableWriterUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/utils/TableWriterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/utils/ZkSequencer.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/utils/ZkSequencer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/derby/vti/SpliceDatasetVTI.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/vti/SpliceDatasetVTI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/example/ExecRowToVectorFunction.java
+++ b/hbase_sql/src/main/java/com/splicemachine/example/ExecRowToVectorFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/example/SparkMLibUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/example/SparkMLibUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/example/SparkStatistics.java
+++ b/hbase_sql/src/main/java/com/splicemachine/example/SparkStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/BackupBaseRegionObserver.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/BackupBaseRegionObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/BackupUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/BackupUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/BytesCopyTaskSplitter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/BytesCopyTaskSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/HBaseRegionLoads.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/HBaseRegionLoads.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/MemstoreAwareObserver.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/MemstoreAwareObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/ReadOnlyHTableDescriptor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/ReadOnlyHTableDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/RegionServerLifecycleObserver.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/RegionServerLifecycleObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/RegionSizeEndpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/RegionSizeEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/SizedInterval.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/SizedInterval.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceCompactionUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceCompactionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceHFileCleaner.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceHFileCleaner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceMasterLock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceMasterLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceMasterObserver.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceMasterObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceMetrics.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/lifecycle/MasterLifecycle.java
+++ b/hbase_sql/src/main/java/com/splicemachine/lifecycle/MasterLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/lifecycle/RegionServerLifecycle.java
+++ b/hbase_sql/src/main/java/com/splicemachine/lifecycle/RegionServerLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/SpliceTableMapReduceUtil.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/SpliceTableMapReduceUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/AbstractSMInputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/AbstractSMInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/HBaseSubregionSplitter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/HBaseSubregionSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/NameType.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/NameType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/PKColumnNamePosition.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/PKColumnNamePosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMInputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMOutputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMOutputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMRecordReaderImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMRecordReaderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMRecordWriterImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMRecordWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMSQLUtil.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMSQLUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMSplit.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMSplit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMTextInputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SMTextInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SubregionSplitter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/SubregionSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/FailureExecHook.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/FailureExecHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/PostExecHook.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/PostExecHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMHIveContextWrapper.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMHIveContextWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMHiveInputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMHiveInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMHiveOutputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMHiveOutputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMHiveRecordReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMHiveRecordReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMHiveRecordWriter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMHiveRecordWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMHiveSplit.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMHiveSplit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMSerDe.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMSerDe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMStorageHandler.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMStorageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/mapreduce/SMInputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/mapreduce/SMInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/mapreduce/SMObjectInspector.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/mapreduce/SMObjectInspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/mapreduce/SMWrappedRecordReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/mapreduce/SMWrappedRecordReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/mapreduce/SpliceJob.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/mapreduce/SpliceJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/mapreduce/SpliceTableOutputCommitter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/mapreduce/SpliceTableOutputCommitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/serde/ExecRowWritable.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/serde/ExecRowWritable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/serde/RowLocationWritable.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/serde/RowLocationWritable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/AbstractOlapHandler.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/AbstractOlapHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/AsyncOlapNIOLayer.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/AsyncOlapNIOLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/Callback.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/Callback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/CancelledResult.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/CancelledResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/CompactionJob.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/CompactionJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/DistributedCompaction.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/DistributedCompaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/FailedOlapResult.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/FailedOlapResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/JobExecutor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/JobExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/MappedJobRegistry.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/MappedJobRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/NotSubmittedResult.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/NotSubmittedResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapCancelHandler.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapCancelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapJobRegistry.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapJobRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapJobStatus.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapJobStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapPipelineFactory.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapPipelineFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapRequestHandler.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapSerializationUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapSerializationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapServer.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapServerMaster.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapServerMaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapServerProvider.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapServerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapServerSubmitter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapServerSubmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/OlapStatusHandler.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/OlapStatusHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/ProgressResult.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/ProgressResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/SubmittedResult.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/SubmittedResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/TimedOlapClient.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/TimedOlapClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/olap/package-info.java
+++ b/hbase_sql/src/main/java/com/splicemachine/olap/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/AbstractOrcDataSource.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/AbstractOrcDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/CachingOrcDataSource.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/CachingOrcDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/ColumnReference.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/ColumnReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/DiskRange.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/DiskRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/FileOrcDataSource.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/FileOrcDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/HdfsOrcDataSource.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/HdfsOrcDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/OrcConf.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/OrcConf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/OrcCorruptionException.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/OrcCorruptionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/OrcDataSource.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/OrcDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/OrcDataSourceUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/OrcDataSourceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/OrcPredicate.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/OrcPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/OrcReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/OrcReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/OrcRecordReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/OrcRecordReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/RowGroup.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/RowGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/StreamDescriptor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/StreamDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/StreamId.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/StreamId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/Stripe.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/Stripe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/StripeReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/StripeReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/AbstractColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/AbstractColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/ArrayColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/ArrayColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/BinaryColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/BinaryColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/BlockFactory.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/BlockFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/BooleanColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/BooleanColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/ByteColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/ByteColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/ColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/ColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/DateColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/DateColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/DecimalColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/DecimalColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/DoubleColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/DoubleColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/FloatColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/FloatColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/IntegerColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/IntegerColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/LazyColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/LazyColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/LazyColumnBlockLoader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/LazyColumnBlockLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/LazyIncludedColumnBlockLoaderImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/LazyIncludedColumnBlockLoaderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/LazyNullColumnBlockLoaderImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/LazyNullColumnBlockLoaderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/LazyPartitionColumnBlockLoaderImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/LazyPartitionColumnBlockLoaderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/LongColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/LongColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/MapColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/MapColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/ShortColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/ShortColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/StringColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/StringColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/StructColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/StructColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/block/TimestampColumnBlock.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/block/TimestampColumnBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/BooleanStreamCheckpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/BooleanStreamCheckpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/ByteArrayStreamCheckpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/ByteArrayStreamCheckpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/ByteStreamCheckpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/ByteStreamCheckpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/Checkpoints.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/Checkpoints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/DecimalStreamCheckpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/DecimalStreamCheckpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/DoubleStreamCheckpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/DoubleStreamCheckpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/FloatStreamCheckpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/FloatStreamCheckpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/InputStreamCheckpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/InputStreamCheckpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/InvalidCheckpointException.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/InvalidCheckpointException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/LongStreamCheckpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/LongStreamCheckpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/LongStreamDwrfCheckpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/LongStreamDwrfCheckpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/LongStreamV1Checkpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/LongStreamV1Checkpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/LongStreamV2Checkpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/LongStreamV2Checkpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/RowGroupDictionaryLengthStreamCheckpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/RowGroupDictionaryLengthStreamCheckpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/StreamCheckpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/checkpoint/StreamCheckpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/input/ColumnarBatchRow.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/input/ColumnarBatchRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/input/OrcMapreduceRecordReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/input/OrcMapreduceRecordReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/input/SpliceOrcNewInputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/input/SpliceOrcNewInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/memory/AbstractAggregatedMemoryContext.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/memory/AbstractAggregatedMemoryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/memory/AggregatedMemoryContext.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/memory/AggregatedMemoryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/memory/LocalMemoryContext.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/memory/LocalMemoryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/BooleanStatistics.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/BooleanStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/ColumnEncoding.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/ColumnEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/ColumnStatistics.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/ColumnStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/CompressionKind.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/CompressionKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/DateStatistics.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/DateStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/DecimalStatistics.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/DecimalStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/DoubleStatistics.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/DoubleStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/DwrfMetadataReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/DwrfMetadataReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/Footer.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/Footer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/HiveBloomFilter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/HiveBloomFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/IntegerStatistics.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/IntegerStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/Metadata.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/Metadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/MetadataReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/MetadataReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/MinMaxStatistics.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/MinMaxStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/OrcMetadataReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/OrcMetadataReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/OrcType.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/OrcType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/PostScript.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/PostScript.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/RangeStatistics.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/RangeStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/RowGroupIndex.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/RowGroupIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/StatsEval.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/StatsEval.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/Stream.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/Stream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/StringStatistics.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/StringStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/StripeFooter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/StripeFooter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/StripeInformation.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/StripeInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/metadata/StripeStatistics.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/metadata/StripeStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/predicate/SpliceORCPredicate.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/predicate/SpliceORCPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/AbstractStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/AbstractStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/BooleanStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/BooleanStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/ByteStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/ByteStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/DecimalStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/DecimalStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/DoubleStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/DoubleStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/FloatStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/FloatStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/IntDictionaryStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/IntDictionaryStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/IntDirectStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/IntDirectStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/IntStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/IntStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/ListStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/ListStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/LongDictionaryStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/LongDictionaryStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/LongDirectStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/LongDirectStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/LongStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/LongStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/MapStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/MapStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/ShortDictionaryStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/ShortDictionaryStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/ShortDirectStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/ShortDirectStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/ShortStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/ShortStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/SliceDictionaryStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/SliceDictionaryStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/SliceDirectStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/SliceDirectStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/SliceStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/SliceStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/StreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/StreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/StreamReaders.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/StreamReaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/StructStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/StructStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/reader/TimestampStreamReader.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/reader/TimestampStreamReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/BooleanStream.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/BooleanStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/ByteArrayStream.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/ByteArrayStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/ByteStream.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/ByteStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/CheckpointStreamSource.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/CheckpointStreamSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/DecimalStream.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/DecimalStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/DoubleStream.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/DoubleStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/FloatStream.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/FloatStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/LongBitPacker.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/LongBitPacker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/LongDecode.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/LongDecode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/LongStream.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/LongStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/LongStreamDwrf.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/LongStreamDwrf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/LongStreamV1.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/LongStreamV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/LongStreamV2.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/LongStreamV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/MissingStreamSource.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/MissingStreamSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/OrcInputStream.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/OrcInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/OrcStreamUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/OrcStreamUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/RowGroupDictionaryLengthStream.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/RowGroupDictionaryLengthStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/StreamSource.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/StreamSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/StreamSources.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/StreamSources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/ValueStream.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/ValueStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/ValueStreamSource.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/ValueStreamSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/orc/stream/ValueStreams.java
+++ b/hbase_sql/src/main/java/com/splicemachine/orc/stream/ValueStreams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/serializer/SpliceKryoSerializer.java
+++ b/hbase_sql/src/main/java/com/splicemachine/serializer/SpliceKryoSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/serializer/SpliceKryoSerializerInstance.java
+++ b/hbase_sql/src/main/java/com/splicemachine/serializer/SpliceKryoSerializerInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/FunctionAdapter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/FunctionAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/KryoDecoder.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/KryoDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/KryoEncoder.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/KryoEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/QueryJob.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/QueryJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/QueryResult.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/QueryResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/RemoteQueryClientImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/RemoteQueryClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/RemoteQueryJob.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/RemoteQueryJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/ResultStreamer.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/ResultStreamer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/SparkCompactionContext.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/SparkCompactionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/StreamListener.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/StreamListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/StreamListenerServer.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/StreamListenerServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/StreamProtocol.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/StreamProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/StreamableRDD.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/StreamableRDD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/accumulator/BadRecordsAccumulator.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/accumulator/BadRecordsAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/handlers/OpenHandler.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/handlers/OpenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/index/HTableOutputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/index/HTableOutputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/index/HTableRecordWriter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/index/HTableRecordWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/output/SMOutputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/output/SMOutputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/output/SMRecordWriter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/output/SMRecordWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/stream/output/SpliceOutputCommitter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/output/SpliceOutputCommitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/utils/BlockingProbe.java
+++ b/hbase_sql/src/main/java/com/splicemachine/utils/BlockingProbe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/com/splicemachine/utils/BlockingProbeEndpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/utils/BlockingProbeEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/org/apache/hadoop/hbase/mapreduce/ScanUtil.java
+++ b/hbase_sql/src/main/java/org/apache/hadoop/hbase/mapreduce/ScanUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/java/org/apache/hadoop/hbase/mapreduce/SpliceMapreduceUtils.java
+++ b/hbase_sql/src/main/java/org/apache/hadoop/hbase/mapreduce/SpliceMapreduceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.SqlEnvironment
+++ b/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.SqlEnvironment
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.db.client.net.ResourceLocalizer
+++ b/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.db.client.net.ResourceLocalizer
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.db.impl.drda.UserManager
+++ b/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.db.impl.drda.UserManager
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.db.io.StorageFactory
+++ b/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.db.io.StorageFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.derby.ddl.DDLEnvironment
+++ b/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.derby.ddl.DDLEnvironment
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.derby.iapi.sql.PropertyManager
+++ b/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.derby.iapi.sql.PropertyManager
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.derby.impl.store.access.FileResourceFactory
+++ b/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.derby.impl.store.access.FileResourceFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.derby.stream.control.output.ParquetWriterFactory
+++ b/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.derby.stream.control.output.ParquetWriterFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2018 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
@@ -14,7 +14,7 @@
 #
 
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.derby.utils.Sequencer
+++ b/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.derby.utils.Sequencer
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.pipeline.security.AclChecker
+++ b/hbase_sql/src/main/resources/META-INF/services/com.splicemachine.pipeline.security.AclChecker
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2018 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/resources/application.properties
+++ b/hbase_sql/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/resources/com/splicemachine/db/modules.properties
+++ b/hbase_sql/src/main/resources/com/splicemachine/db/modules.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/resources/hbase-log4j.properties
+++ b/hbase_sql/src/main/resources/hbase-log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/resources/log4j.properties
+++ b/hbase_sql/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/main/resources/trace-log4j.properties
+++ b/hbase_sql/src/main/resources/trace-log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/HBaseWALBlockingWaitStrategy.java
+++ b/hbase_sql/src/test/java/com/splicemachine/HBaseWALBlockingWaitStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/SpliceDoNotRetryIOExceptionTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/SpliceDoNotRetryIOExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/SpliceDoNotRetryIOExceptionWrappingTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/SpliceDoNotRetryIOExceptionWrappingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/access/client/SpliceHRegionInfoTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/access/client/SpliceHRegionInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/io/HdfsDirFileTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/io/HdfsDirFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/io/WholeTextInputFormatTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/io/WholeTextInputFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/TempTableHBaseIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/TempTableHBaseIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/FailuresSparkIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/FailuresSparkIT.java
@@ -1,6 +1,6 @@
 /*
  *
- *  * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *  * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *  *
  *  * This file is part of Splice Machine.
  *  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/HalfMergeSortSparkIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/HalfMergeSortSparkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiRegionIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiRegionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/PinTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/PinTableIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/S3IT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/S3IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SelfInsertSparkIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SelfInsertSparkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SplitRegionRowCountOperationIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SplitRegionRowCountOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/StressSparkIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/StressSparkIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation_LargeRegionCount_IT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation_LargeRegionCount_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/scanner/TableScannerBuilderTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/scanner/TableScannerBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/SMOutputFormatTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/SMOutputFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/SparkDataSetTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/SparkDataSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/SparkPairDataSetTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/SparkPairDataSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/fake/FakeOutputCommitter.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/fake/FakeOutputCommitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/fake/FakeOutputFormat.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/fake/FakeOutputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/fake/FakeTableWriterBuilder.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/fake/FakeTableWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/fake/FakeWriter.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/stream/spark/fake/FakeWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/test/framework/RegionUtils.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/test/framework/RegionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/test/framework/SpliceSparkWatcher.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/test/framework/SpliceSparkWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/transactions/CallableTransactionIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/transactions/CallableTransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/transactions/ClusterDDLTestIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/transactions/ClusterDDLTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/transactions/PyProcedureIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/transactions/PyProcedureIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/transactions/TransactionResolutionIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/transactions/TransactionResolutionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/utils/VacuumIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/utils/VacuumIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/derby/utils/marshall/SparkValueRowSerializerTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/utils/marshall/SparkValueRowSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/AddColumnWithDefaultBulkLoadIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/AddColumnWithDefaultBulkLoadIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/CheckTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/CheckTableIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/CompactionSplitIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/CompactionSplitIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/CostEstimationIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/CostEstimationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/DistinctAggregateOverMultiplePartitionsIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/DistinctAggregateOverMultiplePartitionsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/HbaseUIIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/HbaseUIIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/KillOperationIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/KillOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/MemstoreAwareObserverTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/MemstoreAwareObserverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/MockSnapshot.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/MockSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/OlapServerIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/OlapServerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/PartitionStatisticsIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/PartitionStatisticsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/PhysicalDeletionIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/PhysicalDeletionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/RowLockIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/RowLockIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/SnapshotIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/SnapshotIT.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/SpliceRegionAdminIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/SpliceRegionAdminIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/StatisticsColumnMergeIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/StatisticsColumnMergeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/BaseMRIOTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/BaseMRIOTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/ClientSideRegionScannerIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/ClientSideRegionScannerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/DataFrameIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/DataFrameIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/HiveIntegrationIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/HiveIntegrationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SMInputFormatIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SMInputFormatIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SMOutputFormatIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SMOutputFormatIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SMRecordReaderImplIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SMRecordReaderImplIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SpliceMemstoreKeyValueScannerIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SpliceMemstoreKeyValueScannerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SplitRegionScannerIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SplitRegionScannerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SplitRegionScannerStressIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SplitRegionScannerStressIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/olap/OlapClientFailureTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/olap/OlapClientFailureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/olap/OlapClientTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/olap/OlapClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/AbstractTestOrcReader.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/AbstractTestOrcReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/OrcReaderIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/OrcReaderIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/OrcTester.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/OrcTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/TestCachingOrcDataSource.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/TestCachingOrcDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/TestFullOrcReader.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/TestFullOrcReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/TestOrcDataSourceUtils.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/TestOrcDataSourceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/TestOrcReader.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/TestOrcReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/TestOrcReaderPositions.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/TestOrcReaderPositions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/TestingOrcDataSource.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/TestingOrcDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/block/DoubleColumnBlockTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/block/DoubleColumnBlockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/block/FloatColumnBlockTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/block/FloatColumnBlockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/block/IntegerColumnBlockTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/block/IntegerColumnBlockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/block/LongColumnBlockTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/block/LongColumnBlockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/block/ShortColumnBlockTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/block/ShortColumnBlockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/block/StringColumnBlockTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/block/StringColumnBlockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/metadata/TestOrcMetadataReader.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/metadata/TestOrcMetadataReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/stream/TestDecimalStream.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/stream/TestDecimalStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/stream/TestLongBitPacker.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/stream/TestLongBitPacker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/orc/stream/TestingBitPackingUtils.java
+++ b/hbase_sql/src/test/java/com/splicemachine/orc/stream/TestingBitPackingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/stream/StreamableRDDTest.java
+++ b/hbase_sql/src/test/java/com/splicemachine/stream/StreamableRDDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/stream/StreamableRDDTest_Failures.java
+++ b/hbase_sql/src/test/java/com/splicemachine/stream/StreamableRDDTest_Failures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/test/HBaseTestUtils.java
+++ b/hbase_sql/src/test/java/com/splicemachine/test/HBaseTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/java/com/splicemachine/test/MiniZooKeeperCluster.java
+++ b/hbase_sql/src/test/java/com/splicemachine/test/MiniZooKeeperCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_sql/src/test/resources/log4j.properties
+++ b/hbase_sql/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/access/client/HBase10ClientSideRegionScanner.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/access/client/HBase10ClientSideRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayer.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayerFactory.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/access/hbase/HBase10TableFactory.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/access/hbase/HBase10TableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/access/hbase/HPartitionCreator.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/access/hbase/HPartitionCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/hbase/SICompactionScanner.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/hbase/SICompactionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/storage/ClientPartition.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/storage/ClientPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/storage/Hbase10PartitionCache.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/storage/Hbase10PartitionCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/storage/LazyPartitionServer.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/storage/LazyPartitionServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/storage/RLServer.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/storage/RLServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/storage/RangedClientPartition.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/storage/RangedClientPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/storage/ReopenableResultScanner.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/storage/ReopenableResultScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/timestamp/hbase/HBaseTimestampHostProvider.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/com/splicemachine/timestamp/hbase/HBaseTimestampHostProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/java/org/apache/hadoop/hbase/regionserver/HBasePlatformUtils.java
+++ b/hbase_storage/hbase1.1.1/src/main/java/org/apache/hadoop/hbase/regionserver/HBasePlatformUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/resources/META-INF/services/com.splicemachine.access.api.PartitionFactory
+++ b/hbase_storage/hbase1.1.1/src/main/resources/META-INF/services/com.splicemachine.access.api.PartitionFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/resources/META-INF/services/com.splicemachine.si.impl.TxnNetworkLayerFactory
+++ b/hbase_storage/hbase1.1.1/src/main/resources/META-INF/services/com.splicemachine.si.impl.TxnNetworkLayerFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/main/resources/META-INF/services/com.splicemachine.storage.PartitionInfoCache
+++ b/hbase_storage/hbase1.1.1/src/main/resources/META-INF/services/com.splicemachine.storage.PartitionInfoCache
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/test/java/com/splicemachine/hbase/util/IteratorRegionScanner.java
+++ b/hbase_storage/hbase1.1.1/src/test/java/com/splicemachine/hbase/util/IteratorRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.1/src/test/java/com/splicemachine/si/testsetup/HBaseSITestEnv.java
+++ b/hbase_storage/hbase1.1.1/src/test/java/com/splicemachine/si/testsetup/HBaseSITestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/client/HBase10ClientSideRegionScanner.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/client/HBase10ClientSideRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayer.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayerFactory.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/hbase/HBase10TableFactory.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/hbase/HBase10TableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/hbase/HPartitionCreator.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/access/hbase/HPartitionCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/SICompactionScanner.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/hbase/SICompactionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/ClientPartition.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/ClientPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/Hbase10PartitionCache.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/Hbase10PartitionCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/LazyPartitionServer.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/LazyPartitionServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/RLServer.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/RLServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/RangedClientPartition.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/RangedClientPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/ReopenableResultScanner.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/ReopenableResultScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/timestamp/hbase/HBaseTimestampHostProvider.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/com/splicemachine/timestamp/hbase/HBaseTimestampHostProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/java/org/apache/hadoop/hbase/regionserver/HBasePlatformUtils.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/java/org/apache/hadoop/hbase/regionserver/HBasePlatformUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/resources/META-INF/services/com.splicemachine.access.api.PartitionFactory
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/resources/META-INF/services/com.splicemachine.access.api.PartitionFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/resources/META-INF/services/com.splicemachine.si.impl.TxnNetworkLayerFactory
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/resources/META-INF/services/com.splicemachine.si.impl.TxnNetworkLayerFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/main/resources/META-INF/services/com.splicemachine.storage.PartitionInfoCache
+++ b/hbase_storage/hbase1.1.2.2.5/src/main/resources/META-INF/services/com.splicemachine.storage.PartitionInfoCache
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/test/java/com/splicemachine/hbase/util/IteratorRegionScanner.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/test/java/com/splicemachine/hbase/util/IteratorRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.5/src/test/java/com/splicemachine/si/testsetup/HBaseSITestEnv.java
+++ b/hbase_storage/hbase1.1.2.2.5/src/test/java/com/splicemachine/si/testsetup/HBaseSITestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/access/client/HBase10ClientSideRegionScanner.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/access/client/HBase10ClientSideRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayer.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayerFactory.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/access/hbase/HBase10TableFactory.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/access/hbase/HBase10TableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/access/hbase/HPartitionCreator.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/access/hbase/HPartitionCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/hbase/SICompactionScanner.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/hbase/SICompactionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/storage/ClientPartition.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/storage/ClientPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/storage/Hbase10PartitionCache.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/storage/Hbase10PartitionCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/storage/LazyPartitionServer.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/storage/LazyPartitionServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/storage/RLServer.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/storage/RLServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/storage/RangedClientPartition.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/storage/RangedClientPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/storage/ReopenableResultScanner.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/storage/ReopenableResultScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/timestamp/hbase/HBaseTimestampHostProvider.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/com/splicemachine/timestamp/hbase/HBaseTimestampHostProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/java/org/apache/hadoop/hbase/regionserver/HBasePlatformUtils.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/java/org/apache/hadoop/hbase/regionserver/HBasePlatformUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/resources/META-INF/services/com.splicemachine.access.api.PartitionFactory
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/resources/META-INF/services/com.splicemachine.access.api.PartitionFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/resources/META-INF/services/com.splicemachine.si.impl.TxnNetworkLayerFactory
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/resources/META-INF/services/com.splicemachine.si.impl.TxnNetworkLayerFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/main/resources/META-INF/services/com.splicemachine.storage.PartitionInfoCache
+++ b/hbase_storage/hbase1.1.2.2.6/src/main/resources/META-INF/services/com.splicemachine.storage.PartitionInfoCache
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/test/java/com/splicemachine/hbase/util/IteratorRegionScanner.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/test/java/com/splicemachine/hbase/util/IteratorRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.2.2.6/src/test/java/com/splicemachine/si/testsetup/HBaseSITestEnv.java
+++ b/hbase_storage/hbase1.1.2.2.6/src/test/java/com/splicemachine/si/testsetup/HBaseSITestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/access/client/HBase10ClientSideRegionScanner.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/access/client/HBase10ClientSideRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayer.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayerFactory.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/access/hbase/HBase10TableFactory.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/access/hbase/HBase10TableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/access/hbase/HPartitionCreator.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/access/hbase/HPartitionCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/hbase/SICompactionScanner.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/hbase/SICompactionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/storage/ClientPartition.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/storage/ClientPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/storage/Hbase10PartitionCache.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/storage/Hbase10PartitionCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/storage/LazyPartitionServer.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/storage/LazyPartitionServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/storage/RLServer.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/storage/RLServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/storage/RangedClientPartition.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/storage/RangedClientPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/storage/ReopenableResultScanner.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/storage/ReopenableResultScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/timestamp/hbase/HBaseTimestampHostProvider.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/com/splicemachine/timestamp/hbase/HBaseTimestampHostProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/java/org/apache/hadoop/hbase/regionserver/HBasePlatformUtils.java
+++ b/hbase_storage/hbase1.1.8/src/main/java/org/apache/hadoop/hbase/regionserver/HBasePlatformUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/resources/META-INF/services/com.splicemachine.access.api.PartitionFactory
+++ b/hbase_storage/hbase1.1.8/src/main/resources/META-INF/services/com.splicemachine.access.api.PartitionFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/resources/META-INF/services/com.splicemachine.si.impl.TxnNetworkLayerFactory
+++ b/hbase_storage/hbase1.1.8/src/main/resources/META-INF/services/com.splicemachine.si.impl.TxnNetworkLayerFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/main/resources/META-INF/services/com.splicemachine.storage.PartitionInfoCache
+++ b/hbase_storage/hbase1.1.8/src/main/resources/META-INF/services/com.splicemachine.storage.PartitionInfoCache
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/test/java/com/splicemachine/hbase/util/IteratorRegionScanner.java
+++ b/hbase_storage/hbase1.1.8/src/test/java/com/splicemachine/hbase/util/IteratorRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.1.8/src/test/java/com/splicemachine/si/testsetup/HBaseSITestEnv.java
+++ b/hbase_storage/hbase1.1.8/src/test/java/com/splicemachine/si/testsetup/HBaseSITestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/client/HBase10ClientSideRegionScanner.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/client/HBase10ClientSideRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayer.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayerFactory.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/hbase/H10TxnNetworkLayerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/hbase/HBase10TableFactory.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/hbase/HBase10TableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/hbase/HBaseConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/hbase/HPartitionCreator.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/hbase/HPartitionCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/hbase/SICompactionScanner.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/hbase/SICompactionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/ClientPartition.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/ClientPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/Hbase10PartitionCache.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/Hbase10PartitionCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/LazyPartitionServer.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/LazyPartitionServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/RLServer.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/RLServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/RangedClientPartition.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/RangedClientPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/ReopenableResultScanner.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/ReopenableResultScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/storage/SplitRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/timestamp/hbase/HBaseTimestampHostProvider.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/timestamp/hbase/HBaseTimestampHostProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/java/org/apache/hadoop/hbase/regionserver/HBasePlatformUtils.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/org/apache/hadoop/hbase/regionserver/HBasePlatformUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/resources/META-INF/services/com.splicemachine.access.api.PartitionFactory
+++ b/hbase_storage/hbase1.2.0/src/main/resources/META-INF/services/com.splicemachine.access.api.PartitionFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/resources/META-INF/services/com.splicemachine.si.impl.TxnNetworkLayerFactory
+++ b/hbase_storage/hbase1.2.0/src/main/resources/META-INF/services/com.splicemachine.si.impl.TxnNetworkLayerFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/main/resources/META-INF/services/com.splicemachine.storage.PartitionInfoCache
+++ b/hbase_storage/hbase1.2.0/src/main/resources/META-INF/services/com.splicemachine.storage.PartitionInfoCache
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/test/java/com/splicemachine/hbase/util/IteratorRegionScanner.java
+++ b/hbase_storage/hbase1.2.0/src/test/java/com/splicemachine/hbase/util/IteratorRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/hbase1.2.0/src/test/java/com/splicemachine/si/testsetup/HBaseSITestEnv.java
+++ b/hbase_storage/hbase1.2.0/src/test/java/com/splicemachine/si/testsetup/HBaseSITestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/pom.xml
+++ b/hbase_storage/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/access/HBaseConfigurationSource.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/HBaseConfigurationSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/access/HConfiguration.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/HConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/ClientRegionConstants.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/ClientRegionConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/CountingRegionScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/CountingRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/MemstoreAware.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/MemstoreAware.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/ReadOnlyTableDescriptor.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/ReadOnlyTableDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/SkeletonClientSideRegionScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/SkeletonClientSideRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/SpliceHRegionInfo.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/SpliceHRegionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/SpliceKVComparator.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/SpliceKVComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/access/hbase/AdapterTableFactory.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/hbase/AdapterTableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/access/hbase/H10PartitionAdmin.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/hbase/H10PartitionAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/access/hbase/HBaseTableDescriptor.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/hbase/HBaseTableDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/access/hbase/HBaseTableInfoFactory.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/hbase/HBaseTableInfoFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/access/hbase/HFilesystemAdmin.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/hbase/HFilesystemAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/access/hbase/HServer.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/hbase/HServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/access/hbase/HSnowflakeFactory.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/hbase/HSnowflakeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/constants/EnvUtils.java
+++ b/hbase_storage/src/main/java/com/splicemachine/constants/EnvUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/constants/SpliceConfiguration.java
+++ b/hbase_storage/src/main/java/com/splicemachine/constants/SpliceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/constants/package-info.java
+++ b/hbase_storage/src/main/java/com/splicemachine/constants/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/derby/hbase/AllocatedFilter.java
+++ b/hbase_storage/src/main/java/com/splicemachine/derby/hbase/AllocatedFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/hbase/CellByteBufferArrayUtils.java
+++ b/hbase_storage/src/main/java/com/splicemachine/hbase/CellByteBufferArrayUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/hbase/CellUtils.java
+++ b/hbase_storage/src/main/java/com/splicemachine/hbase/CellUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/hbase/SpliceZooKeeperManager.java
+++ b/hbase_storage/src/main/java/com/splicemachine/hbase/SpliceZooKeeperManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/hbase/ZkServiceDiscovery.java
+++ b/hbase_storage/src/main/java/com/splicemachine/hbase/ZkServiceDiscovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/hbase/ZkUtils.java
+++ b/hbase_storage/src/main/java/com/splicemachine/hbase/ZkUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/mrio/MRConstants.java
+++ b/hbase_storage/src/main/java/com/splicemachine/mrio/MRConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/HExceptionFactory.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/HExceptionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/ExtendedOperationStatus.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/ExtendedOperationStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/HOperationStatusFactory.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/HOperationStatusFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/AdapterSIEnvironment.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/AdapterSIEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/CoprocessorUtils.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/CoprocessorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/HBaseComparator.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/HBaseComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/HBaseSIEnvironment.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/HBaseSIEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/PartitionCacheService.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/PartitionCacheService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/SIObserver.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/SIObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/TableFactoryService.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/TableFactoryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/TableType.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/TableType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/TxnLifecycleEndpoint.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/TxnLifecycleEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/package-info.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/rollforward/HBaseRollForward.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/rollforward/HBaseRollForward.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/rollforward/RFEvent.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/rollforward/RFEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/AdditiveWriteConflict.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/AdditiveWriteConflict.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/CoprocessorTxnStore.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/CoprocessorTxnStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/HCallTimeout.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/HCallTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/HCallerDisconnected.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/HCallerDisconnected.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/HCannotCommitException.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/HCannotCommitException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/HFailedServer.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/HFailedServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/HNotServingRegion.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/HNotServingRegion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/HOperationFactory.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/HOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/HReadOnlyModificationException.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/HReadOnlyModificationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/HRegionTooBusy.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/HRegionTooBusy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/HTransactionTimeout.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/HTransactionTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/HWriteConflict.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/HWriteConflict.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/HWrongRegion.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/HWrongRegion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/QueuedKeepAliveScheduler.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/QueuedKeepAliveScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/SIFilterPacked.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/SIFilterPacked.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/SkeletonTxnNetworkLayer.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/SkeletonTxnNetworkLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/TxnNetworkLayer.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/TxnNetworkLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/TxnNetworkLayerFactory.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/TxnNetworkLayerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/package-info.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/readresolve/SynchronousReadResolver.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/readresolve/SynchronousReadResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/region/ActiveTxnFilter.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/region/ActiveTxnFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/region/RegionServerControl.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/region/RegionServerControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/region/RegionTxnStore.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/region/RegionTxnStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/region/TXNDecoderUtils.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/region/TXNDecoderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/region/TxnDecoder.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/region/TxnDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/region/TxnStoreUtils.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/region/TxnStoreUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/region/V2TxnDecoder.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/region/V2TxnDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/server/AbstractSICompactionScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/server/AbstractSICompactionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/server/CompactionContext.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/server/CompactionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/server/SICompactionState.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/server/SICompactionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/server/SimpleCompactionContext.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/server/SimpleCompactionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/AdapterPartition.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/AdapterPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/CellIterable.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/CellIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HCell.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HCell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HClusterHealthFactory.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HClusterHealthFactory.java
@@ -1,6 +1,6 @@
 /*
  *
- *  * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ *  * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *  *
  *  * This file is part of Splice Machine.
  *  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HDataFilterWrapper.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HDataFilterWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HDelete.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HFilterFactory.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HFilterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HFilterWrapper.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HFilterWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HGet.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HGet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HLock.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HMutation.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HMutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HMutationStatus.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HMutationStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HPartitionDescriptor.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HPartitionDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HPartitionLoad.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HPartitionLoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HPut.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HPut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HResult.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HScan.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HServerLoad.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HServerLoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/ListingResultScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/ListingResultScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/RegionDataScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/RegionDataScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/RegionPartition.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/RegionPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/RegionResultScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/RegionResultScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/ResultDataScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/ResultDataScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/SkeletonHBaseClientPartition.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/SkeletonHBaseClientPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/util/MeasuredListScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/util/MeasuredListScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/util/MeasuredResultScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/util/MeasuredResultScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/storage/util/PartitionInRangePredicate.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/util/PartitionInRangePredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/timestamp/hbase/ZkTimestampBlockManager.java
+++ b/hbase_storage/src/main/java/com/splicemachine/timestamp/hbase/ZkTimestampBlockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/com/splicemachine/timestamp/hbase/ZkTimestampSource.java
+++ b/hbase_storage/src/main/java/com/splicemachine/timestamp/hbase/ZkTimestampSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/org/apache/hadoop/hbase/client/SpliceFailFastInterceptor.java
+++ b/hbase_storage/src/main/java/org/apache/hadoop/hbase/client/SpliceFailFastInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/org/apache/hadoop/hbase/client/SpliceRPCRetryingCallerFactory.java
+++ b/hbase_storage/src/main/java/org/apache/hadoop/hbase/client/SpliceRPCRetryingCallerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/org/apache/hadoop/hbase/ipc/RpcUtils.java
+++ b/hbase_storage/src/main/java/org/apache/hadoop/hbase/ipc/RpcUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/BaseHRegionUtil.java
+++ b/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/BaseHRegionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionUtil.java
+++ b/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/org/apache/hadoop/hdfs/HDFSUtil.java
+++ b/hbase_storage/src/main/java/org/apache/hadoop/hdfs/HDFSUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/org/apache/hadoop/hdfs/ProxiedDFSClient.java
+++ b/hbase_storage/src/main/java/org/apache/hadoop/hdfs/ProxiedDFSClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/main/java/org/apache/hadoop/hdfs/ProxiedFilesystem.java
+++ b/hbase_storage/src/main/java/org/apache/hadoop/hdfs/ProxiedFilesystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/test/java/com/splicemachine/access/HConfigurationTest.java
+++ b/hbase_storage/src/test/java/com/splicemachine/access/HConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/test/java/com/splicemachine/access/client/MemstoreKeyValueScannerTest.java
+++ b/hbase_storage/src/test/java/com/splicemachine/access/client/MemstoreKeyValueScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 - 2016 Splice Machine, Inc.
+ * Copyright 2012 - 2019 Splice Machine, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy of the

--- a/hbase_storage/src/test/java/com/splicemachine/hbase/util/AbstractIteratorRegionScanner.java
+++ b/hbase_storage/src/test/java/com/splicemachine/hbase/util/AbstractIteratorRegionScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/test/java/com/splicemachine/impl/MockRegionUtils.java
+++ b/hbase_storage/src/test/java/com/splicemachine/impl/MockRegionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/test/java/com/splicemachine/si/impl/RegionTxnStoreTest.java
+++ b/hbase_storage/src/test/java/com/splicemachine/si/impl/RegionTxnStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/test/java/com/splicemachine/si/impl/SynchronousReadResolverTest.java
+++ b/hbase_storage/src/test/java/com/splicemachine/si/impl/SynchronousReadResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/test/java/com/splicemachine/si/testsetup/ConcurrentTimestampSource.java
+++ b/hbase_storage/src/test/java/com/splicemachine/si/testsetup/ConcurrentTimestampSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/test/java/com/splicemachine/si/testsetup/HBaseDataEnv.java
+++ b/hbase_storage/src/test/java/com/splicemachine/si/testsetup/HBaseDataEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/test/java/com/splicemachine/si/txn/ScriptGen.java
+++ b/hbase_storage/src/test/java/com/splicemachine/si/txn/ScriptGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/test/resources/META-INF/services/com.splicemachine.si.testenv.SITestDataEnv
+++ b/hbase_storage/src/test/resources/META-INF/services/com.splicemachine.si.testenv.SITestDataEnv
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/test/resources/META-INF/services/com.splicemachine.si.testenv.SITestEnv
+++ b/hbase_storage/src/test/resources/META-INF/services/com.splicemachine.si.testenv.SITestEnv
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/test/resources/log4j.properties
+++ b/hbase_storage/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/hbase_storage/src/test/resources/splice-site.xml
+++ b/hbase_storage/src/test/resources/splice-site.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_pipeline/pom.xml
+++ b/mem_pipeline/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_pipeline/src/main/java/com/splicemachine/pipeline/MPipelineEnv.java
+++ b/mem_pipeline/src/main/java/com/splicemachine/pipeline/MPipelineEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_pipeline/src/main/java/com/splicemachine/pipeline/mem/ConstraintViolation.java
+++ b/mem_pipeline/src/main/java/com/splicemachine/pipeline/mem/ConstraintViolation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_pipeline/src/main/java/com/splicemachine/pipeline/mem/DirectBulkWriter.java
+++ b/mem_pipeline/src/main/java/com/splicemachine/pipeline/mem/DirectBulkWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_pipeline/src/main/java/com/splicemachine/pipeline/mem/DirectBulkWriterFactory.java
+++ b/mem_pipeline/src/main/java/com/splicemachine/pipeline/mem/DirectBulkWriterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_pipeline/src/main/java/com/splicemachine/pipeline/mem/DirectPipelineExceptionFactory.java
+++ b/mem_pipeline/src/main/java/com/splicemachine/pipeline/mem/DirectPipelineExceptionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_pipeline/src/main/java/com/splicemachine/pipeline/mem/MTooBusy.java
+++ b/mem_pipeline/src/main/java/com/splicemachine/pipeline/mem/MTooBusy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_pipeline/src/main/java/com/splicemachine/pipeline/mem/MWrongPartition.java
+++ b/mem_pipeline/src/main/java/com/splicemachine/pipeline/mem/MWrongPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_pipeline/src/test/java/com/splicemachine/pipeline/testsetup/MPipelineTestDataEnv.java
+++ b/mem_pipeline/src/test/java/com/splicemachine/pipeline/testsetup/MPipelineTestDataEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_pipeline/src/test/java/com/splicemachine/pipeline/testsetup/MPipelineTestEnv.java
+++ b/mem_pipeline/src/test/java/com/splicemachine/pipeline/testsetup/MPipelineTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_pipeline/src/test/resources/META-INF/services/com.splicemachine.pipeline.testsetup.PipelineTestDataEnv
+++ b/mem_pipeline/src/test/resources/META-INF/services/com.splicemachine.pipeline.testsetup.PipelineTestDataEnv
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_pipeline/src/test/resources/META-INF/services/com.splicemachine.pipeline.testsetup.PipelineTestEnv
+++ b/mem_pipeline/src/test/resources/META-INF/services/com.splicemachine.pipeline.testsetup.PipelineTestEnv
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/pom.xml
+++ b/mem_sql/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/ddl/MemDDLEnvironment.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/ddl/MemDDLEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/ControlOnlyDataSetProcessorFactory.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/ControlOnlyDataSetProcessorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/DirectPartitionLoadWatcher.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/DirectPartitionLoadWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/DirectPropertyManager.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/DirectPropertyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/LocalOlapClient.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/LocalOlapClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/MSqlExceptionFactory.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/MSqlExceptionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/NoOpBackupManager.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/NoOpBackupManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/NoOpManager.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/NoOpManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/execute/MemDropIndexConstantOperation.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/execute/MemDropIndexConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/execute/MemExecutionFactory.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/execute/MemExecutionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/execute/MemGenericConstantActionFactory.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/execute/MemGenericConstantActionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/store/access/MFile.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/store/access/MFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/store/access/MemFileResourceFactory.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/store/access/MemFileResourceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/store/access/MemStorageFactory.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/store/access/MemStorageFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MEnginePartitionAdmin.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MEnginePartitionAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MEngineSqlEnv.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MEngineSqlEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MPipelinePartitionFactory.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MPipelinePartitionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MemDatabase.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MemDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/PipelinePartitionCreator.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/PipelinePartitionCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/derby/utils/AtomicSequencer.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/utils/AtomicSequencer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/java/com/splicemachine/management/DirectDatabaseAdministrator.java
+++ b/mem_sql/src/main/java/com/splicemachine/management/DirectDatabaseAdministrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/resources/META-INF/services/com.splicemachine.SqlEnvironment
+++ b/mem_sql/src/main/resources/META-INF/services/com.splicemachine.SqlEnvironment
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/resources/META-INF/services/com.splicemachine.db.io.StorageFactory
+++ b/mem_sql/src/main/resources/META-INF/services/com.splicemachine.db.io.StorageFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/resources/META-INF/services/com.splicemachine.derby.ddl.DDLEnvironment
+++ b/mem_sql/src/main/resources/META-INF/services/com.splicemachine.derby.ddl.DDLEnvironment
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/resources/META-INF/services/com.splicemachine.derby.iapi.sql.PropertyManager
+++ b/mem_sql/src/main/resources/META-INF/services/com.splicemachine.derby.iapi.sql.PropertyManager
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/resources/META-INF/services/com.splicemachine.derby.impl.store.access.FileResourceFactory
+++ b/mem_sql/src/main/resources/META-INF/services/com.splicemachine.derby.impl.store.access.FileResourceFactory
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/resources/META-INF/services/com.splicemachine.derby.utils.Sequencer
+++ b/mem_sql/src/main/resources/META-INF/services/com.splicemachine.derby.utils.Sequencer
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/resources/com/splicemachine/db/modules.properties
+++ b/mem_sql/src/main/resources/com/splicemachine/db/modules.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_sql/src/main/resources/log4j.properties
+++ b/mem_sql/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/pom.xml
+++ b/mem_storage/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/MemSIEnvironment.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/MemSIEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/ReflectingConfigurationSource.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/ReflectingConfigurationSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/MCannotCommitException.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/MCannotCommitException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/MOpStatusFactory.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/MOpStatusFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/MOperationFactory.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/MOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/MSynchronousReadResolver.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/MSynchronousReadResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/MTransactionTimeout.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/MTransactionTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/MWriteConflict.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/MWriteConflict.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/MemTimestampSource.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/MemTimestampSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/MemTxnStore.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/MemTxnStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/TxnPartition.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/TxnPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/data/MAdditiveWriteConflict.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/data/MAdditiveWriteConflict.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/data/MCallerDisconnected.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/data/MCallerDisconnected.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/data/MExceptionFactory.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/data/MExceptionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/data/MFailedServer.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/data/MFailedServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/data/MNoSuchFamily.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/data/MNoSuchFamily.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/data/MNotServingPartition.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/data/MNotServingPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/data/MReadOnly.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/data/MReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/data/NoOpConstraintChecker.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/data/NoOpConstraintChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MCell.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MCell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MClusterHealth.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MClusterHealth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MClusterHealthWatcher.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MClusterHealthWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MDelete.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MFilterFactory.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MFilterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MGet.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MGet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MOperationStatus.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MOperationStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MPartition.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MPartitionCache.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MPartitionCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MPartitionFactory.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MPartitionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MPartitionLoad.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MPartitionLoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MPartitionServer.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MPartitionServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MPut.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MPut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MResult.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MScan.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MServerControl.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MServerControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MSnowflakeFactory.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MSnowflakeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MTxnFilterWrapper.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MTxnFilterWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MTxnPartitionFactory.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MTxnPartitionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/MemFileSystem.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MemFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/main/java/com/splicemachine/storage/SetScanner.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/SetScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/test/java/com/splicemachine/si/MemSIDataEnv.java
+++ b/mem_storage/src/test/java/com/splicemachine/si/MemSIDataEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/test/java/com/splicemachine/si/MemSITestEnv.java
+++ b/mem_storage/src/test/java/com/splicemachine/si/MemSITestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/test/resources/META-INF/services/com.splicemachine.si.testenv.SITestDataEnv
+++ b/mem_storage/src/test/resources/META-INF/services/com.splicemachine.si.testenv.SITestDataEnv
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/mem_storage/src/test/resources/META-INF/services/com.splicemachine.si.testenv.SITestEnv
+++ b/mem_storage/src/test/resources/META-INF/services/com.splicemachine.si.testenv.SITestEnv
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/pom.xml
+++ b/pipeline_api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2018 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/lifecycle/DatabaseLifecycleManager.java
+++ b/pipeline_api/src/main/java/com/splicemachine/lifecycle/DatabaseLifecycleManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/lifecycle/DatabaseLifecycleService.java
+++ b/pipeline_api/src/main/java/com/splicemachine/lifecycle/DatabaseLifecycleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/lifecycle/PipelineEnvironmentLoadService.java
+++ b/pipeline_api/src/main/java/com/splicemachine/lifecycle/PipelineEnvironmentLoadService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/lifecycle/PipelineLoadService.java
+++ b/pipeline_api/src/main/java/com/splicemachine/lifecycle/PipelineLoadService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/AclCheckerService.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/AclCheckerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/ContextFactoryDriverService.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/ContextFactoryDriverService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/MappedPipelineFactory.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/MappedPipelineFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/PartitionWritePipeline.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/PartitionWritePipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineDriver.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineEnvironment.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineWriter.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/api/BulkWriter.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/api/BulkWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/api/BulkWriterFactory.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/api/BulkWriterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/api/Code.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/api/Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/api/Constraint.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/api/Constraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/api/PipelineExceptionFactory.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/api/PipelineExceptionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/api/PipelineMeter.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/api/PipelineMeter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/api/PipelineTooBusy.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/api/PipelineTooBusy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/api/RecordingContext.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/api/RecordingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/api/WriteCoordinatorStatus.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/api/WriteCoordinatorStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/api/WritePipelineFactory.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/api/WritePipelineFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/api/WriteResponse.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/api/WriteResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/api/WriteStats.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/api/WriteStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/api/Writer.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/api/Writer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/api/WriterStatus.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/api/WriterStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/BufferConfiguration.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/BufferConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/CallBuffer.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/CallBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/ForwardRecordingCallBuffer.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/ForwardRecordingCallBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/ForwardingCallBuffer.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/ForwardingCallBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/PartitionBuffer.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/PartitionBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/PipingCallBuffer.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/PipingCallBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/PreFlushHook.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/PreFlushHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/Rebuildable.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/Rebuildable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/RecordingCallBuffer.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/RecordingCallBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/ServerCallBuffer.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/callbuffer/ServerCallBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/client/ActionStatusReporter.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/client/ActionStatusReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/client/BulkWrite.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/client/BulkWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/client/BulkWriteAction.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/client/BulkWriteAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/client/BulkWriteResult.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/client/BulkWriteResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/client/BulkWrites.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/client/BulkWrites.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/client/BulkWritesResult.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/client/BulkWritesResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/client/MergingWriteStats.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/client/MergingWriteStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/client/Monitor.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/client/Monitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/client/PipelineEncoding.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/client/PipelineEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/client/SimpleWriteStats.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/client/SimpleWriteStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/client/WriteCoordinator.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/client/WriteCoordinator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/client/WriteFailedException.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/client/WriteFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/client/WriteResult.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/client/WriteResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/config/BaseWriteConfiguration.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/config/BaseWriteConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/config/CountingWriteConfiguration.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/config/CountingWriteConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/config/DefaultWriteConfiguration.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/config/DefaultWriteConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/config/ForwardingWriteConfiguration.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/config/ForwardingWriteConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/config/RollforwardWriteConfiguration.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/config/RollforwardWriteConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/config/SharedWriteConfiguration.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/config/SharedWriteConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/config/UnsafeWriteConfiguration.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/config/UnsafeWriteConfiguration.java
@@ -1,6 +1,6 @@
 /*
  *
- *  * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ *  * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *  *
  *  * This file is part of Splice Machine.
  *  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/config/UpdatingWriteConfiguration.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/config/UpdatingWriteConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/config/WriteConfiguration.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/config/WriteConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/constraint/BatchConstraintChecker.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/constraint/BatchConstraintChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/constraint/ChainConstraintChecker.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/constraint/ChainConstraintChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/constraint/ConstraintContext.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/constraint/ConstraintContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/constraint/ForeignKeyViolation.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/constraint/ForeignKeyViolation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/constraint/PrimaryKeyConstraint.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/constraint/PrimaryKeyConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/constraint/UniqueConstraint.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/constraint/UniqueConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/constraint/UniqueConstraintChecker.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/constraint/UniqueConstraintChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/constraint/UniqueConstraintViolation.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/constraint/UniqueConstraintViolation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/context/NoOpPipelineMeter.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/context/NoOpPipelineMeter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/context/PipelineWriteContext.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/context/PipelineWriteContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/context/WriteContext.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/context/WriteContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/context/WriteNode.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/context/WriteNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/ConstraintFactory.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/ConstraintFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/ContextFactoryDriver.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/ContextFactoryDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/ContextFactoryLoader.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/ContextFactoryLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/ListWriteFactoryGroup.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/ListWriteFactoryGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/LocalWriteContextFactory.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/LocalWriteContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/LocalWriteFactory.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/LocalWriteFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/ReferenceCountingFactoryDriver.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/ReferenceCountingFactoryDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/SetWriteFactoryGroup.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/SetWriteFactoryGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/State.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/State.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/UnmanagedFactoryLoader.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/UnmanagedFactoryLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/WriteContextFactory.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/WriteContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/WriteContextFactoryManager.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/WriteContextFactoryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/WriteFactoryGroup.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/contextfactory/WriteFactoryGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/exception/IndexNotSetUpException.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/exception/IndexNotSetUpException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/security/AclChecker.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/security/AclChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/threadpool/MonitoredThreadPool.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/threadpool/MonitoredThreadPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/threadpool/ThreadPoolStatus.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/threadpool/ThreadPoolStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/traffic/AtomicSpliceWriteControl.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/traffic/AtomicSpliceWriteControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/traffic/SpliceWriteControl.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/traffic/SpliceWriteControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/traffic/SynchronousWriteControl.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/traffic/SynchronousWriteControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/traffic/WriteStatus.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/traffic/WriteStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/utils/PipelineCompressor.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/utils/PipelineCompressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/utils/PipelineUtils.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/utils/PipelineUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/utils/SimplePipelineCompressor.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/utils/SimplePipelineCompressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/ConstraintWriteHandler.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/ConstraintWriteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/ForbidPastWritersHandler.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/ForbidPastWritersHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/PartitionWriteHandler.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/PartitionWriteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/RoutingWriteHandler.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/RoutingWriteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/SharedCallBufferFactory.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/SharedCallBufferFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/SharedPreFlushHook.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/SharedPreFlushHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/SnapshotIsolatedWriteHandler.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/SnapshotIsolatedWriteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/WriteHandler.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/writehandler/WriteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/writer/AsyncBucketingWriter.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/writer/AsyncBucketingWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/writer/RegulatedWriter.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/writer/RegulatedWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/writer/SynchronousBucketingWriter.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/writer/SynchronousBucketingWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/writerstatus/ActionStatusMonitor.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/writerstatus/ActionStatusMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/test/java/com/splicemachine/pipeline/ManualContextFactoryLoader.java
+++ b/pipeline_api/src/test/java/com/splicemachine/pipeline/ManualContextFactoryLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/test/java/com/splicemachine/pipeline/PipelineTest.java
+++ b/pipeline_api/src/test/java/com/splicemachine/pipeline/PipelineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/test/java/com/splicemachine/pipeline/client/BulkWriteActionTest.java
+++ b/pipeline_api/src/test/java/com/splicemachine/pipeline/client/BulkWriteActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/test/java/com/splicemachine/pipeline/constraint/ConstraintContextTest.java
+++ b/pipeline_api/src/test/java/com/splicemachine/pipeline/constraint/ConstraintContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/test/java/com/splicemachine/pipeline/testsetup/PipelineTestDataEnv.java
+++ b/pipeline_api/src/test/java/com/splicemachine/pipeline/testsetup/PipelineTestDataEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/test/java/com/splicemachine/pipeline/testsetup/PipelineTestEnv.java
+++ b/pipeline_api/src/test/java/com/splicemachine/pipeline/testsetup/PipelineTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/test/java/com/splicemachine/pipeline/testsetup/PipelineTestEnvironment.java
+++ b/pipeline_api/src/test/java/com/splicemachine/pipeline/testsetup/PipelineTestEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/test/java/com/splicemachine/pipeline/traffic/SpliceWriteControlTest.java
+++ b/pipeline_api/src/test/java/com/splicemachine/pipeline/traffic/SpliceWriteControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/test/java/com/splicemachine/pipeline/writeconfiguration/DefaultWriteConfigurationTest.java
+++ b/pipeline_api/src/test/java/com/splicemachine/pipeline/writeconfiguration/DefaultWriteConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pipeline_api/src/test/java/com/splicemachine/pipeline/writehandler/PartitionWriteHandlerTest.java
+++ b/pipeline_api/src/test/java/com/splicemachine/pipeline/writehandler/PartitionWriteHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/pom.xml
+++ b/platform_it/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/spark2.1.0-mapr-1710/src/test/resources/yarn-site.xml
+++ b/platform_it/spark2.1.0-mapr-1710/src/test/resources/yarn-site.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/spark2.1.0.cloudera1/src/test/resources/yarn-site.xml
+++ b/platform_it/spark2.1.0.cloudera1/src/test/resources/yarn-site.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/spark2.1.1.2.6.1.0-129/src/test/resources/yarn-site.xml
+++ b/platform_it/spark2.1.1.2.6.1.0-129/src/test/resources/yarn-site.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/spark2.2.0.2.6.3.0-235/src/test/resources/yarn-site.xml
+++ b/platform_it/spark2.2.0.2.6.3.0-235/src/test/resources/yarn-site.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/spark2.2.0.2.6.4.0-91/src/test/resources/yarn-site.xml
+++ b/platform_it/spark2.2.0.2.6.4.0-91/src/test/resources/yarn-site.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/spark2.2.0.cloudera1/src/test/resources/yarn-site.xml
+++ b/platform_it/spark2.2.0.cloudera1/src/test/resources/yarn-site.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/spark2.2.0.cloudera2/src/test/resources/yarn-site.xml
+++ b/platform_it/spark2.2.0.cloudera2/src/test/resources/yarn-site.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/spark2.2.0/src/test/resources/yarn-site.xml
+++ b/platform_it/spark2.2.0/src/test/resources/yarn-site.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/spark2.3.0.2.6.5.0-292/src/test/resources/yarn-site.xml
+++ b/platform_it/spark2.3.0.2.6.5.0-292/src/test/resources/yarn-site.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/spark2.3.0.cloudera3/src/test/resources/yarn-site.xml
+++ b/platform_it/spark2.3.0.cloudera3/src/test/resources/yarn-site.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/main/resources/fairscheduler.xml
+++ b/platform_it/src/main/resources/fairscheduler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/main/resources/info-log4j.properties
+++ b/platform_it/src/main/resources/info-log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/main/resources/olap-log4j.properties
+++ b/platform_it/src/main/resources/olap-log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/test/java/com/splicemachine/kafka/TestKafkaCluster.java
+++ b/platform_it/src/test/java/com/splicemachine/kafka/TestKafkaCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestClusterParticipant.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestClusterParticipant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestDfsPlatform.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestDfsPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestKDCPlatform.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestKDCPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatform.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformShutdownThread.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformShutdownThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformUsage.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestYarnPlatform.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestYarnPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/test/java/com/splicemachine/yarn/test/BareYarnTest.java
+++ b/platform_it/src/test/java/com/splicemachine/yarn/test/BareYarnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAMRMClient.java
+++ b/platform_it/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAMRMClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/test/java/org/apache/hadoop/yarn/server/MiniYARNClusterSplice.java
+++ b/platform_it/src/test/java/org/apache/hadoop/yarn/server/MiniYARNClusterSplice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/test/java/org/apache/hadoop/yarn/server/TestMiniYARNClusterForHA.java
+++ b/platform_it/src/test/java/org/apache/hadoop/yarn/server/TestMiniYARNClusterForHA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/test/jmeter/tpch1-micro-suite.jmx
+++ b/platform_it/src/test/jmeter/tpch1-micro-suite.jmx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/test/jmeter/tpch1.jmx
+++ b/platform_it/src/test/jmeter/tpch1.jmx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/test/jmeter/user.properties
+++ b/platform_it/src/test/jmeter/user.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/platform_it/src/test/resources/assertion-results.xsl
+++ b/platform_it/src/test/resources/assertion-results.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/scala_util/src/main/scala/com/splicemachine/spark/splicemachine/ShuffleUtils.scala
+++ b/scala_util/src/main/scala/com/splicemachine/spark/splicemachine/ShuffleUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/scala_util/src/main/scala/com/splicemachine/spark/splicemachine/ShuffledDependency.scala
+++ b/scala_util/src/main/scala/com/splicemachine/spark/splicemachine/ShuffledDependency.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/scala_util/src/main/scala/com/splicemachine/spark/splicemachine/ShuffledPartition.scala
+++ b/scala_util/src/main/scala/com/splicemachine/spark/splicemachine/ShuffledPartition.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/scala_util/src/main/scala/com/splicemachine/spark/splicemachine/ShuffledPartitionsRDD.scala
+++ b/scala_util/src/main/scala/com/splicemachine/spark/splicemachine/ShuffledPartitionsRDD.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/pom.xml
+++ b/splice_access_api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2018 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/CallTimeoutException.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/CallTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/DatabaseVersion.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/DatabaseVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/DistributedFileOpenOption.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/DistributedFileOpenOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/DistributedFileSystem.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/DistributedFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/FileInfo.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/FileInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/FilesystemAdmin.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/FilesystemAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/NotServingPartitionException.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/NotServingPartitionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/OperationCancelledException.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/OperationCancelledException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/PartitionAdmin.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/PartitionAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/PartitionCreator.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/PartitionCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/PartitionFactory.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/PartitionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/RegionBusyException.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/RegionBusyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/STableInfoFactory.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/STableInfoFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/ServerControl.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/ServerControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/ServerStoppedException.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/ServerStoppedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/ServiceDiscovery.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/ServiceDiscovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/SnowflakeFactory.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/SnowflakeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/TableDescriptor.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/TableDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/VersionedRow.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/VersionedRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/WrongPartitionException.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/WrongPartitionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/AuthenticationConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/AuthenticationConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationDefault.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationDefault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationDefaultsList.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationDefaultsList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationSource.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/DDLConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/DDLConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/HBaseConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/HBaseConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/HConfigurationDefaultsList.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/HConfigurationDefaultsList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/OlapConfigurations.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/OlapConfigurations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/OperationConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/OperationConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/PipelineConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/PipelineConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SIConfigurations.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SIConfigurations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SQLConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SQLConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/StatsConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/StatsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/StorageConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/StorageConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/util/ByteComparisons.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/util/ByteComparisons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/util/CachedPartitionFactory.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/util/CachedPartitionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/util/NetworkUtils.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/util/NetworkUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/access/util/ReflectingConfigurationSource.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/util/ReflectingConfigurationSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/Attributable.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/Attributable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/CellType.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/CellType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/DataCell.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/DataCell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/DataDelete.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/DataDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/DataFilter.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/DataFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/DataFilterFactory.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/DataFilterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/DataGet.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/DataGet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/DataMutation.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/DataMutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/DataPut.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/DataPut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/DataResult.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/DataResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/DataResultScanner.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/DataResultScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/DataScan.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/DataScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/DataScanner.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/DataScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/MutationStatus.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/MutationStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/Partition.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/Partition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/PartitionDescriptor.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/PartitionDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/PartitionInfoCache.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/PartitionInfoCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/PartitionLoad.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/PartitionLoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/PartitionLocation.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/PartitionLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/PartitionServer.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/PartitionServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/PartitionServerLoad.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/PartitionServerLoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/ServerLogging.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/ServerLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/util/MapAttributes.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/util/MapAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/storage/util/MappedDataResultScanner.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/util/MappedDataResultScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/tools/version/ManifestFinder.java
+++ b/splice_access_api/src/main/java/com/splicemachine/tools/version/ManifestFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/tools/version/ManifestReader.java
+++ b/splice_access_api/src/main/java/com/splicemachine/tools/version/ManifestReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_access_api/src/main/java/com/splicemachine/tools/version/SimpleDatabaseVersion.java
+++ b/splice_access_api/src/main/java/com/splicemachine/tools/version/SimpleDatabaseVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/pom.xml
+++ b/splice_encoding/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2018 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/encoding/BigDecimalEncoding.java
+++ b/splice_encoding/src/main/java/com/splicemachine/encoding/BigDecimalEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/encoding/ByteEncoding.java
+++ b/splice_encoding/src/main/java/com/splicemachine/encoding/ByteEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/encoding/DecodingIterator.java
+++ b/splice_encoding/src/main/java/com/splicemachine/encoding/DecodingIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/encoding/DoubleEncoding.java
+++ b/splice_encoding/src/main/java/com/splicemachine/encoding/DoubleEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/encoding/Encoding.java
+++ b/splice_encoding/src/main/java/com/splicemachine/encoding/Encoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/encoding/ExpandedDecoder.java
+++ b/splice_encoding/src/main/java/com/splicemachine/encoding/ExpandedDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/encoding/ExpandingEncoder.java
+++ b/splice_encoding/src/main/java/com/splicemachine/encoding/ExpandingEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/encoding/FloatEncoding.java
+++ b/splice_encoding/src/main/java/com/splicemachine/encoding/FloatEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/encoding/MultiFieldDecoder.java
+++ b/splice_encoding/src/main/java/com/splicemachine/encoding/MultiFieldDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/encoding/MultiFieldEncoder.java
+++ b/splice_encoding/src/main/java/com/splicemachine/encoding/MultiFieldEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/encoding/ScalarEncoding.java
+++ b/splice_encoding/src/main/java/com/splicemachine/encoding/ScalarEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/encoding/StringEncoding.java
+++ b/splice_encoding/src/main/java/com/splicemachine/encoding/StringEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/encoding/debug/DataType.java
+++ b/splice_encoding/src/main/java/com/splicemachine/encoding/debug/DataType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/kvpair/KVPair.java
+++ b/splice_encoding/src/main/java/com/splicemachine/kvpair/KVPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/AlwaysAcceptAccumulationSet.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/AlwaysAcceptAccumulationSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/BaseEntryAccumulator.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/BaseEntryAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/BitReader.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/BitReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/BitWriter.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/BitWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/ByteEntryAccumulator.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/ByteEntryAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/EntryAccumulationSet.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/EntryAccumulationSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/EntryAccumulator.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/EntryAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/EntryDecoder.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/EntryDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/EntryEncoder.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/EntryEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/EntryPredicateFilter.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/EntryPredicateFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/HasPredicateFilter.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/HasPredicateFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/Indexed.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/Indexed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/SparseAccumulationSet.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/SparseAccumulationSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/index/BitIndex.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/index/BitIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/index/BitIndexing.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/index/BitIndexing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/index/DeltaCoding.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/index/DeltaCoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/index/DenseCompressedBitIndex.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/index/DenseCompressedBitIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/index/LazyBitIndex.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/index/LazyBitIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/index/SparseBitIndex.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/index/SparseBitIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/index/UncompressedBitIndex.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/index/UncompressedBitIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/index/UncompressedLazyBitIndex.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/index/UncompressedLazyBitIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/storage/index/package-info.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/index/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/BitSets.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/BitSets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/ByteDataInput.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/ByteDataInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/ByteDataOutput.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/ByteDataOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/ByteSlice.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/ByteSlice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/CachedByteSlice.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/CachedByteSlice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/GreenLight.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/GreenLight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/IntArrays.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/IntArrays.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/SliceIterator.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/SliceIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/Source.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/Source.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/SpliceLogUtils.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/SpliceLogUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/TrafficControl.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/TrafficControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/kryo/AbstractKryoPool.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/kryo/AbstractKryoPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/kryo/ExternalizableSerializer.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/kryo/ExternalizableSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/kryo/KryoObjectInput.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/kryo/KryoObjectInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/kryo/KryoObjectOutput.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/kryo/KryoObjectOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/kryo/KryoPool.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/kryo/KryoPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/logging/LogManager.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/logging/LogManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/main/java/com/splicemachine/utils/logging/Logging.java
+++ b/splice_encoding/src/main/java/com/splicemachine/utils/logging/Logging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/bytes/BytesUtil_ParameterizedTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/bytes/BytesUtil_ParameterizedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/BigDecimalEncoding_FixedTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/BigDecimalEncoding_FixedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/BigDecimalEncoding_RandomizedTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/BigDecimalEncoding_RandomizedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/BigDecimalEncoding_SortTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/BigDecimalEncoding_SortTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/BitFormat.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/BitFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/BooleanEncodingTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/BooleanEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/ByteEncoding_FixedTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/ByteEncoding_FixedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/ByteEncoding_RandomizedTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/ByteEncoding_RandomizedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/DecimalEncodingMicroBenchmark.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/DecimalEncodingMicroBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/DoubleEncoding_FixedTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/DoubleEncoding_FixedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/DoubleEncoding_RandomizedTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/DoubleEncoding_RandomizedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/EncodingTestUtil.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/EncodingTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/ExhaustiveBigDecimalEncodingTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/ExhaustiveBigDecimalEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/ExhaustiveLongEncodingTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/ExhaustiveLongEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/FloatEncoding_FixedTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/FloatEncoding_FixedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/FloatEncoding_RandomizedTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/FloatEncoding_RandomizedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/IntegerEncodingMicroBenchmark.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/IntegerEncodingMicroBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/MultiFieldDecoderTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/MultiFieldDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/MultiFieldEncoder_FixedTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/MultiFieldEncoder_FixedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/MultiFieldEncoder_RandomizedTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/MultiFieldEncoder_RandomizedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/ScalarEncoding_FixedTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/ScalarEncoding_FixedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/ScalarEncoding_RandomizedTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/ScalarEncoding_RandomizedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/StringEncodingMicroBenchmark.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/StringEncodingMicroBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/StringEncoding_FixedTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/StringEncoding_FixedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/StringEncoding_RandomizedTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/StringEncoding_RandomizedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/TestType.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/TestType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/storage/AlwaysAcceptEntryAccumulatorTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/storage/AlwaysAcceptEntryAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/storage/EntryAccumulatorTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/storage/EntryAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/storage/EntryDecoderTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/storage/EntryDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/storage/EntryEncoderDecoderTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/storage/EntryEncoderDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/storage/EntryEncoderTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/storage/EntryEncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/storage/EntryPredicateFilterTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/storage/EntryPredicateFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/storage/SparseEntryAccumulatorTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/storage/SparseEntryAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/storage/index/IterativeBitIndexTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/storage/index/IterativeBitIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/storage/index/SparseBitIndexTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/storage/index/SparseBitIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/storage/index/UncompressedBitIndexTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/storage/index/UncompressedBitIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/testutil/ParallelTheoryRunner.java
+++ b/splice_encoding/src/test/java/com/splicemachine/testutil/ParallelTheoryRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/testutil/RandomDerbyDecimalBuilder.java
+++ b/splice_encoding/src/test/java/com/splicemachine/testutil/RandomDerbyDecimalBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/utils/ByteSliceTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/utils/ByteSliceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/utils/IntArraysTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/utils/IntArraysTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_encoding/src/test/java/com/splicemachine/utils/ObjectArrayListBufferTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/utils/ObjectArrayListBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/pom.xml
+++ b/splice_machine/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2018 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/EngineDriver.java
+++ b/splice_machine/src/main/java/com/splicemachine/EngineDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
+++ b/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/SqlEnvironment.java
+++ b/splice_machine/src/main/java/com/splicemachine/SqlEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/SqlExceptionFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/SqlExceptionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/authentication/JNDIAuthenticationService.java
+++ b/splice_machine/src/main/java/com/splicemachine/authentication/JNDIAuthenticationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupJobStatus.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupJobStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupRestoreConstants.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupRestoreConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupSystemProcedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/colperms/ColPermsManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/colperms/ColPermsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/AddForeignKeyToPipeline.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/AddForeignKeyToPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/AddIndexToPipeline.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/AddIndexToPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/AddUniqueConstraintToPipeline.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/AddUniqueConstraintToPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/AlterTableDDLDescriptor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/AlterTableDDLDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/AsynchronousDDLController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/AsynchronousDDLController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/AsynchronousDDLWatcher.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/AsynchronousDDLWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/CommunicationListener.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/CommunicationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLAction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLChangeType.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLChangeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLCommunicator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLCommunicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLDriver.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLEnvironment.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLEnvironmentLoader.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLEnvironmentLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatchChecker.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatchChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatchRefresher.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatchRefresher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatcher.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DropForeignKeyFromPipeline.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DropForeignKeyFromPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DropIndexFromPipeline.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DropIndexFromPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/InterfaceSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/InterfaceSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/SynchronousDDLWatcher.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/SynchronousDDLWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/TentativeAddColumnDesc.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/TentativeAddColumnDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/TentativeAddConstraintDesc.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/TentativeAddConstraintDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/TentativeDDLDesc.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/TentativeDDLDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/TentativeDropColumnDesc.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/TentativeDropColumnDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/TentativeDropPKConstraintDesc.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/TentativeDropPKConstraintDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/TransformingDDLDescriptor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/TransformingDDLDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/PartitionLoadWatcher.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/PartitionLoadWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/PropertyManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/PropertyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/PropertyManagerService.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/PropertyManagerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/ConvertedResultSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/ConvertedResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/DataSetProcessorFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/DataSetProcessorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/OperationManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/OperationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/OperationManagerImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/OperationManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/SingleRowCursorResultSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/SingleRowCursorResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/SpliceOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/SpliceOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/SpliceOperationContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/SpliceOperationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/StandardCloseable.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/StandardCloseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/olap/AbstractOlapResult.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/olap/AbstractOlapResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/olap/DistributedJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/olap/DistributedJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/olap/OlapCallable.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/olap/OlapCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/olap/OlapClient.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/olap/OlapClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/olap/OlapResult.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/olap/OlapResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/olap/OlapStatus.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/olap/OlapStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/olap/SuccessfulOlapResult.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/olap/SuccessfulOlapResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/SpliceMethod.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/SpliceMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/SpliceService.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/SpliceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/db/AuthenticationType.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/db/AuthenticationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/job/fk/FkJobSubmitter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/job/fk/FkJobSubmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/load/HdfsImport.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/load/HdfsImport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/load/ImportUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/load/ImportUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/load/SpliceCsvReader.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/load/SpliceCsvReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/services/reflect/SpliceReflectClasses.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/services/reflect/SpliceReflectClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/services/streams/ConfiguredStream.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/services/streams/ConfiguredStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/JoinTable.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/JoinTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemAggregatorGenerator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemAggregatorGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/Splice_DD_Version.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/Splice_DD_Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/LassenUpgradeScript.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/LassenUpgradeScript.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScript.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScript.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptBase.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptFor260.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptFor260.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForDroppedConglomerates.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForDroppedConglomerates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForFuji.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForFuji.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForModifySchemaPermissionAndDefaultRole.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForModifySchemaPermissionAndDefaultRole.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForSysTokens.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForSysTokens.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptToAddUseExtrapolationInSysColumns.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptToAddUseExtrapolationInSysColumns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptToCleanSysRoutinePerms.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptToCleanSysRoutinePerms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptToRemoveFKDependencyOnPrivileges.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptToRemoveFKDependencyOnPrivileges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/BroadcastJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/BroadcastJoinStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/ColumnOrdering.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/ColumnOrdering.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/CostUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/CostUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/HalfMergeSortJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/HalfMergeSortJoinStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/JoinStrategyUtil.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/JoinStrategyUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeJoinStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SimpleCostEstimate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SimpleCostEstimate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceLevel2OptimizerFactoryImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceLevel2OptimizerFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceLevel2OptimizerImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceLevel2OptimizerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceNodeFactoryImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceNodeFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/depend/SpliceDependencyManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/depend/SpliceDependencyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/AbstractDropIndexConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/AbstractDropIndexConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/LazyDataValueFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/LazyDataValueFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/LazyScan.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/LazyScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceExecutionFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceExecutionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericConstantActionFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericConstantActionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/TemporaryRowHolderImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/TemporaryRowHolderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ActiveTransactionReader.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ActiveTransactionReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/AlterTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/AlterTableConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ConstraintConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ConstraintConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateAliasConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateAliasConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateConstraintAction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateConstraintAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateConstraintConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateConstraintConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreatePinConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreatePinConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateRoleConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateRoleConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateSchemaConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateSchemaConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateSequenceConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateSequenceConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTriggerConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTriggerConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateViewConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateViewConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DDLConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DDLConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DDLSingleTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DDLSingleTableConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DeleteConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DeleteConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropAliasConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropAliasConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropConstraintConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropConstraintConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropPinConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropPinConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropRoleConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropRoleConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropSchemaConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropSchemaConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropSequenceConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropSequenceConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropStatisticsConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropStatisticsConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropTableConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropTriggerConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropTriggerConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropViewConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropViewConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/GrantRevokeConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/GrantRevokeConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/GrantRoleConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/GrantRoleConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/IndexConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/IndexConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/InsertConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/InsertConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/LockTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/LockTableConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/RenameConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/RenameConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/RevokeRoleConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/RevokeRoleConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SavepointConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SavepointConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SetConstraintsConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SetConstraintsConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SetRoleConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SetRoleConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SetSchemaConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SetSchemaConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SetSessionPropertyConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SetSessionPropertyConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SetTransactionIsolationConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SetTransactionIsolationConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SpliceCreateTableOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SpliceCreateTableOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/TruncateTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/TruncateTableConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/UpdatableVTIConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/UpdatableVTIConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/UpdateConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/UpdateConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/WriteCursorConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/WriteCursorConstantOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/package-info.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/altertable/AlterTableRowTransformer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/altertable/AlterTableRowTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/altertable/AlterTableTransformJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/altertable/AlterTableTransformJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/altertable/DistributedAlterTableTransformJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/altertable/DistributedAlterTableTransformJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/BulkLoadIndexJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/BulkLoadIndexJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/BulkLoadIndexJobImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/BulkLoadIndexJobImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/DistributedPopulateIndexJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/DistributedPopulateIndexJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/IndexTransformer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/IndexTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/PopulateIndexJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/PopulateIndexJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/SamplingJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/SamplingJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/SamplingJobImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/SamplingJobImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/SamplingResult.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/SamplingResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/package-info.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/AnyOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/AnyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinCache.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastLeftOuterJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastLeftOuterJoinOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ByteBufferMapTableLoader.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ByteBufferMapTableLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ByteBufferMappedJoinTable.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ByteBufferMappedJoinTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/CachedOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/CachedOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/CallStatementOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/CallStatementOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DMLTriggerEventMapper.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DMLTriggerEventMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DMLWriteOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DMLWriteOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DeleteOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DeleteOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DerbyDMLWriteInfo.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DerbyDMLWriteInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DerbyOperationInformation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DerbyOperationInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DerbyScanInformation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DerbyScanInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctGroupedAggregateOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctGroupedAggregateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctScalarAggregateOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctScalarAggregateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctScanOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/GenericAggregateOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/GenericAggregateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/GroupedAggregateOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/GroupedAggregateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/HalfMergeSortJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/HalfMergeSortJoinOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/HalfMergeSortLeftOuterJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/HalfMergeSortLeftOuterJoinOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowReader.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowReaderBuilder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowReaderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowToBaseRowOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowToBaseRowOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/InsertOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/InsertOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/JoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/JoinOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/JoinUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/JoinUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/LastIndexKeyOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/LastIndexKeyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeJoinOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeLeftOuterJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeLeftOuterJoinOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeSortJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeSortJoinOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeSortLeftOuterJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeSortLeftOuterJoinOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MiscOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MiscOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeDerbyScanInformation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeDerbyScanInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperation.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NestedLoopJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NestedLoopJoinOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NestedLoopLeftOuterJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NestedLoopLeftOuterJoinOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NoRowsOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NoRowsOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NormalizeOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NormalizeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/OnceOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/OnceOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/OperationUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/OperationUtils.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ProjectRestrictOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ProjectRestrictOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/QualifierUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/QualifierUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/RowCountOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/RowCountOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/RowOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/RowOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScalarAggregateOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScalarAggregateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScanOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScrollInsensitiveOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScrollInsensitiveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SetOpOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SetOpOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SetTransactionOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SetTransactionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SortOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SortOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceStddevPop.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceStddevPop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceStddevSamp.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceStddevSamp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceUDAStableVariance.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceUDAStableVariance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceUDAVariance.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceUDAVariance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TemporaryRowHolderOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TemporaryRowHolderOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TriggerHandler.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TriggerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/UnionOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/UnionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperation.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/WindowOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/WindowOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/batchonce/BatchOnceOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/batchonce/BatchOnceOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/batchonce/BatchOnceVisitor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/batchonce/BatchOnceVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportCSVWriterBuilder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportCSVWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportExecRowWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportExecRowWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportFile.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportParams.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportPermissionCheck.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportPermissionCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/framework/DerbyAggregateContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/framework/DerbyAggregateContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/framework/SpliceGenericAggregator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/framework/SpliceGenericAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/groupedaggregate/DerbyGroupedAggregateContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/groupedaggregate/DerbyGroupedAggregateContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/groupedaggregate/GroupedAggregateContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/groupedaggregate/GroupedAggregateContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/AggregateContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/AggregateContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/DMLWriteInfo.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/DMLWriteInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/OperationInformation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/OperationInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/Restriction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/Restriction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/ScanInformation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/ScanInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/WarningCollector.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/WarningCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/package-info.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/scanner/SIFilterFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/scanner/SIFilterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/scanner/SITableScanner.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/scanner/SITableScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/scanner/TableScannerBuilder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/scanner/TableScannerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/DerbyWindowContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/DerbyWindowContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/FrameDefinition.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/FrameDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/WindowAggregator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/WindowAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/WindowAggregatorImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/WindowAggregatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/WindowContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/WindowContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/AvgAggregator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/AvgAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/CountAggregator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/CountAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/DenseRankFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/DenseRankFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/FirstLastValueFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/FirstLastValueFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/LeadLagFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/LeadLagFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/MaxMinAggregator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/MaxMinAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/RankFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/RankFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/RowNumberFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/RowNumberFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/SpliceGenericWindowFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/SpliceGenericWindowFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/SumAggregator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/SumAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/DistributedIsCachedJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/DistributedIsCachedJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/DistributedPopulatePinJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/DistributedPopulatePinJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/DropPinJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/DropPinJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/GetIsCachedResult.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/GetIsCachedResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/IsCachedJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/IsCachedJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/PopulatePinJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/PopulatePinJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/RemoteDropPinJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/pin/RemoteDropPinJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/AbstractSequence.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/AbstractSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/Sequence.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/Sequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/SequenceKey.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/SequenceKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/SpliceSequence.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/SpliceSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/stats/RegionLoadStatistics.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/stats/RegionLoadStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/stats/StoreCostControllerImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/stats/StoreCostControllerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/CheckTableJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/CheckTableJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/CheckTableResult.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/CheckTableResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/DistributedCheckTableJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/DistributedCheckTableJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/KeyByBaseRowIdFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/KeyByBaseRowIdFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/KeyByRowIdFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/KeyByRowIdFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/TableSplit.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/TableSplit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/ExecRowAccumulator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/ExecRowAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/BaseSpliceTransaction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/BaseSpliceTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/CacheableConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/CacheableConglomerate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/FileResourceFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/FileResourceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/FileResourceFactoryService.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/FileResourceFactoryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/HBaseStore.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/HBaseStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/NoLockOwner.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/NoLockOwner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/NoLockSpace.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/NoLockSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/PropertyConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/PropertyConglomerate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceAccessManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceAccessManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceLockFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceLockFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransaction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransactionContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransactionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransactionFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransactionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransactionManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransactionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransactionManagerContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransactionManagerContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransactionView.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransactionView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceXAResourceManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceXAResourceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/StorageFactoryService.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/StorageFactoryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/TempGroupedAggregateCostController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/TempGroupedAggregateCostController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/TempScalarAggregateCostController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/TempScalarAggregateCostController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/TempSortController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/TempSortController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/OpenSpliceConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/OpenSpliceConglomerate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceBaseFileResource.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceBaseFileResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceConglomerate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceConglomerateFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceConglomerateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceLocalFileResource.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceLocalFileResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceScan.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/btree/IndexConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/btree/IndexConglomerate.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/btree/IndexConglomerateFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/btree/IndexConglomerateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/btree/IndexController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/btree/IndexController.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/hbase/HBaseConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/hbase/HBaseConglomerate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/hbase/HBaseConglomerateFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/hbase/HBaseConglomerateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/hbase/HBaseController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/hbase/HBaseController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/jdbc/SpliceTransactionResourceImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/jdbc/SpliceTransactionResourceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/DistributedDerbyStartup.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/DistributedDerbyStartup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/EngineLifecycleService.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/EngineLifecycleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/EngineSqlEnvironment.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/EngineSqlEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/ManagerLoader.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/ManagerLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/MonitoredLifecycleService.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/MonitoredLifecycleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/NetworkLifecycleService.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/NetworkLifecycleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/SqlEnvironmentLoader.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/SqlEnvironmentLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/logging/DerbyOutputLoggerWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/logging/DerbyOutputLoggerWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/management/StatementManagement.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/management/StatementManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/management/TransactionalSysTableWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/management/TransactionalSysTableWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/serialization/ActivationSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/serialization/ActivationSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/serialization/SpliceObserverInstructions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/serialization/SpliceObserverInstructions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/BadRecordsRecorder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/BadRecordsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlOperationContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlOperationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlPairDataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlPairDataSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlTableChecker.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlTableChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/FutureIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/FutureIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/output/ControlExportDataSetWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/output/ControlExportDataSetWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/output/ParquetWriterFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/output/ParquetWriterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/output/ParquetWriterService.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/output/ParquetWriterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AbstractFileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AbstractFileFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AbstractSpliceFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AbstractSpliceFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AggregateFinisherFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AggregateFinisherFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AntiJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AntiJoinFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AntiJoinRestrictionFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AntiJoinRestrictionFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/BatchOnceFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/BatchOnceFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/BulkDeleteRowIndexGenerationFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/BulkDeleteRowIndexGenerationFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/BulkImportKeyerFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/BulkImportKeyerFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/BulkInsertRowIndexGenerationFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/BulkInsertRowIndexGenerationFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CloneFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CloneFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CogroupAntiJoinRestrictionFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CogroupAntiJoinRestrictionFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CogroupInnerJoinRestrictionFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CogroupInnerJoinRestrictionFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CogroupOuterJoinRestrictionFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CogroupOuterJoinRestrictionFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ColumnComparator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ColumnComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CountJoinedLeftFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CountJoinedLeftFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CountJoinedRightFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CountJoinedRightFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CountProducedFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CountProducedFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CountReadFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CountReadFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CountWriteFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/CountWriteFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/DistinctAggregateKeyCreation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/DistinctAggregateKeyCreation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/DistinctAggregatesPrepareFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/DistinctAggregatesPrepareFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/EmptyFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/EmptyFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ExportFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ExportFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ExternalizableFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ExternalizableFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ExternalizableFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ExternalizableFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/FileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/FileFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/GroupedAggregateRollupFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/GroupedAggregateRollupFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/HTableScanTupleFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/HTableScanTupleFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/IndexToBaseRowFilterPredicateFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/IndexToBaseRowFilterPredicateFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/IndexToBaseRowFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/IndexToBaseRowFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/IndexTransformFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/IndexTransformFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/InnerJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/InnerJoinFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/InnerJoinNullFilterFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/InnerJoinNullFilterFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/InnerJoinRestrictionFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/InnerJoinRestrictionFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/InnerJoinRestrictionFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/InnerJoinRestrictionFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/InsertPairFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/InsertPairFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/IteratorUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/IteratorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/JoinRestrictionPredicateFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/JoinRestrictionPredicateFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/KVPairFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/KVPairFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/KeyerFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/KeyerFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/LocatedRowToRowFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/LocatedRowToRowFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeAllAggregatesFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeAllAggregatesFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeAllAggregatesFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeAllAggregatesFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeAllAggregatesFunctionForMixedRows.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeAllAggregatesFunctionForMixedRows.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeNonDistinctAggregatesFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeNonDistinctAggregatesFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeNonDistinctAggregatesFunctionForMixedRows.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeNonDistinctAggregatesFunctionForMixedRows.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeStatisticsFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeStatisticsFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeStatisticsHolder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeStatisticsHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeStatisticsHolderFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeStatisticsHolderFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeWindowFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MergeWindowFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MutableCSVTokenizer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/MutableCSVTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJAntiJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJAntiJoinFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJInnerJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJInnerJoinFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJOneRowInnerJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJOneRowInnerJoinFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJOuterJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJOuterJoinFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJoinFunction.java
@@ -1,5 +1,5 @@
  /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NormalizeFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NormalizeFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/OffsetFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/OffsetFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/OuterJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/OuterJoinFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/OuterJoinPairFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/OuterJoinPairFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/OuterJoinRestrictionFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/OuterJoinRestrictionFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/Partitioner.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/Partitioner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ProjectRestrictMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ProjectRestrictMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ProjectRestrictPredicateFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ProjectRestrictPredicateFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/QuoteTrackingTokenizer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/QuoteTrackingTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ReturnStatisticsFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ReturnStatisticsFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/RowAndIndexGenerator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/RowAndIndexGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/RowComparator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/RowComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/RowKeyStatisticsFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/RowKeyStatisticsFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/RowOperationFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/RowOperationFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/RowToLocatedRowAvroFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/RowToLocatedRowAvroFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/RowToLocatedRowFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/RowToLocatedRowFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/RowTransformFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/RowTransformFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ScalarAggregateFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ScalarAggregateFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ScrollInsensitiveFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ScrollInsensitiveFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SetCurrentLocatedRowAndRowKeyFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SetCurrentLocatedRowAndRowKeyFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SetCurrentLocatedRowFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SetCurrentLocatedRowFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SpliceFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SpliceFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SpliceFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SpliceFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SpliceFunction2.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SpliceFunction2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SpliceJoinFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SpliceJoinFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SpliceJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SpliceJoinFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SplicePairFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SplicePairFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SplicePredicateFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SplicePredicateFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SplittingFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/SplittingFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/StatisticsFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/StatisticsFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/StitchMixedRowFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/StitchMixedRowFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/StitchMixedRowFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/StitchMixedRowFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/StreamFileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/StreamFileFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/TableScanPredicateFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/TableScanPredicateFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/TableScanTupleMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/TableScanTupleMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/TakeFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/TakeFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/TxnViewDecoderFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/TxnViewDecoderFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/UpdateNoOpPredicateFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/UpdateNoOpPredicateFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/WindowFinisherFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/WindowFinisherFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ZipperFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/ZipperFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/broadcast/AbstractBroadcastJoinFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/broadcast/AbstractBroadcastJoinFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/broadcast/BroadcastJoinFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/broadcast/BroadcastJoinFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/broadcast/CogroupBroadcastJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/broadcast/CogroupBroadcastJoinFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/broadcast/SubtractByKeyBroadcastJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/broadcast/SubtractByKeyBroadcastJoinFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/merge/AbstractMergeJoinFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/merge/AbstractMergeJoinFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/merge/MergeAntiJoinFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/merge/MergeAntiJoinFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/merge/MergeInnerJoinFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/merge/MergeInnerJoinFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/merge/MergeOuterJoinFlatMapFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/merge/MergeOuterJoinFlatMapFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DistributedDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DistributedDataSetProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/IterableJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/IterableJoinFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/OperationContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/OperationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/PairDataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/PairDataSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/PartitionAwareIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/PartitionAwareIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/RemoteQueryClient.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/RemoteQueryClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/ScanSetBuilder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/ScanSetBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/ScopeNamed.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/ScopeNamed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/TableChecker.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/TableChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/TableWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/TableWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/package-info.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/DirectScanner.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/DirectScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/DirectScannerIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/DirectScannerIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/GetNLJoinAntiIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/GetNLJoinAntiIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/GetNLJoinInnerIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/GetNLJoinInnerIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/GetNLJoinIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/GetNLJoinIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/GetNLJoinLeftOuterIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/GetNLJoinLeftOuterIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/GetNLJoinOneRowIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/GetNLJoinOneRowIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/NestedLoopJoinIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/NestedLoopJoinIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/PartitionAwarePushBackIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/PartitionAwarePushBackIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/TableScannerIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/TableScannerIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/merge/AbstractMergeJoinIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/merge/AbstractMergeJoinIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/merge/MergeAntiJoinIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/merge/MergeAntiJoinIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/merge/MergeInnerJoinIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/merge/MergeInnerJoinIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/merge/MergeOuterJoinIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/merge/MergeOuterJoinIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/AbstractPipelineWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/AbstractPipelineWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/BulkDeleteDataSetWriterBuilder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/BulkDeleteDataSetWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/BulkInsertDataSetWriterBuilder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/BulkInsertDataSetWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/BulkLoadIndexDataSetWriterBuilder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/BulkLoadIndexDataSetWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/DataSetWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/DataSetWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/DataSetWriterBuilder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/DataSetWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/ExportDataSetWriterBuilder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/ExportDataSetWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/InsertDataSetWriterBuilder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/InsertDataSetWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/PermissiveInsertWriteConfiguration.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/PermissiveInsertWriteConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/UpdateDataSetWriterBuilder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/UpdateDataSetWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/WriteReadUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/WriteReadUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/delete/DeletePipelineWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/delete/DeletePipelineWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/delete/DeleteTableWriterBuilder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/delete/DeleteTableWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/direct/DirectDataSetWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/direct/DirectDataSetWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/direct/DirectPipelineWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/direct/DirectPipelineWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/direct/DirectTableWriterBuilder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/direct/DirectTableWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/insert/InsertPipelineWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/insert/InsertPipelineWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/insert/InsertTableWriterBuilder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/insert/InsertTableWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/update/NonPkRowHash.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/update/NonPkRowHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/update/PkDataHash.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/update/PkDataHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/update/PkRowHash.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/update/PkRowHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/update/ResultSupplier.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/update/ResultSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/update/UpdatePipelineWriter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/update/UpdatePipelineWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/output/update/UpdateTableWriterBuilder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/output/update/UpdateTableWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/package-info.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/BooleanList.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/BooleanList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ConcatenatedIterable.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ConcatenatedIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ExternalTableUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ExternalTableUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ForwardingDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ForwardingDataSetProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/StreamLogUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/StreamLogUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/StreamUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/StreamUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/window/BaseFrameBuffer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/window/BaseFrameBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/window/LogicalGroupFrameBuffer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/window/LogicalGroupFrameBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/window/PhysicalGroupFrameBuffer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/window/PhysicalGroupFrameBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/window/WindowFrameBuffer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/window/WindowFrameBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/BaseAdminProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/BaseAdminProcedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/ConglomerateUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/ConglomerateUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/DataDictionaryUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/DataDictionaryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/DatabasePropertyManagement.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/DatabasePropertyManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/DatabasePropertyManagementImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/DatabasePropertyManagementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/DerbyBytesUtil.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/DerbyBytesUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/EngineUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/EngineUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/FormatableBitSetUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/FormatableBitSetUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/GenericSpliceFunctions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/GenericSpliceFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/NumericFunctions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/NumericFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/PipelineAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/PipelineAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/Scans.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/Scans.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/Sequencer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/Sequencer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SerializationUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SerializationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateFunctions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceStringFunctions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceStringFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceTableAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceTableAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/StandardIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/StandardIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsFunctions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsOperation.java
@@ -26,7 +26,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.derby.utils;

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/TimestampAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/TimestampAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/TransactionAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/TransactionAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/Vacuum.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/Vacuum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/kryo/DataValueDescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/kryo/DataValueDescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/kryo/ListDataTypeSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/kryo/ListDataTypeSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/kryo/ValueRowSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/kryo/ValueRowSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/BareKeyHash.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/BareKeyHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/DataHash.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/DataHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/EntryDataDecoder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/EntryDataDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/EntryDataHash.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/EntryDataHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/FixedBucketPrefix.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/FixedBucketPrefix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/FixedDataHash.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/FixedDataHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/FixedPrefix.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/FixedPrefix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/HashPrefix.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/HashPrefix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/KeyDecoder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/KeyDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/KeyEncoder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/KeyEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/KeyHashDecoder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/KeyHashDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/KeyPostfix.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/KeyPostfix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/NoOpDataHash.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/NoOpDataHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/NoOpKeyHashDecoder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/NoOpKeyHashDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/NoOpPostfix.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/NoOpPostfix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/NoOpPrefix.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/NoOpPrefix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/PairDecoder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/PairDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/PairEncoder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/PairEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/SaltedPrefix.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/SaltedPrefix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/SkippingKeyDecoder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/SkippingKeyDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/UniquePostfix.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/UniquePostfix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/AbstractTimeDescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/AbstractTimeDescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/BooleanDescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/BooleanDescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/DateDescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/DateDescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/DecimalDescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/DecimalDescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/DescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/DescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/DoubleDescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/DoubleDescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/EntryRowSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/EntryRowSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/KryoDescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/KryoDescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/NullDescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/NullDescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/RealDescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/RealDescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/RefDescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/RefDescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/RowSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/RowSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/ScalarDescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/ScalarDescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/SerializerMap.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/SerializerMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/StringDescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/StringDescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/TimeDescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/TimeDescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/TimeValuedSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/TimeValuedSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/TimestampV1DescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/TimestampV1DescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/TimestampV2DescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/TimestampV2DescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/TypeProvider.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/TypeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/UDTDescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/UDTDescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/UDTInputStream.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/UDTInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/UnsortedBinaryDescriptorSerializer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/UnsortedBinaryDescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/V1SerializerMap.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/V1SerializerMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/V2SerializerMap.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/V2SerializerMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/VersionedSerializers.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/marshall/dvd/VersionedSerializers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/ResultSetIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/ResultSetIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceFileVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceFileVTI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceIteratorVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceIteratorVTI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceJDBCVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceJDBCVTI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/iapi/DatasetProvider.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/iapi/DatasetProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/package-info.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/encryption/EncryptionManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/encryption/EncryptionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/hbase/JMXThreadPool.java
+++ b/splice_machine/src/main/java/com/splicemachine/hbase/JMXThreadPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/hbase/ManagedThreadPool.java
+++ b/splice_machine/src/main/java/com/splicemachine/hbase/ManagedThreadPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/hbase/jmx/JMXUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/hbase/jmx/JMXUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/management/DatabaseAdministrator.java
+++ b/splice_machine/src/main/java/com/splicemachine/management/DatabaseAdministrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/management/JmxDatabaseAdminstrator.java
+++ b/splice_machine/src/main/java/com/splicemachine/management/JmxDatabaseAdminstrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/management/Manager.java
+++ b/splice_machine/src/main/java/com/splicemachine/management/Manager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/AlterTableWriteFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/AlterTableWriteFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/ConglomerateDescriptors.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/ConglomerateDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/DerbyContextFactoryLoader.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/DerbyContextFactoryLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/DropIndexFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/DropIndexFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/ErrorState.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/ErrorState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/Exceptions.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/Exceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/IndexFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/IndexFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/IndexWriteHandler.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/IndexWriteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/RowTransformer.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/RowTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/SimpleActivation.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/SimpleActivation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/SpliceStandardException.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/SpliceStandardException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/altertable/AlterTableInterceptWriteHandler.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/altertable/AlterTableInterceptWriteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/FKWriteFactoryHolder.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/FKWriteFactoryHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyChildInterceptWriteFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyChildInterceptWriteFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyChildInterceptWriteHandler.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyChildInterceptWriteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyParentInterceptWriteFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyParentInterceptWriteFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyParentInterceptWriteHandler.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyParentInterceptWriteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyViolationProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyViolationProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/package-info.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/procedures/ProcedureUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/procedures/ProcedureUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/procedures/external/CreateExternalTableJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/procedures/external/CreateExternalTableJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/procedures/external/DistributedCreateExternalTableJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/procedures/external/DistributedCreateExternalTableJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/procedures/external/DistributedGetSchemaExternalJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/procedures/external/DistributedGetSchemaExternalJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/procedures/external/DistributedRefreshExternalTableSchemaJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/procedures/external/DistributedRefreshExternalTableSchemaJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/procedures/external/ExternalTableSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/procedures/external/ExternalTableSystemProcedures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/procedures/external/GetSchemaExternalJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/procedures/external/GetSchemaExternalJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/procedures/external/GetSchemaExternalResult.java
+++ b/splice_machine/src/main/java/com/splicemachine/procedures/external/GetSchemaExternalResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/procedures/external/RefreshTableSchemaTableJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/procedures/external/RefreshTableSchemaTableJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/protobuf/ProtoUtil.java
+++ b/splice_machine/src/main/java/com/splicemachine/protobuf/ProtoUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/tools/EmbedConnectionMaker.java
+++ b/splice_machine/src/main/java/com/splicemachine/tools/EmbedConnectionMaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/main/java/com/splicemachine/uuid/UUIDService.java
+++ b/splice_machine/src/main/java/com/splicemachine/uuid/UUIDService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/client/workday/OmsLogTable.java
+++ b/splice_machine/src/test/java/com/splicemachine/client/workday/OmsLogTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/client/workday/WorkdayTinyIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/client/workday/WorkdayTinyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/customer/CreatePrice.java
+++ b/splice_machine/src/test/java/com/splicemachine/customer/CreatePrice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/customer/Median.java
+++ b/splice_machine/src/test/java/com/splicemachine/customer/Median.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/customer/NielsenTesting.java
+++ b/splice_machine/src/test/java/com/splicemachine/customer/NielsenTesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/customer/Price.java
+++ b/splice_machine/src/test/java/com/splicemachine/customer/Price.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/iapi/types/SQLDateTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/iapi/types/SQLDateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/ast/LimitOffsetVisitorIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/ast/LimitOffsetVisitorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/BaseJoinSelectivityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/BaseJoinSelectivityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/BroadcastJoinMemoryLimitIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/BroadcastJoinMemoryLimitIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/BroadcastJoinSelectivityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/BroadcastJoinSelectivityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DistinctScanSelectivityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DistinctScanSelectivityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/GroupBySelectivityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/GroupBySelectivityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/InListMultiprobeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/InListMultiprobeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/IndexSelectivityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/IndexSelectivityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/JoinSelectivityNoIndexesIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/JoinSelectivityNoIndexesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/MergeJoinSelectivityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/MergeJoinSelectivityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NestedLoopJoinSelectivityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NestedLoopJoinSelectivityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ProjectionPruningIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ProjectionPruningIT.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.sql.compile;

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ScanCostFunctionTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ScanCostFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ScanSelectivityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ScanSelectivityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SelectForUpdateIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SelectForUpdateIT.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SelectivityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SelectivityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SessionPropertyIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SessionPropertyIT.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.db.impl.sql.compile;

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SortMergeJoinSelectivityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SortMergeJoinSelectivityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/StatsUsageIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/StatsUsageIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/UnsatTreePruningIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/UnsatTreePruningIT.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ValuesSelectivityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ValuesSelectivityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/client/TestUnknownClient.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/client/TestUnknownClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/ddl/AsynchronousDDLControllerTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/ddl/AsynchronousDDLControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/ddl/CountingListener.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/ddl/CountingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/ddl/DDLCoordinationTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/ddl/DDLCoordinationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/ddl/DDLWatchRefresherTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/ddl/DDLWatchRefresherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/ddl/IncrementingClock.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/ddl/IncrementingClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/ddl/TestChecker.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/ddl/TestChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/ddl/TestDDLCommunicator.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/ddl/TestDDLCommunicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/CaseSensitiveImportIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/CaseSensitiveImportIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HBaseBulkLoadIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HBaseBulkLoadIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HBaseBulkLoadIndexIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HBaseBulkLoadIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsImportCharacterTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsImportCharacterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsImportIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsImportIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsUnsafeImportIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsUnsafeImportIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/ImportBinaryValueIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/ImportBinaryValueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/ImportDefaultValueIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/ImportDefaultValueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/ImportErrorIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/ImportErrorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/ImportNullityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/ImportNullityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/ImportTestUtils.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/ImportTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/ImportWithDifferentColumnOrderIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/ImportWithDifferentColumnOrderIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/TestFileGenerator.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/TestFileGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/UpportIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/UpportIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/CsvUtil.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/CsvUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/CustomerTable.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/CustomerTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/EmailableTable.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/EmailableTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/HeaderTable.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/HeaderTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/IndexIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/IndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/IndexNullityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/IndexNullityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/NewOrderTable.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/NewOrderTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/OrderLineTable.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/OrderLineTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/OrderTable.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/OrderTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/PreparedIndexIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/PreparedIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/catalog/SqlFunctionParamsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/catalog/SqlFunctionParamsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/catalog/SqlJJarIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/catalog/SqlJJarIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/catalog/SqlProcedureColsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/catalog/SqlProcedureColsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/catalog/SqlStatisticsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/catalog/SqlStatisticsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/catalog/TheSysDummyIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/catalog/TheSysDummyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/ColumnReferenceIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/ColumnReferenceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/CostUtilsTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/CostUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/NonCoveringIndexIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/NonCoveringIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/OrderByEliminationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/OrderByEliminationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/OuterJoinOrderByEliminationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/OuterJoinOrderByEliminationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/SelectTableWithSchemaChangeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/SelectTableWithSchemaChangeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/StringTypesToNumericTypeConversionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/StringTypesToNumericTypeConversionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/UpdateFromSubqueryIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/UpdateFromSubqueryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/AbstractIndexTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/AbstractIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/AddColumnTransactionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/AddColumnTransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/AlterTableConstantOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/AlterTableConstantOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/CheckConstraintIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/CheckConstraintIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/CompoundNonUniqueIndexIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/CompoundNonUniqueIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/CompoundNonUniqueIndexImportIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/CompoundNonUniqueIndexImportIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/CompoundPrimaryKeyIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/CompoundPrimaryKeyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/CompoundUniqueIndexTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/CompoundUniqueIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/ConstraintConstantOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/ConstraintConstantOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/ConstraintTransactionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/ConstraintTransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/DropColumnTransactionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/DropColumnTransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/LockTableConstantOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/LockTableConstantOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/NonNullConstraintIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/NonNullConstraintIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/NonUniqueIndexIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/NonUniqueIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/ResultCountIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/ResultCountIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/SavepointConstantOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/SavepointConstantOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/SchemaConstantIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/SchemaConstantIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/TableConstantOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/TableConstantOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/TempTableIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/TempTableIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/TruncateTableIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/TruncateTableIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/UniqueConstraintIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/UniqueConstraintIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/UniqueIndexIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/UniqueIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/ViewConstantOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/ViewConstantOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/WriteWriteRollbackIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/WriteWriteRollbackIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/AddColumnWithDefaultIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/AddColumnWithDefaultIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/AnalyzeTableIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/AnalyzeTableIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/AnyOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/AnyOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/BatchOnceOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/BatchOnceOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CallStatementOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CallStatementOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CharTableScanOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CharTableScanOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateSchemaIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateSchemaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableWithDataIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableWithDataIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DMLTriggerEventMapperTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DMLTriggerEventMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DefaultIndexIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DefaultIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DeleteOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DeleteOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctGroupedAggregateOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctGroupedAggregateOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctScalarAggregateOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctScalarAggregateOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctScanOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctScanOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DropColumnIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DropColumnIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DropTableIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DropTableIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DropViewIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DropViewIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/EmbeddedCallStatementOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/EmbeddedCallStatementOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/FixedSITableScannerTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/FixedSITableScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/FunctionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/FunctionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/GeneratedColumnIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/GeneratedColumnIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/GroupByOrderByIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/GroupByOrderByIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/GroupedAggregateOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/GroupedAggregateOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowToBaseRowOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowToBaseRowOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/IndividualPrimaryKeyScanIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/IndividualPrimaryKeyScanIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/InsertOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/InsertOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/JoinOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/JoinOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/JoinSelectionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/JoinSelectionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/KeyDecoderIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/KeyDecoderIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/LastIndexKeyOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/LastIndexKeyOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MetatablesIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MetatablesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MiscOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MiscOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiGroupGroupedAggregateOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiGroupGroupedAggregateOperationIT.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeScanInPrepareIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeScanInPrepareIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperatonIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperatonIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultipleDistinctAggregatesIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultipleDistinctAggregatesIT.java
@@ -25,7 +25,7 @@
  *
  * Splice Machine, Inc. has modified the Apache Derby code in this file.
  *
- * All such Splice Machine modifications are Copyright 2012 - 2017 Splice Machine, Inc.,
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
  * and are licensed to you under the GNU Affero General Public License.
  */
 package com.splicemachine.derby.impl.sql.execute.operations;

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/NotNullFilterIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/NotNullFilterIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/NullNumericalComparisonIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/NullNumericalComparisonIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/NullableColumnIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/NullableColumnIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/OnceOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/OnceOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/OrderByIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/OrderByIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/PreparedStatementIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/PreparedStatementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/PrimaryKeyIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/PrimaryKeyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/PrimaryKeyScanIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/PrimaryKeyScanIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ProjectRestrictOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ProjectRestrictOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/RowCountOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/RowCountOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/RowIdIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/RowIdIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ScalarAggregateOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ScalarAggregateOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SelfInsertIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SelfInsertIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SetOpOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SetOpOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SimpleDateArithmeticIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SimpleDateArithmeticIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SingleGroupGroupedAggregateOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SingleGroupGroupedAggregateOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SortOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SortOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SpecificRowMarshallerTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SpecificRowMarshallerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceUDAVarianceTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceUDAVarianceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceUDTIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceUDTIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/StddevIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/StddevIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TernaryOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TernaryOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimeTableScanIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimeTableScanIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimestampIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimestampIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TruncateFunctionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TruncateFunctionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UnionOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UnionOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateMultiOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateMultiOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ViewIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ViewIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WindowFunctionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WindowFunctionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WithStatementIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WithStatementIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportCSVWriterBuilderTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportCSVWriterBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportExecRowWriterTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportExecRowWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportFileTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportParamsTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportPermissionCheckTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportPermissionCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/ArrayJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/ArrayJoinIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/BroadcastJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/BroadcastJoinIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/EquiJoinOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/EquiJoinOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/HalfSortMergeJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/HalfSortMergeJoinIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/HashNestedLoopJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/HashNestedLoopJoinIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/HashNestedLoopLeftOuterJoinOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/HashNestedLoopLeftOuterJoinOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/InnerJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/InnerJoinIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/JoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/JoinIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/JoinWithFunctionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/JoinWithFunctionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/JoinWithTrimIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/JoinWithTrimIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/MergeJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/MergeJoinIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/NestedLoopJoinOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/NestedLoopJoinOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/NestedLoopLeftOuterJoinOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/NestedLoopLeftOuterJoinOperationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/OuterJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/OuterJoinIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/ThreeTableEquiJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/ThreeTableEquiJoinIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/TwoTableMergeJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/TwoTableMergeJoinIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/microstrategy/MicrostrategiesCustomerIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/microstrategy/MicrostrategiesCustomerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/microstrategy/MicrostrategiesDemoIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/microstrategy/MicrostrategiesDemoIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/microstrategy/MicrostrategiesItemIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/microstrategy/MicrostrategiesItemIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/microstrategy/MsOrderDetailIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/microstrategy/MsOrderDetailIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/LeadLagBufferTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/window/function/LeadLagBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/sequence/AbstractSequenceTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/sequence/AbstractSequenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/sequence/SpliceSequenceIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/sequence/SpliceSequenceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/tester/Column.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/tester/Column.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/tester/DataTypeCheckNegIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/tester/DataTypeCheckNegIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/tester/DataTypeCorrectnessIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/tester/DataTypeCorrectnessIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/tester/NumericConstantsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/tester/NumericConstantsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/tester/NumericPromoteCompareIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/tester/NumericPromoteCompareIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/tester/TimestampTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/tester/TimestampTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/stats/ExplainRow.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/stats/ExplainRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/stats/ExplainTableScanIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/stats/ExplainTableScanIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/stats/FixedStatsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/stats/FixedStatsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/stats/StatisticsDataTypeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/stats/StatisticsDataTypeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/stats/TestDataBuilder.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/stats/TestDataBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/store/access/hbase/HBaseRowLocationTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/store/access/hbase/HBaseRowLocationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/security/AuthenticationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/security/AuthenticationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/security/AuthorizationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/security/AuthorizationIT.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/security/DefaultRoleIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/security/DefaultRoleIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/security/SchemaPrivilegeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/security/SchemaPrivilegeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/serialization/ActivationSerializerTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/serialization/ActivationSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/serialization/KryoTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/serialization/KryoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/stream/AbstractDataSetTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/stream/AbstractDataSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/stream/AbstractPairDataSetTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/stream/AbstractPairDataSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/stream/BaseStreamTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/stream/BaseStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/stream/control/ControlDataSetLimiterTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/stream/control/ControlDataSetLimiterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/stream/control/ControlDataSetTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/stream/control/ControlDataSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/stream/function/QuoteTrackingTokenizerTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/stream/function/QuoteTrackingTokenizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/DatabaseMetaDataTestIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/DatabaseMetaDataTestIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/ManagedCallableStatement.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/ManagedCallableStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/SpliceNetDerbyTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/SpliceNetDerbyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/TPCC.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/TPCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/TPCHIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/TPCHIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/TransactionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/TransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/ManagedPreparedStatement.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/ManagedPreparedStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/ManagedStatement.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/ManagedStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/RuledConnection.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/RuledConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SQLClosures.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SQLClosures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SchemaRule.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SchemaRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SetupFailureException.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SetupFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceDataWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceDataWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceFunctionWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceFunctionWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceGrantWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceGrantWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceIndexWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceIndexWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceNetConnection.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceNetConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceRoleWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceRoleWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceSchemaWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceSchemaWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceTableWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceTableWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceTestDataSource.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceTestDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTestReference.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTestReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUserWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUserWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceViewWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceViewWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/TableRule.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/TableRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/TestConnection.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/TestConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/TestConnectionPool.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/TestConnectionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/tables/SpliceCustomerTable.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/tables/SpliceCustomerTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/tables/SpliceItemTable.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/tables/SpliceItemTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/tables/SpliceOrderLineTable.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/tables/SpliceOrderLineTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/transactions/ConcurrentDDLIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/transactions/ConcurrentDDLIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/transactions/CreateTableTransactionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/transactions/CreateTableTransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/transactions/DropTableTransactionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/transactions/DropTableTransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/transactions/IndexTransactionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/transactions/IndexTransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/transactions/InsertInsertTransactionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/transactions/InsertInsertTransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/transactions/InsertUpdateTransactionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/transactions/InsertUpdateTransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/transactions/QueryTimeoutIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/transactions/QueryTimeoutIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/transactions/SchemaTransactionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/transactions/SchemaTransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/transactions/SetRoleTransactionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/transactions/SetRoleTransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/transactions/TransactionAdminIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/transactions/TransactionAdminIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/transactions/UpdateTransactionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/transactions/UpdateTransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/ExceptionsTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/ExceptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SerializationComparison.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SerializationComparison.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceAdminIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceAdminIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceAdmin_OperationsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceAdmin_OperationsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceDateFunctionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceDateFunctionsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceDateFunctionsTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceDateFunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/StatisticsAdminIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/StatisticsAdminIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/StringUtilsTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/StringUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/TimestampAdminIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/TimestampAdminIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/UserFunctionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/UserFunctionsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/marshall/BareKeyHashTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/marshall/BareKeyHashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/marshall/PairEncoderTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/marshall/PairEncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/marshall/dvd/TimestampV2DescriptorSerializerTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/marshall/dvd/TimestampV2DescriptorSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/setFromTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/setFromTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/test/DecoderIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/test/DecoderIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/test/DerbyBytesUtilTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/test/DerbyBytesUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/test/TestingDataType.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/test/TestingDataType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/derby/windows/WindowsTestingFramework.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/windows/WindowsTestingFramework.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKeyMetadataIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKeyMetadataIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKey_Action_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKey_Action_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKey_AlterDropTable_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKey_AlterDropTable_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKey_Check_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKey_Check_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKey_Concurrent_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKey_Concurrent_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKey_Define_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKey_Define_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/homeless/SerializationUtils.java
+++ b/splice_machine/src/test/java/com/splicemachine/homeless/SerializationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/homeless/TestUtils.java
+++ b/splice_machine/src/test/java/com/splicemachine/homeless/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/jdbc/JdbcApiIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/jdbc/JdbcApiIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/pipeline/error/SpliceStandardExceptionTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/pipeline/error/SpliceStandardExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/pl/PL_SaveSourceCode_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/pl/PL_SaveSourceCode_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/subquery/SubqueryITUtil.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/SubqueryITUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Aggregate_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Aggregate_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_ExistsBetween_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_ExistsBetween_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Exists_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Exists_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Exists_Union_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Exists_Union_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_InList_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_InList_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Join_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Join_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_NotExists_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_NotExists_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_NotExists_Union_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_NotExists_Union_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_SSQ_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_SSQ_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_SSQ_To_FromSubquery_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_SSQ_To_FromSubquery_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Values_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Values_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_NestedWhere_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_NestedWhere_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Scalar_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Scalar_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Table_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Table_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test/BackupTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/test/BackupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test/HBaseTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/test/HBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test/RestoreTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/test/RestoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test/SerialTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/test/SerialTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test/SlowTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/test/SlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test/SpliceTestPlatformWait.java
+++ b/splice_machine/src/test/java/com/splicemachine/test/SpliceTestPlatformWait.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test/Transactions.java
+++ b/splice_machine/src/test/java/com/splicemachine/test/Transactions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test/suites/MicrostrategiesTests.java
+++ b/splice_machine/src/test/java/com/splicemachine/test/suites/MicrostrategiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test/suites/OperationCategories.java
+++ b/splice_machine/src/test/java/com/splicemachine/test/suites/OperationCategories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test/suites/Stats.java
+++ b/splice_machine/src/test/java/com/splicemachine/test/suites/Stats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test_dao/Constraint.java
+++ b/splice_machine/src/test/java/com/splicemachine/test_dao/Constraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test_dao/ConstraintDAO.java
+++ b/splice_machine/src/test/java/com/splicemachine/test_dao/ConstraintDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test_dao/JDBCTemplate.java
+++ b/splice_machine/src/test/java/com/splicemachine/test_dao/JDBCTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test_dao/RowMapper.java
+++ b/splice_machine/src/test/java/com/splicemachine/test_dao/RowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test_dao/SchemaDAO.java
+++ b/splice_machine/src/test/java/com/splicemachine/test_dao/SchemaDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test_dao/TableDAO.java
+++ b/splice_machine/src/test/java/com/splicemachine/test_dao/TableDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test_dao/TriggerBuilder.java
+++ b/splice_machine/src/test/java/com/splicemachine/test_dao/TriggerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test_dao/TriggerDAO.java
+++ b/splice_machine/src/test/java/com/splicemachine/test_dao/TriggerDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test_dao/package-info.java
+++ b/splice_machine/src/test/java/com/splicemachine/test_dao/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test_tools/CountGeneratedRowCreator.java
+++ b/splice_machine/src/test/java/com/splicemachine/test_tools/CountGeneratedRowCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test_tools/IntegerRows.java
+++ b/splice_machine/src/test/java/com/splicemachine/test_tools/IntegerRows.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test_tools/IterableRowCreator.java
+++ b/splice_machine/src/test/java/com/splicemachine/test_tools/IterableRowCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test_tools/RowCreator.java
+++ b/splice_machine/src/test/java/com/splicemachine/test_tools/RowCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test_tools/Rows.java
+++ b/splice_machine/src/test/java/com/splicemachine/test_tools/Rows.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/test_tools/TableCreator.java
+++ b/splice_machine/src/test/java/com/splicemachine/test_tools/TableCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/tools/version/ManifestFinderTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/tools/version/ManifestFinderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/tools/version/ManifestReaderTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/tools/version/ManifestReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/tools/version/SimpleDatabaseVersionTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/tools/version/SimpleDatabaseVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Multi_Trigger_Values_Update_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Multi_Trigger_Values_Update_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Create_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Create_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Dependency_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Dependency_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Exec_Stored_Proc_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Exec_Stored_Proc_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Row_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Row_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Row_Transition_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Row_Transition_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Statement_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Statement_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/util/EmptyConfigurationDefaultsList.java
+++ b/splice_machine/src/test/java/com/splicemachine/util/EmptyConfigurationDefaultsList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/util/StatementUtils.java
+++ b/splice_machine/src/test/java/com/splicemachine/util/StatementUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/util/concurrent/TestCondition.java
+++ b/splice_machine/src/test/java/com/splicemachine/util/concurrent/TestCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/java/com/splicemachine/util/concurrent/TestLock.java
+++ b/splice_machine/src/test/java/com/splicemachine/util/concurrent/TestLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/resources/log4j-file.properties
+++ b/splice_machine/src/test/resources/log4j-file.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_machine/src/test/resources/log4j.properties
+++ b/splice_machine/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_protocol/findbugs-exclude.xml
+++ b/splice_protocol/findbugs-exclude.xml
@@ -1,6 +1,6 @@
 <?xml version="1.1"?>
 <!--
-  ~ Copyright (c) 2012 - 2018 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_protocol/pom.xml
+++ b/splice_protocol/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2018 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_protocol/src/main/java/com/google/protobuf/ZeroCopyLiteralByteString.java
+++ b/splice_protocol/src/main/java/com/google/protobuf/ZeroCopyLiteralByteString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/pom.xml
+++ b/splice_si_api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/data/ExceptionFactory.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/data/ExceptionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/data/OperationFactory.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/data/OperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/data/OperationStatusFactory.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/data/OperationStatusFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/data/ReadOnlyModificationException.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/data/ReadOnlyModificationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/data/TxnOperationFactory.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/data/TxnOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/data/package-info.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/data/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/filter/RowAccumulator.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/filter/RowAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/filter/SIFilter.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/filter/SIFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/filter/TransactionReadController.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/filter/TransactionReadController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/filter/TransactionalFilter.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/filter/TransactionalFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/filter/TxnFilter.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/filter/TxnFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/readresolve/AsyncReadResolver.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/readresolve/AsyncReadResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/readresolve/KeyedReadResolver.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/readresolve/KeyedReadResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/readresolve/ReadResolver.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/readresolve/ReadResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/rollforward/RollForward.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/rollforward/RollForward.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/rollforward/RollForwardAction.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/rollforward/RollForwardAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/rollforward/RollForwardBean.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/rollforward/RollForwardBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/server/ClusterHealth.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/server/ClusterHealth.java
@@ -1,6 +1,6 @@
 /*
  *
- *  * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ *  * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *  *
  *  * This file is part of Splice Machine.
  *  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/server/ConstraintChecker.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/server/ConstraintChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/server/DisconnectException.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/server/DisconnectException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/server/FailedServerException.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/server/FailedServerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/server/TransactionalRegion.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/server/TransactionalRegion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/server/TransactionalRegionFactory.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/server/TransactionalRegionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/server/Transactor.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/server/Transactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/ActiveTxnTracker.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/ActiveTxnTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/ConflictType.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/ConflictType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/KeepAliveScheduler.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/KeepAliveScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TaskId.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TaskId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TransactionCacheManagement.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TransactionCacheManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TransactionMissing.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TransactionMissing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TransactionStatus.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TransactionStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TransactorListener.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TransactorListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/Txn.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/Txn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TxnLifecycleManager.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TxnLifecycleManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TxnStore.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TxnStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TxnStoreManagement.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TxnStoreManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TxnSupplier.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TxnSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TxnView.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TxnView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/WriteConflict.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/WriteConflict.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/lifecycle/CannotCommitException.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/lifecycle/CannotCommitException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/lifecycle/TransactionTimeoutException.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/lifecycle/TransactionTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/lifecycle/TxnLifecycleStore.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/lifecycle/TxnLifecycleStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/lifecycle/TxnPartition.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/lifecycle/TxnPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/constants/SIConstants.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/constants/SIConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/BaseTransaction.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/BaseTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/ClientTxnLifecycleManager.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/ClientTxnLifecycleManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/ConflictResults.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/ConflictResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/DDLFilter.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/DDLFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/ForwardingLifecycleManager.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/ForwardingLifecycleManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/ForwardingTxnView.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/ForwardingTxnView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/ManualKeepAliveScheduler.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/ManualKeepAliveScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/SavePointNotFoundException.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/SavePointNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnOperationFactory.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/Tracer.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/Tracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/Transaction.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/Transaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/TransactionImpl.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/TransactionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/TransactionViewImpl.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/TransactionViewImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/TxnRegion.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/TxnRegion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/TxnUtils.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/TxnUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/UnsupportedLifecycleManager.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/UnsupportedLifecycleManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/data/StripedTxnLifecycleStore.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/data/StripedTxnLifecycleStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIDriver.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIEnvironment.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/execution/JMXThreadPool.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/execution/JMXThreadPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/execution/ManagedThreadPool.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/execution/ManagedThreadPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/execution/NonRejectingExecutor.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/execution/NonRejectingExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/filter/HRowAccumulator.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/filter/HRowAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/filter/PackedTxnFilter.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/filter/PackedTxnFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/hlc/HLC.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/hlc/HLC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/hlc/HLCTimestampSource.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/hlc/HLCTimestampSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/package-info.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/readresolve/NoOpReadResolver.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/readresolve/NoOpReadResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/region/TransactionResolver.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/region/TransactionResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/rollforward/NoopRollForward.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/rollforward/NoopRollForward.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/rollforward/RollForwardManagement.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/rollforward/RollForwardManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/rollforward/RollForwardStatus.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/rollforward/RollForwardStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/server/ConflictRollForward.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/server/ConflictRollForward.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/server/SITransactor.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/server/SITransactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/server/SITransactorUtil.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/server/SITransactorUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/store/ActiveTxnCacheSupplier.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/store/ActiveTxnCacheSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/store/CompletedTxnCacheSupplier.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/store/CompletedTxnCacheSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/store/IgnoreTxnSupplier.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/store/IgnoreTxnSupplier.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/store/SimpleCompletedTxnCacheSupplier.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/store/SimpleCompletedTxnCacheSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/AbstractTxn.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/AbstractTxn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/AbstractTxnView.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/AbstractTxnView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/ActiveWriteTxn.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/ActiveWriteTxn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/CommittedTxn.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/CommittedTxn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/DDLTxnView.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/DDLTxnView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/InheritingTxnView.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/InheritingTxnView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/LazyTxnView.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/LazyTxnView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/ReadOnlyTxn.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/ReadOnlyTxn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/RolledBackTxn.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/RolledBackTxn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/SITransactionReadController.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/SITransactionReadController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/WritableTxn.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/WritableTxn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/jmx/ManagedTransactor.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/jmx/ManagedTransactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/java/com/splicemachine/si/jmx/TransactorStatus.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/jmx/TransactorStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/main/resources/application.properties
+++ b/splice_si_api/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/ActiveTransactionTest.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/ActiveTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/SITransactorInMemTest.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/SITransactorInMemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 - 2016 Splice Machine, Inc.
+ * Copyright 2012 - 2019 Splice Machine, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/SITransactorTest.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/SITransactorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/SavepointsTest.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/SavepointsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/TransactionInteractionTest.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/TransactionInteractionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/impl/SimpleTxnFilterTest.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/impl/SimpleTxnFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/impl/TestingFileSystem.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/impl/TestingFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/impl/TxnTestUtils.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/impl/TxnTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/impl/hlc/HLCTest.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/impl/hlc/HLCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/impl/store/ActiveTxnCacheTest.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/impl/store/ActiveTxnCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/impl/store/CompletedTxnCacheSupplierTest.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/impl/store/CompletedTxnCacheSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/impl/store/TestingTimestampSource.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/impl/store/TestingTimestampSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/impl/store/TestingTxnStore.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/impl/store/TestingTxnStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/testenv/ArchitectureIndependent.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/testenv/ArchitectureIndependent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/testenv/ArchitectureSpecific.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/testenv/ArchitectureSpecific.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/testenv/SITestDataEnv.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/testenv/SITestDataEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/testenv/SITestEnv.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/testenv/SITestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/testenv/SITestEnvironment.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/testenv/SITestEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/testenv/TestServerControl.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/testenv/TestServerControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/testenv/TestTransactionSetup.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/testenv/TestTransactionSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/java/com/splicemachine/si/testenv/TransactorTestUtility.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/testenv/TransactorTestUtility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_si_api/src/test/resources/log4j.properties
+++ b/splice_si_api/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2017 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/main/scala/com/splicemachine/spark/splicemachine/SpliceJDBCOptions.scala
+++ b/splice_spark/src/main/scala/com/splicemachine/spark/splicemachine/SpliceJDBCOptions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/main/spark2.1/com/splicemachine/spark/splicemachine/DefaultSource.scala
+++ b/splice_spark/src/main/spark2.1/com/splicemachine/spark/splicemachine/DefaultSource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/main/spark2.1/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
+++ b/splice_spark/src/main/spark2.1/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/main/spark2.1/org/apache/spark/sql/execution/datasources/jdbc/SplicemachineDialectNoTime.scala
+++ b/splice_spark/src/main/spark2.1/org/apache/spark/sql/execution/datasources/jdbc/SplicemachineDialectNoTime.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/main/spark2.2/com/splicemachine/spark/splicemachine/DefaultSource.scala
+++ b/splice_spark/src/main/spark2.2/com/splicemachine/spark/splicemachine/DefaultSource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/main/spark2.2/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
+++ b/splice_spark/src/main/spark2.2/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/main/spark2.2/org/apache/spark/sql/execution/datasources/jdbc/SplicemachineDialectNoTime.scala
+++ b/splice_spark/src/main/spark2.2/org/apache/spark/sql/execution/datasources/jdbc/SplicemachineDialectNoTime.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/main/spark2.3/com/splicemachine/spark/splicemachine/DefaultSource.scala
+++ b/splice_spark/src/main/spark2.3/com/splicemachine/spark/splicemachine/DefaultSource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/main/spark2.3/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
+++ b/splice_spark/src/main/spark2.3/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/main/spark2.3/org/apache/spark/sql/execution/datasources/jdbc/SplicemachineDialectNoTime.scala
+++ b/splice_spark/src/main/spark2.3/org/apache/spark/sql/execution/datasources/jdbc/SplicemachineDialectNoTime.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/test/java/com/splice/custom/reader/ReaderWriterExample.java
+++ b/splice_spark/src/test/java/com/splice/custom/reader/ReaderWriterExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceTest.scala
+++ b/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/test/spark2.1/com/splicemachine/spark/splicemachine/SparkStreamingTest.scala
+++ b/splice_spark/src/test/spark2.1/com/splicemachine/spark/splicemachine/SparkStreamingTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/test/spark2.1/com/splicemachine/spark/splicemachine/TestContext.scala
+++ b/splice_spark/src/test/spark2.1/com/splicemachine/spark/splicemachine/TestContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/test/spark2.1/com/splicemachine/spark/splicemachine/TestStreamingContext.scala
+++ b/splice_spark/src/test/spark2.1/com/splicemachine/spark/splicemachine/TestStreamingContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/test/spark2.2/com/splicemachine/spark/splicemachine/SparkStreamingTest.scala
+++ b/splice_spark/src/test/spark2.2/com/splicemachine/spark/splicemachine/SparkStreamingTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/test/spark2.2/com/splicemachine/spark/splicemachine/TestContext.scala
+++ b/splice_spark/src/test/spark2.2/com/splicemachine/spark/splicemachine/TestContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/test/spark2.2/com/splicemachine/spark/splicemachine/TestStreamingContext.scala
+++ b/splice_spark/src/test/spark2.2/com/splicemachine/spark/splicemachine/TestStreamingContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/test/spark2.3/com/splicemachine/spark/splicemachine/SparkStreamingTest.scala
+++ b/splice_spark/src/test/spark2.3/com/splicemachine/spark/splicemachine/SparkStreamingTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/test/spark2.3/com/splicemachine/spark/splicemachine/TestContext.scala
+++ b/splice_spark/src/test/spark2.3/com/splicemachine/spark/splicemachine/TestContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_spark/src/test/spark2.3/com/splicemachine/spark/splicemachine/TestStreamingContext.scala
+++ b/splice_spark/src/test/spark2.3/com/splicemachine/spark/splicemachine/TestStreamingContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_timestamp_api/pom.xml
+++ b/splice_timestamp_api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2017 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/api/Callback.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/api/Callback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/api/TimestampBlockManager.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/api/TimestampBlockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/api/TimestampClientStatistics.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/api/TimestampClientStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/api/TimestampHostProvider.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/api/TimestampHostProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/api/TimestampIOException.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/api/TimestampIOException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/api/TimestampOracleStatistics.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/api/TimestampOracleStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/api/TimestampSource.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/api/TimestampSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/ClientCallback.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/ClientCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampBaseHandler.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampBaseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampClient.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampOracle.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampOracle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampPipelineFactoryLite.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampPipelineFactoryLite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampServer.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampServerHandler.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2017 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/splice_timestamp_api/src/test/java/com/splicemachine/timestamp/impl/TimestampClientTest.java
+++ b/splice_timestamp_api/src/test/java/com/splicemachine/timestamp/impl/TimestampClientTest.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/sqlj-it-procs/pom.xml
+++ b/sqlj-it-procs/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2012 - 2018 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/sqlj-it-procs/src/main/java/com/splicemachine/derby/transactions/TestProcs.java
+++ b/sqlj-it-procs/src/main/java/com/splicemachine/derby/transactions/TestProcs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/sqlj-it-procs/src/main/java/com/splicemachine/triggers/TriggerProcs.java
+++ b/sqlj-it-procs/src/main/java/com/splicemachine/triggers/TriggerProcs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/sqlj-it-procs/src/main/java/org/splicetest/sqlj/PropertiesFileVTI.java
+++ b/sqlj-it-procs/src/main/java/org/splicetest/sqlj/PropertiesFileVTI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 - 2016 Splice Machine, Inc.
+ * Copyright 2012 - 2019 Splice Machine, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy of the

--- a/sqlj-it-procs/src/main/java/org/splicetest/sqlj/SqlJTestProcs.java
+++ b/sqlj-it-procs/src/main/java/org/splicetest/sqlj/SqlJTestProcs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/txn-it-procs/pom.xml
+++ b/txn-it-procs/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2018 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/txn-it-procs/src/main/java/org/splicetest/txn/TxnTestProcs.java
+++ b/txn-it-procs/src/main/java/org/splicetest/txn/TxnTestProcs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/txn-it-procs/src/test/java/org/splicetest/txn/AppTest.java
+++ b/txn-it-procs/src/test/java/org/splicetest/txn/AppTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/pom.xml
+++ b/utilities/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2012 - 2018 Splice Machine, Inc.
+  ~ Copyright (c) 2012 - 2019 Splice Machine, Inc.
   ~
   ~ This file is part of Splice Machine.
   ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/annotations/Description.java
+++ b/utilities/src/main/java/com/splicemachine/annotations/Description.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/annotations/PName.java
+++ b/utilities/src/main/java/com/splicemachine/annotations/PName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/annotations/ThreadSafe.java
+++ b/utilities/src/main/java/com/splicemachine/annotations/ThreadSafe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/annotations/Untested.java
+++ b/utilities/src/main/java/com/splicemachine/annotations/Untested.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/collections/CloseableIterator.java
+++ b/utilities/src/main/java/com/splicemachine/collections/CloseableIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/collections/DoubleBuffer.java
+++ b/utilities/src/main/java/com/splicemachine/collections/DoubleBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/collections/EmptyNavigableSet.java
+++ b/utilities/src/main/java/com/splicemachine/collections/EmptyNavigableSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/collections/FloatBuffer.java
+++ b/utilities/src/main/java/com/splicemachine/collections/FloatBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/collections/ForwardingCloseableIterator.java
+++ b/utilities/src/main/java/com/splicemachine/collections/ForwardingCloseableIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/collections/LongBuffer.java
+++ b/utilities/src/main/java/com/splicemachine/collections/LongBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/collections/LongKeyedCache.java
+++ b/utilities/src/main/java/com/splicemachine/collections/LongKeyedCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/collections/NavigableCastingSet.java
+++ b/utilities/src/main/java/com/splicemachine/collections/NavigableCastingSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/collections/NullStopIterator.java
+++ b/utilities/src/main/java/com/splicemachine/collections/NullStopIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/collections/Partition.java
+++ b/utilities/src/main/java/com/splicemachine/collections/Partition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/collections/RingBuffer.java
+++ b/utilities/src/main/java/com/splicemachine/collections/RingBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/collections/Sample.java
+++ b/utilities/src/main/java/com/splicemachine/collections/Sample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/collections/SingletonSortedSet.java
+++ b/utilities/src/main/java/com/splicemachine/collections/SingletonSortedSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/collections/hashtable/BaseRobinHoodHashTable.java
+++ b/utilities/src/main/java/com/splicemachine/collections/hashtable/BaseRobinHoodHashTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/collections/hashtable/HashTable.java
+++ b/utilities/src/main/java/com/splicemachine/collections/hashtable/HashTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/collections/hashtable/LongObjectHashTable.java
+++ b/utilities/src/main/java/com/splicemachine/collections/hashtable/LongObjectHashTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/collections/hashtable/SimpleHashTable.java
+++ b/utilities/src/main/java/com/splicemachine/collections/hashtable/SimpleHashTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/compression/SpliceSnappy.java
+++ b/utilities/src/main/java/com/splicemachine/compression/SpliceSnappy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/BalancedBlockingQueue.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/BalancedBlockingQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/CancellableCompletionService.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/CancellableCompletionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/Clock.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/Clock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/ConcurrentTicker.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/ConcurrentTicker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/CountDownLatches.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/CountDownLatches.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/CountedReference.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/CountedReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/DynamicScheduledRunnable.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/DynamicScheduledRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/IncrementingClock.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/IncrementingClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/KeyedCompletionService.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/KeyedCompletionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/KeyedFuture.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/KeyedFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/LockFactory.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/LockFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/LoggingScheduledThreadPoolExecutor.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/LoggingScheduledThreadPoolExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/LongStripedSynchronizer.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/LongStripedSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/MoreExecutors.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/MoreExecutors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/ReentrantLockFactory.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/ReentrantLockFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/ResettableCountDownLatch.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/ResettableCountDownLatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/SameThreadExecutorService.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/SameThreadExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/SingleInstanceLockFactory.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/SingleInstanceLockFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/Striped.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/Striped.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/SystemClock.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/SystemClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/ThreadLocalRandom.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/ThreadLocalRandom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/Threads.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/Threads.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/concurrent/TickingClock.java
+++ b/utilities/src/main/java/com/splicemachine/concurrent/TickingClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/encoding/Encodeable.java
+++ b/utilities/src/main/java/com/splicemachine/encoding/Encodeable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/encoding/Encoder.java
+++ b/utilities/src/main/java/com/splicemachine/encoding/Encoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/hash/BooleanHash.java
+++ b/utilities/src/main/java/com/splicemachine/hash/BooleanHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/hash/Hash32.java
+++ b/utilities/src/main/java/com/splicemachine/hash/Hash32.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/hash/Hash64.java
+++ b/utilities/src/main/java/com/splicemachine/hash/Hash64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/hash/HashFunctions.java
+++ b/utilities/src/main/java/com/splicemachine/hash/HashFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/hash/Murmur32.java
+++ b/utilities/src/main/java/com/splicemachine/hash/Murmur32.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/hash/Murmur64.java
+++ b/utilities/src/main/java/com/splicemachine/hash/Murmur64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/AtomicTimer.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/AtomicTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/BaseIOStats.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/BaseIOStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/BaseTimeMeasure.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/BaseTimeMeasure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/CompositeTimer.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/CompositeTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/ConcurrentEWMA.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/ConcurrentEWMA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/Counter.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/Counter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/DisplayTime.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/DisplayTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/DistributionTimeView.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/DistributionTimeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/Gauge.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/Gauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/IOStats.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/IOStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/LatencyTimer.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/LatencyTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/LatencyView.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/LatencyView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/MetricFactory.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/MetricFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/Metrics.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/Metrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/MultiStatsView.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/MultiStatsView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/MultiTimeView.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/MultiTimeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/SampleTimeMeasure.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/SampleTimeMeasure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/SampledTimer.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/SampledTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/SamplingCompositeTimer.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/SamplingCompositeTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/SimpleMultiTimeView.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/SimpleMultiTimeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/SimpleTimer.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/SimpleTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/Stats.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/Stats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/TimeMeasure.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/TimeMeasure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/TimeView.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/TimeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/Timer.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/Timer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/util/DoubleFolder.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/util/DoubleFolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/util/Folders.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/util/Folders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/metrics/util/LongLongFolder.java
+++ b/utilities/src/main/java/com/splicemachine/metrics/util/LongLongFolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/primitives/BigEndianBits.java
+++ b/utilities/src/main/java/com/splicemachine/primitives/BigEndianBits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/primitives/BooleanArrays.java
+++ b/utilities/src/main/java/com/splicemachine/primitives/BooleanArrays.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/primitives/ByteComparator.java
+++ b/utilities/src/main/java/com/splicemachine/primitives/ByteComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/primitives/Bytes.java
+++ b/utilities/src/main/java/com/splicemachine/primitives/Bytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/primitives/LittleEndianBits.java
+++ b/utilities/src/main/java/com/splicemachine/primitives/LittleEndianBits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/primitives/MoreArrays.java
+++ b/utilities/src/main/java/com/splicemachine/primitives/MoreArrays.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/range/ByteInterval.java
+++ b/utilities/src/main/java/com/splicemachine/range/ByteInterval.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/stream/AbstractMeasuredStream.java
+++ b/utilities/src/main/java/com/splicemachine/stream/AbstractMeasuredStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/stream/AbstractStream.java
+++ b/utilities/src/main/java/com/splicemachine/stream/AbstractStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/stream/Accumulator.java
+++ b/utilities/src/main/java/com/splicemachine/stream/Accumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/stream/ForwardingMeasuredStream.java
+++ b/utilities/src/main/java/com/splicemachine/stream/ForwardingMeasuredStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/stream/ForwardingStream.java
+++ b/utilities/src/main/java/com/splicemachine/stream/ForwardingStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/stream/MeasuredStream.java
+++ b/utilities/src/main/java/com/splicemachine/stream/MeasuredStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/stream/MeasuredStreams.java
+++ b/utilities/src/main/java/com/splicemachine/stream/MeasuredStreams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/stream/PeekableStream.java
+++ b/utilities/src/main/java/com/splicemachine/stream/PeekableStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/stream/Predicate.java
+++ b/utilities/src/main/java/com/splicemachine/stream/Predicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/stream/Stream.java
+++ b/utilities/src/main/java/com/splicemachine/stream/Stream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/stream/StreamException.java
+++ b/utilities/src/main/java/com/splicemachine/stream/StreamException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/stream/StreamIterator.java
+++ b/utilities/src/main/java/com/splicemachine/stream/StreamIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/stream/Streams.java
+++ b/utilities/src/main/java/com/splicemachine/stream/Streams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/stream/Transformer.java
+++ b/utilities/src/main/java/com/splicemachine/stream/Transformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/stream/TransformingStream.java
+++ b/utilities/src/main/java/com/splicemachine/stream/TransformingStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/system/FileSystemConfiguration.java
+++ b/utilities/src/main/java/com/splicemachine/system/FileSystemConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/system/Scales.java
+++ b/utilities/src/main/java/com/splicemachine/system/Scales.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/system/SystemConfiguration.java
+++ b/utilities/src/main/java/com/splicemachine/system/SystemConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/system/package-info.java
+++ b/utilities/src/main/java/com/splicemachine/system/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/tools/CachedResourcePool.java
+++ b/utilities/src/main/java/com/splicemachine/tools/CachedResourcePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/tools/Comparables.java
+++ b/utilities/src/main/java/com/splicemachine/tools/Comparables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/tools/ResourcePool.java
+++ b/utilities/src/main/java/com/splicemachine/tools/ResourcePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/utils/ComparableComparator.java
+++ b/utilities/src/main/java/com/splicemachine/utils/ComparableComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/utils/Pair.java
+++ b/utilities/src/main/java/com/splicemachine/utils/Pair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/utils/Sleeper.java
+++ b/utilities/src/main/java/com/splicemachine/utils/Sleeper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/utils/StringUtils.java
+++ b/utilities/src/main/java/com/splicemachine/utils/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/utils/UnsafeUtil.java
+++ b/utilities/src/main/java/com/splicemachine/utils/UnsafeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/uuid/BasicUUIDGenerator.java
+++ b/utilities/src/main/java/com/splicemachine/uuid/BasicUUIDGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/uuid/Snowflake.java
+++ b/utilities/src/main/java/com/splicemachine/uuid/Snowflake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/uuid/Type1UUID.java
+++ b/utilities/src/main/java/com/splicemachine/uuid/Type1UUID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/main/java/com/splicemachine/uuid/UUIDGenerator.java
+++ b/utilities/src/main/java/com/splicemachine/uuid/UUIDGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/collections/LongKeyedCacheTest.java
+++ b/utilities/src/test/java/com/splicemachine/collections/LongKeyedCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/collections/PartitionTest.java
+++ b/utilities/src/test/java/com/splicemachine/collections/PartitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/collections/RingBufferTest.java
+++ b/utilities/src/test/java/com/splicemachine/collections/RingBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/collections/hashtable/SimpleHashTableTest.java
+++ b/utilities/src/test/java/com/splicemachine/collections/hashtable/SimpleHashTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/concurrent/BalancedBlockingQueueTest.java
+++ b/utilities/src/test/java/com/splicemachine/concurrent/BalancedBlockingQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/concurrent/CountDownLatchesTest.java
+++ b/utilities/src/test/java/com/splicemachine/concurrent/CountDownLatchesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/concurrent/DynamicScheduledRunnableTest.java
+++ b/utilities/src/test/java/com/splicemachine/concurrent/DynamicScheduledRunnableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/concurrent/LongStripedSynchronizerTest.java
+++ b/utilities/src/test/java/com/splicemachine/concurrent/LongStripedSynchronizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/concurrent/MoreExecutorsTest.java
+++ b/utilities/src/test/java/com/splicemachine/concurrent/MoreExecutorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/concurrent/ThreadsTest.java
+++ b/utilities/src/test/java/com/splicemachine/concurrent/ThreadsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/hash/FixedMurmur32Test.java
+++ b/utilities/src/test/java/com/splicemachine/hash/FixedMurmur32Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/hash/Murmur32Test.java
+++ b/utilities/src/test/java/com/splicemachine/hash/Murmur32Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/hash/Murmur64Test.java
+++ b/utilities/src/test/java/com/splicemachine/hash/Murmur64Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/primitives/BigEndianBitsTest.java
+++ b/utilities/src/test/java/com/splicemachine/primitives/BigEndianBitsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/primitives/BytesTest.java
+++ b/utilities/src/test/java/com/splicemachine/primitives/BytesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/primitives/LittleEndianBitsTest.java
+++ b/utilities/src/test/java/com/splicemachine/primitives/LittleEndianBitsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/stream/AbstractStreamTest.java
+++ b/utilities/src/test/java/com/splicemachine/stream/AbstractStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/stream/StreamsTest.java
+++ b/utilities/src/test/java/com/splicemachine/stream/StreamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/uuid/SnowflakeGeneratorTest.java
+++ b/utilities/src/test/java/com/splicemachine/uuid/SnowflakeGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/uuid/SnowflakeTest.java
+++ b/utilities/src/test/java/com/splicemachine/uuid/SnowflakeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/java/com/splicemachine/uuid/Type1UUIDGeneratorTest.java
+++ b/utilities/src/test/java/com/splicemachine/uuid/Type1UUIDGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2018 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the

--- a/utilities/src/test/resources/log4j.properties
+++ b/utilities/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2018 Splice Machine, Inc.
+# Copyright (c) 2012 - 2019 Splice Machine, Inc.
 #
 # This file is part of Splice Machine.
 # Splice Machine is free software: you can redistribute it and/or modify it under the terms of the


### PR DESCRIPTION
Added the missing .properties files from the last PR and this commit doesn't truncate existing newlines in the files.