### PR TITLE
DB-7918: fix hdp2.6.5 on standalone by excluding kafka dependency

### DIFF
--- a/platform_it/pom.xml
+++ b/platform_it/pom.xml
@@ -145,6 +145,10 @@
                     <groupId>net.jpountz.lz4</groupId>
                     <artifactId>lz4</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- Yarn dependencies -->


### PR DESCRIPTION
hdp2.6.5 on standalone is broken by version conflict of com.fasterxml.jackson.core:jackson-databind,this fixes it by excluding from kafka's dependency.