### PR TITLE
SPLICE-2304 Wrong results in broadcast join with numeric data types.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLArray.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLArray.java
@@ -42,6 +42,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.unsafe.Platform;
+import scala.util.hashing.MurmurHash3;
 
 import javax.ws.rs.NotSupportedException;
 import java.io.*;
@@ -606,6 +607,13 @@ public class SQLArray extends DataType implements ArrayDataValue {
 	@Override
 	public void setSparkObject(Object sparkObject) throws StandardException {
 
+	}
+
+	public int hashCode() {
+		if (value.length > 0)
+			return MurmurHash3.arrayHashing().hash(value);
+		else
+			return 0;
 	}
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLReal.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLReal.java
@@ -31,27 +31,13 @@
 
 package com.splicemachine.db.iapi.types;
 
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
-
+import com.splicemachine.db.iapi.services.cache.ClassSize;
 import com.splicemachine.db.iapi.services.io.ArrayInputStream;
-
 import com.splicemachine.db.iapi.services.io.Storable;
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
-
-import com.splicemachine.db.iapi.error.StandardException;
-
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
-
-import com.splicemachine.db.iapi.services.cache.ClassSize;
-
-import java.io.ObjectOutput;
-import java.io.ObjectInput;
-import java.io.IOException;
-
-import java.math.BigDecimal;
-import java.sql.ResultSet;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
 import com.splicemachine.db.iapi.types.DataValueFactoryImpl.Format;
 import com.yahoo.sketches.theta.UpdateSketch;
 import org.apache.spark.sql.Row;
@@ -61,6 +47,14 @@ import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeArrayWriter;
 import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 /**
  * SQLReal satisfies the DataValueDescriptor
@@ -159,7 +153,7 @@ public final class SQLReal
 	 */
 	public double	getDouble()
 	{
-		return (double) value;
+		return Double.parseDouble(Float.valueOf(value).toString());
 	}
 
 	/**
@@ -877,7 +871,7 @@ public final class SQLReal
 
 		if (longVal != value)
 		{
-			longVal = Double.doubleToLongBits(value);
+			longVal = Double.doubleToLongBits(getDouble());
 		}
 
 		return (int) (longVal ^ (longVal >> 32));	

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
@@ -363,7 +363,10 @@ public class ValueRow implements ExecRow, Externalizable {
 
 	public int hashCode() {
 		if (hash == 0) {
-			hash = MurmurHash3.arrayHashing().hash(column);
+			if (column.length > 0)
+			    hash = MurmurHash3.arrayHashing().hash(column);
+			else
+				hash = 123456789;
 		}
 		return hash;
 	}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinCache.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinCache.java
@@ -47,7 +47,7 @@ public class BroadcastJoinCache{
     }
 
     public BroadcastJoinCache(){
-       this(ByteBufferMapTableLoader.INSTANCE);
+       this(ValueRowMapTableLoader.INSTANCE);
     }
 
     public BroadcastJoinCache(JoinTableLoader tableLoader){


### PR DESCRIPTION
This fixes broadcast join on the control path when the join columns are both numeric, but different data types, e.g.  decimal = real, double = float.

See [SPLICE-2304](https://splice.atlassian.net/browse/SPLICE-2304?oldIssueView=true) for more details.