### PR TITLE
SPLICE-2291 Avoid slow IndexLookups when row count estimates are bad.

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowReader.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowReader.java
@@ -91,16 +91,20 @@ public class IndexRowReader implements Iterator<ExecRow>, Iterable<ExecRow>{
         this.outputTemplate=outputTemplate;
         this.txn=txn;
         batchSize=lookupBatchSize;
-        this.numBlocks=numConcurrentLookups;
+        this.numBlocks=Math.max(numConcurrentLookups, 2);
         this.mainTableConglomId=mainTableConglomId;
         this.predicateFilterBytes=predicateFilterBytes;
         this.tableFactory=tableFactory;
         this.keyDecoder=new KeyDecoder(keyDecoder,0);
         this.rowDecoder=rowDecoder;
         this.indexCols=indexCols;
-        this.resultFutures=Lists.newArrayListWithCapacity(numConcurrentLookups);
+        this.resultFutures=Lists.newArrayListWithCapacity(this.numBlocks);
         this.operationFactory = operationFactory;
     }
+
+    // Return the maximum number of threads that could be simultaneously
+    // doing base conglomerate row lookups.
+    public int getMaxConcurrency() {return this.numBlocks;}
 
     public void close() throws IOException{
         rowDecoder.close();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowReaderBuilder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowReaderBuilder.java
@@ -191,7 +191,7 @@ public class IndexRowReaderBuilder implements Externalizable{
                 outputTemplate,
                 txn,
                 lookupBatchSize,
-                Math.max(numConcurrentLookups,0),
+                Math.max(numConcurrentLookups,2),
                 mainTableConglomId,
                 epfBytes,
                 keyDecoder,

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowToBaseRowOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowToBaseRowOperation.java
@@ -311,7 +311,7 @@ public class IndexRowToBaseRowOperation extends SpliceBaseOperation{
                     .mainTableVersion(tableVersion)
                     .mainTableRowDecodingMap(operationInformation.getBaseColumnMap())
                     .mainTableAccessedRowColumns(getMainTableRowColumns())
-                    .numConcurrentLookups((getEstimatedRowCount()>2*indexBatchSize?lookupBlocks:-1))
+                    .numConcurrentLookups(lookupBlocks)
                     .lookupBatchSize(indexBatchSize);
         }
         OperationContext context = dsp.createOperationContext(this);

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowReaderTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/IndexRowReaderTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.impl.sql.execute.operations;
+
+import com.splicemachine.si.testenv.ArchitectureIndependent;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@Category(ArchitectureIndependent.class)
+public class IndexRowReaderTest {
+
+    // Checks that the lowest maximum concurrency of an index row reader is 2, even if
+    // fewer threads are requested.
+    @Test
+    public void testReaderConcurrency() throws Exception {
+        IndexRowReader irr = new IndexRowReader(
+            null,
+            null,
+            null,
+            4000,
+            0, // numConcurrentLookup = 0
+            0,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+        assertTrue("Expected a max concurrency of 2", irr.getMaxConcurrency() == 2);
+
+        irr = new IndexRowReader(
+            null,
+            null,
+            null,
+            4000,
+            -5000, // numConcurrentLookup = 0
+            0,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+        assertTrue("Expected a max concurrency of 2", irr.getMaxConcurrency() == 2);
+    }
+}


### PR DESCRIPTION
This fix decouples the selected max concurrency of index row lookups from optimizer row count estimates.  For large number of rows, we should still allow concurrency, even if the optimizer predicted we have less rows.

More info in: [SPLICE-2291](https://splice.atlassian.net/browse/SPLICE-2291?oldIssueView=true)