### PR TITLE
DB-8082 Fix DB-7960 regression

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowResultSetNode.java
@@ -736,6 +736,8 @@ public class WindowResultSetNode extends SingleChildResultSetNode {
             List<ValueNode> operands = windowFunctionNode.getOperands();
             int[] inputVIDs = new int[operands.size()];
             int i = 0;
+            ColumnPullupVisitor columnPuller =
+               new ColumnPullupVisitor(WindowFunctionNode.class, LOG, ((SingleChildResultSetNode) this.childResult).getChildResult(), rCtoCRfactory);
             for (ValueNode exp : operands) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("addWindowFunctionColumns() operand expression instance of : " + exp.getClass().getSimpleName());
@@ -779,12 +781,12 @@ public class WindowResultSetNode extends SingleChildResultSetNode {
                         LOG.debug("addWindowFunctionColumns() operand does not have an RC: " + exp.getColumnName() +
                                       ". Creating one for it in " + wdn.toString());
                     }
+                    exp.accept(columnPuller);
 
                     tmpRC = (ResultColumn) getNodeFactory().getNode(C_NodeTypes.RESULT_COLUMN,
-                                                                           "##" + windowFunctionNode.getAggregateName() +
-                                                                               "_Input_" + exp.getColumnName(),
-                                                                           exp,
-                                                                           getContextManager());
+                             "##" + windowFunctionNode.getAggregateName() + "_Input_" +
+                             exp.getColumnName(), exp, getContextManager());
+
                     tmpRC.markGenerated();
                     tmpRC.bindResultColumnToExpression();
                 }
@@ -813,7 +815,6 @@ public class WindowResultSetNode extends SingleChildResultSetNode {
             newRC.setName("##" + windowFunctionNode.getAggregateName() + "Function");
             childRCL.addElement(newRC);
             newRC.setVirtualColumnId(childRCL.size());
-            int fnVID = newRC.getVirtualColumnId();
 
 			/*
 			** Add a reference to this column in the windowing RCL.
@@ -822,6 +823,7 @@ public class WindowResultSetNode extends SingleChildResultSetNode {
                                      getContextManager(), this.getLevel(), this.getLevel());
             winRCL.addElement(tmpRC);
             tmpRC.setVirtualColumnId(winRCL.size());
+            int fnVID = tmpRC.getVirtualColumnId();
 
             /*
 			** Create an window function result expression

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowResultSetNode.java
@@ -815,6 +815,7 @@ public class WindowResultSetNode extends SingleChildResultSetNode {
             newRC.setName("##" + windowFunctionNode.getAggregateName() + "Function");
             childRCL.addElement(newRC);
             newRC.setVirtualColumnId(childRCL.size());
+            int fnVID = newRC.getVirtualColumnId();
 
 			/*
 			** Add a reference to this column in the windowing RCL.
@@ -823,7 +824,6 @@ public class WindowResultSetNode extends SingleChildResultSetNode {
                                      getContextManager(), this.getLevel(), this.getLevel());
             winRCL.addElement(tmpRC);
             tmpRC.setVirtualColumnId(winRCL.size());
-            int fnVID = tmpRC.getVirtualColumnId();
 
             /*
 			** Create an window function result expression


### PR DESCRIPTION
Fixes an incorrect result regression from DB-7960, caused by adding a CAST operator in a window function.
The root cause is poor support for expressions in aggregate functions of complex window function queries.
For details, please see [DB-8082](https://splicemachine.atlassian.net/browse/DB-8082?focusedCommentId=60300&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-60300).