### PR TITLE
DB-8155 set tcpNoDelay to true in TimestampClient

### DIFF
--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampClient.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampClient.java
@@ -121,7 +121,7 @@ public class TimestampClient extends TimestampBaseHandler implements TimestampCl
         bootstrap.getPipeline().addLast("decoder", new FixedLengthFrameDecoder(FIXED_MSG_RECEIVED_LENGTH));
         bootstrap.getPipeline().addLast("handler", this);
 
-        bootstrap.setOption("tcpNoDelay", false);
+        bootstrap.setOption("tcpNoDelay", true);
         bootstrap.setOption("keepAlive", true);
         bootstrap.setOption("reuseAddress", true);
         // bootstrap.setOption("connectTimeoutMillis", 120000);

--- a/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampServer.java
+++ b/splice_timestamp_api/src/main/java/com/splicemachine/timestamp/impl/TimestampServer.java
@@ -71,10 +71,10 @@ public class TimestampServer {
 
         bootstrap.setPipelineFactory(new TimestampPipelineFactoryLite(handler));
 
-        bootstrap.setOption("tcpNoDelay", false);
+        bootstrap.setOption("tcpNoDelay", true);
         // bootstrap.setOption("child.sendBufferSize", 1048576);
         // bootstrap.setOption("child.receiveBufferSize", 1048576);
-        bootstrap.setOption("child.tcpNoDelay", false);
+        bootstrap.setOption("child.tcpNoDelay", true);
         bootstrap.setOption("child.keepAlive", true);
         bootstrap.setOption("child.reuseAddress", true);
         // bootstrap.setOption("child.connectTimeoutMillis", 120000);


### PR DESCRIPTION
Disable Nagle's algorithm responsible for delays obtaining timestamps (transaction IDs) from the oracle.