### PR TITLE
DB-8200 fix NPE and wrong result for nested loop join with UNION operation as right table

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/JoinConditionVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/JoinConditionVisitor.java
@@ -333,7 +333,7 @@ public class JoinConditionVisitor extends AbstractSpliceVisitor {
         // except for Except and Intersect node.
         // because for NLJ, join condition could be pushed down under union operation and joins.
         Iterable<ResultSetNode> rights = Iterables.filter(
-                RSUtils.nodesUntilSetOperatorNodeExcludeUnion(j.getRightResultSet()),
+                RSUtils.nodesUntilBinaryNodeExcludeUnion(j.getRightResultSet()),
                 RSUtils.rsnHasPreds);
 
         org.spark_project.guava.base.Predicate<Predicate> joinScoped = evalableAtNode(j);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/JoinConditionVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/JoinConditionVisitor.java
@@ -329,9 +329,11 @@ public class JoinConditionVisitor extends AbstractSpliceVisitor {
     		LOG.debug(String.format("rewriteNLJColumnRefs joinNode=%s", j));
         List<Predicate> joinPreds = new LinkedList<>();
 
-        // Collect PRs, FBTs until a binary node (Union, Join) found, or end
-        Iterable<ResultSetNode> rightsUntilBinary = Iterables.filter(
-                RSUtils.nodesUntilBinaryNode(j.getRightResultSet()),
+        // Collect PRs, FBTs from the right source of NLJ. We need to collect ResultSet until leave nodes
+        // except for Except and Intersect node.
+        // because for NLJ, join condition could be pushed down under union operation and joins.
+        Iterable<ResultSetNode> rights = Iterables.filter(
+                RSUtils.nodesUntilSetOperatorNodeExcludeUnion(j.getRightResultSet()),
                 RSUtils.rsnHasPreds);
 
         org.spark_project.guava.base.Predicate<Predicate> joinScoped = evalableAtNode(j);
@@ -339,9 +341,9 @@ public class JoinConditionVisitor extends AbstractSpliceVisitor {
     	if (LOG.isDebugEnabled())
     		LOG.debug(String.format("joinScoped joinScoped=%s",joinScoped));
 
-        for (ResultSetNode rsn: rightsUntilBinary) {
+        for (ResultSetNode rsn: rights) {
         	if (LOG.isDebugEnabled())
-        		LOG.debug(String.format("rewriteNLJColumnRefs rightsUntilBinary=%s",rsn));
+        		LOG.debug(String.format("rewriteNLJColumnRefs rights=%s",rsn));
         	// Encode whether to pull up predicate to join:
             //  when can't evaluate on node but can evaluate at join
             org.spark_project.guava.base.Predicate<Predicate> predOfInterest =
@@ -365,13 +367,14 @@ public class JoinConditionVisitor extends AbstractSpliceVisitor {
      */
     public static Set<Integer> resultSetRefs(Predicate p) throws StandardException {
         return Sets.newHashSet(
-                Lists.transform(RSUtils.collectNodes(p, ColumnReference.class),
+                Iterables.filter(Lists.transform(RSUtils.collectNodes(p, ColumnReference.class),
                         new Function<ColumnReference, Integer>() {
                             @Override
                             public Integer apply(ColumnReference cr) {
-                                return (int) (cr.getSource().getCoordinates() >> 32);
+                                // ColumnReference pointing to a subquery may have source set to null
+                                return (int) ((cr.getSource()==null)?-1:cr.getSource().getCoordinates() >> 32);
                             }
-                        }));
+                        }), (rsnNumber -> rsnNumber >= 0)));
     }
 
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/RSUtils.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/RSUtils.java
@@ -119,8 +119,14 @@ public class RSUtils {
             UnionNode.class,
             IntersectOrExceptNode.class);
 
+    public static final Set<?> setRSNsExcludeUnion = ImmutableSet.of(
+            IntersectOrExceptNode.class);
+
     public static final org.spark_project.guava.base.Predicate<Object> isBinaryRSN =
             Predicates.compose(Predicates.in(binaryRSNs), classOf);
+
+    public static final org.spark_project.guava.base.Predicate<Object> isSetRSNExcludeUnion =
+            Predicates.compose(Predicates.in(setRSNsExcludeUnion), classOf);
 
     // leafRSNs might need VTI eventually
     public static final Set<?> leafRSNs = ImmutableSet.of(
@@ -195,6 +201,13 @@ public class RSUtils {
         return CollectingVisitorBuilder.forClass(ResultSetNode.class)
                 .onAxis(isRSN)
                 .until(isBinaryRSN)
+                .collect(rsn);
+    }
+
+    public static List<ResultSetNode> nodesUntilSetOperatorNodeExcludeUnion(ResultSetNode rsn) throws StandardException {
+        return CollectingVisitorBuilder.forClass(ResultSetNode.class)
+                .onAxis(isRSN)
+                .until(isSetRSNExcludeUnion)
                 .collect(rsn);
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/RSUtils.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/RSUtils.java
@@ -119,14 +119,16 @@ public class RSUtils {
             UnionNode.class,
             IntersectOrExceptNode.class);
 
-    public static final Set<?> setRSNsExcludeUnion = ImmutableSet.of(
+    public static final Set<?> binaryRSNsExcludeUnion = ImmutableSet.of(
+            JoinNode.class,
+            HalfOuterJoinNode.class,
             IntersectOrExceptNode.class);
 
     public static final org.spark_project.guava.base.Predicate<Object> isBinaryRSN =
             Predicates.compose(Predicates.in(binaryRSNs), classOf);
 
-    public static final org.spark_project.guava.base.Predicate<Object> isSetRSNExcludeUnion =
-            Predicates.compose(Predicates.in(setRSNsExcludeUnion), classOf);
+    public static final org.spark_project.guava.base.Predicate<Object> isBinaryRSNExcludeUnion =
+            Predicates.compose(Predicates.in(binaryRSNsExcludeUnion), classOf);
 
     // leafRSNs might need VTI eventually
     public static final Set<?> leafRSNs = ImmutableSet.of(
@@ -204,10 +206,10 @@ public class RSUtils {
                 .collect(rsn);
     }
 
-    public static List<ResultSetNode> nodesUntilSetOperatorNodeExcludeUnion(ResultSetNode rsn) throws StandardException {
+    public static List<ResultSetNode> nodesUntilBinaryNodeExcludeUnion(ResultSetNode rsn) throws StandardException {
         return CollectingVisitorBuilder.forClass(ResultSetNode.class)
                 .onAxis(isRSN)
-                .until(isSetRSNExcludeUnion)
+                .until(isBinaryRSNExcludeUnion)
                 .collect(rsn);
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseTableNumbersVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseTableNumbersVisitor.java
@@ -58,6 +58,8 @@ public class BaseTableNumbersVisitor implements Visitor
 	 * base table was.
 	 */
 	private int columnNumber;
+	private boolean doNotAllowLimitN = false;
+	private boolean stopTraversing = false;
 
 	/**
 	 * Constructor: takes a JBitSet to use as the holder for any base table
@@ -71,6 +73,12 @@ public class BaseTableNumbersVisitor implements Visitor
 		columnNumber = -1;
 	}
 
+	public BaseTableNumbersVisitor(JBitSet tableMap, boolean doNotAllowLimitN)
+	{
+		this.tableMap = tableMap;
+		columnNumber = -1;
+		this.doNotAllowLimitN = doNotAllowLimitN;
+	}
 	/**
 	 * Set a new JBitSet to serve as the holder for base table numbers
 	 * we find while walking.
@@ -89,6 +97,7 @@ public class BaseTableNumbersVisitor implements Visitor
 	{
 		tableMap.clearAll();
 		columnNumber = -1;
+		stopTraversing = false;
 	}
 
 	/**
@@ -133,6 +142,13 @@ public class BaseTableNumbersVisitor implements Visitor
 			rc = (ResultColumn)node;
 		else if (node instanceof SelectNode)
 		{
+			if (doNotAllowLimitN && (((SelectNode) node).offset != null || ((SelectNode) node).fetchFirst != null)) {
+				stopTraversing = true;
+				tableMap.clearAll();
+				columnNumber = -1;
+				return node;
+			}
+
 			// If the node is a SelectNode we just need to look at its
 			// FROM list.
 			((SelectNode)node).getFromList().accept(this);
@@ -225,7 +241,7 @@ public class BaseTableNumbersVisitor implements Visitor
 	 */
 	public boolean stopTraversal()
 	{
-		return false;
+		return stopTraversing;
 	}
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetOperatorNode.java
@@ -337,7 +337,7 @@ abstract class SetOperatorNode extends TableOperatorNode
 
 		JBitSet tableNums = new JBitSet(getReferencedTableMap().size());
 		BaseTableNumbersVisitor btnVis =
-			new BaseTableNumbersVisitor(tableNums);
+			new BaseTableNumbersVisitor(tableNums, true);
 
 		// Check the left child.
 		leftResultSet.accept(btnVis);


### PR DESCRIPTION
A second submission for DB-8200. This has the additional fix to address the intermittent wrong result exposed in the IT. For more details of the problem and fix, please see [this comment in DB-8200](https://splicemachine.atlassian.net/browse/DB-8200?focusedCommentId=61038&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-61038).