### PR TITLE
[MINOR][BUILD] Use scala.binary.version (not a hardcoded Scala version)

### DIFF
--- a/mem_sql/pom.xml
+++ b/mem_sql/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.11</artifactId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
         </dependency>
 

--- a/splice_machine/pom.xml
+++ b/splice_machine/pom.xml
@@ -105,7 +105,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.11</artifactId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/sqlj-it-procs/pom.xml
+++ b/sqlj-it-procs/pom.xml
@@ -37,7 +37,7 @@
 
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.11</artifactId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/txn-it-procs/pom.xml
+++ b/txn-it-procs/pom.xml
@@ -53,7 +53,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.11</artifactId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
Use `scala.binary.version` (not a hardcoded Scala version)