### PR TITLE
DB-8296 Roll back changes to DRDA maintenance code to re-enable ODBC

### DIFF
--- a/db-shared/src/main/resources/com/splicemachine/db/info/DBMS.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/DBMS.properties
@@ -32,7 +32,7 @@
 derby.version.major            = 10
 derby.version.minor            = 9
 derby.version.maint            = 2000002
-derby.version.drdamaint        = 1
+derby.version.drdamaint        = 0
 derby.build.number             = 1
 derby.product.technology.name  = Splice Machine Embedded Engine
 derby.product.external.name    = Splice Machine

--- a/db-shared/src/main/resources/com/splicemachine/db/info/dnc.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/dnc.properties
@@ -32,7 +32,7 @@
 derby.version.major            = 10
 derby.version.minor            = 9
 derby.version.maint            = 2000002
-derby.version.drdamaint        = 1
+derby.version.drdamaint        = 0
 derby.build.number             = 1
 derby.product.technology.name  = Splice Machine Network Client
 derby.product.external.name    = Splice Machine

--- a/db-shared/src/main/resources/com/splicemachine/db/info/net.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/net.properties
@@ -32,7 +32,7 @@
 derby.version.major            = 10
 derby.version.minor            = 9
 derby.version.maint            = 2000002
-derby.version.drdamaint        = 1
+derby.version.drdamaint        = 0
 derby.build.number             = 1
 derby.product.technology.name  = Splice Machine Network Server
 derby.product.external.name    = Splice Machine

--- a/db-shared/src/main/resources/com/splicemachine/db/info/tools.properties
+++ b/db-shared/src/main/resources/com/splicemachine/db/info/tools.properties
@@ -32,7 +32,7 @@
 derby.version.major            = 10
 derby.version.minor            = 9
 derby.version.maint            = 2000002
-derby.version.drdamaint        = 1
+derby.version.drdamaint        = 0
 derby.build.number             = 1
 derby.product.technology.name  = Splice Machine Tools
 derby.product.external.name    = Splice Machine


### PR DESCRIPTION
roll back changes to DRDA maintenance code

Rolling this back as just a temporary measure in the 2.7 branch only just to resolve the current ODBC issue. Will investigate a long term approach in the next couple of weeks.