### PR TITLE
SPLICE-2364 Properly close internal region scanners

### DIFF
--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/TxnLifecycleEndpoint.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/TxnLifecycleEndpoint.java
@@ -231,12 +231,14 @@ public class TxnLifecycleEndpoint extends TxnMessage.TxnLifecycleService impleme
         long startTxnId=request.getStartTxnId();
         try (RpcUtils.RootEnv env = RpcUtils.getRootEnv()) {
             byte[] destTables=null;
-            if(request.hasDestinationTables())
-                destTables=request.getDestinationTables().toByteArray();
-            Source<TxnMessage.Txn> activeTxns=lifecycleStore.getActiveTransactions(destTables,startTxnId,endTxnId);
-            TxnMessage.ActiveTxnResponse.Builder response=TxnMessage.ActiveTxnResponse.newBuilder();
-            while(activeTxns.hasNext()){
-                response.addTxns(activeTxns.next());
+            if (request.hasDestinationTables()) {
+                destTables = request.getDestinationTables().toByteArray();
+            }
+            TxnMessage.ActiveTxnResponse.Builder response = TxnMessage.ActiveTxnResponse.newBuilder();
+            try (Source<TxnMessage.Txn> activeTxns = lifecycleStore.getActiveTransactions(destTables, startTxnId, endTxnId)) {
+                while (activeTxns.hasNext()) {
+                    response.addTxns(activeTxns.next());
+                }
             }
             done.run(response.build());
         }catch(IOException e){

--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
@@ -294,6 +294,7 @@ class SpliceTestPlatformConfig {
         config.set("splice.authentication.impersonation.users", "dgf=splice;splice=*");
         config.setBoolean("splice.authentication.impersonation.enabled", true);
         config.set("splice.authentication.ldap.mapGroupAttr", "jy=splice,dgf=splice");
+        config.setInt("splice.txn.completedTxns.cacheSize", 4096);
    //     config.setBoolean("splice.metadataRestrictionEnabled", true);
 
         if (derbyPort > SQLConfiguration.DEFAULT_NETWORK_BIND_PORT) {


### PR DESCRIPTION
Use try-with-resources to ensure underlying scanners are closed and associated memory is released (when MemStoreLAB is enabled).
Reduce splice.txn.completedTxns.cacheSize for ITs to ease memory pressure.