### PR TITLE
DB-8492 Wrong results when cross join strategy is used for TableScan.

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/CrossJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/CrossJoinStrategy.java
@@ -128,8 +128,8 @@ public class CrossJoinStrategy extends BaseJoinStrategy {
 
     @Override
     public void divideUpPredicateLists(Optimizable innerTable, OptimizablePredicateList originalRestrictionList, OptimizablePredicateList storeRestrictionList, OptimizablePredicateList nonStoreRestrictionList, OptimizablePredicateList requalificationRestrictionList, DataDictionary dd) throws StandardException {
-        originalRestrictionList.transferPredicates(storeRestrictionList, innerTable.getReferencedTableMap(), innerTable);
-        originalRestrictionList.copyPredicatesToOtherList(nonStoreRestrictionList);
+       originalRestrictionList.transferPredicates(storeRestrictionList, innerTable.getReferencedTableMap(), innerTable);
+       originalRestrictionList.copyPredicatesToOtherList(nonStoreRestrictionList);
     }
 
     @Override
@@ -181,6 +181,13 @@ public class CrossJoinStrategy extends BaseJoinStrategy {
                             CostEstimate outerCost,
                             boolean wasHinted,
                             boolean skipKeyCheck) throws StandardException {
+
+	// Cross join can't handle IndexLookups on the inner table currently because
+        // the join predicates get mapped to the IndexScan instead of the CrossJoin.
+        // Broadcast join has a similar restriction.
+	if (JoinStrategyUtil.isNonCoveringIndex(innerTable))
+            return false;
+
         AccessPath currentAccessPath = innerTable.getCurrentAccessPath();
         boolean isSpark = false;
         boolean isForcedControl = false;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/CrossJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/CrossJoinStrategy.java
@@ -128,7 +128,8 @@ public class CrossJoinStrategy extends BaseJoinStrategy {
 
     @Override
     public void divideUpPredicateLists(Optimizable innerTable, OptimizablePredicateList originalRestrictionList, OptimizablePredicateList storeRestrictionList, OptimizablePredicateList nonStoreRestrictionList, OptimizablePredicateList requalificationRestrictionList, DataDictionary dd) throws StandardException {
-        // originalRestrictionList.setPredicatesAndProperties(storeRestrictionList);
+        originalRestrictionList.transferPredicates(storeRestrictionList, innerTable.getReferencedTableMap(), innerTable);
+        originalRestrictionList.copyPredicatesToOtherList(nonStoreRestrictionList);
     }
 
     @Override

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/CrossJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/CrossJoinIT.java
@@ -457,6 +457,21 @@ public class CrossJoinIT extends SpliceUnitTest {
     }
 
     @Test
+    public void testSingleTableWithCrossJoinHint() throws Exception {
+        String sqlText = format("select * from \n" +
+                "a --splice-properties joinStrategy=CROSS, useSpark=%s\n" +
+                "where c2=1", useSpark);
+        String expected = "C1 |C2 |\n" +
+                            "--------\n" +
+                            " 1 | 1 |";
+
+        ResultSet rs = classWatcher.executeQuery(sqlText);
+        String resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+        assertEquals("\n" + sqlText + "\n" + "expected result: " + expected + "\n,actual result: " + resultString, expected, resultString);
+        rs.close();
+    }
+
+    @Test
     public void testInequalityCrossJoin() throws Exception {
         try {
             if (idx.equals(NOT_COVER_IDX)) {


### PR DESCRIPTION
Fixes wrong results due to a filter predicate getting lost when using cross join strategy for a single-table scan.

See [DB-8492](https://splicemachine.atlassian.net/browse/DB-8492)