### PR TITLE
DB-8166 Quit join execution immediately when one side is empty.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/db/Database.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/db/Database.java
@@ -92,6 +92,7 @@ public interface Database extends com.splicemachine.db.database.Database, Locale
 													 CompilerContext.DataSetProcessorType dataSetProcessorType,
 													 boolean skipStats,
 													 double defaultSelectivityFactor,
+													 boolean explainMode,
 													 String ipAddress,
 													 String defaultSchema,
 													 Properties sessionProperties

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/AccessPath.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/AccessPath.java
@@ -118,6 +118,23 @@ public interface AccessPath {
 	int getLockMode();
 
 	/**
+	 *
+	 *  Access path for an Exists subquery.
+	 *
+	 * @return
+	 */
+	boolean isExistsTable();
+
+	/**
+	 *
+	 * Set the isExists flag.
+	 *
+	 *
+	 * @param isExistsTable
+	 */
+	void setExistsTable(boolean isExistsTable);
+
+	/**
 	 * Copy all information from the given AccessPath to this one.
 	 */
 	void copy(AccessPath copyFrom);

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CostEstimate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CostEstimate.java
@@ -87,6 +87,41 @@ public interface CostEstimate extends StoreCostResult {
     void setAntiJoin(boolean isAntiJoin);
 
     /**
+     *
+     *  Key flag to identify Exists subquery table.
+     *
+     * @return
+     */
+    boolean isExistsTable();
+
+    /**
+     *
+     * Set the isExistsTable flag on the cost so illegal join strategies can be avoided.
+     *
+     *
+     * @param isExistsTable
+     */
+    void setExistsTable(boolean isExistsTable);
+
+    /**
+     *
+     *  Flag to indicate the outermost optimizable's cost.
+     *  Used when costing an operation on a single source, not a join.
+     *
+     * @return
+     */
+    boolean isOuterMostOptimizable();
+
+    /**
+     *
+     * Set the isOuterMostOptimizable flag on the cost.
+     *
+     *
+     * @param isOuterMostOptimizable
+     */
+    void setOuterMostOptimizable(boolean isOuterMostOptimizable);
+
+    /**
      * Copy the values from the given cost estimate into this one.
      */
     void setCost(CostEstimate other);

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionFactory.java
@@ -125,6 +125,7 @@ public interface LanguageConnectionFactory {
                                 CompilerContext.DataSetProcessorType type,
 								boolean skipStats,
 								double defaultSelectivityFactor,
+								boolean explainMode,
 								String ipAddress,
                                 String defaultSchema,
                                 Properties sessionProperties)

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/SessionProperties.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/SessionProperties.java
@@ -45,7 +45,8 @@ public interface SessionProperties {
         DEFAULTSELECTIVITYFACTOR(1),
         SKIPSTATS(2),
         RECURSIVEQUERYITERATIONLIMIT(3),
-        OLAPQUEUE(4);
+        OLAPQUEUE(4),
+        EXPLAINMODE(5);
 
         public static int COUNT = PROPERTYNAME.values().length;
 
@@ -77,7 +78,7 @@ public interface SessionProperties {
             property = SessionProperties.PROPERTYNAME.valueOf(propertyNameString);
         } catch (IllegalArgumentException e) {
             throw StandardException.newException(SQLState.LANG_INVALID_SESSION_PROPERTY,propertyNameString,
-                    "useSpark, defaultSelectivityFactor, skipStats, olapQueue, recursiveQueryIterationLimit");
+                    "useSpark, defaultSelectivityFactor, skipStats, olapQueue, recursiveQueryIterationLimit, explainMode");
         }
 
         String valString = pair.getSecond();
@@ -87,6 +88,7 @@ public interface SessionProperties {
         switch (property) {
             case USESPARK:
             case SKIPSTATS:
+            case EXPLAINMODE:
                 try {
                     boolean val = Boolean.parseBoolean(valString);
                 } catch (Exception e) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/db/BasicDatabase.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/db/BasicDatabase.java
@@ -274,6 +274,7 @@ public class BasicDatabase implements ModuleControl, ModuleSupportable, Property
 													 CompilerContext.DataSetProcessorType type,
 													 boolean skipStats,
 													 double defaultSelectivityFactor,
+													 boolean explainMode,
 													 String ipAddress,
 													 String defaultSchema,
 													 Properties sessionProperties)
@@ -287,7 +288,7 @@ public class BasicDatabase implements ModuleControl, ModuleSupportable, Property
 		// push a database shutdown context
 		// we also need to push a language connection context.
 		LanguageConnectionContext lctx = lcf.newLanguageConnectionContext(cm, tc, lf, this, user, groupuserlist, drdaID, dbname,
-                rdbIntTkn, type,skipStats,defaultSelectivityFactor, ipAddress, defaultSchema, sessionProperties);
+                rdbIntTkn, type,skipStats,defaultSelectivityFactor, explainMode, ipAddress, defaultSchema, sessionProperties);
 
 		// push the context that defines our class factory
 		pushClassFactoryContext(cm, lcf.getClassFactory());

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/TransactionResourceImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/TransactionResourceImpl.java
@@ -134,6 +134,7 @@ public final class TransactionResourceImpl
 	private String drdaID;
 	private String rdbIntTkn;
     private CompilerContext.DataSetProcessorType useSpark;
+    private boolean explainMode;
     private boolean skipStats;
     private double defaultSelectivityFactor;
 	private String ipAddress;
@@ -180,6 +181,16 @@ public final class TransactionResourceImpl
             }
         } else
             useSpark = CompilerContext.DataSetProcessorType.DEFAULT_CONTROL;
+
+        String explainModeString = info.getProperty("explainMode",null);
+        if (explainModeString != null) {
+            try {
+                explainMode = Boolean.parseBoolean(StringUtil.SQLToUpperCase(explainModeString));
+            } catch (Exception sparkE) {
+                throw new SQLException(StandardException.newException(SQLState.LANG_INVALID_EXPLAIN_MODE, explainModeString).getMessage(), SQLState.LANG_INVALID_EXPLAIN_MODE);
+            }
+        } else
+            explainMode = false;
 
         String skipStatsString = info.getProperty("skipStats", null);
         if (skipStatsString != null) {
@@ -242,7 +253,7 @@ public final class TransactionResourceImpl
 	{
 		// setting up local connection
 		lcc = database.setupConnection(cm, username, groupuserlist, drdaID, dbname, rdbIntTkn, useSpark,
-                skipStats, defaultSelectivityFactor, ipAddress, defaultSchema, sessionProperties);
+                skipStats, defaultSelectivityFactor, explainMode, ipAddress, defaultSchema, sessionProperties);
 	}
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AccessPathImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AccessPathImpl.java
@@ -53,6 +53,7 @@ class AccessPathImpl implements AccessPath{
     private CostEstimate costEstimate=null;
     private boolean isJoinStrategyHinted = false;
     private boolean missingHashKeyOK = false;
+    private boolean isExistsTable = false;
 
     AccessPathImpl(Optimizer optimizer){
         this.optimizer=optimizer;
@@ -82,6 +83,8 @@ class AccessPathImpl implements AccessPath{
             else
                 this.costEstimate.setCost(costEstimate);
         }
+        if (this.costEstimate != null && isExistsTable)
+            this.costEstimate.setExistsTable(isExistsTable);
     }
 
     @Override public boolean getCoveringIndexScan(){ return coveringIndexScan; }
@@ -97,6 +100,9 @@ class AccessPathImpl implements AccessPath{
 
     @Override public int getLockMode(){ return lockMode; }
     @Override public void setLockMode(int lockMode){ this.lockMode=lockMode; }
+
+    @Override public boolean isExistsTable() { return isExistsTable; }
+    @Override public void setExistsTable(boolean isExistsTable) { this.isExistsTable = isExistsTable; }
 
     @Override
     public void copy(AccessPath copyFrom){

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CostEstimateImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CostEstimateImpl.java
@@ -43,6 +43,8 @@ public class CostEstimateImpl implements CostEstimate {
     public double	singleScanRowCount;
     public boolean isOuterJoin;
     public boolean isAntiJoin;
+    public boolean isExistsTable;
+    public boolean isOuterMostOptimizable;
 
     private boolean singleRow = false;
 
@@ -496,6 +498,26 @@ public class CostEstimateImpl implements CostEstimate {
     @Override
     public void setAntiJoin(boolean isAntiJoin) {
         this.isAntiJoin = isAntiJoin;
+    }
+
+    @Override
+    public boolean isExistsTable() {
+        return isExistsTable;
+    }
+
+    @Override
+    public void setExistsTable(boolean isExistsTable) {
+        this.isExistsTable = isExistsTable;
+    }
+
+    @Override
+    public boolean isOuterMostOptimizable()  {
+        return isOuterMostOptimizable;
+    }
+
+    @Override
+    public void setOuterMostOptimizable(boolean isOuterMostOptimizable) {
+        this.isOuterMostOptimizable = isOuterMostOptimizable;
     }
 
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
@@ -700,20 +700,39 @@ public abstract class FromTable extends ResultSetNode implements Optimizable{
         return isOneRowResultSet();
     }
 
+    private void setExistsTable(AccessPath accessPath) {
+        FromTable fromTable = this;
+
+        if (fromTable instanceof ProjectRestrictNode &&
+            ((ProjectRestrictNode) fromTable).childResult instanceof SelectNode) {
+            SelectNode sn = (SelectNode)((ProjectRestrictNode) fromTable).childResult;
+            accessPath.setExistsTable(sn.hasDistinct());
+            return;
+        }
+        while (fromTable instanceof ProjectRestrictNode &&
+            ((ProjectRestrictNode)fromTable).childResult instanceof FromTable)
+            fromTable = (FromTable)((ProjectRestrictNode)fromTable).childResult;
+        accessPath.setExistsTable(fromTable.existsTable);
+    }
+
     @Override
     public void initAccessPaths(Optimizer optimizer){
         if(currentAccessPath==null){
             currentAccessPath=optimizer.newAccessPath();
         }
+        setExistsTable(currentAccessPath);
         if(bestAccessPath==null){
             bestAccessPath=optimizer.newAccessPath();
         }
+        setExistsTable(bestAccessPath);
         if(bestSortAvoidancePath==null){
             bestSortAvoidancePath=optimizer.newAccessPath();
         }
+        setExistsTable(bestSortAvoidancePath);
         if(trulyTheBestAccessPath==null){
             trulyTheBestAccessPath=optimizer.newAccessPath();
         }
+        setExistsTable(trulyTheBestAccessPath);
     }
 
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -126,6 +126,7 @@ import com.splicemachine.db.iapi.sql.dictionary.ViewDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
 
 import com.splicemachine.db.iapi.sql.conn.Authorizer;
+import com.splicemachine.db.iapi.sql.conn.SessionProperties;
 import com.splicemachine.db.iapi.sql.execute.ConstantAction;
 import com.splicemachine.db.iapi.sql.execute.ExecutionContext;
 import com.splicemachine.db.impl.sql.execute.TriggerEventDML;
@@ -3878,44 +3879,53 @@ StatementNode
 preparableSQLDataStatement() throws StandardException :
 {
 	StatementNode	dmlStatement;
+	boolean eligibleForExplainMode = false;
 }
 {
 	/*
 	** RESOLVE: Ignoring temporary table declarations for now.
 	*/
+	(
 	dmlStatement = preparableDeleteStatement()
 	{
-		return dmlStatement;
+	    eligibleForExplainMode = true;
 	}
 |
 	dmlStatement = preparableSelectStatement(true)
 	{
-		return dmlStatement;
+	    eligibleForExplainMode = true;
 	}
+
 |
 	dmlStatement = insertStatement()
 	{
-		return dmlStatement;
+	    eligibleForExplainMode = true;
 	}
 |
 	dmlStatement = preparableUpdateStatement()
 	{
-		return dmlStatement;
+	    eligibleForExplainMode = true;
 	}
 |
 	dmlStatement = callStatement()
-	{
-		return dmlStatement;
-	}
+
 |
 	dmlStatement = savepointStatement()
-	{
-		return dmlStatement;
-	}
+
 | dmlStatement = analyzeStatements()
-  {
-    return dmlStatement;
-  }
+
+  )
+
+  	{
+  	    Boolean explainMode = (Boolean)getLanguageConnectionContext().getSessionProperties().getProperty(SessionProperties.PROPERTYNAME.EXPLAINMODE);
+
+        if (eligibleForExplainMode && explainMode != null && explainMode == true)
+                return (ExplainNode) nodeFactory.getNode(C_NodeTypes.EXPLAIN_NODE,
+                                   dmlStatement,
+                                   getContextManager());
+        else
+		    return dmlStatement;
+	}
 }
 
 StatementNode
@@ -3927,6 +3937,9 @@ explainStatement() throws StandardException :
 {
     <EXPLAIN> statementNode = preparableSQLDataStatement()
     {
+        if (statementNode instanceof ExplainNode)
+            return statementNode;
+        else
         return (ExplainNode) nodeFactory.getNode(C_NodeTypes.EXPLAIN_NODE,
                                    statementNode,
                                    getContextManager());

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -358,6 +358,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             CompilerContext.DataSetProcessorType type,
             boolean skipStats,
             double defaultSelectivityFactor,
+            boolean explainMode,
             String ipAddress,
             String defaultSchema,
             Properties connectionProperties
@@ -415,6 +416,8 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             }
         }
 
+        if (explainMode)
+            this.sessionProperties.setProperty(SessionProperties.PROPERTYNAME.EXPLAINMODE, new Boolean(explainMode).toString());
         String ignoreCommentOptEnabledStr = PropertyUtil.getCachedDatabaseProperty(this, MATCHING_STATEMENT_CACHE_IGNORING_COMMENT_OPTIMIZATION_ENABLED);
         ignoreCommentOptEnabled = Boolean.valueOf(ignoreCommentOptEnabledStr);
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionFactory.java
@@ -154,6 +154,7 @@ public class GenericLanguageConnectionFactory
         CompilerContext.DataSetProcessorType type,
 		boolean skipStats,
 		double defaultSelectvityFactor,
+		boolean explainMode,
 		String ipAddresss,
 		String defaultSchema,
 		Properties sessionProperties) throws StandardException {
@@ -172,6 +173,7 @@ public class GenericLanguageConnectionFactory
                                                     type,
 				                                    skipStats,
 				                                    defaultSelectvityFactor,
+													explainMode,
 													ipAddresss,
                                                     defaultSchema,
                                                     sessionProperties

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/SessionPropertiesImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/SessionPropertiesImpl.java
@@ -33,6 +33,10 @@ package com.splicemachine.db.impl.sql.conn;
 import com.splicemachine.db.iapi.sql.conn.SessionProperties;
 
 import static com.splicemachine.db.iapi.sql.conn.SessionProperties.PROPERTYNAME.*;
+import static com.splicemachine.db.iapi.sql.conn.SessionProperties.PROPERTYNAME.DEFAULTSELECTIVITYFACTOR;
+import static com.splicemachine.db.iapi.sql.conn.SessionProperties.PROPERTYNAME.SKIPSTATS;
+import static com.splicemachine.db.iapi.sql.conn.SessionProperties.PROPERTYNAME.USESPARK;
+import static com.splicemachine.db.iapi.sql.conn.SessionProperties.PROPERTYNAME.EXPLAINMODE;
 
 /**
  * Created by yxia on 6/1/18.
@@ -67,6 +71,10 @@ public class SessionPropertiesImpl implements SessionProperties {
             case RECURSIVEQUERYITERATIONLIMIT:
                 int recursiveQueryIterationLimit = Integer.parseInt(valString);
                 properties[RECURSIVEQUERYITERATIONLIMIT.getId()] = recursiveQueryIterationLimit;
+                break;
+            case EXPLAINMODE:
+                boolean explainModeVal = Boolean.valueOf(valString);
+                properties[EXPLAINMODE.getId()] = explainModeVal;
                 break;
             default:
                 break;

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -1050,7 +1050,8 @@ public interface SQLState {
 	String LANG_TRIGGER_BAD_REF_CLAUSE_DUPS                            = "42Y93";
 	String LANG_BINARY_LOGICAL_NON_BOOLEAN                             = "42Y94";
 	String LANG_BINARY_OPERATOR_NOT_SUPPORTED                          = "42Y95";
-  String LANG_INVALID_SORT_STRATEGY                                  = "42Y96";
+        String LANG_INVALID_SORT_STRATEGY                                  = "42Y96";
+        String LANG_INVALID_EXPLAIN_MODE                                   = "42Y98";
 	String LANG_UNKNOWN												                         = "42Y96.U";
 	String LANG_INVALID_ESCAPE										                     = "42Y97";
 	String LANG_JAVACC_SYNTAX										                       = "42Y98.U";

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -2814,7 +2814,11 @@ Guide.
                 <arg>lineNumber</arg>
                 <arg>columnName</arg>
             </msg>
-
+            <msg>
+                <name>42Y98</name>
+                <text>The hint explainMode needs (true/false) and does not support '{0}'.</text>
+                <arg>tableName</arg>
+            </msg>
             <msg>
                 <name>42Z02</name>
                 <text>Multiple DISTINCT aggregates are not supported at this time.</text>

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
@@ -536,10 +536,14 @@ public class SpliceSparkKryoRegistrator implements KryoRegistrator, KryoPool.Kry
                     public void write(Kryo kryo, Output output, IndexRow object) {
                         super.write(kryo, output, object);
                         boolean[] orderedNulls = object.getOrderedNulls();
-                        output.writeInt(orderedNulls.length);
-                        for (boolean orderedNull : orderedNulls) {
-                            output.writeBoolean(orderedNull);
+                        if (orderedNulls != null) {
+                            output.writeInt(orderedNulls.length);
+                            for (boolean orderedNull : orderedNulls) {
+                                output.writeBoolean(orderedNull);
+                            }
                         }
+                        else
+                            output.writeInt(0);
                     }
 
                     @Override
@@ -551,7 +555,8 @@ public class SpliceSparkKryoRegistrator implements KryoRegistrator, KryoPool.Kry
                         for(int i=0;i<orderedNulls.length;i++){
                             orderedNulls[i] = input.readBoolean();
                         }
-                        row.setOrderedNulls(orderedNulls);
+                        if (orderedNulls.length != 0)
+                            row.setOrderedNulls(orderedNulls);
                         return row;
                     }
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
@@ -24,6 +24,7 @@ import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.SpliceSpark;
 import com.splicemachine.derby.impl.sql.execute.operations.DMLWriteOperation;
+import com.splicemachine.derby.impl.sql.execute.operations.JoinOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.MultiProbeTableScanOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.export.ExportExecRowWriter;
 import com.splicemachine.derby.impl.sql.execute.operations.export.ExportFile.COMPRESSION;
@@ -65,6 +66,7 @@ import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.security.TokenCache;
+import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.sql.Column;
@@ -476,7 +478,7 @@ public class SparkDataSet<V> implements DataSet<V> {
 
     @Override
     public boolean isEmpty() {
-        return rdd.take(1).isEmpty();
+        return rdd.isEmpty();
     }
 
     @Override
@@ -671,6 +673,15 @@ public class SparkDataSet<V> implements DataSet<V> {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public DataSet<V> join(OperationContext context, DataSet<V> rightDataSet, JoinType joinType, boolean isBroadcast) throws StandardException {
+        boolean isInnerOrSemijoin = ((JoinOperation)context.getOperation()).isInnerOrSemiJoin();
+        boolean isOuterJoin = ((JoinOperation)context.getOperation()).isOuterJoin;
+
+        if ((isInnerOrSemijoin && rightDataSet.isEmpty()) ||
+            ((isInnerOrSemijoin || isOuterJoin) && this.isEmpty())) {
+            JavaRDD emptyRDD = this.isEmpty() ? rdd :
+                               rightDataSet.getRDD();
+            return new SparkDataSet<>(emptyRDD);
+        }
         Dataset<Row> leftDF = SpliceSpark.getSession().createDataFrame(
                 rdd.map(new LocatedRowToRowFunction()),
                         context.getOperation().getLeftOperation().getExecRowDefinition().schema());
@@ -682,6 +693,11 @@ public class SparkDataSet<V> implements DataSet<V> {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public DataSet<V> crossJoin(OperationContext context, DataSet<V> rightDataSet) throws StandardException {
+        if (rightDataSet.isEmpty() || this.isEmpty()) {
+            JavaRDD emptyRDD = this.isEmpty() ? rdd :
+                               rightDataSet.getRDD();
+            return new SparkDataSet<>(emptyRDD);
+        }
         Dataset<Row> leftDF = SpliceSpark.getSession().createDataFrame(
                 rdd.map(new LocatedRowToRowFunction()),
                         context.getOperation().getLeftOperation().getExecRowDefinition().schema());
@@ -894,4 +910,7 @@ public class SparkDataSet<V> implements DataSet<V> {
     public TableSamplerBuilder sample(OperationContext operationContext) throws StandardException {
         return new SparkTableSamplerBuilder(this, operationContext);
     }
+
+    @Override
+    public JavaRDD getRDD() { return this.rdd; }
 }

--- a/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
+++ b/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
@@ -660,10 +660,14 @@ public class SpliceKryoRegistry implements KryoPool.KryoRegistry{
                     public void write(Kryo kryo,Output output,com.splicemachine.db.impl.sql.execute.IndexRow object){
                         super.write(kryo,output,object);
                         boolean[] orderedNulls=object.getOrderedNulls();
-                        output.writeInt(orderedNulls.length);
-                        for(boolean orderedNull : orderedNulls){
-                            output.writeBoolean(orderedNull);
+                        if (orderedNulls != null) {
+                            output.writeInt(orderedNulls.length);
+                            for(boolean orderedNull : orderedNulls){
+                                output.writeBoolean(orderedNull);
+                            }
                         }
+                        else
+                            output.writeInt(0);
                     }
 
                     @Override
@@ -675,7 +679,8 @@ public class SpliceKryoRegistry implements KryoPool.KryoRegistry{
                         for(int i=0;i<orderedNulls.length;i++){
                             orderedNulls[i]=input.readBoolean();
                         }
-                        row.setOrderedNulls(orderedNulls);
+                        if (orderedNulls.length != 0)
+                            row.setOrderedNulls(orderedNulls);
                         return row;
                     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
@@ -126,13 +126,14 @@ public class SpliceDatabase extends BasicDatabase{
                                                      CompilerContext.DataSetProcessorType dspt,
                                                      boolean skipStats,
                                                      double defaultSelectivityFactor,
+                                                     boolean explainMode,
                                                      String ipAddress,
                                                      String defaultSchema,
                                                      Properties sessionProperties)
             throws StandardException{
 
         final LanguageConnectionContext lctx=super.setupConnection(cm, user, groupuserlist,
-                drdaID, dbname, rdbIntTkn, dspt, skipStats, defaultSelectivityFactor, ipAddress, defaultSchema, sessionProperties);
+                drdaID, dbname, rdbIntTkn, dspt, skipStats, defaultSelectivityFactor, explainMode, ipAddress, defaultSchema, sessionProperties);
 
         // If you add a visitor, be careful of ordering.
 
@@ -165,12 +166,13 @@ public class SpliceDatabase extends BasicDatabase{
                                                                        CompilerContext.DataSetProcessorType type,
                                                                        boolean skipStats,
                                                                        double defaultSelectivityFactor,
+                                                                       boolean explainMode,
                                                                        String ipAddress) throws StandardException{
         TransactionController tc=((SpliceAccessManager)af).marshallTransaction(cm,txn);
         cm.setLocaleFinder(this);
         pushDbContext(cm);
         LanguageConnectionContext lctx=lcf.newLanguageConnectionContext(cm,tc,lf,this,user,
-                groupuserlist,drdaID,dbname,rdbIntTkn,type,skipStats, defaultSelectivityFactor, ipAddress,
+                groupuserlist,drdaID,dbname,rdbIntTkn,type,skipStats, defaultSelectivityFactor, explainMode, ipAddress,
                 null, null);
 
         pushClassFactoryContext(cm,lcf.getClassFactory());

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/JoinTable.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/JoinTable.java
@@ -32,6 +32,8 @@ public interface JoinTable extends AutoCloseable{
 
     Iterator<ExecRow> fetchInner(ExecRow outer) throws IOException, StandardException;
 
+    boolean isEmpty();
+
     @Override
     void close();
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/CrossJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/CrossJoinStrategy.java
@@ -182,6 +182,10 @@ public class CrossJoinStrategy extends BaseJoinStrategy {
                             boolean wasHinted,
                             boolean skipKeyCheck) throws StandardException {
 
+	// Only use cross join for joins.
+	if (outerCost.isOuterMostOptimizable())
+	    return false;
+
 	// Cross join can't handle IndexLookups on the inner table currently because
         // the join predicates get mapped to the IndexScan instead of the CrossJoin.
         // Broadcast join has a similar restriction.
@@ -203,10 +207,9 @@ public class CrossJoinStrategy extends BaseJoinStrategy {
         }
         // Only use cross join when it is inner join
         // Only use cross join when it is on Spark, forced control and isHinted is for debug purpose
-        // Cross join illegal for exists subquery.
-        // Only use cross join for joins.
+        // Cross join is illegal for exists subquery.
         return !outerCost.isOuterJoin() && (isSpark || (isForcedControl && isHinted)) &&
-               !isOneRow && !existsJoin && !outerCost.isOuterMostOptimizable();
+               !isOneRow && !existsJoin;
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SimpleCostEstimate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SimpleCostEstimate.java
@@ -32,6 +32,8 @@ public class SimpleCostEstimate implements CostEstimate{
      */
     private boolean isOuterJoin;
     private boolean isAntiJoin;
+    private boolean isExistsTable;
+    private boolean isOuterMostOptimizable;
     private double localCost = Double.MAX_VALUE;
     private double remoteCost;
     private int numPartitions;
@@ -283,6 +285,8 @@ public class SimpleCostEstimate implements CostEstimate{
         }
         SimpleCostEstimate clone=new SimpleCostEstimate(localCost,remoteCost,numRows,singleScanRowCount,numPartitions);
         clone.isAntiJoin = this.isAntiJoin;
+        clone.isExistsTable = this.isExistsTable;
+        // Don't copy isOuterMostOptimizable on purpose.
         clone.isOuterJoin = this.isOuterJoin();
         clone.setRowOrdering(roClone);
         clone.setPredicateList(predicateList);
@@ -438,6 +442,26 @@ public class SimpleCostEstimate implements CostEstimate{
     @Override
     public void setAntiJoin(boolean isAntiJoin) {
         this.isAntiJoin = isAntiJoin;
+    }
+
+    @Override
+    public boolean isExistsTable() {
+        return isExistsTable;
+    }
+
+    @Override
+    public void setExistsTable(boolean isExistsTable) {
+        this.isExistsTable = isExistsTable;
+    }
+
+    @Override
+    public boolean isOuterMostOptimizable()  {
+        return isOuterMostOptimizable;
+    }
+
+    @Override
+    public void setOuterMostOptimizable(boolean isOuterMostOptimizable) {
+        this.isOuterMostOptimizable = isOuterMostOptimizable;
     }
 
     public double getProjectionRows() {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinCache.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinCache.java
@@ -128,6 +128,11 @@ public class BroadcastJoinCache{
         }
 
         @Override
+        public boolean isEmpty() {
+            return delegate.isEmpty();
+        }
+
+        @Override
         public void close(){
             if (closed)
                 return;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/JoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/JoinOperation.java
@@ -368,4 +368,18 @@ public abstract class JoinOperation extends SpliceBaseOperation {
 	public String getVTIFileName() {
 		return getSubOperations().get(0).getVTIFileName();
 	}
+
+	public ExecRow getLeftRow() { return leftRow; }
+	public ExecRow getRightRow() { return rightRow; }
+
+	public boolean isInnerJoin() {
+    	    return !isOuterJoin        &&
+                   !notExistsRightSide &&
+	           !isOneRowRightSide();
+        }
+
+	public boolean isInnerOrSemiJoin() {
+    	    return !isOuterJoin        &&
+                   !notExistsRightSide;
+        }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeJoinOperation.java
@@ -150,8 +150,12 @@ public class MergeJoinOperation extends JoinOperation {
         DataSet<ExecRow> left = leftResultSet.getDataSet(dsp);
         
         operationContext.pushScope();
+
         try {
             left = left.map(new CountJoinedLeftFunction(operationContext));
+            if (dsp.getType().equals(DataSetProcessor.Type.SPARK) &&
+                (isOuterJoin || isInnerOrSemiJoin()) && left.isEmpty())
+                return left;
             if (isOuterJoin)
                 return left.mapPartitions(new MergeOuterJoinFlatMapFunction(operationContext), true);
             else {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NestedLoopJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NestedLoopJoinOperation.java
@@ -101,6 +101,11 @@ public class NestedLoopJoinOperation extends JoinOperation {
 
         operationContext.pushScope();
         try {
+
+            if (dsp.getType().equals(DataSetProcessor.Type.SPARK) &&
+                isInnerOrSemiJoin() && left.isEmpty())
+                return left;
+
             if (isOuterJoin)
                 return left.mapPartitions(new NLJOuterJoinFunction(operationContext), true);
             else {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ValueRowMappedJoinTable.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ValueRowMappedJoinTable.java
@@ -59,6 +59,12 @@ class ValueRowMappedJoinTable implements JoinTable{
             return rows.iterator();
     }
 
+
+    @Override
+    public boolean isEmpty() {
+        return table.isEmpty();
+    }
+
     //nothing to close
     @Override public void close(){}
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/jdbc/SpliceTransactionResourceImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/jdbc/SpliceTransactionResourceImpl.java
@@ -89,7 +89,7 @@ public final class SpliceTransactionResourceImpl implements AutoCloseable{
 
             ArrayList<String> grouplist = new ArrayList<>();
             grouplist.add(username);
-            lcc=database.generateLanguageConnectionContext(txn, cm, username,grouplist,drdaID, dbname, rdbIntTkn, CompilerContext.DataSetProcessorType.DEFAULT_CONTROL,false, -1, ipAddress);
+            lcc=database.generateLanguageConnectionContext(txn, cm, username,grouplist,drdaID, dbname, rdbIntTkn, CompilerContext.DataSetProcessorType.DEFAULT_CONTROL,false, -1, false, ipAddress);
 
             return true;
         } catch (Throwable t) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
@@ -59,6 +59,7 @@ import com.splicemachine.utils.Pair;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.collections.IteratorUtils;
 import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder;
 import org.apache.spark.sql.catalyst.encoders.RowEncoder;
@@ -361,7 +362,7 @@ public class ControlDataSet<V> implements DataSet<V> {
 
     @Override
     public boolean isEmpty() {
-        return iterator.hasNext();
+        return !iterator.hasNext();
     }
 
     @Override
@@ -766,5 +767,6 @@ public class ControlDataSet<V> implements DataSet<V> {
         };
     }
 
-
+    @Override
+    public JavaRDD getRDD() { throw new UnsupportedOperationException(); }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/MaterializedControlDataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/MaterializedControlDataSet.java
@@ -23,4 +23,9 @@ public class MaterializedControlDataSet<V> extends ControlDataSet<V> {
     public DataSet getClone() {
         return new MaterializedControlDataSet<V>(dataset);
     }
+
+    @Override
+    public boolean isEmpty() {
+        return this.dataset.isEmpty();
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
@@ -22,6 +22,7 @@ import com.splicemachine.derby.impl.sql.execute.operations.window.WindowContext;
 import com.splicemachine.derby.stream.function.*;
 import com.splicemachine.derby.stream.output.*;
 import com.splicemachine.utils.Pair;
+import org.apache.spark.api.java.JavaRDD;
 
 import java.io.Serializable;
 import java.util.Iterator;
@@ -362,4 +363,6 @@ public interface DataSet<V> extends //Iterable<V>,
     InsertDataSetWriterBuilder insertData(OperationContext operationContext) throws StandardException;
     UpdateDataSetWriterBuilder updateData(OperationContext operationContext) throws StandardException;
     TableSamplerBuilder sample(OperationContext operationContext) throws StandardException;
+
+    JavaRDD getRDD();
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/merge/MergeInnerJoinIterator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iterator/merge/MergeInnerJoinIterator.java
@@ -52,6 +52,9 @@ public class MergeInnerJoinIterator extends AbstractMergeJoinIterator {
                     operationContext.recordFilter();
                 }
             }
+            if (moreRightRows.isFalse())
+                return false;
+
             while (leftRS.hasNext()) {
                 if (left == null)
                     left = leftRS.next().getClone();
@@ -59,6 +62,8 @@ public class MergeInnerJoinIterator extends AbstractMergeJoinIterator {
                     left.transfer(leftRS.next());
                 if (!joinColumnHasNull(left, true)) {
                     currentRightIterator = rightsForLeft(left);
+                    if (moreRightRows.isFalse())
+                        return false;
                     while (currentRightIterator.hasNext()) {
                         currentExecRow = mergeRows(left, currentRightIterator.next());
                         if (mergeJoinOperation.getRestriction().apply(currentExecRow)) {
@@ -70,6 +75,8 @@ public class MergeInnerJoinIterator extends AbstractMergeJoinIterator {
                         operationContext.recordFilter();
                     }
                 }
+                else if (moreRightRows.isFalse())
+                    return false;
             }
             return false;
         }  catch (Exception e) {

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SessionPropertyIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SessionPropertyIT.java
@@ -130,6 +130,22 @@ public class SessionPropertyIT extends SpliceUnitTest {
     }
 
     @Test
+    public void testExplainModeSessionProperty() throws Exception {
+        TestConnection conn = methodWatcher.createConnection();
+        conn.execute("set session_property explainMode=true");
+
+        String sqlText = "select * from t1 where a1=1";
+
+        // The query output should be the explain text.
+        rowContainsQuery(1, sqlText, "Cursor", conn);
+
+        // reset property
+        conn.execute("set session_property explainMode=null");
+
+        conn.close();
+    }
+
+    @Test
     public void testUseSparkSessionProperty() throws Exception {
         TestConnection conn = methodWatcher.createConnection();
         conn.execute("set session_property useSpark=true");

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/CrossJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/CrossJoinIT.java
@@ -27,7 +27,9 @@ import org.spark_project.guava.collect.Lists;
 
 import java.math.BigDecimal;
 import java.sql.*;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import static com.splicemachine.test_tools.Rows.row;
 import static com.splicemachine.test_tools.Rows.rows;
@@ -461,14 +463,14 @@ public class CrossJoinIT extends SpliceUnitTest {
         String sqlText = format("select * from \n" +
                 "a --splice-properties joinStrategy=CROSS, useSpark=%s\n" +
                 "where c2=1", useSpark);
-        String expected = "C1 |C2 |\n" +
-                            "--------\n" +
-                            " 1 | 1 |";
 
-        ResultSet rs = classWatcher.executeQuery(sqlText);
-        String resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
-        assertEquals("\n" + sqlText + "\n" + "expected result: " + expected + "\n,actual result: " + resultString, expected, resultString);
-        rs.close();
+        List<String> expectedErrors =
+           Arrays.asList("Unexpected error message: No valid execution plan was found for this statement. This is usually because an infeasible join strategy was chosen, or because an index was chosen which prevents the chosen join strategy from being used.");
+
+        // Single-table query plan now will never use cross join.
+        // NestedLoopJoinStrategy handles this.  Eliminating selection of cross
+        // join for single-table access simplifies join planning as well since
+        testFail(sqlText, expectedErrors, classWatcher);
     }
 
     @Test

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/CrossJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/CrossJoinIT.java
@@ -465,11 +465,12 @@ public class CrossJoinIT extends SpliceUnitTest {
                 "where c2=1", useSpark);
 
         List<String> expectedErrors =
-           Arrays.asList("Unexpected error message: No valid execution plan was found for this statement. This is usually because an infeasible join strategy was chosen, or because an index was chosen which prevents the chosen join strategy from being used.");
+           Arrays.asList("No valid execution plan was found for this statement. This is usually because an infeasible join strategy was chosen, or because an index was chosen which prevents the chosen join strategy from being used.");
 
         // Single-table query plan now will never use cross join.
         // NestedLoopJoinStrategy handles this.  Eliminating selection of cross
         // join for single-table access simplifies join planning as well since
+        // cross join can't handle subqueries.
         testFail(sqlText, expectedErrors, classWatcher);
     }
 


### PR DESCRIPTION
Performance improvement for joins (Broadcast, Merge, SortMerge, NestedLoop and Cross) to quit evaluation of the join if one of the "join tables" has no rows.  The left and right side of a join could really be a sequence of joins, ProjectRestricts, etc.  Such a sequence of operations that yields no rows would likewise allow us to skip the join.

The rules are:
- If the join is a semijoin or inner join, and either side has no rows, return an empty DataSet or row iterator instead of performing the join.
- If the join is an outer join and the outer table has no rows , return an empty DataSet or row iterator, instead of performing the join.

Also added the following:
- A fix to inner merge join to quit scanning the left when the right has no more rows.
- A fix to avoid using cross join for EXISTS subqueries.
- The addition of session property "explainMode", which when set to true in the JDBC connection string or in a "set session_property" SQL statement, causes all queries to be EXPLAINed instead of executed.
Example of setting explainMode in a connection string:
     `connect 'jdbc:splice://localhost:1527/splicedb;user=splice;password=admin;explainMode=true';`
Example of setting explainMode via SQL:
     `set session_property explainMode=true;`

See [DB-8166](https://splicemachine.atlassian.net/browse/DB-8166)