### PR TITLE
DB-8204 Avoid native spark SortMergeJoin involving the Real data type.

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/JoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/JoinOperation.java
@@ -20,6 +20,7 @@ import com.splicemachine.db.iapi.services.loader.GeneratedMethod;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.db.iapi.types.SQLReal;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperationContext;
 import com.splicemachine.derby.impl.SpliceMethod;
@@ -368,4 +369,23 @@ public abstract class JoinOperation extends SpliceBaseOperation {
 	public String getVTIFileName() {
 		return getSubOperations().get(0).getVTIFileName();
 	}
+
+        protected boolean containsUnsafeSQLRealComparison() throws StandardException {
+            int[] leftHashKeys = getLeftHashKeys();
+            int[] rightHashKeys = getRightHashKeys();
+
+	    int numKeys = leftHashKeys.length;
+	    ExecRow LeftExecRow = getLeftOperation().getExecRowDefinition();
+	    ExecRow RightExecRow = getRightOperation().getExecRowDefinition();
+	    for (int i = 0; i < numKeys; i++) {
+	        if (LeftExecRow.getColumn(leftHashKeys[i]+1) instanceof SQLReal)
+	            if (! (RightExecRow.getColumn(rightHashKeys[i]+1) instanceof SQLReal))
+	                return true;
+
+	        if (RightExecRow.getColumn(rightHashKeys[i]+1) instanceof SQLReal)
+	            if (! (LeftExecRow.getColumn(leftHashKeys[i]+1) instanceof SQLReal))
+	                return true;
+            }
+	    return false;
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeSortJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeSortJoinOperation.java
@@ -205,7 +205,8 @@ public class MergeSortJoinOperation extends JoinOperation {
                     isOuterJoin ? "outer" : "inner", notExistsRightSide, restriction != null);
                 rightDataSet1.map(new CountJoinedRightFunction(operationContext));
         DataSet<ExecRow> joined;
-        if (dsp.getType().equals(DataSetProcessor.Type.SPARK) && restriction == null && !rightFromSSQ) {
+        if (dsp.getType().equals(DataSetProcessor.Type.SPARK) && restriction == null && !rightFromSSQ &&
+            !containsUnsafeSQLRealComparison()){
             if (isOuterJoin)
                 joined = leftDataSet2.join(operationContext,rightDataSet2, DataSet.JoinType.LEFTOUTER,false);
             else if (notExistsRightSide)

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/BroadcastJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/BroadcastJoinIT.java
@@ -287,7 +287,7 @@ public class BroadcastJoinIT extends SpliceUnitTest {
     }
     
     @Test
-    public void testNumericColumnsBroadCastJoin() throws Exception {
+    public void testNumericJoinColumns() throws Exception {
 
         String [] joinTypes = {"NestedLoop", "SortMerge", "Broadcast", "Cross" };
         for (String strategy:joinTypes) {

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/BroadcastJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/BroadcastJoinIT.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.derby.impl.sql.execute.operations.joins;
 
+import com.splicemachine.db.iapi.sql.compile.JoinStrategy;
 import com.splicemachine.derby.test.framework.*;
 import com.splicemachine.homeless.TestUtils;
 import com.splicemachine.test_tools.TableCreator;
@@ -36,6 +37,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Collection;
 
+import static com.splicemachine.db.iapi.sql.compile.JoinStrategy.JoinStrategyType.NESTED_LOOP;
 import static com.splicemachine.test_tools.Rows.row;
 import static com.splicemachine.test_tools.Rows.rows;
 import static org.junit.Assert.assertEquals;
@@ -287,94 +289,97 @@ public class BroadcastJoinIT extends SpliceUnitTest {
     @Test
     public void testNumericColumnsBroadCastJoin() throws Exception {
 
-        String expected = "1 |\n" +
+        String [] joinTypes = {"NestedLoop", "SortMerge", "Broadcast", "Cross" };
+        for (String strategy:joinTypes) {
+            String expected = "1 |\n" +
             "----\n" +
             " 1 |\n" +
             " 1 |";
-    
-        String expected2 = "1 |\n" +
+
+            String expected2 = "1 |\n" +
             "----\n" +
             " 1 |";
-        
-        String sqlText = format("select 1 from " + s3 + " tab1, " + s3 + " tab2 " +
-            " --SPLICE-PROPERTIES joinStrategy=BROADCAST,useSpark=%s \n" +
-            " where tab1.num1=tab2.num2", useSpark
-        );
 
-        ResultSet rs = classWatcher.executeQuery(sqlText);
-        String resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
-        assertEquals("\n" + sqlText + "\n" + "expected result: " + expected + "\n,actual result: " + resultString, expected, resultString);
-        rs.close();
-    
-        sqlText = format("select 1 from " + s3 + " tab1, " + s3 + " tab2 " +
-            " --SPLICE-PROPERTIES joinStrategy=BROADCAST,useSpark=%s \n" +
-            " where tab1.num1=tab2.num3", useSpark
-        );
-    
-        rs = classWatcher.executeQuery(sqlText);
-        resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
-        assertEquals("\n" + sqlText + "\n" + "expected result: " + expected + "\n,actual result: " + resultString, expected, resultString);
-        rs.close();
-    
-        sqlText = format("select 1 from " + s3 + " tab1, " + s3 + " tab2 " +
-            " --SPLICE-PROPERTIES joinStrategy=BROADCAST,useSpark=%s \n" +
-            " where tab1.num1=tab2.num4", useSpark
-        );
-    
-        rs = classWatcher.executeQuery(sqlText);
-        resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
-        assertEquals("\n" + sqlText + "\n" + "expected result: " + expected + "\n,actual result: " + resultString, expected, resultString);
-        rs.close();
-    
-        sqlText = format("select 1 from " + s3 + " tab1, " + s3 + " tab2 " +
-            " --SPLICE-PROPERTIES joinStrategy=BROADCAST,useSpark=%s \n" +
-            " where tab1.num1=tab2.num5", useSpark
-        );
-    
-        rs = classWatcher.executeQuery(sqlText);
-        resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
-        assertEquals("\n" + sqlText + "\n" + "expected result: " + expected2 + "\n,actual result: " + resultString, expected2, resultString);
-        rs.close();
-    
-        sqlText = format("select 1 from " + s3 + " tab1, " + s3 + " tab2 " +
-            " --SPLICE-PROPERTIES joinStrategy=BROADCAST,useSpark=%s \n" +
-            " where tab1.num3=tab2.num1", useSpark
-        );
-    
-        rs = classWatcher.executeQuery(sqlText);
-        resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
-        assertEquals("\n" + sqlText + "\n" + "expected result: " + expected + "\n,actual result: " + resultString, expected, resultString);
-        rs.close();
-    
-        sqlText = format("select 1 from " + s3 + " tab1, " + s3 + " tab2 " +
-            " --SPLICE-PROPERTIES joinStrategy=BROADCAST,useSpark=%s \n" +
-            " where tab1.num3=tab2.num2", useSpark
-        );
-    
-        rs = classWatcher.executeQuery(sqlText);
-        resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
-        assertEquals("\n" + sqlText + "\n" + "expected result: " + expected + "\n,actual result: " + resultString, expected, resultString);
-        rs.close();
-    
-        sqlText = format("select 1 from " + s3 + " tab1, " + s3 + " tab2 " +
-            " --SPLICE-PROPERTIES joinStrategy=BROADCAST,useSpark=%s \n" +
-            " where tab1.num3=tab2.num4", useSpark
-        );
-    
-        rs = classWatcher.executeQuery(sqlText);
-        resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
-        assertEquals("\n" + sqlText + "\n" + "expected result: " + expected + "\n,actual result: " + resultString, expected, resultString);
-        rs.close();
-    
-        sqlText = format("select 1 from " + s3 + " tab1, " + s3 + " tab2 " +
-            " --SPLICE-PROPERTIES joinStrategy=BROADCAST,useSpark=%s \n" +
-            " where tab1.num3=tab2.num5", useSpark
-        );
-    
-        rs = classWatcher.executeQuery(sqlText);
-        resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
-        assertEquals("\n" + sqlText + "\n" + "expected result: " + expected2 + "\n,actual result: " + resultString, expected2, resultString);
-        rs.close();
+            String sqlText = format("select 1 from " + s3 + " tab1, " + s3 + " tab2 " +
+            " --SPLICE-PROPERTIES joinStrategy=%s,useSpark=%s \n" +
+            " where tab1.num1=tab2.num2", strategy, useSpark
+            );
+
+            ResultSet rs = classWatcher.executeQuery(sqlText);
+            String resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            assertEquals("\n" + sqlText + "\n" + "expected result: " + expected + "\n,actual result: " + resultString, expected, resultString);
+            rs.close();
+
+            sqlText = format("select 1 from " + s3 + " tab1, " + s3 + " tab2 " +
+            " --SPLICE-PROPERTIES joinStrategy=%s,useSpark=%s \n" +
+            " where tab1.num1=tab2.num3", strategy, useSpark
+            );
+
+            rs = classWatcher.executeQuery(sqlText);
+            resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            assertEquals("\n" + sqlText + "\n" + "expected result: " + expected + "\n,actual result: " + resultString, expected, resultString);
+            rs.close();
+
+            sqlText = format("select 1 from " + s3 + " tab1, " + s3 + " tab2 " +
+            " --SPLICE-PROPERTIES joinStrategy=%s,useSpark=%s \n" +
+            " where tab1.num1=tab2.num4", strategy, useSpark
+            );
+
+            rs = classWatcher.executeQuery(sqlText);
+            resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            assertEquals("\n" + sqlText + "\n" + "expected result: " + expected + "\n,actual result: " + resultString, expected, resultString);
+            rs.close();
+
+            sqlText = format("select 1 from " + s3 + " tab1, " + s3 + " tab2 " +
+            " --SPLICE-PROPERTIES joinStrategy=%s,useSpark=%s \n" +
+            " where tab1.num1=tab2.num5", strategy, useSpark
+            );
+
+            rs = classWatcher.executeQuery(sqlText);
+            resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            assertEquals("\n" + sqlText + "\n" + "expected result: " + expected2 + "\n,actual result: " + resultString, expected2, resultString);
+            rs.close();
+
+            sqlText = format("select 1 from " + s3 + " tab1, " + s3 + " tab2 " +
+            " --SPLICE-PROPERTIES joinStrategy=%s,useSpark=%s \n" +
+            " where tab1.num3=tab2.num1", strategy, useSpark
+            );
+
+            rs = classWatcher.executeQuery(sqlText);
+            resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            assertEquals("\n" + sqlText + "\n" + "expected result: " + expected + "\n,actual result: " + resultString, expected, resultString);
+            rs.close();
+
+            sqlText = format("select 1 from " + s3 + " tab1, " + s3 + " tab2 " +
+            " --SPLICE-PROPERTIES joinStrategy=%s,useSpark=%s \n" +
+            " where tab1.num3=tab2.num2", strategy, useSpark
+            );
+
+            rs = classWatcher.executeQuery(sqlText);
+            resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            assertEquals("\n" + sqlText + "\n" + "expected result: " + expected + "\n,actual result: " + resultString, expected, resultString);
+            rs.close();
+
+            sqlText = format("select 1 from " + s3 + " tab1, " + s3 + " tab2 " +
+            " --SPLICE-PROPERTIES joinStrategy=%s,useSpark=%s \n" +
+            " where tab1.num3=tab2.num4", strategy, useSpark
+            );
+
+            rs = classWatcher.executeQuery(sqlText);
+            resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            assertEquals("\n" + sqlText + "\n" + "expected result: " + expected + "\n,actual result: " + resultString, expected, resultString);
+            rs.close();
+
+            sqlText = format("select 1 from " + s3 + " tab1, " + s3 + " tab2 " +
+            " --SPLICE-PROPERTIES joinStrategy=%s,useSpark=%s \n" +
+            " where tab1.num3=tab2.num5", strategy, useSpark
+            );
+
+            rs = classWatcher.executeQuery(sqlText);
+            resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            assertEquals("\n" + sqlText + "\n" + "expected result: " + expected2 + "\n,actual result: " + resultString, expected2, resultString);
+            rs.close();
+        }
     }
 
     @Test


### PR DESCRIPTION
Wrong results can occur when executing joining on columns of the Real data type and the join is done natively on spark.  Execute the join via Splice functions in this case.

[DB-8204](https://splicemachine.atlassian.net/browse/DB-8204)