### PR TITLE
DB-8193 Comments in CTAS mask the rest of the SELECT statement.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -2353,9 +2353,25 @@ public class SQLParser
      * CREATE TABLE X AS [SELECT A, B, C FROM Y] WITH DATA
      */
    public String parseQueryString(String src) {
-       boolean inSection = false;
-       StringBuilder buf = new StringBuilder();
+        boolean inSection = false;
+        StringBuilder buf = new StringBuilder();
+
+        // Use a non-printable character as an end-of-hint marker.
+        char endOfHintMarker = 0x01;
+
+        // Strip out comments starting with --, except --splice-properties hints.
+        src = src.replaceFirst("(--)(?i)(?!splice-properties)(.*?)(\\n|\\r|\\r\\n)", " ");
+
+        // Add an end-of-hint marker to a --splice-properties hint, so we know where to
+        // place the newline later on.
+        src = src.replaceFirst("(--)(?i)(?=splice-properties)(.*?)(\\n|\\r|\\r\\n)",
+                               "$1$2$3"+Character.toString(endOfHintMarker));
+
+        // Strip out C-style comments:   /* This type of comment */
+        src = src.replaceFirst("(/\\*.*?\\*/)(\\n|\\r|\\r\\n)", " ");
         for (String part : src.split("\\s+")) {
+            if (part.charAt(0) == endOfHintMarker)
+                part = "\n" + part.substring(1);
             if (inSection && part.equalsIgnoreCase("with")) {
                 inSection = false;
             } else if (inSection) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -2359,16 +2359,17 @@ public class SQLParser
         // Use a non-printable character as an end-of-hint marker.
         char endOfHintMarker = 0x01;
 
+        // Strip out C-style comments:   /* This type of comment */
+        src = src.replaceAll("(/\\*.*?\\*/)", " ");
+
         // Strip out comments starting with --, except --splice-properties hints.
-        src = src.replaceFirst("(--)(?i)(?!splice-properties)(.*?)(\\n|\\r|\\r\\n)", " ");
+        src = src.replaceAll("(--)(?i)(?!splice-properties)(.*?)(\\n|\\r|\\r\\n)", " ");
 
         // Add an end-of-hint marker to a --splice-properties hint, so we know where to
         // place the newline later on.
-        src = src.replaceFirst("(--)(?i)(?=splice-properties)(.*?)(\\n|\\r|\\r\\n)",
+        src = src.replaceAll("(--)(?i)(?=splice-properties)(.*?)(\\n|\\r|\\r\\n)",
                                "$1$2$3"+Character.toString(endOfHintMarker));
 
-        // Strip out C-style comments:   /* This type of comment */
-        src = src.replaceFirst("(/\\*.*?\\*/)(\\n|\\r|\\r\\n)", " ");
         for (String part : src.split("\\s+")) {
             if (part.charAt(0) == endOfHintMarker)
                 part = "\n" + part.substring(1);

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableWithDataIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableWithDataIT.java
@@ -306,7 +306,6 @@ public class CreateTableWithDataIT{
         testCommentsInCTAS("/* WITH and AS in a C-style comment */", viewRef);
         testCommentsInCTAS("/* A C-style comment followed be newline */\n", viewRef);
         testCommentsInCTAS("/* A C-style comment \n spanning \n multiple \n lines */", viewRef);
-        testCommentsInCTAS("/* /* A nested C-style comment */ */", viewRef);
         testCommentsInCTAS("/* -- dash dash comment inside a C-style comment */", viewRef);
         testCommentsInCTAS("/* --splice-properties useSpark=true  hint inside comment should be OK */", viewRef);
         // A splice properties hint should work

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableWithDataIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableWithDataIT.java
@@ -211,6 +211,29 @@ public class CreateTableWithDataIT{
             s.executeUpdate("drop table "+spliceSchemaWatcher.schemaName+".t5");
         }
     }
+
+    private void testCommentsInCTAS(String commentString, String viewRef) throws Exception {
+        String depsalTable = "depsal";
+        String depsalTableRef = spliceSchemaWatcher.schemaName + "." + depsalTable;
+        String depsalTableDef = format("create table %s as " +
+                "select dept, salary, ssn from %s %s where dept < 3 with data", depsalTableRef, viewRef, commentString);
+        new TableDAO(methodWatcher.getOrCreateConnection()).drop(spliceSchemaWatcher.schemaName, depsalTable);
+
+        methodWatcher.executeUpdate(depsalTableDef);
+        String sqlText = format("select * from %s order by dept, salary", depsalTableRef);
+        ResultSet rs = methodWatcher.executeQuery(sqlText);
+
+        String expected = "DEPT |SALARY |   SSN   |\n" +
+                "------------------------\n" +
+                "  1  | 75000 |11199222 |\n" +
+                "  2  | 52000 |22200555 |\n" +
+                "  2  | 78000 |88844777 |";
+        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        try(PreparedStatement ps=methodWatcher.prepareStatement(String.format("drop table %s",depsalTableRef))){
+            ps.executeUpdate();
+        }
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void createTableWithViewJoins() throws Exception {
@@ -276,23 +299,20 @@ public class CreateTableWithDataIT{
 
         methodWatcher.execute(viewDef);
 
-        String depsalTable = "depsal";
-        String depsalTableRef = spliceSchemaWatcher.schemaName + "." + depsalTable;
-        String depsalTableDef = format("create table %s as " +
-                "select dept, salary, ssn from %s with data", depsalTableRef, viewRef);
-        new TableDAO(methodWatcher.getOrCreateConnection()).drop(spliceSchemaWatcher.schemaName, depsalTable);
-
-        methodWatcher.executeUpdate(depsalTableDef);
-        String sqlText = format("select * from %s order by dept, salary", depsalTableRef);
-        ResultSet rs = methodWatcher.executeQuery(sqlText);
-
-        String expected = "DEPT |SALARY |   SSN   |\n" +
-                "------------------------\n" +
-                "  1  | 75000 |11199222 |\n" +
-                "  2  | 52000 |22200555 |\n" +
-                "  2  | 78000 |88844777 |\n" +
-                "  3  | 76000 |33366777 |";
-        assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        testCommentsInCTAS("--comment hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello\n", viewRef);
+        testCommentsInCTAS("-- WITH and AS in a comment \n", viewRef);
+        testCommentsInCTAS("-- /* C-style comment inside a '--' comment */ \n", viewRef);
+        testCommentsInCTAS("/* A C-style comment */", viewRef);
+        testCommentsInCTAS("/* WITH and AS in a C-style comment */", viewRef);
+        testCommentsInCTAS("/* A C-style comment followed be newline */\n", viewRef);
+        testCommentsInCTAS("/* A C-style comment \n spanning \n multiple \n lines */", viewRef);
+        testCommentsInCTAS("/* /* A nested C-style comment */ */", viewRef);
+        testCommentsInCTAS("/* -- dash dash comment inside a C-style comment */", viewRef);
+        testCommentsInCTAS("/* --splice-properties useSpark=true  hint inside comment should be OK */", viewRef);
+        // A splice properties hint should work
+        testCommentsInCTAS("--splice-properties useSpark=true\n", viewRef);
+        // Mixed case hints should work too.
+        testCommentsInCTAS("--spLice-prOperties useSpark=true\n", viewRef);
     }
 }
 


### PR DESCRIPTION
A comment in CREATE TABLE ... AS, such as the following:
```
create table mws.t2 as
select * from mws.t1 --comment
where a = 1;
```
... masks out the rest of the SELECT.  In this case, it would mask out the WHERE clause, leading to an incorrect table definition.  The fix is in sqlgrammar.jj, to use a newline separator instead of single space.

[DB-8193](https://splicemachine.atlassian.net/browse/DB-8193)
