### PR TITLE
DB-8480 do not flatten non-correlated scalar aggregate subquery

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
@@ -1757,16 +1757,10 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
         if (!nopProjectRestrict()) {
             setDepth(depth);
             tree.add(this);
-            if (projectSubquerys != null && !projectSubquerys.isEmpty()) {
-                for (SubqueryNode node:projectSubquerys) {
-                    node.buildTree(tree,depth+1);
-                }
-            }
-            if (restrictSubquerys != null && !restrictSubquerys.isEmpty()) {
-                for (SubqueryNode node:restrictSubquerys) {
-                    node.buildTree(tree,depth+1);
-                }
-            }
+            // look for subqueries in restrictions, print if any
+            for (SubqueryNode sub: RSUtils.collectExpressionNodes(this, SubqueryNode.class))
+                sub.buildTree(tree,depth+1);
+
             childResult.buildTree(tree, depth+1);
         }
         else {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/aggregate/AggregateSubqueryPredicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/subquery/aggregate/AggregateSubqueryPredicate.java
@@ -79,6 +79,13 @@ class AggregateSubqueryPredicate implements org.spark_project.guava.base.Predica
         /* Find column references in the aggregate expression */
         List<ColumnReference> aggregateColumnRefs = RSUtils.collectNodes(resultColumns.elementAt(0).getExpression(), ColumnReference.class);
 
+        // if this is a scalar aggregate subquery, do not flatten it, as it is more performant to compute the subquery once and
+        // cache and reuse it
+        if (subqueryNode.isNonCorrelatedSubquery() &&
+                (subquerySelectNode.getGroupByList() == null || subquerySelectNode.getGroupByList().isEmpty()))
+            return false;
+
+
         /* subquery where clause must meet several conditions */
         ValueNode whereClause = subquerySelectNode.getWhereClause();
         /* If there is no where clause on the subquery then ok */

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HBaseBulkLoadIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HBaseBulkLoadIT.java
@@ -350,7 +350,7 @@ public class HBaseBulkLoadIT extends SpliceUnitTest {
         executeUpdate(sql15a);
         executeQuery(sql15b, "", false);
 
-        assertSubqueryNodeCount(conn(), sql15b, ZERO_SUBQUERY_NODES);
+        assertSubqueryNodeCount(conn(), sql15b, ONE_SUBQUERY_NODE);
     }
 
     @Test
@@ -411,7 +411,7 @@ public class HBaseBulkLoadIT extends SpliceUnitTest {
             return;
         String sql = getContent("22.sql");
         executeQuery(sql, getContent("22.expected.txt"), true);
-        assertSubqueryNodeCount(conn(), sql, ZERO_SUBQUERY_NODES);
+        assertSubqueryNodeCount(conn(), sql, ONE_SUBQUERY_NODE);
     }
 
     @Test

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HBaseBulkLoadIndexIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HBaseBulkLoadIndexIT.java
@@ -14,7 +14,6 @@
 
 package com.splicemachine.derby.impl.load;
 
-import com.splicemachine.db.client.am.Connection;
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
@@ -32,9 +31,7 @@ import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import static com.splicemachine.subquery.SubqueryITUtil.ONE_SUBQUERY_NODE;
-import static com.splicemachine.subquery.SubqueryITUtil.ZERO_SUBQUERY_NODES;
-import static com.splicemachine.subquery.SubqueryITUtil.assertSubqueryNodeCount;
+import static com.splicemachine.subquery.SubqueryITUtil.*;
 import static com.splicemachine.test_tools.Rows.row;
 import static com.splicemachine.test_tools.Rows.rows;
 import static org.junit.Assert.assertEquals;
@@ -363,7 +360,7 @@ public class HBaseBulkLoadIndexIT extends SpliceUnitTest {
         executeUpdate(sql15a);
         executeQuery(sql15b, "", false);
 
-        assertSubqueryNodeCount(conn(), sql15b, ZERO_SUBQUERY_NODES);
+        assertSubqueryNodeCount(conn(), sql15b, ONE_SUBQUERY_NODE);
     }
 
     @Test
@@ -424,7 +421,7 @@ public class HBaseBulkLoadIndexIT extends SpliceUnitTest {
             return;
         String sql = getContent("22.sql");
         executeQuery(sql, getContent("22.expected.txt"), true);
-        assertSubqueryNodeCount(conn(), sql, ZERO_SUBQUERY_NODES);
+        assertSubqueryNodeCount(conn(), sql, ONE_SUBQUERY_NODE);
     }
 
     @Test

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/TPCHIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/TPCHIT.java
@@ -191,7 +191,7 @@ public class TPCHIT extends SpliceUnitTest {
         executeUpdate(sql15a);
         executeQuery(sql15b, "", false);
 
-        assertSubqueryNodeCount(conn(), sql15b, ZERO_SUBQUERY_NODES);
+        assertSubqueryNodeCount(conn(), sql15b, ONE_SUBQUERY_NODE);
     }
 
     @Test
@@ -238,7 +238,7 @@ public class TPCHIT extends SpliceUnitTest {
     public void sql22() throws Exception {
         String sql = getContent("22.sql");
         executeQuery(sql, getContent("22.expected.txt"), true);
-        assertSubqueryNodeCount(conn(), sql, ZERO_SUBQUERY_NODES);
+        assertSubqueryNodeCount(conn(), sql, ONE_SUBQUERY_NODE);
     }
 
     @Test

--- a/splice_machine/src/test/java/com/splicemachine/subquery/SubqueryITUtil.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/SubqueryITUtil.java
@@ -31,6 +31,8 @@ public class SubqueryITUtil {
     public static final int ZERO_SUBQUERY_NODES = 0;
     public static final int ONE_SUBQUERY_NODE = 1;
     public static final int TWO_SUBQUERY_NODES = 2;
+    public static final int THREE_SUBQUERY_NODES = 3;
+    public static final int FOUR_SUBQUERY_NODES = 4;
 
     /* See SubqueryFlatteningTestTables.sql.  Queries that select from A with predicates that do not eliminate
      * any rows expect this result. */


### PR DESCRIPTION
Please see [DB-8480](https://splicemachine.atlassian.net/browse/DB-8480) for details.
There is an IT update in ee branch, please review the corresponding [PR#378](https://github.com/splicemachine/spliceengine-ee/pull/378)