### PR TITLE
DB-DB-8536: No need to close internal connections during shutdown (2.7)

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/EngineLifecycleService.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/lifecycle/EngineLifecycleService.java
@@ -152,13 +152,7 @@ public class EngineLifecycleService implements DatabaseLifecycleService{
 
     @Override
     public void shutdown() throws Exception{
-        try{
-            if(internalConnection!=null)
-                internalConnection.close();
-        }catch(Exception e){
-            LOG.error("Unexpected error during shutdown",e);
-        }
-
+        
         EngineDriver.shutdownDriver();
 
         try{


### PR DESCRIPTION
Closing an internal connection needs to get a timestamp to start a txn. However, timestamp server may have shutdown. This will cause retry and prevent region server to shutdown within graceful shutdown timeout