### PR TITLE
SPLICE-2369 Fix join costing involving large data sets.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CostEstimate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CostEstimate.java
@@ -274,13 +274,21 @@ public interface CostEstimate extends StoreCostResult {
 
     double getRemoteCost();
 
-    double localCostPerPartition();
+    double getLocalCostPerPartition();
 
-    double remoteCostPerPartition();
+    double getRemoteCostPerPartition();
 
+    // Sets the value of localCostPerPartition directly.
     void setLocalCostPerPartition(double localCostPerPartition);
 
+    // Sets the value of remoteCostPerPartition directly.
     void setRemoteCostPerPartition(double remoteCostPerPartition);
+
+    // Sets localCostPerPartition as the total localCost divided by numPartitions.
+    void setLocalCostPerPartition(double localCost, int numPartitions);
+
+    // Sets remoteCostPerPartition as the total remoteCost divided by numPartitions.
+    void setRemoteCostPerPartition(double remoteCost, int numPartitions);
 
     double getAccumulatedMemory();
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CostEstimate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CostEstimate.java
@@ -276,7 +276,11 @@ public interface CostEstimate extends StoreCostResult {
 
     double localCostPerPartition();
 
+    double remoteCostPerPartition();
+
     void setLocalCostPerPartition(double localCostPerPartition);
+
+    void setRemoteCostPerPartition(double remoteCostPerPartition);
 
     double getAccumulatedMemory();
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizable.java
@@ -433,4 +433,20 @@ public interface Optimizable {
 	 * get the current optimizable's memory usage if its best join plan is a broadcast join
 	 */
 	double getMemoryUsage4BroadcastJoin();
+
+	/**
+	 * Does this cost estimate indicate more rows are being accessed
+	 * than the spark threshold.
+	 *
+	 * @param costEstimate The cost estimate to test.
+	 */
+        boolean isAboveSparkThreshold(CostEstimate costEstimate);
+
+	/**
+	 * Does this access path indicate more rows are being accessed
+	 * than the spark threshold.
+	 *
+	 * @param accessPath The access path to test.
+	 */
+        boolean isAboveSparkThreshold(AccessPath accessPath);
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/LimitOffsetVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/LimitOffsetVisitor.java
@@ -300,6 +300,10 @@ public class LimitOffsetVisitor extends AbstractSpliceVisitor {
         } else {
             costEstimate.setEstimatedRowCount(currentOffset+currentFetchFirst);
             costEstimate.setRemoteCost(scaleFactor*costEstimate.getRemoteCost());
+            int numPartitions = costEstimate.partitionCount();
+            if (numPartitions <= 0)
+                numPartitions = 1;
+            costEstimate.setRemoteCostPerPartition(costEstimate.remoteCost()/numPartitions);
         }
 
     }
@@ -335,6 +339,10 @@ public class LimitOffsetVisitor extends AbstractSpliceVisitor {
                 costEstimate.setFromBaseTableRows(costEstimate.getFromBaseTableRows()*scaleFactor);
                 costEstimate.setScannedBaseTableRows(costEstimate.getScannedBaseTableRows()*scaleFactor);
                 costEstimate.setEstimatedCost(costEstimate.getEstimatedCost()*scaleFactor);
+                int numPartitions = costEstimate.partitionCount();
+                if (numPartitions <= 0)
+                    numPartitions = 1;
+                costEstimate.setRemoteCostPerPartition(costEstimate.remoteCost()/numPartitions);
         }
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/LimitOffsetVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/LimitOffsetVisitor.java
@@ -300,10 +300,7 @@ public class LimitOffsetVisitor extends AbstractSpliceVisitor {
         } else {
             costEstimate.setEstimatedRowCount(currentOffset+currentFetchFirst);
             costEstimate.setRemoteCost(scaleFactor*costEstimate.getRemoteCost());
-            int numPartitions = costEstimate.partitionCount();
-            if (numPartitions <= 0)
-                numPartitions = 1;
-            costEstimate.setRemoteCostPerPartition(costEstimate.remoteCost()/numPartitions);
+            costEstimate.setRemoteCostPerPartition(costEstimate.remoteCost(), costEstimate.partitionCount());
         }
 
     }
@@ -339,10 +336,7 @@ public class LimitOffsetVisitor extends AbstractSpliceVisitor {
                 costEstimate.setFromBaseTableRows(costEstimate.getFromBaseTableRows()*scaleFactor);
                 costEstimate.setScannedBaseTableRows(costEstimate.getScannedBaseTableRows()*scaleFactor);
                 costEstimate.setEstimatedCost(costEstimate.getEstimatedCost()*scaleFactor);
-                int numPartitions = costEstimate.partitionCount();
-                if (numPartitions <= 0)
-                    numPartitions = 1;
-                costEstimate.setRemoteCostPerPartition(costEstimate.remoteCost()/numPartitions);
+                costEstimate.setRemoteCostPerPartition(costEstimate.remoteCost(), costEstimate.partitionCount());
         }
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CostEstimateImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CostEstimateImpl.java
@@ -579,16 +579,22 @@ public class CostEstimateImpl implements CostEstimate {
     }
 
     @Override
-    public void setLocalCostPerPartition(double remoteCost){ }
+    public void setLocalCostPerPartition(double remoteCost) { }
 
     @Override
-    public double localCostPerPartition(){ return 0;}
+    public void setLocalCostPerPartition(double localCost, int numPartitions) { }
 
     @Override
-    public double remoteCostPerPartition(){ return 0;}
+    public void setRemoteCostPerPartition(double remoteCost, int numPartitions) { }
 
     @Override
-    public void setRemoteCostPerPartition(double remoteCost){ }
+    public double getLocalCostPerPartition() { return 0; }
+
+    @Override
+    public double getRemoteCostPerPartition() { return 0; }
+
+    @Override
+    public void setRemoteCostPerPartition(double remoteCost) { }
 
     @Override
     public double getAccumulatedMemory() {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CostEstimateImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CostEstimateImpl.java
@@ -585,6 +585,12 @@ public class CostEstimateImpl implements CostEstimate {
     public double localCostPerPartition(){ return 0;}
 
     @Override
+    public double remoteCostPerPartition(){ return 0;}
+
+    @Override
+    public void setRemoteCostPerPartition(double remoteCost){ }
+
+    @Override
     public double getAccumulatedMemory() {
         return 0.0d;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DistinctNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DistinctNode.java
@@ -199,6 +199,8 @@ public class DistinctNode extends SingleChildResultSetNode
         costEstimate.setLocalCost(totalLocalCost);
         costEstimate.setRemoteCost(totalRemoteCost);
         costEstimate.setNumPartitions(1);
+        costEstimate.setLocalCostPerPartition(totalLocalCost);
+        costEstimate.setRemoteCostPerPartition(totalRemoteCost);
         costEstimate.setRowCount(tableCardinality);
         costEstimate.setEstimatedHeapSize((long)outputHeapSize);
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
@@ -245,6 +245,12 @@ public class FromVTI extends FromTable implements VTIEnvironment {
                 costEstimate.setSingleScanRowCount(estimatedRowCount);
                 costEstimate.setLocalCost(estimatedCost);
                 costEstimate.setRemoteCost(estimatedCost);
+                int numPartitions = costEstimate.partitionCount();
+                if (numPartitions <= 0)
+                    numPartitions = 1;
+                costEstimate.setLocalCostPerPartition(estimatedCost/numPartitions);
+                costEstimate.setRemoteCostPerPartition(estimatedCost/numPartitions);
+
             }
             catch (SQLException sqle)
             {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
@@ -245,11 +245,8 @@ public class FromVTI extends FromTable implements VTIEnvironment {
                 costEstimate.setSingleScanRowCount(estimatedRowCount);
                 costEstimate.setLocalCost(estimatedCost);
                 costEstimate.setRemoteCost(estimatedCost);
-                int numPartitions = costEstimate.partitionCount();
-                if (numPartitions <= 0)
-                    numPartitions = 1;
-                costEstimate.setLocalCostPerPartition(estimatedCost/numPartitions);
-                costEstimate.setRemoteCostPerPartition(estimatedCost/numPartitions);
+                costEstimate.setLocalCostPerPartition(estimatedCost, costEstimate.partitionCount());
+                costEstimate.setRemoteCostPerPartition(estimatedCost, costEstimate.partitionCount());
 
             }
             catch (SQLException sqle)

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
@@ -1516,6 +1516,8 @@ public class OptimizerImpl implements Optimizer{
     private void addCost(CostEstimate addend,CostEstimate destCost){
         destCost.setRemoteCost(addend.remoteCost());
         destCost.setLocalCost(destCost.localCost()+addend.localCost());
+        destCost.setRemoteCostPerPartition(addend.remoteCostPerPartition());
+        destCost.setLocalCostPerPartition(destCost.localCostPerPartition()+addend.localCostPerPartition());
         destCost.setRowCount(addend.rowCount());
         destCost.setSingleScanRowCount(addend.singleScanRowCount());
         destCost.setEstimatedHeapSize(addend.getEstimatedHeapSize());
@@ -1918,6 +1920,10 @@ public class OptimizerImpl implements Optimizer{
 
         currentCost.setLocalCost(newLocalCost);
         currentCost.setRemoteCost(newRemoteCost);
+        // For join costing, cost and cost per partition are the same.
+        currentCost.setLocalCostPerPartition(newLocalCost);
+        currentCost.setRemoteCostPerPartition(newRemoteCost);
+
         currentCost.setRowCount(prevRowCount);
         currentCost.setSingleScanRowCount(prevSingleScanRowCount);
         currentCost.setBase(null);
@@ -1936,6 +1942,8 @@ public class OptimizerImpl implements Optimizer{
                 AccessPath ap=pullMe.getBestSortAvoidancePath();
                 double prevLocalCost;
                 double prevRemoteCost;
+                double prevLocalCostPerPartition;
+                double prevRemoteCostPerPartition;
 
 				/*
 				** Subtract the sort avoidance cost estimate of the
@@ -1957,6 +1965,8 @@ public class OptimizerImpl implements Optimizer{
 					 */
                     prevRemoteCost=outermostCostEstimate.remoteCost();
                     prevLocalCost=outermostCostEstimate.localCost();
+                    prevLocalCostPerPartition=outermostCostEstimate.localCostPerPartition();
+                    prevRemoteCostPerPartition=outermostCostEstimate.remoteCostPerPartition();
                 }else{
                     CostEstimate localCE= optimizableList.getOptimizable(prevPosition)
                             .getBestSortAvoidancePath().getCostEstimate();
@@ -1964,27 +1974,41 @@ public class OptimizerImpl implements Optimizer{
                     prevSingleScanRowCount=localCE.singleScanRowCount();
                     prevRemoteCost= currentSortAvoidanceCost.remoteCost()-ap.getCostEstimate().remoteCost();
                     prevLocalCost= currentSortAvoidanceCost.localCost()-ap.getCostEstimate().localCost();
+                    prevLocalCostPerPartition=currentSortAvoidanceCost.localCostPerPartition() -
+		                                  ap.getCostEstimate().localCostPerPartition();
+                    prevRemoteCostPerPartition=currentSortAvoidanceCost.remoteCostPerPartition() -
+		                                  ap.getCostEstimate().remoteCostPerPartition();
                 }
 
                 // See discussion above for "newCost"; same applies here.
                 if(prevRemoteCost<=0.0){
-                    if(joinPosition==0)
-                        prevRemoteCost=0.0;
+                    if(joinPosition==0) {
+			prevRemoteCost = 0.0;
+			prevRemoteCostPerPartition = 0.0;
+		    }
                     else{
                         prevRemoteCost= recoverCostFromProposedJoinOrder(true);
+                        // Join planning stores cost per partition in remoteCost and localCost.
+                        prevRemoteCostPerPartition = prevRemoteCost;
                     }
                 }
 
                 if(prevLocalCost<=0.0){
-                    if(joinPosition==0)
-                        prevLocalCost=0.0;
+                    if(joinPosition==0) {
+	   	        prevLocalCost = 0.0;
+		        prevLocalCostPerPartition = 0.0;
+		    }
                     else{
                         prevLocalCost= recoverCostFromProposedJoinOrder(true);
+                        // Join planning stores cost per partition in remoteCost and localCost.
+                        prevLocalCostPerPartition=prevLocalCost;
                     }
                 }
 
                 currentSortAvoidanceCost.setLocalCost(prevLocalCost);
                 currentSortAvoidanceCost.setRemoteCost(prevRemoteCost);
+                currentSortAvoidanceCost.setLocalCostPerPartition(prevLocalCostPerPartition);
+                currentSortAvoidanceCost.setRemoteCostPerPartition(prevRemoteCostPerPartition);
                 currentSortAvoidanceCost.setRowCount(prevRowCount);
                 currentSortAvoidanceCost.setSingleScanRowCount(prevSingleScanRowCount);
                 currentSortAvoidanceCost.setBase(null);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
@@ -1516,8 +1516,8 @@ public class OptimizerImpl implements Optimizer{
     private void addCost(CostEstimate addend,CostEstimate destCost){
         destCost.setRemoteCost(addend.remoteCost());
         destCost.setLocalCost(destCost.localCost()+addend.localCost());
-        destCost.setRemoteCostPerPartition(addend.remoteCostPerPartition());
-        destCost.setLocalCostPerPartition(destCost.localCostPerPartition()+addend.localCostPerPartition());
+        destCost.setRemoteCostPerPartition(addend.getRemoteCostPerPartition());
+        destCost.setLocalCostPerPartition(destCost.getLocalCostPerPartition()+addend.getLocalCostPerPartition());
         destCost.setRowCount(addend.rowCount());
         destCost.setSingleScanRowCount(addend.singleScanRowCount());
         destCost.setEstimatedHeapSize(addend.getEstimatedHeapSize());
@@ -1965,19 +1965,21 @@ public class OptimizerImpl implements Optimizer{
 					 */
                     prevRemoteCost=outermostCostEstimate.remoteCost();
                     prevLocalCost=outermostCostEstimate.localCost();
-                    prevLocalCostPerPartition=outermostCostEstimate.localCostPerPartition();
-                    prevRemoteCostPerPartition=outermostCostEstimate.remoteCostPerPartition();
+                    prevLocalCostPerPartition=outermostCostEstimate.getLocalCostPerPartition();
+                    prevRemoteCostPerPartition=outermostCostEstimate.getRemoteCostPerPartition();
                 }else{
-                    CostEstimate localCE= optimizableList.getOptimizable(prevPosition)
+                    CostEstimate localCE = optimizableList.getOptimizable(prevPosition)
                             .getBestSortAvoidancePath().getCostEstimate();
-                    prevRowCount=localCE.rowCount();
-                    prevSingleScanRowCount=localCE.singleScanRowCount();
-                    prevRemoteCost= currentSortAvoidanceCost.remoteCost()-ap.getCostEstimate().remoteCost();
-                    prevLocalCost= currentSortAvoidanceCost.localCost()-ap.getCostEstimate().localCost();
-                    prevLocalCostPerPartition=currentSortAvoidanceCost.localCostPerPartition() -
-		                                  ap.getCostEstimate().localCostPerPartition();
-                    prevRemoteCostPerPartition=currentSortAvoidanceCost.remoteCostPerPartition() -
-		                                  ap.getCostEstimate().remoteCostPerPartition();
+                    prevRowCount = localCE.rowCount();
+                    prevSingleScanRowCount = localCE.singleScanRowCount();
+                    prevRemoteCost = currentSortAvoidanceCost.remoteCost() -
+		                         ap.getCostEstimate().remoteCost();
+                    prevLocalCost = currentSortAvoidanceCost.localCost() -
+		                        ap.getCostEstimate().localCost();
+                    prevLocalCostPerPartition = currentSortAvoidanceCost.getLocalCostPerPartition() -
+		                                    ap.getCostEstimate().getLocalCostPerPartition();
+                    prevRemoteCostPerPartition = currentSortAvoidanceCost.getRemoteCostPerPartition() -
+		                                     ap.getCostEstimate().getRemoteCostPerPartition();
                 }
 
                 // See discussion above for "newCost"; same applies here.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderByList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderByList.java
@@ -338,8 +338,8 @@ public class OrderByList extends OrderedColumnList implements RequiredRowOrderin
             if (optimizer == null) {
                 double parallelCost = (baseCost.localCost()+baseCost.remoteCost())/baseCost.partitionCount();
                 baseCost.setLocalCost(baseCost.localCost()+parallelCost);
-                baseCost.setLocalCostPerPartition(baseCost.localCost()/baseCost.partitionCount());
-                baseCost.setRemoteCostPerPartition(baseCost.remoteCost()/baseCost.partitionCount());
+                baseCost.setLocalCostPerPartition(baseCost.localCost(), baseCost.partitionCount());
+                baseCost.setRemoteCostPerPartition(baseCost.remoteCost(), baseCost.partitionCount());
                 return;
             } else {
                 scc = optimizer.newSortCostController(this);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderByList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderByList.java
@@ -338,6 +338,8 @@ public class OrderByList extends OrderedColumnList implements RequiredRowOrderin
             if (optimizer == null) {
                 double parallelCost = (baseCost.localCost()+baseCost.remoteCost())/baseCost.partitionCount();
                 baseCost.setLocalCost(baseCost.localCost()+parallelCost);
+                baseCost.setLocalCostPerPartition(baseCost.localCost()/baseCost.partitionCount());
+                baseCost.setRemoteCostPerPartition(baseCost.remoteCost()/baseCost.partitionCount());
                 return;
             } else {
                 scc = optimizer.newSortCostController(this);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowResultSetNode.java
@@ -579,6 +579,7 @@ public class RowResultSetNode extends FromTable {
         costEstimate = optimizer.newCostEstimate();
         costEstimate.setCost(1.0d, outerRows, outerRows);
         costEstimate.setLocalCost(1.0d);
+        costEstimate.setLocalCostPerPartition(1.0d);
         if (resultColumns != null)
             costEstimate.setEstimatedHeapSize(resultColumns.getTotalColumnSize());
         else

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ScanCostFunction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ScanCostFunction.java
@@ -233,8 +233,8 @@ public class ScanCostFunction{
         scanCost.setProjectionCost(lookupCost+baseCost+projectionCost);
         scanCost.setLocalCost(baseCost+lookupCost+projectionCost);
         scanCost.setNumPartitions(scc.getNumPartitions() != 0 ? scc.getNumPartitions() : 1);
-        scanCost.setLocalCostPerPartition(scanCost.localCost()/scanCost.partitionCount());
-        scanCost.setRemoteCostPerPartition(scanCost.remoteCost()/scanCost.partitionCount());
+        scanCost.setLocalCostPerPartition(scanCost.localCost(), scanCost.partitionCount());
+        scanCost.setRemoteCostPerPartition(scanCost.remoteCost(), scanCost.partitionCount());
         if (LOG.isTraceEnabled()) {
             LOG.trace(String.format("\n" +
                             "============= generateOneRowCost() for table: %s =============%n" +
@@ -361,8 +361,8 @@ public class ScanCostFunction{
         assert localCost >= 0 : "localCost cannot be negative -> " + localCost;
         scanCost.setLocalCost(localCost);
         scanCost.setNumPartitions(scc.getNumPartitions() != 0 ? scc.getNumPartitions() : 1);
-        scanCost.setLocalCostPerPartition((baseCost + lookupCost + projectionCost)/scanCost.partitionCount());
-        scanCost.setRemoteCostPerPartition(scanCost.remoteCost()/scanCost.partitionCount());
+        scanCost.setLocalCostPerPartition((baseCost + lookupCost + projectionCost), scanCost.partitionCount());
+        scanCost.setRemoteCostPerPartition(scanCost.remoteCost(), scanCost.partitionCount());
 
         if (LOG.isTraceEnabled()) {
             LOG.trace(String.format("\n" +

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ScanCostFunction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ScanCostFunction.java
@@ -232,7 +232,9 @@ public class ScanCostFunction{
         scanCost.setProjectionRows(scanCost.getEstimatedRowCount());
         scanCost.setProjectionCost(lookupCost+baseCost+projectionCost);
         scanCost.setLocalCost(baseCost+lookupCost+projectionCost);
-        scanCost.setNumPartitions(scc.getNumPartitions());
+        scanCost.setNumPartitions(scc.getNumPartitions() != 0 ? scc.getNumPartitions() : 1);
+        scanCost.setLocalCostPerPartition(scanCost.localCost()/scanCost.partitionCount());
+        scanCost.setRemoteCostPerPartition(scanCost.remoteCost()/scanCost.partitionCount());
         if (LOG.isTraceEnabled()) {
             LOG.trace(String.format("\n" +
                             "============= generateOneRowCost() for table: %s =============%n" +
@@ -358,8 +360,9 @@ public class ScanCostFunction{
         double localCost = baseCost+lookupCost+projectionCost;
         assert localCost >= 0 : "localCost cannot be negative -> " + localCost;
         scanCost.setLocalCost(localCost);
-        scanCost.setNumPartitions(scc.getNumPartitions());
-        scanCost.setLocalCostPerPartition((baseCost + lookupCost + projectionCost)/scc.getNumPartitions());
+        scanCost.setNumPartitions(scc.getNumPartitions() != 0 ? scc.getNumPartitions() : 1);
+        scanCost.setLocalCostPerPartition((baseCost + lookupCost + projectionCost)/scanCost.partitionCount());
+        scanCost.setRemoteCostPerPartition(scanCost.remoteCost()/scanCost.partitionCount());
 
         if (LOG.isTraceEnabled()) {
             LOG.trace(String.format("\n" +

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
@@ -247,18 +247,26 @@ public class SelectivityUtil {
                         (outerHeapSize/(outerRowCount<1.0d?1.0d:outerRowCount)));
     }
 
-    public static double getTotalRemoteCost(CostEstimate innerCostEstimate,
-                                            CostEstimate outerCostEstimate,
-                                            double totalOutputRows){
+    public static double getTotalPerPartitionRemoteCost(CostEstimate innerCostEstimate,
+                                                        CostEstimate outerCostEstimate,
+                                                        double totalOutputRows){
+
+        // Join costing is done on a per-partition basis, so remote costs
+        // for a JoinOperation are calculated this way too, to make the units consistent.
+        // The operation is initiated from the outer table, so it determines the
+        // number of partitions.
+        int numpartitions = outerCostEstimate.partitionCount();
+        if (numpartitions <= 0)
+            numpartitions = 1;
         return getTotalRemoteCost(outerCostEstimate.remoteCost(),innerCostEstimate.remoteCost(),
-                outerCostEstimate.rowCount(),innerCostEstimate.rowCount(),totalOutputRows);
+                outerCostEstimate.rowCount(),innerCostEstimate.rowCount(),totalOutputRows)/numpartitions;
     }
 
-    public static double getTotalRemoteCost(double outerRemoteCost,
-                                        double innerRemoteCost,
-                                        double outerRowCount,
-                                        double innerRowCount,
-                                        double totalOutputRows){
+    private static double getTotalRemoteCost(double outerRemoteCost,
+                                             double innerRemoteCost,
+                                             double outerRowCount,
+                                             double innerRowCount,
+                                             double totalOutputRows){
         return totalOutputRows*(
                 (innerRemoteCost/(innerRowCount<1.0d?1.0d:innerRowCount)) +
                         (outerRemoteCost/(outerRowCount<1.0d?1.0d:outerRowCount)));

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
@@ -258,7 +258,8 @@ public class SelectivityUtil {
         int numpartitions = outerCostEstimate.partitionCount();
         if (numpartitions <= 0)
             numpartitions = 1;
-        return getTotalRemoteCost(outerCostEstimate.remoteCost(),innerCostEstimate.remoteCost(),
+        return getTotalRemoteCost(outerCostEstimate.remoteCost(),
+                                  innerCostEstimate.remoteCost(),
                 outerCostEstimate.rowCount(),innerCostEstimate.rowCount(),totalOutputRows)/numpartitions;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnionNode.java
@@ -312,6 +312,8 @@ public class UnionNode extends SetOperatorNode{
         costEstimate.setRowCount(outputRows);
         costEstimate.setEstimatedHeapSize((long)heapSize);
         costEstimate.setNumPartitions(partitions);
+        costEstimate.setLocalCostPerPartition(costEstimate.localCost()/costEstimate.partitionCount());
+        costEstimate.setRemoteCostPerPartition(costEstimate.remoteCost()/costEstimate.partitionCount());
 
 
 		/*

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnionNode.java
@@ -312,8 +312,8 @@ public class UnionNode extends SetOperatorNode{
         costEstimate.setRowCount(outputRows);
         costEstimate.setEstimatedHeapSize((long)heapSize);
         costEstimate.setNumPartitions(partitions);
-        costEstimate.setLocalCostPerPartition(costEstimate.localCost()/costEstimate.partitionCount());
-        costEstimate.setRemoteCostPerPartition(costEstimate.remoteCost()/costEstimate.partitionCount());
+        costEstimate.setLocalCostPerPartition(costEstimate.localCost(), costEstimate.partitionCount());
+        costEstimate.setRemoteCostPerPartition(costEstimate.remoteCost(), costEstimate.partitionCount());
 
 
 		/*

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/BroadcastJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/BroadcastJoinStrategy.java
@@ -143,7 +143,9 @@ public class BroadcastJoinStrategy extends HashableJoinStrategy {
             double joinCost = broadcastJoinStrategyLocalCost(innerCost, outerCost, totalJoinedRows);
             innerCost.setLocalCost(joinCost);
             innerCost.setLocalCostPerPartition(joinCost);
-            innerCost.setRemoteCost(SelectivityUtil.getTotalPerPartitionRemoteCost(innerCost, outerCost, totalOutputRows));
+            double remoteCostPerPartition = SelectivityUtil.getTotalPerPartitionRemoteCost(innerCost, outerCost, totalOutputRows);
+            innerCost.setRemoteCost(remoteCostPerPartition);
+            innerCost.setRemoteCostPerPartition(remoteCostPerPartition);
             innerCost.setRowOrdering(outerCost.getRowOrdering());
             innerCost.setRowCount(totalOutputRows);
             innerCost.setEstimatedHeapSize((long) SelectivityUtil.getTotalHeapSize(innerCost, outerCost, totalOutputRows));
@@ -152,6 +154,8 @@ public class BroadcastJoinStrategy extends HashableJoinStrategy {
             // Set cost to max to rule out broadcast join
             innerCost.setLocalCost(Double.MAX_VALUE);
             innerCost.setRemoteCost(Double.MAX_VALUE);
+            innerCost.setLocalCostPerPartition(Double.MAX_VALUE);
+            innerCost.setRemoteCostPerPartition(Double.MAX_VALUE);
         }
     }
 
@@ -169,7 +173,9 @@ public class BroadcastJoinStrategy extends HashableJoinStrategy {
         SConfiguration config = EngineDriver.driver().getConfiguration();
         double localLatency = config.getFallbackLocalLatency();
         double joiningRowCost = numOfJoinedRows * localLatency;
-        return (outerCost.localCostPerPartition())+innerCost.localCost()+innerCost.remoteCost()+innerCost.getOpenCost()+innerCost.getCloseCost()+.01 // .01 Hash Cost//
+        assert innerCost.localCostPerPartition() != 0d || innerCost.localCost() == 0d;
+        assert innerCost.remoteCostPerPartition() != 0d || innerCost.remoteCost() == 0d;
+        return (outerCost.localCostPerPartition())+((innerCost.localCostPerPartition()+innerCost.remoteCostPerPartition()) * innerCost.partitionCount())+innerCost.getOpenCost()+innerCost.getCloseCost()+.01 // .01 Hash Cost//
                + joiningRowCost/outerCost.partitionCount();
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/BroadcastJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/BroadcastJoinStrategy.java
@@ -173,9 +173,9 @@ public class BroadcastJoinStrategy extends HashableJoinStrategy {
         SConfiguration config = EngineDriver.driver().getConfiguration();
         double localLatency = config.getFallbackLocalLatency();
         double joiningRowCost = numOfJoinedRows * localLatency;
-        assert innerCost.localCostPerPartition() != 0d || innerCost.localCost() == 0d;
-        assert innerCost.remoteCostPerPartition() != 0d || innerCost.remoteCost() == 0d;
-        return (outerCost.localCostPerPartition())+((innerCost.localCostPerPartition()+innerCost.remoteCostPerPartition()) * innerCost.partitionCount())+innerCost.getOpenCost()+innerCost.getCloseCost()+.01 // .01 Hash Cost//
+        assert innerCost.getLocalCostPerPartition() != 0d || innerCost.localCost() == 0d;
+        assert innerCost.getRemoteCostPerPartition() != 0d || innerCost.remoteCost() == 0d;
+        return (outerCost.getLocalCostPerPartition())+((innerCost.getLocalCostPerPartition()+innerCost.getRemoteCostPerPartition()) * innerCost.partitionCount())+innerCost.getOpenCost()+innerCost.getCloseCost()+.01 // .01 Hash Cost//
                + joiningRowCost/outerCost.partitionCount();
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/BroadcastJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/BroadcastJoinStrategy.java
@@ -143,7 +143,7 @@ public class BroadcastJoinStrategy extends HashableJoinStrategy {
             double joinCost = broadcastJoinStrategyLocalCost(innerCost, outerCost, totalJoinedRows);
             innerCost.setLocalCost(joinCost);
             innerCost.setLocalCostPerPartition(joinCost);
-            innerCost.setRemoteCost(SelectivityUtil.getTotalRemoteCost(innerCost, outerCost, totalOutputRows));
+            innerCost.setRemoteCost(SelectivityUtil.getTotalPerPartitionRemoteCost(innerCost, outerCost, totalOutputRows));
             innerCost.setRowOrdering(outerCost.getRowOrdering());
             innerCost.setRowCount(totalOutputRows);
             innerCost.setEstimatedHeapSize((long) SelectivityUtil.getTotalHeapSize(innerCost, outerCost, totalOutputRows));

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/CrossJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/CrossJoinStrategy.java
@@ -263,14 +263,14 @@ public class CrossJoinStrategy extends BaseJoinStrategy {
         SConfiguration config = EngineDriver.driver().getConfiguration();
         double localLatency = config.getFallbackLocalLatency();
         double joiningRowCost = numOfJoinedRows * localLatency;
-        assert outerCost.localCostPerPartition() != 0d || outerCost.localCost() == 0d;
-        assert innerCost.localCostPerPartition() != 0d || innerCost.localCost() == 0d;
-        assert innerCost.remoteCostPerPartition() != 0d || innerCost.remoteCost() == 0d;
-        assert outerCost.remoteCostPerPartition() != 0d || outerCost.remoteCost() == 0d;
-        double innerLocalCost = innerCost.localCostPerPartition()*innerCost.partitionCount();
-        double innerRemoteCost = innerCost.remoteCostPerPartition()*innerCost.partitionCount();
-        return outerCost.localCostPerPartition() +
-                outerCost.remoteCostPerPartition()  +
+        assert outerCost.getLocalCostPerPartition() != 0d || outerCost.localCost() == 0d;
+        assert innerCost.getLocalCostPerPartition() != 0d || innerCost.localCost() == 0d;
+        assert innerCost.getRemoteCostPerPartition() != 0d || innerCost.remoteCost() == 0d;
+        assert outerCost.getRemoteCostPerPartition() != 0d || outerCost.remoteCost() == 0d;
+        double innerLocalCost = innerCost.getLocalCostPerPartition()*innerCost.partitionCount();
+        double innerRemoteCost = innerCost.getRemoteCostPerPartition()*innerCost.partitionCount();
+        return outerCost.getLocalCostPerPartition() +
+                outerCost.getRemoteCostPerPartition()  +
                 (outerCost.rowCount()/outerCost.partitionCount()) * (innerLocalCost + innerRemoteCost) +
                 joiningRowCost/outerCost.partitionCount();
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/CrossJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/CrossJoinStrategy.java
@@ -237,7 +237,7 @@ public class CrossJoinStrategy extends BaseJoinStrategy {
         double joinCost = crossJoinStrategyLocalCost(innerCost, outerCost, totalJoinedRows);
         innerCost.setLocalCost(joinCost);
         innerCost.setLocalCostPerPartition(joinCost);
-        innerCost.setRemoteCost(SelectivityUtil.getTotalRemoteCost(innerCost, outerCost, totalOutputRows));
+        innerCost.setRemoteCost(SelectivityUtil.getTotalPerPartitionRemoteCost(innerCost, outerCost, totalOutputRows));
         innerCost.setRowCount(totalOutputRows);
         innerCost.setEstimatedHeapSize((long) SelectivityUtil.getTotalHeapSize(innerCost, outerCost, totalOutputRows));
         innerCost.setNumPartitions(outerCost.partitionCount());

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/HalfMergeSortJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/HalfMergeSortJoinStrategy.java
@@ -115,7 +115,7 @@ public class HalfMergeSortJoinStrategy extends HashableJoinStrategy {
         double joinCost = 0.9D * MergeSortJoinStrategy.mergeSortJoinStrategyLocalCost(innerCost, outerCost, totalJoinedRows);
         innerCost.setLocalCost(joinCost);
         innerCost.setLocalCostPerPartition(joinCost);
-        innerCost.setRemoteCost(SelectivityUtil.getTotalRemoteCost(innerCost, outerCost, totalOutputRows));
+        innerCost.setRemoteCost(SelectivityUtil.getTotalPerPartitionRemoteCost(innerCost, outerCost, totalOutputRows));
         innerCost.setRowCount(totalOutputRows);
         innerCost.setEstimatedHeapSize((long) SelectivityUtil.getTotalHeapSize(innerCost, outerCost, totalOutputRows));
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/HalfMergeSortJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/HalfMergeSortJoinStrategy.java
@@ -115,7 +115,9 @@ public class HalfMergeSortJoinStrategy extends HashableJoinStrategy {
         double joinCost = 0.9D * MergeSortJoinStrategy.mergeSortJoinStrategyLocalCost(innerCost, outerCost, totalJoinedRows);
         innerCost.setLocalCost(joinCost);
         innerCost.setLocalCostPerPartition(joinCost);
-        innerCost.setRemoteCost(SelectivityUtil.getTotalPerPartitionRemoteCost(innerCost, outerCost, totalOutputRows));
+        double remoteCostPerPartition = SelectivityUtil.getTotalPerPartitionRemoteCost(innerCost, outerCost, totalOutputRows);
+        innerCost.setRemoteCost(remoteCostPerPartition);
+        innerCost.setRemoteCostPerPartition(remoteCostPerPartition);
         innerCost.setRowCount(totalOutputRows);
         innerCost.setEstimatedHeapSize((long) SelectivityUtil.getTotalHeapSize(innerCost, outerCost, totalOutputRows));
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeJoinStrategy.java
@@ -163,13 +163,13 @@ public class MergeJoinStrategy extends HashableJoinStrategy{
         double localLatency = config.getFallbackLocalLatency();
         double joiningRowCost = numOfJoinedRows * localLatency;
 
-        assert innerCost.remoteCostPerPartition() != 0d || innerCost.remoteCost() == 0d;
-        double innerRemoteCost = innerCost.remoteCostPerPartition() * innerCost.partitionCount();
+        assert innerCost.getRemoteCostPerPartition() != 0d || innerCost.remoteCost() == 0d;
+        double innerRemoteCost = innerCost.getRemoteCostPerPartition() * innerCost.partitionCount();
         if (outerTableEmpty) {
-            return (outerCost.localCostPerPartition())+innerCost.getOpenCost()+innerCost.getCloseCost();
+            return (outerCost.getLocalCostPerPartition())+innerCost.getOpenCost()+innerCost.getCloseCost();
         }
         else
-            return outerCost.localCostPerPartition()+innerCost.localCostPerPartition()+
+            return outerCost.getLocalCostPerPartition()+innerCost.getLocalCostPerPartition()+
                 innerRemoteCost/outerCost.partitionCount() +
                 innerCost.getOpenCost()+innerCost.getCloseCost()
                         + joiningRowCost/outerCost.partitionCount();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeJoinStrategy.java
@@ -66,14 +66,16 @@ public class MergeJoinStrategy extends HashableJoinStrategy{
         //we can't work if the outer table isn't sorted, regardless of what else happens
         if(outerCost==null) return false;
         RowOrdering outerRowOrdering=outerCost.getRowOrdering();
-        if(outerRowOrdering==null) return false;
+        if(outerRowOrdering==null)
+            return false;
 
         /* Currently MergeJoin does not work with a right side IndexRowToBaseRowOperation */
         if(JoinStrategyUtil.isNonCoveringIndex(innerTable)){
             return false;
         }
         boolean hashFeasible=super.feasible(innerTable, predList, optimizer, outerCost, wasHinted, skipKeyCheck);
-        if(!hashFeasible) return false;
+        if(!hashFeasible)
+            return false;
 
         /*
          * MergeJoin is only feasible if the inner and outer tables are both
@@ -135,7 +137,7 @@ public class MergeJoinStrategy extends HashableJoinStrategy{
         double joinCost = mergeJoinStrategyLocalCost(innerCost, outerCost, empty, totalJoinedRows);
         innerCost.setLocalCost(joinCost);
         innerCost.setLocalCostPerPartition(joinCost);
-        innerCost.setRemoteCost(SelectivityUtil.getTotalRemoteCost(innerCost, outerCost, totalOutputRows));
+        innerCost.setRemoteCost(SelectivityUtil.getTotalPerPartitionRemoteCost(innerCost, outerCost, totalOutputRows));
         innerCost.setRowOrdering(outerCost.getRowOrdering());
         innerCost.setRowCount(totalOutputRows);
         innerCost.setEstimatedHeapSize((long)SelectivityUtil.getTotalHeapSize(innerCost,outerCost,totalOutputRows));
@@ -162,8 +164,10 @@ public class MergeJoinStrategy extends HashableJoinStrategy{
             return (outerCost.localCostPerPartition())+innerCost.getOpenCost()+innerCost.getCloseCost();
         }
         else
-            return outerCost.localCostPerPartition()+innerCost.localCostPerPartition()+innerCost.remoteCost()/outerCost.partitionCount()+innerCost.getOpenCost()+innerCost.getCloseCost()
-                    + joiningRowCost/outerCost.partitionCount();
+            return outerCost.localCostPerPartition()+innerCost.localCostPerPartition()+
+                innerCost.remoteCost()/outerCost.partitionCount() +
+                innerCost.getOpenCost()+innerCost.getCloseCost()
+                        + joiningRowCost/outerCost.partitionCount();
     }
 
     /* ****************************************************************************************************************/
@@ -288,11 +292,13 @@ public class MergeJoinStrategy extends HashableJoinStrategy{
                 }
             }
         }
-        if(innerColumns.cardinality()<=0) return false; //we have no matching join predicates, so we can't work
+        if(innerColumns.cardinality()<=0)
+            return false; //we have no matching join predicates, so we can't work
         //compute the and to look for the mismatch position
         outerColumns.and(innerColumns);
         int misMatchPos = outerColumns.nextClearBit(0);
-        if(misMatchPos==0) return false; //we are missing the first key, so that won't work
+        if(misMatchPos==0)
+            return false; //we are missing the first key, so that won't work
 
         /*
          * We need to determine that the join predicates are on matched columns--i.e. that
@@ -304,13 +310,16 @@ public class MergeJoinStrategy extends HashableJoinStrategy{
         for(int i=0;i<innerToOuterJoinColumnMap.length;i++){
             int outerCol = innerToOuterJoinColumnMap[i];
             if(outerCol==-1) continue;
-            if(outerCol<lastOuterCol) return false; //we have a join out of order
+            if(outerCol<lastOuterCol)
+                return false; //we have a join out of order
             for (int j = lastOuterCol+1; j < outerCol; ++j) {
-                if (!outerColumns.get(j)) return false;
+                if (!outerColumns.get(j))
+                    return false;
             }
 
             for (int j = lastInnerCol+1; j < i; ++j) {
-                if (!innerColumns.get(j)) return false;
+                if (!innerColumns.get(j))
+                    return false;
             }
             lastOuterCol = outerCol;
             lastInnerCol = i;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
@@ -157,19 +157,19 @@ public class MergeSortJoinStrategy extends HashableJoinStrategy {
         double outerSortCost =
             getSortCost(outerRowCountPerPartition, localLatency*factor);
 
-        assert outerCost.localCostPerPartition() != 0d || outerCost.localCost() == 0d;
-        assert innerCost.localCostPerPartition() != 0d || innerCost.localCost() == 0d;
-        assert outerCost.remoteCostPerPartition() != 0d || outerCost.remoteCost() == 0d;
-        assert innerCost.remoteCostPerPartition() != 0d || innerCost.remoteCost() == 0d;
+        assert outerCost.getLocalCostPerPartition() != 0d || outerCost.localCost() == 0d;
+        assert innerCost.getLocalCostPerPartition() != 0d || innerCost.localCost() == 0d;
+        assert outerCost.getRemoteCostPerPartition() != 0d || outerCost.remoteCost() == 0d;
+        assert innerCost.getRemoteCostPerPartition() != 0d || innerCost.remoteCost() == 0d;
 
-        double outerLocalCost = outerCost.localCostPerPartition()*outerCost.partitionCount();
-        double innerLocalCost = innerCost.localCostPerPartition()*innerCost.partitionCount();
+        double outerLocalCost = outerCost.getLocalCostPerPartition()*outerCost.partitionCount();
+        double innerLocalCost = innerCost.getLocalCostPerPartition()*innerCost.partitionCount();
 
-        double outerShuffleCost = outerCost.localCostPerPartition()
-                +outerCost.remoteCostPerPartition()*outerCost.partitionCount()
+        double outerShuffleCost = outerCost.getLocalCostPerPartition()
+                +outerCost.getRemoteCostPerPartition()*outerCost.partitionCount()
                 +outerCost.getOpenCost()+outerCost.getCloseCost();
-        double innerShuffleCost = innerCost.localCostPerPartition()
-                +innerCost.remoteCostPerPartition()*innerCost.partitionCount()
+        double innerShuffleCost = innerCost.getLocalCostPerPartition()
+                +innerCost.getRemoteCostPerPartition()*innerCost.partitionCount()
                 +innerCost.getOpenCost()+innerCost.getCloseCost();
         double outerReadCost = outerLocalCost/outerCost.partitionCount();
         double innerReadCost = innerLocalCost/outerCost.partitionCount();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
@@ -166,10 +166,10 @@ public class MergeSortJoinStrategy extends HashableJoinStrategy {
         double innerLocalCost = innerCost.getLocalCostPerPartition()*innerCost.partitionCount();
 
         double outerShuffleCost = outerCost.getLocalCostPerPartition()
-                +outerCost.getRemoteCostPerPartition()*outerCost.partitionCount()
+                +outerCost.getRemoteCostPerPartition()
                 +outerCost.getOpenCost()+outerCost.getCloseCost();
         double innerShuffleCost = innerCost.getLocalCostPerPartition()
-                +innerCost.getRemoteCostPerPartition()*innerCost.partitionCount()
+                +innerCost.getRemoteCostPerPartition()
                 +innerCost.getOpenCost()+innerCost.getCloseCost();
         double outerReadCost = outerLocalCost/outerCost.partitionCount();
         double innerReadCost = innerLocalCost/outerCost.partitionCount();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
@@ -323,16 +323,16 @@ public class NestedLoopJoinStrategy extends BaseJoinStrategy{
         // the primary key or index on the inner table, could be to sort the outer
         // table on the join key and then perform a merge join with the inner table.
 
-        double innerLocalCost = innerCost.localCostPerPartition()*innerCost.partitionCount();
-        double innerRemoteCost = innerCost.remoteCostPerPartition()*innerCost.partitionCount();
+        double innerLocalCost = innerCost.getLocalCostPerPartition()*innerCost.partitionCount();
+        double innerRemoteCost = innerCost.getRemoteCostPerPartition()*innerCost.partitionCount();
         if (useSparkCostFormula)
-            return outerCost.localCostPerPartition() +
+            return outerCost.getLocalCostPerPartition() +
                    ((outerCost.rowCount()/outerCost.partitionCount())
                     * innerLocalCost) +
             ((outerCost.rowCount())*(innerRemoteCost))
                     + joiningRowCost/outerCost.partitionCount();
         else
-            return outerCost.localCostPerPartition() +
+            return outerCost.getLocalCostPerPartition() +
                    (outerCost.rowCount()/outerCost.partitionCount())
                     * (innerCost.localCost()+innerCost.getRemoteCost()) +
                    joiningRowCost/outerCost.partitionCount();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
@@ -327,10 +327,9 @@ public class NestedLoopJoinStrategy extends BaseJoinStrategy{
         double innerRemoteCost = innerCost.remoteCostPerPartition()*innerCost.partitionCount();
         if (useSparkCostFormula)
             return outerCost.localCostPerPartition() +
-            //(outerCost.rowCount()/outerCost.partitionCount())*(innerLocalCost+innerRemoteCost)
                    ((outerCost.rowCount()/outerCost.partitionCount())
                     * innerLocalCost) +
-            ((outerCost.rowCount())*(innerRemoteCost))  // msirek-temp
+            ((outerCost.rowCount())*(innerRemoteCost))
                     + joiningRowCost/outerCost.partitionCount();
         else
             return outerCost.localCostPerPartition() +

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SimpleCostEstimate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SimpleCostEstimate.java
@@ -69,10 +69,8 @@ public class SimpleCostEstimate implements CostEstimate{
         this.numRows=numRows>1?numRows:1;
         this.singleScanRowCount=singleScanRowCount;
         this.numPartitions=numPartitions;
-        if (numPartitions <= 0)
-            numPartitions = 1;
-        this.localCostPerPartition = localCost/numPartitions;
-        this.remoteCostPerPartition = remoteCost/numPartitions;
+        setLocalCostPerPartition(localCost, numPartitions);
+        setLocalCostPerPartition(remoteCost, numPartitions);
     }
 
     @Override public double getOpenCost(){ return openCost; }
@@ -125,8 +123,8 @@ public class SimpleCostEstimate implements CostEstimate{
         this.projectionCost = other.getProjectionCost();
         this.projectionRows = other.getProjectionRows();
         this.scannedBaseTableRows = other.getScannedBaseTableRows();
-        this.localCostPerPartition = other.localCostPerPartition();
-        this.remoteCostPerPartition = other.remoteCostPerPartition();
+        this.localCostPerPartition = other.getLocalCostPerPartition();
+        this.remoteCostPerPartition = other.getRemoteCostPerPartition();
         this.accumulatedMemory = other.getAccumulatedMemory();
         this.setSingleRow(other.isSingleRow());
     }
@@ -369,7 +367,7 @@ public class SimpleCostEstimate implements CostEstimate{
 
         double sumLocalCost = addend.localCost()+localCost;
         double sumRemoteCost = addend.remoteCost()+remoteCost;
-        double sumRemoteCostPerPartition = addend.remoteCostPerPartition()+remoteCostPerPartition;
+        double sumRemoteCostPerPartition = addend.getRemoteCostPerPartition()+remoteCostPerPartition;
         double rowCount = addend.rowCount()+numRows;
 
         if(retval==null)
@@ -526,7 +524,7 @@ public class SimpleCostEstimate implements CostEstimate{
     }
 
     @Override
-    public double localCostPerPartition() {
+    public double getLocalCostPerPartition() {
         return localCostPerPartition;
     }
 
@@ -536,7 +534,21 @@ public class SimpleCostEstimate implements CostEstimate{
     }
 
     @Override
-    public double remoteCostPerPartition() {
+    public void setLocalCostPerPartition(double localCost, int numPartitions) {
+        if (numPartitions <= 0)
+            numPartitions = 1;
+        setLocalCostPerPartition(localCost / numPartitions);
+    }
+
+    @Override
+    public void setRemoteCostPerPartition(double remoteCost, int numPartitions) {
+        if (numPartitions <= 0)
+            numPartitions = 1;
+        setRemoteCostPerPartition(remoteCost / numPartitions);
+    }
+
+    @Override
+    public double getRemoteCostPerPartition() {
         return remoteCostPerPartition;
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SimpleCostEstimate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SimpleCostEstimate.java
@@ -52,6 +52,7 @@ public class SimpleCostEstimate implements CostEstimate{
     protected double projectionRows =-1.0d;
     protected double scannedBaseTableRows = -1.0d;
     private double localCostPerPartition;
+    private double remoteCostPerPartition;
     /* consecutive broadcast joins memory used in bytes */
     private double accumulatedMemory = 0.0d;
     private boolean singleRow = false;
@@ -68,6 +69,10 @@ public class SimpleCostEstimate implements CostEstimate{
         this.numRows=numRows>1?numRows:1;
         this.singleScanRowCount=singleScanRowCount;
         this.numPartitions=numPartitions;
+        if (numPartitions <= 0)
+            numPartitions = 1;
+        this.localCostPerPartition = localCost/numPartitions;
+        this.remoteCostPerPartition = remoteCost/numPartitions;
     }
 
     @Override public double getOpenCost(){ return openCost; }
@@ -87,6 +92,8 @@ public class SimpleCostEstimate implements CostEstimate{
         this.numRows = rowCount > 1 ? rowCount : 1;
         this.singleScanRowCount = singleScanRowCount;
         this.numPartitions = numPartitions;
+        assert (numPartitions >= 1);
+        this.localCostPerPartition = localCost/numPartitions;
     }
 
     @Override
@@ -119,6 +126,7 @@ public class SimpleCostEstimate implements CostEstimate{
         this.projectionRows = other.getProjectionRows();
         this.scannedBaseTableRows = other.getScannedBaseTableRows();
         this.localCostPerPartition = other.localCostPerPartition();
+        this.remoteCostPerPartition = other.remoteCostPerPartition();
         this.accumulatedMemory = other.getAccumulatedMemory();
         this.setSingleRow(other.isSingleRow());
     }
@@ -300,6 +308,7 @@ public class SimpleCostEstimate implements CostEstimate{
         clone.setProjectionRows(projectionRows);
         clone.setScannedBaseTableRows(scannedBaseTableRows);
         clone.setLocalCostPerPartition(localCostPerPartition);
+        clone.setRemoteCostPerPartition(remoteCostPerPartition);
         clone.setSingleRow(singleRow);
         return clone;
     }
@@ -360,12 +369,14 @@ public class SimpleCostEstimate implements CostEstimate{
 
         double sumLocalCost = addend.localCost()+localCost;
         double sumRemoteCost = addend.remoteCost()+remoteCost;
+        double sumRemoteCostPerPartition = addend.remoteCostPerPartition()+remoteCostPerPartition;
         double rowCount = addend.rowCount()+numRows;
 
         if(retval==null)
             retval = new SimpleCostEstimate();
 
         retval.setRemoteCost(sumRemoteCost);
+        retval.setRemoteCostPerPartition(sumRemoteCostPerPartition);
         retval.setCost(sumLocalCost,rowCount,singleScanRowCount,numPartitions);
         retval.setEstimatedHeapSize(estimatedHeapSize+addend.getEstimatedHeapSize());
         return retval;
@@ -386,12 +397,14 @@ public class SimpleCostEstimate implements CostEstimate{
 
         double multLocalCost = localCost*multiplicand;
         double multRemoteCost = remoteCost*multiplicand;
+        double multRemoteCostPerPartition = remoteCostPerPartition*multiplicand;
         double rowCount = numRows*multiplicand;
 
         if(retval==null)
             retval = new SimpleCostEstimate();
 
         retval.setRemoteCost(multRemoteCost);
+        retval.setRemoteCostPerPartition(multRemoteCostPerPartition);
         retval.setCost(multLocalCost,rowCount,singleScanRowCount,numPartitions);
         retval.setEstimatedHeapSize((long)(estimatedHeapSize*multiplicand));
         return retval;
@@ -399,15 +412,17 @@ public class SimpleCostEstimate implements CostEstimate{
 
     @Override
     public CostEstimate divide(double divisor,CostEstimate retval){
-        double multLocalCost = localCost/divisor;
-        double multRemoteCost = remoteCost/divisor;
+        double dividedLocalCost = localCost/divisor;
+        double dividedRemoteCost = remoteCost/divisor;
+        double dividedRemoteCostPerPartition = remoteCostPerPartition/divisor;
         double rowCount = numRows/divisor;
 
         if(retval==null)
             retval = new SimpleCostEstimate();
 
-        retval.setRemoteCost(multRemoteCost);
-        retval.setCost(multLocalCost,rowCount,singleScanRowCount,numPartitions);
+        retval.setRemoteCost(dividedRemoteCost);
+        retval.setRemoteCostPerPartition(dividedRemoteCostPerPartition);
+        retval.setCost(dividedLocalCost,rowCount,singleScanRowCount,numPartitions);
         retval.setEstimatedHeapSize((long)(estimatedHeapSize/divisor));
         return retval;
     }
@@ -518,6 +533,16 @@ public class SimpleCostEstimate implements CostEstimate{
     @Override
     public void setLocalCostPerPartition(double localCostPerPartition) {
         this.localCostPerPartition = localCostPerPartition;
+    }
+
+    @Override
+    public double remoteCostPerPartition() {
+        return remoteCostPerPartition;
+    }
+
+    @Override
+    public void setRemoteCostPerPartition(double remoteCostPerPartition) {
+        this.remoteCostPerPartition = remoteCostPerPartition;
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/stats/StoreCostControllerImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/stats/StoreCostControllerImpl.java
@@ -204,6 +204,8 @@ public class StoreCostControllerImpl implements StoreCostController {
         cost.setLocalCost(fallbackLocalLatency);
         cost.setEstimatedHeapSize((long) columnSizeFactor*tableStatistics.avgRowWidth());
         cost.setNumPartitions(1);
+        cost.setRemoteCostPerPartition(cost.remoteCost());
+        cost.setLocalCostPerPartition(cost.localCost());
         cost.setEstimatedRowCount(1l);
         cost.setOpenCost(openLatency);
         cost.setCloseCost(closeLatency);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/TempGroupedAggregateCostController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/TempGroupedAggregateCostController.java
@@ -94,6 +94,11 @@ public class TempGroupedAggregateCostController implements AggregateCostControll
         //cost information
         newEstimate.setLocalCost(baseLocalCost+localCostPerRow*outputRows);
         newEstimate.setRemoteCost(remoteCostPerRow*outputRows);
+        int numPartitions = newEstimate.partitionCount();
+        if (numPartitions <= 0)
+            numPartitions = 1;
+        newEstimate.setLocalCostPerPartition(newEstimate.localCost()/numPartitions);
+        newEstimate.setRemoteCostPerPartition(newEstimate.remoteCost()/numPartitions);
 
         return newEstimate;
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/TempGroupedAggregateCostController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/TempGroupedAggregateCostController.java
@@ -94,11 +94,8 @@ public class TempGroupedAggregateCostController implements AggregateCostControll
         //cost information
         newEstimate.setLocalCost(baseLocalCost+localCostPerRow*outputRows);
         newEstimate.setRemoteCost(remoteCostPerRow*outputRows);
-        int numPartitions = newEstimate.partitionCount();
-        if (numPartitions <= 0)
-            numPartitions = 1;
-        newEstimate.setLocalCostPerPartition(newEstimate.localCost()/numPartitions);
-        newEstimate.setRemoteCostPerPartition(newEstimate.remoteCost()/numPartitions);
+        newEstimate.setLocalCostPerPartition(newEstimate.localCost(), newEstimate.partitionCount());
+        newEstimate.setRemoteCostPerPartition(newEstimate.remoteCost(), newEstimate.partitionCount());
 
         return newEstimate;
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/TempScalarAggregateCostController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/TempScalarAggregateCostController.java
@@ -111,6 +111,8 @@ public class TempScalarAggregateCostController implements AggregateCostControlle
         newEstimate.setNumPartitions(1);
         newEstimate.setRemoteCost(totalRemoteCost);
         newEstimate.setLocalCost(totalLocalCost);
+        newEstimate.setRemoteCostPerPartition(totalRemoteCost);
+        newEstimate.setLocalCostPerPartition(totalLocalCost);
         newEstimate.setEstimatedRowCount(1);
         newEstimate.setEstimatedHeapSize((long)heapSize);
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/TempSortController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/TempSortController.java
@@ -61,6 +61,6 @@ public class TempSortController implements SortCostController{
         double parallelCost = (baseCost.localCost()+baseCost.remoteCost())/baseCost.partitionCount();
 //        baseCost.setBase(baseCost.cloneMe());
         baseCost.setLocalCost(baseCost.localCost()+parallelCost);
-        baseCost.setLocalCostPerPartition(baseCost.localCost()/baseCost.partitionCount());
+        baseCost.setLocalCostPerPartition(baseCost.localCost(), baseCost.partitionCount());
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/TempSortController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/TempSortController.java
@@ -61,5 +61,6 @@ public class TempSortController implements SortCostController{
         double parallelCost = (baseCost.localCost()+baseCost.remoteCost())/baseCost.partitionCount();
 //        baseCost.setBase(baseCost.cloneMe());
         baseCost.setLocalCost(baseCost.localCost()+parallelCost);
+        baseCost.setLocalCostPerPartition(baseCost.localCost()/baseCost.partitionCount());
     }
 }


### PR DESCRIPTION
This PR addresses join costing issues which prevent merge join from being selected by the join planner in queries with many join tables with large data sets.

Fixes:

1. Give localCost and remoteCost consistent units when costing joins.
2. Add sort cost estimates to the MergeSortJoin cost formula.
3. Update nested loop join costing to reflect the network bottleneck of retrieving inner table rows via RPC requests.

See [SPLICE-2369](https://splice.atlassian.net/browse/SPLICE-2369?focusedCommentId=27871&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-27871)

I will remove the changes in platform_it/pom.xml, SpliceTestPlatformConfig.java and SpliceTestYarnPlatform.java before merging.  