### PR TITLE
DB-8604 Deserialize SpliceDateTimeFormatters in AbstractFileFunction.

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AbstractFileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AbstractFileFunction.java
@@ -79,17 +79,17 @@ public abstract class AbstractFileFunction<I> extends SpliceFlatMapFunction<Spli
 
         this.dateFormatter      = (dateFormat == null ||
                                    dateFormat.equals(defaultDateFormatString)) ?
-                                  defaultDateFormatter :
+        DEFAULT_DATE_FORMATTER :
                                   new SpliceDateTimeFormatter(dateFormat,
                                        SpliceDateTimeFormatter.FormatterType.DATE);
         this.timestampFormatter = (timestampFormat == null ||
                                    timestampFormat.equals(defaultTimestampFormatString)) ?
-                                  defaultTimestampFormatter :
+        DEFAULT_TIMESTAMP_FORMATTER :
                                   new SpliceDateTimeFormatter(timestampFormat,
                                        SpliceDateTimeFormatter.FormatterType.TIMESTAMP);
         this.timeFormatter      = (timeFormat == null ||
                                    timeFormat.equals(defaultTimeFormatString)) ?
-                                  defaultTimeFormatter :
+        DEFAULT_TIME_FORMATTER :
                                   new SpliceDateTimeFormatter(timeFormat,
                                        SpliceDateTimeFormatter.FormatterType.TIME);
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AbstractFileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AbstractFileFunction.java
@@ -45,6 +45,7 @@ import java.util.GregorianCalendar;
 import java.util.List;
 
 import static com.splicemachine.derby.utils.SpliceDateFunctions.TO_DATE;
+import static com.splicemachine.derby.utils.SpliceDateTimeFormatter.*;
 
 /**
  *
@@ -59,7 +60,7 @@ public abstract class AbstractFileFunction<I> extends SpliceFlatMapFunction<Spli
     private String columnDelimiter;
     protected ExecRow execRow;
     private String timeFormat;
-    private String dateTimeFormat;
+    private String dateFormat;
     private SpliceDateTimeFormatter dateFormatter;
     private SpliceDateTimeFormatter timestampFormatter;
     private SpliceDateTimeFormatter timeFormatter;
@@ -71,27 +72,42 @@ public abstract class AbstractFileFunction<I> extends SpliceFlatMapFunction<Spli
     @SuppressWarnings("WeakerAccess") //weaker access isn't allowed because we have to be serializable
     public AbstractFileFunction() { }
 
+    private void setupFormatters() {
+        // Create a date formatter, time formatter and timestamp formatter
+        // that can be reused, to save memory, instead of
+        // constructing a new one every to TO_DATE , TO_TIME or TO_TIMESTAMP is called.
+
+        this.dateFormatter      = (dateFormat == null ||
+                                   dateFormat.equals(defaultDateFormatString)) ?
+                                  defaultDateFormatter :
+                                  new SpliceDateTimeFormatter(dateFormat,
+                                       SpliceDateTimeFormatter.FormatterType.DATE);
+        this.timestampFormatter = (timestampFormat == null ||
+                                   timestampFormat.equals(defaultTimestampFormatString)) ?
+                                  defaultTimestampFormatter :
+                                  new SpliceDateTimeFormatter(timestampFormat,
+                                       SpliceDateTimeFormatter.FormatterType.TIMESTAMP);
+        this.timeFormatter      = (timeFormat == null ||
+                                   timeFormat.equals(defaultTimeFormatString)) ?
+                                  defaultTimeFormatter :
+                                  new SpliceDateTimeFormatter(timeFormat,
+                                       SpliceDateTimeFormatter.FormatterType.TIME);
+    }
+
     @SuppressWarnings("unchecked")
     @SuppressFBWarnings(value = "EI_EXPOSE_REP2",justification = "Intentional")
-    AbstractFileFunction(String characterDelimiter,String columnDelimiter,ExecRow execRow,int[] columnIndex,String timeFormat,
-                         String dateTimeFormat,String timestampFormat,OperationContext operationContext) {
+    AbstractFileFunction(String characterDelimiter, String columnDelimiter, ExecRow execRow, int[] columnIndex, String timeFormat,
+                         String dateFormat, String timestampFormat, OperationContext operationContext) {
         super(operationContext);
         this.characterDelimiter = characterDelimiter;
         this.columnDelimiter = columnDelimiter;
         this.execRow = execRow;
         this.timeFormat = timeFormat;
-        this.dateTimeFormat = dateTimeFormat;
+        this.dateFormat = dateFormat;
         this.timestampFormat = timestampFormat;
         this.columnIndex = columnIndex;
 
-        // Create a date formatter that can be reused, to save memory, instead of
-        // constructing a new one every to TO_DATE is called.
-        this.dateFormatter      = new SpliceDateTimeFormatter(dateTimeFormat,
-                                                          SpliceDateTimeFormatter.FormatterType.DATE);
-        this.timestampFormatter = new SpliceDateTimeFormatter(timestampFormat,
-                                                          SpliceDateTimeFormatter.FormatterType.TIMESTAMP);
-        this.timeFormatter      = new SpliceDateTimeFormatter(timeFormat,
-                                                          SpliceDateTimeFormatter.FormatterType.TIME);
+        setupFormatters();
     }
 
     @Override
@@ -104,7 +120,7 @@ public abstract class AbstractFileFunction<I> extends SpliceFlatMapFunction<Spli
         if (columnDelimiter!=null)
             out.writeUTF(columnDelimiter);
         writeNullableUTF(out, timeFormat);
-        writeNullableUTF(out, dateTimeFormat);
+        writeNullableUTF(out, dateFormat);
         writeNullableUTF(out,timestampFormat);
         try {
             ArrayUtil.writeIntArray(out, WriteReadUtils.getExecRowTypeFormatIds(execRow));
@@ -126,15 +142,10 @@ public abstract class AbstractFileFunction<I> extends SpliceFlatMapFunction<Spli
         if (in.readBoolean())
             timeFormat = in.readUTF();
         if (in.readBoolean())
-            dateTimeFormat = in.readUTF();
+            dateFormat = in.readUTF();
         if (in.readBoolean())
             timestampFormat = in.readUTF();
-        this.dateFormatter      = new SpliceDateTimeFormatter(dateTimeFormat,
-                                                          SpliceDateTimeFormatter.FormatterType.DATE);
-        this.timestampFormatter = new SpliceDateTimeFormatter(timestampFormat,
-                                                          SpliceDateTimeFormatter.FormatterType.TIMESTAMP);
-        this.timeFormatter      = new SpliceDateTimeFormatter(timeFormat,
-                                                          SpliceDateTimeFormatter.FormatterType.TIME);
+        setupFormatters();
         execRow =WriteReadUtils.getExecRowFromTypeFormatIds(ArrayUtil.readIntArray(in));
         if (in.readBoolean())
             columnIndex = ArrayUtil.readIntArray(in);
@@ -149,7 +160,7 @@ public abstract class AbstractFileFunction<I> extends SpliceFlatMapFunction<Spli
     @SuppressFBWarnings(value = "REC_CATCH_EXCEPTION",justification = "Intentional")
     public ExecRow call(List<String> values,BooleanList quotedColumns) throws Exception {
         return getRow(values, quotedColumns, operationContext, execRow, calendar, timeFormat,
-                dateTimeFormat, timestampFormat, this.dateFormatter, this.timestampFormatter, this.timeFormatter);
+        dateFormat, timestampFormat, this.dateFormatter, this.timestampFormatter, this.timeFormatter);
     }
 
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AbstractFileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AbstractFileFunction.java
@@ -129,6 +129,12 @@ public abstract class AbstractFileFunction<I> extends SpliceFlatMapFunction<Spli
             dateTimeFormat = in.readUTF();
         if (in.readBoolean())
             timestampFormat = in.readUTF();
+        this.dateFormatter      = new SpliceDateTimeFormatter(dateTimeFormat,
+                                                          SpliceDateTimeFormatter.FormatterType.DATE);
+        this.timestampFormatter = new SpliceDateTimeFormatter(timestampFormat,
+                                                          SpliceDateTimeFormatter.FormatterType.TIMESTAMP);
+        this.timeFormatter      = new SpliceDateTimeFormatter(timeFormat,
+                                                          SpliceDateTimeFormatter.FormatterType.TIME);
         execRow =WriteReadUtils.getExecRowFromTypeFormatIds(ArrayUtil.readIntArray(in));
         if (in.readBoolean())
             columnIndex = ArrayUtil.readIntArray(in);

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateFunctions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateFunctions.java
@@ -31,6 +31,8 @@ import java.time.*;
 import java.util.Calendar;
 import java.util.Map;
 
+import static com.splicemachine.derby.utils.SpliceDateTimeFormatter.*;
+
 
 /**
  * Implementation of standard Splice Date functions,
@@ -59,8 +61,12 @@ public class SpliceDateFunctions {
     public static Timestamp
     TO_TIMESTAMP(String source, String format, SpliceDateTimeFormatter formatter) throws SQLException {
         if (source == null) return null;
-        if (formatter == null)
-            formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.TIMESTAMP);
+        if (formatter == null) {
+            if (format == null || format.equals(defaultTimestampFormatString))
+                formatter = defaultTimestampFormatter;
+            else
+                formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.TIMESTAMP);
+        }
         return Timestamp.valueOf(stringWithFormatToLocalDateTime(source, formatter));
     }
 
@@ -78,8 +84,13 @@ public class SpliceDateFunctions {
     public static Timestamp
     TO_TIMESTAMP(String source, String format, ZoneId zoneId) throws SQLException {
         if (source == null) return null;
-        SpliceDateTimeFormatter formatter =
-          new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.TIMESTAMP);
+        SpliceDateTimeFormatter formatter;
+        if (zoneId == null &&
+            (format == null || format.equals(defaultTimestampFormatString)))
+            formatter = defaultTimestampFormatter;
+        else
+            formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.TIMESTAMP);
+
         if (zoneId != null)
             formatter.setFormatter(formatter.getFormatter().withZone(zoneId));
 
@@ -102,7 +113,12 @@ public class SpliceDateFunctions {
 
     public static Time TO_TIME(String source, String format, ZoneId zoneId) throws SQLException {
         if (source == null) return null;
-        SpliceDateTimeFormatter formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.TIME);
+        SpliceDateTimeFormatter formatter;
+        if (zoneId == null &&
+            (format == null || format.equals(defaultTimeFormatString)))
+            formatter = defaultTimeFormatter;
+        else
+            formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.TIME);
         if (zoneId != null)
             formatter.setFormatter(formatter.getFormatter().withZone(zoneId));
         if (formatter.isTimeOnlyFormat())
@@ -125,8 +141,12 @@ public class SpliceDateFunctions {
 
     public static Time TO_TIME(String source, String format, SpliceDateTimeFormatter formatter) throws SQLException {
         if (source == null) return null;
-        if (formatter == null)
-            formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.TIME);
+        if (formatter == null) {
+            if (format == null || format.equals(defaultTimeFormatString))
+                formatter = defaultTimeFormatter;
+            else
+                formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.TIME);
+        }
         if (formatter.isTimeOnlyFormat())
             return Time.valueOf(stringWithFormatToLocalTime(source, formatter));
 
@@ -162,7 +182,12 @@ public class SpliceDateFunctions {
 
     public static Date TO_DATE(String source, String format, ZoneId zoneId) throws SQLException {
         if (source == null) return null;
-        SpliceDateTimeFormatter formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.DATE);
+        SpliceDateTimeFormatter formatter;
+        if (zoneId == null &&
+            (format == null || format.equals(defaultDateFormatString)))
+            formatter = defaultDateFormatter;
+        else
+            formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.DATE);
         if (zoneId != null)
             formatter.setFormatter(formatter.getFormatter().withZone(zoneId));
 
@@ -184,9 +209,12 @@ public class SpliceDateFunctions {
 
     public static Date TO_DATE(String source, String format, SpliceDateTimeFormatter formatter) throws SQLException {
         if (source == null) return null;
-        if (formatter == null)
-            formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.DATE);
-
+        if (formatter == null) {
+            if (format == null || format.equals(defaultDateFormatString))
+                formatter = defaultDateFormatter;
+            else
+                formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.DATE);
+        }
         // First, try to parse a DateTime.  If unable to, try to parse a date-only value.
         // If we succeed with a parse-only format, set a flag to avoid the work of attempting to
         // parse a full timestamp the next time around.

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateFunctions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateFunctions.java
@@ -63,7 +63,7 @@ public class SpliceDateFunctions {
         if (source == null) return null;
         if (formatter == null) {
             if (format == null || format.equals(defaultTimestampFormatString))
-                formatter = defaultTimestampFormatter;
+                formatter = DEFAULT_TIMESTAMP_FORMATTER;
             else
                 formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.TIMESTAMP);
         }
@@ -87,7 +87,7 @@ public class SpliceDateFunctions {
         SpliceDateTimeFormatter formatter;
         if (zoneId == null &&
             (format == null || format.equals(defaultTimestampFormatString)))
-            formatter = defaultTimestampFormatter;
+            formatter = DEFAULT_TIMESTAMP_FORMATTER;
         else
             formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.TIMESTAMP);
 
@@ -116,7 +116,7 @@ public class SpliceDateFunctions {
         SpliceDateTimeFormatter formatter;
         if (zoneId == null &&
             (format == null || format.equals(defaultTimeFormatString)))
-            formatter = defaultTimeFormatter;
+            formatter = DEFAULT_TIME_FORMATTER;
         else
             formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.TIME);
         if (zoneId != null)
@@ -143,7 +143,7 @@ public class SpliceDateFunctions {
         if (source == null) return null;
         if (formatter == null) {
             if (format == null || format.equals(defaultTimeFormatString))
-                formatter = defaultTimeFormatter;
+                formatter = DEFAULT_TIME_FORMATTER;
             else
                 formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.TIME);
         }
@@ -185,7 +185,7 @@ public class SpliceDateFunctions {
         SpliceDateTimeFormatter formatter;
         if (zoneId == null &&
             (format == null || format.equals(defaultDateFormatString)))
-            formatter = defaultDateFormatter;
+            formatter = DEFAULT_DATE_FORMATTER;
         else
             formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.DATE);
         if (zoneId != null)
@@ -211,7 +211,7 @@ public class SpliceDateFunctions {
         if (source == null) return null;
         if (formatter == null) {
             if (format == null || format.equals(defaultDateFormatString))
-                formatter = defaultDateFormatter;
+                formatter = DEFAULT_DATE_FORMATTER;
             else
                 formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.DATE);
         }

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateFunctions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateFunctions.java
@@ -215,6 +215,9 @@ public class SpliceDateFunctions {
             else
                 formatter = new SpliceDateTimeFormatter(format, SpliceDateTimeFormatter.FormatterType.DATE);
         }
+        if (formatter.isDateOnlyFormat())
+            return stringWithFormatToDate(source, formatter);
+
         // First, try to parse a DateTime.  If unable to, try to parse a date-only value.
         // If we succeed with a parse-only format, set a flag to avoid the work of attempting to
         // parse a full timestamp the next time around.

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateTimeFormatter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateTimeFormatter.java
@@ -39,12 +39,12 @@ public class SpliceDateTimeFormatter {
     public static final String defaultTimeFormatString = "HH:mm:ss";
     public static final String defaultTimestampFormatString = "yyyy-MM-dd HH:mm:ss";
 
-    public static SpliceDateTimeFormatter defaultDateFormatter =
-        new SpliceDateTimeFormatter(null, FormatterType.DATE);
-    public static SpliceDateTimeFormatter defaultTimeFormatter =
-        new SpliceDateTimeFormatter(null, FormatterType.TIME);
-    public static SpliceDateTimeFormatter defaultTimestampFormatter =
-        new SpliceDateTimeFormatter(null, FormatterType.TIMESTAMP);
+    public static SpliceDateTimeFormatter DEFAULT_DATE_FORMATTER =
+                  SpliceDateTimeFormatter.of(FormatterType.DATE);
+    public static SpliceDateTimeFormatter DEFAULT_TIME_FORMATTER =
+                  SpliceDateTimeFormatter.of(FormatterType.TIME);
+    public static SpliceDateTimeFormatter DEFAULT_TIMESTAMP_FORMATTER =
+                  SpliceDateTimeFormatter.of(FormatterType.TIMESTAMP);
 
     private FormatterType formatterType;
     private final String format;
@@ -82,6 +82,10 @@ public class SpliceDateTimeFormatter {
             formatterType = FormatterType.DATE;
         }
         formatterType = FormatterType.TIMESTAMP;
+    }
+
+    public static SpliceDateTimeFormatter of(FormatterType formatterType) {
+        return new SpliceDateTimeFormatter(null, formatterType);
     }
 
 /**

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateTimeFormatter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateTimeFormatter.java
@@ -35,6 +35,17 @@ public class SpliceDateTimeFormatter {
         TIME
     }
 
+    public static final String defaultDateFormatString = "yyyy-MM-dd";
+    public static final String defaultTimeFormatString = "HH:mm:ss";
+    public static final String defaultTimestampFormatString = "yyyy-MM-dd HH:mm:ss";
+
+    public static SpliceDateTimeFormatter defaultDateFormatter =
+        new SpliceDateTimeFormatter(null, FormatterType.DATE);
+    public static SpliceDateTimeFormatter defaultTimeFormatter =
+        new SpliceDateTimeFormatter(null, FormatterType.TIME);
+    public static SpliceDateTimeFormatter defaultTimestampFormatter =
+        new SpliceDateTimeFormatter(null, FormatterType.TIMESTAMP);
+
     private FormatterType formatterType;
     private final String format;
     private java.time.format.DateTimeFormatter formatter = null;
@@ -96,16 +107,16 @@ public class SpliceDateTimeFormatter {
             this.formatterType = formatterType;
             if (formatterType == FormatterType.DATE) {
                 format = "yyyy-M-d";
-                this.format = "yyyy-MM-dd";
+                this.format = defaultDateFormatString;
             }
             else if (formatterType == FormatterType.TIMESTAMP) {
                 format = "yyyy-M-d [H][:m][:s].SSSSSS";
-                this.format = "yyyy-MM-dd HH:mm:ss";
+                this.format = defaultTimestampFormatString;
                 needsTsRemoved = true;
             }
             else if (formatterType == FormatterType.TIME) {
                 format = "H:m:s";
-                this.format = "HH:mm:ss";
+                this.format = defaultTimeFormatString;
             }
             else {
                 // Leave the formatter uninitialized.

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateTimeFormatter.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateTimeFormatter.java
@@ -79,7 +79,7 @@ public class SpliceDateTimeFormatter {
                     " ISO8601 pattern such as, yyyy-MM-dd'T'HH:mm:ss.SSSZZ, yyyy-MM-dd'T'HH:mm:ssZ or yyyy-MM-dd",
                     SQLState.LANG_DATE_SYNTAX_EXCEPTION);
 
-            formatterType = FormatterType.TIME;
+            formatterType = FormatterType.DATE;
         }
         formatterType = FormatterType.TIMESTAMP;
     }


### PR DESCRIPTION
Fixes a performance regression in IMPORT_DATA due to DateTime formatters not being built when AbstractFileFunction is deserialized, causing a new SpliceDateTimeFormatter object to be built for every row which is imported.

I also added static formatters, which can be used if TO_DATE, TO_TIME or TO_TIMESTAMP are called with no format specified (which may help performance if these functions are used in a SELECT query reading many rows).