### PR TITLE
SPLICE-2377 Always use native spark broadcast join, if possible.

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
@@ -194,9 +194,15 @@ public class BroadcastJoinOperation extends JoinOperation{
 
         SConfiguration configuration= EngineDriver.driver().getConfiguration();
 
-        boolean useDataset = SpliceClient.isClient() ||
+        // Temporarily always use DataSet broadcast join, if it is legal,
+        // to avoid poor performance in large OLAP queries.
+        // SPLICE-2380 will remove this fix make the decision based
+        // on the number of tables in the query and other factors.
+        boolean useDataset = true ||
+                             SpliceClient.isClient() ||
                 rightResultSet.getEstimatedCost() / 1000 > configuration.getBroadcastDatasetCostThreshold() ||
                         rightResultSet.accessExternalTable();
+
         /** For semi-join, it is possible that the right side is a result from complex operations, like a sequence
          * of joins or some aggregations on top of base table. So heuristically it is better to go through the dataset implementation
          * if the rightResultSet is not a simple access of the base table


### PR DESCRIPTION
Temporary change to avoid poor-performing OLAP queries.

SPLICE-2380 will re-implement DB-5872 to avoid Dataset broadcast joins for many table queries (e.g. 100-table join queries) involving small tables with few rows.