### PR TITLE
DB-8655 Increase time allowed for splice to come up when running ITs.

### DIFF
--- a/splice_machine/src/test/java/com/splicemachine/test/SpliceTestPlatformWait.java
+++ b/splice_machine/src/test/java/com/splicemachine/test/SpliceTestPlatformWait.java
@@ -59,7 +59,7 @@ public class SpliceTestPlatformWait {
         int port = Integer.valueOf(arguments[1]);
 
 
-        if (!wait(hostname, port, 180L)) {
+        if (!wait(hostname, port, 360L)) {
             System.exit(-1);
         }
 


### PR DESCRIPTION
ITs run in Jenkins sporadically fail when multiple tests are run. It's worse now that we have 4 releases to build.  Increasing the timeout will give enough time for splice to come up.