### PR TITLE
DB-8579: fixed false positives in tpch1 on account of the rounding changes in SPLICE-2302

### DIFF
--- a/platform_it/src/test/jmeter/tpch1.jmx
+++ b/platform_it/src/test/jmeter/tpch1.jmx
@@ -2184,11 +2184,11 @@ order by
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="response assertion" enabled="true">
             <collectionProp name="Asserion.test_strings">
-              <stringProp name="-1511144821">L_RETURNFLAG	L_LINESTATUS	SUM_QTY	SUM_BASE_PRICE	SUM_DISC_PRICE	SUM_CHARGE	AVG_QTY	AVG_PRICE	AVG_DISC	COUNT_ORDER
-A	F	37734107.00	56586554400.73	53758257134.8700	55909065222.827692	25.5220	38273.1297	0.0499	1478493
-N	F	991417.00	1487504710.38	1413082168.0541	1469649223.194375	25.5164	38284.4677	0.0500	38854
-N	O	74476040.00	111701729697.74	106118230307.6056	110367043872.497010	25.5022	38249.1179	0.0499	2920374
-R	F	37719753.00	56568041380.90	53741292684.6040	55889619119.831932	25.5057	38250.8546	0.0500	1478870
+              <stringProp name="-2080553801">L_RETURNFLAG	L_LINESTATUS	SUM_QTY	SUM_BASE_PRICE	SUM_DISC_PRICE	SUM_CHARGE	AVG_QTY	AVG_PRICE	AVG_DISC	COUNT_ORDER
+A	F	37734107.00	56586554400.73	53758257134.8700	55909065222.827692	25.5220	38273.1297	0.0500	1478493
+N	F	991417.00	1487504710.38	1413082168.0541	1469649223.194375	25.5165	38284.4678	0.0501	38854
+N	O	74476040.00	111701729697.74	106118230307.6056	110367043872.497010	25.5022	38249.1180	0.0500	2920374
+R	F	37719753.00	56568041380.90	53741292684.6040	55889619119.831932	25.5058	38250.8546	0.0500	1478870
 </stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -2678,9 +2678,9 @@ order by
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="response assertion" enabled="true">
             <collectionProp name="Asserion.test_strings">
-              <stringProp name="1776068021">O_YEAR	MKT_SHARE
+              <stringProp name="1776068052">O_YEAR	MKT_SHARE
 1995	0.0344
-1996	0.0414
+1996	0.0415
 </stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -4488,8 +4488,8 @@ where
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="response assertion" enabled="true">
             <collectionProp name="Asserion.test_strings">
-              <stringProp name="1800425523">PROMO_REVENUE
-16.3807
+              <stringProp name="1800425554">PROMO_REVENUE
+16.3808
 </stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -22980,8 +22980,8 @@ where
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="response assertion" enabled="true">
             <collectionProp name="Asserion.test_strings">
-              <stringProp name="2140744975">AVG_YEARLY
-348406.0542
+              <stringProp name="2140745006">AVG_YEARLY
+348406.0543
 </stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>


### PR DESCRIPTION
tested on against splice standalone master 3.1.0.1928-SNAPSHOT, attempting to fix the following build pipeline error:
http://nexus.splicemachine.com:8080/job/spliceengine-master/job/test-tpch1-spliceengine-master/1418/platform=cdh5.12.2/artifact/platform_it/src/test/jmeter/logs/tpch1/assertion-results.html