### PR TITLE
Revert "SPLICE-2377 Always use native spark broadcast join, if possible (3.0)"

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
@@ -194,15 +194,9 @@ public class BroadcastJoinOperation extends JoinOperation{
 
         SConfiguration configuration= EngineDriver.driver().getConfiguration();
 
-        // Temporarily always use DataSet broadcast join, if it is legal,
-        // to avoid poor performance in large OLAP queries.
-        // SPLICE-2380 will remove this fix make the decision based
-        // on the number of tables in the query and other factors.
-        boolean useDataset = true ||
-                             SpliceClient.isClient() ||
+        boolean useDataset = SpliceClient.isClient() ||
                 rightResultSet.getEstimatedCost() / 1000 > configuration.getBroadcastDatasetCostThreshold() ||
                         rightResultSet.accessExternalTable();
-
         /** For semi-join, it is possible that the right side is a result from complex operations, like a sequence
          * of joins or some aggregations on top of base table. So heuristically it is better to go through the dataset implementation
          * if the rightResultSet is not a simple access of the base table


### PR DESCRIPTION
Reverts splicemachine/spliceengine#2845
Causes a regression on HBase 2.0, documented in [DB-8660](https://splicemachine.atlassian.net/browse/DB-8660)