### PR TITLE
DB-8677 Comment out ZK maven debugging option to avoid IT hangs.

### DIFF
--- a/platform_it/pom.xml
+++ b/platform_it/pom.xml
@@ -672,7 +672,9 @@
                                 <argument>-XX:MinHeapFreeRatio=10</argument>
                                 <argument>-XX:MaxHeapFreeRatio=50</argument>
                                 <argument>-XX:+CMSClassUnloadingEnabled</argument>
+                                <!-- Uncomment this to enable debugging of zookeeper on standalone via port 4002
                                 <argument>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=4002</argument>
+                                  -->
                                 <argument>org.apache.zookeeper.server.ZooKeeperServerMain</argument>
                                 <argument>2181</argument>
                                 <argument>${project.build.directory}/zookeeper</argument>


### PR DESCRIPTION
Zookeeper fails to start during some IT runs, causing failures.
The following was seen in the logs: 
> Listening for transport dt_socket at address: 4002

Sometimes this situation causes the process to suspend until the debugger is attached, even though "suspend=n" is specified.