### PR TITLE
SPLICE-1504 Skip compaction of external tables.

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.derby.impl.sql.execute.operations;
 
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
@@ -2974,6 +2975,14 @@ public class ExternalTableIT extends SpliceUnitTest{
         }
     }
 
+    @Test
+    public void testCompactionIgnoresExternalTables() throws Exception {
+        try {
+            methodWatcher.executeUpdate(String.format("CALL SYSCS_UTIL.SYSCS_PERFORM_MAJOR_COMPACTION_ON_SCHEMA('%s')",SCHEMA_NAME));
+        } catch (SQLException | StandardException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     public static class ExtThread extends Thread{
         private TestConnection conn;


### PR DESCRIPTION
Calling SYSCS_PERFORM_MAJOR_COMPACTION_ON_SCHEMA attempts to perform major compaction on the all tables in the schema, including external tables, which errors out since external tables aren't backed by HBase tables.  This causes compaction to not run on all tables in the schema.

`create external table t1 (a int, b int)
STORED AS PARQUET
LOCATION '/tmp/t1';

CALL SYSCS_UTIL.SYSCS_PERFORM_MAJOR_COMPACTION_ON_SCHEMA('MWS');

splice> ERROR SE001: Splice Engine exception: unexpected exception
ERROR XJ001: Java exception: 'splice:3536: org.apache.hadoop.hbase.TableNotFoundException'.

`