### PR TITLE
SPLICE-2362 Native Spark join with inequality conditions.

### DIFF
--- a/db-engine/pom.xml
+++ b/db-engine/pom.xml
@@ -77,6 +77,18 @@
             <version>2.2.2</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <!-- org.spark_project.guava -->
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-network-common_${scala.binary.version}</artifactId>

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
@@ -1202,7 +1202,8 @@ public interface ResultSetFactory {
 											  double optimizerEstimatedRowCount,
 											  double optimizerEstimatedCost,
 											  String userSuppliedOptimizerOverrides,
-											  String explainPlan)
+											  String explainPlan,
+											  String sparkExpressionTreeAsString)
 			throws StandardException;
 
 	NoPutResultSet getCrossJoinResultSet(NoPutResultSet leftResultSet,
@@ -1219,7 +1220,8 @@ public interface ResultSetFactory {
 											  double optimizerEstimatedRowCount,
 											  double optimizerEstimatedCost,
 											  String userSuppliedOptimizerOverrides,
-											  String explainPlan)
+											  String explainPlan,
+											  String sparkExpressionTreeAsString)
 			throws StandardException;
 
 	NoPutResultSet getMergeSortJoinResultSet(NoPutResultSet leftResultSet,
@@ -1236,7 +1238,8 @@ public interface ResultSetFactory {
 											 double optimizerEstimatedRowCount,
 											 double optimizerEstimatedCost,
 											 String userSuppliedOptimizerOverrides,
-											 String explainPlan)
+											 String explainPlan,
+											 String sparkExpressionTreeAsString)
 			throws StandardException;
 
 	NoPutResultSet getHalfMergeSortJoinResultSet(NoPutResultSet leftResultSet,
@@ -1253,7 +1256,8 @@ public interface ResultSetFactory {
 												 double optimizerEstimatedRowCount,
 												 double optimizerEstimatedCost,
 												 String userSuppliedOptimizerOverrides,
-												 String explainPlan)
+												 String explainPlan,
+												 String sparkExpressionTreeAsString)
 			throws StandardException;
 
     NoPutResultSet getMergeJoinResultSet(NoPutResultSet leftResultSet,
@@ -1272,7 +1276,8 @@ public interface ResultSetFactory {
 										 double optimizerEstimatedRowCount,
 										 double optimizerEstimatedCost,
 										 String userSuppliedOptimizerOverrides,
-										 String explainPlan)
+										 String explainPlan,
+										 String sparkExpressionTreeAsString)
 					   throws StandardException;
 
     NoPutResultSet getBroadcastJoinResultSet(NoPutResultSet leftResultSet,
@@ -1289,7 +1294,8 @@ public interface ResultSetFactory {
 											 double optimizerEstimatedRowCount,
 											 double optimizerEstimatedCost,
 											 String userSuppliedOptimizerOverrides,
-											 String explainPlan)
+											 String explainPlan,
+					                                                 String sparkExpressionTreeAsString)
 			           throws StandardException;
 
 	/**
@@ -1343,7 +1349,8 @@ public interface ResultSetFactory {
 													   double optimizerEstimatedRowCount,
 													   double optimizerEstimatedCost,
 													   String userSuppliedOptimizerOverrides,
-													   String explainPlan)
+													   String explainPlan,
+													   String sparkExpressionTreeAsString)
 			throws StandardException;
 
 	/**
@@ -1392,7 +1399,8 @@ public interface ResultSetFactory {
 												 double optimizerEstimatedRowCount,
 												 double optimizerEstimatedCost,
 												 String userSuppliedOptimizerOverrides,
-												 String explainPlan)
+												 String explainPlan,
+												 String sparkExpressionTreeAsString)
 			throws StandardException;
 
 	/**
@@ -1487,7 +1495,8 @@ public interface ResultSetFactory {
 													  double optimizerEstimatedRowCount,
 													  double optimizerEstimatedCost,
 													  String userSuppliedOptimizerOverrides,
-													  String explainPlan)
+													  String explainPlan,
+													  String sparkExpressionTreeAsString)
 			throws StandardException;
 
 	NoPutResultSet getHalfMergeSortLeftOuterJoinResultSet(NoPutResultSet leftResultSet,
@@ -1506,7 +1515,178 @@ public interface ResultSetFactory {
 														  double optimizerEstimatedRowCount,
 														  double optimizerEstimatedCost,
 														  String userSuppliedOptimizerOverrides,
-														  String explainPlan)
+														  String explainPlan,
+														  String sparkExpressionTreeAsString)
+			throws StandardException;
+
+	NoPutResultSet getMergeLeftOuterJoinResultSet(NoPutResultSet leftResultSet,
+												  int leftNumCols,
+												  NoPutResultSet rightResultSet,
+												  int rightNumCols,
+												  int leftHashKeyItem,
+												  int rightHashKeyItem,
+												  int rightHashKeyToBaseTableMapItem,
+												  int rightHashKeySortOrderItem,
+												  GeneratedMethod joinClause,
+												  int resultSetNUmber,
+												  GeneratedMethod emptyRowFun,
+												  boolean wasRightOuterJoin,
+												  boolean oneRowRightSide,
+												  boolean noExistsRightSide,
+												  boolean rightFromSSQ,
+												  double optimizerEstimatedRowCount,
+												  double optimizerEstimatedCost,
+												  String userSuppliedOptimizerOverrides,
+												  String explainPlan,
+												  String sparkExpressionTreeAsString)
+	throws StandardException;
+
+	NoPutResultSet getBroadcastLeftOuterJoinResultSet(NoPutResultSet leftResultSet,
+													  int leftNumCols,
+													  NoPutResultSet rightResultSet,
+													  int rightNumCols,
+													  int leftHashKeyItem,
+													  int rightHashKeyItem,
+													  GeneratedMethod joinClause,
+													  int resultSetNUmber,
+													  GeneratedMethod emptyRowFun,
+													  boolean wasRightOuterJoin,
+													  boolean oneRowRightSide,
+													  boolean noExistsRightSide,
+													  boolean rightFromSSQ,
+													  double optimizerEstimatedRowCount,
+													  double optimizerEstimatedCost,
+													  String userSuppliedOptimizerOverrides,
+													  String explainPlan,
+													  String sparkExpressionTreeAsString)
+	throws StandardException;
+
+	/**
+          Support old versions of getXXXJoinResultSet, so SHOW SCHEMAS and other statements
+	  which store these serialized objects on disk won't break upon upgrade.
+	 */
+
+	NoPutResultSet getNestedLoopJoinResultSet(NoPutResultSet leftResultSet,
+											  int leftNumCols,
+											  NoPutResultSet rightResultSet,
+											  int rightNumCols,
+											  GeneratedMethod joinClause,
+											  int resultSetNumber,
+											  boolean oneRowRightSide,
+											  boolean notExistsRightSide,
+											  boolean rightFromSSQ,
+											  double optimizerEstimatedRowCount,
+											  double optimizerEstimatedCost,
+											  String userSuppliedOptimizerOverrides,
+											  String explainPlan)
+			throws StandardException;
+
+	NoPutResultSet getCrossJoinResultSet(NoPutResultSet leftResultSet,
+											  int leftNumCols,
+											  NoPutResultSet rightResultSet,
+											  int rightNumCols,
+                                              int leftHashKeyItem,
+                                              int rightHashKeyItem,
+											  GeneratedMethod joinClause,
+											  int resultSetNumber,
+											  boolean oneRowRightSide,
+											  boolean notExistsRightSide,
+											  boolean rightFromSSQ,
+											  double optimizerEstimatedRowCount,
+											  double optimizerEstimatedCost,
+											  String userSuppliedOptimizerOverrides,
+											  String explainPlan)
+			throws StandardException;
+
+	NoPutResultSet getMergeSortJoinResultSet(NoPutResultSet leftResultSet,
+											 int leftNumCols,
+											 NoPutResultSet rightResultSet,
+											 int rightNumCols,
+											 int leftHashKeyItem,
+											 int rightHashKeyItem,
+											 GeneratedMethod joinClause,
+											 int resultSetNumber,
+											 boolean oneRowRightSide,
+											 boolean notExistsRightSide,
+											 boolean rightFromSSQ,
+											 double optimizerEstimatedRowCount,
+											 double optimizerEstimatedCost,
+											 String userSuppliedOptimizerOverrides,
+											 String explainPlan)
+			throws StandardException;
+
+
+    NoPutResultSet getMergeJoinResultSet(NoPutResultSet leftResultSet,
+										 int leftNumCols,
+										 NoPutResultSet rightResultSet,
+										 int rightNumCols,
+										 int leftHashKeyItem,
+										 int rightHashKeyItem,
+										 int rightHashKeyToBaseTableMapItem,
+										 int rightHashKeySortOrderItem,
+										 GeneratedMethod joinClause,
+										 int resultSetNumber,
+										 boolean oneRowRightSide,
+										 boolean notExistsRightSide,
+										 boolean rightFromSSQ,
+										 double optimizerEstimatedRowCount,
+										 double optimizerEstimatedCost,
+										 String userSuppliedOptimizerOverrides,
+										 String explainPlan)
+					   throws StandardException;
+
+    NoPutResultSet getBroadcastJoinResultSet(NoPutResultSet leftResultSet,
+											 int leftNumCols,
+											 NoPutResultSet rightResultSet,
+											 int rightNumCols,
+											 int leftHashKeyItem,
+											 int rightHashKeyItem,
+											 GeneratedMethod joinClause,
+											 int resultSetNumber,
+											 boolean oneRowRightSide,
+											 boolean notExistsRightSide,
+											 boolean rightFromSSQ,
+											 double optimizerEstimatedRowCount,
+											 double optimizerEstimatedCost,
+											 String userSuppliedOptimizerOverrides,
+											 String explainPlan)
+			           throws StandardException;
+
+
+	NoPutResultSet getNestedLoopLeftOuterJoinResultSet(NoPutResultSet leftResultSet,
+													   int leftNumCols,
+													   NoPutResultSet rightResultSet,
+													   int rightNumCols,
+													   GeneratedMethod joinClause,
+													   int resultSetNumber,
+													   GeneratedMethod emptyRowFun,
+													   boolean wasRightOuterJoin,
+													   boolean oneRowRightSide,
+													   boolean notExistsRightSide,
+													   boolean rightFromSSQ,
+													   double optimizerEstimatedRowCount,
+													   double optimizerEstimatedCost,
+													   String userSuppliedOptimizerOverrides,
+													   String explainPlan)
+			throws StandardException;
+
+	NoPutResultSet getMergeSortLeftOuterJoinResultSet(NoPutResultSet leftResultSet,
+													  int leftNumCols,
+													  NoPutResultSet rightResultSet,
+													  int rightNumCols,
+													  int leftHashKeyItem,
+													  int rightHashKeyItem,
+													  GeneratedMethod joinClause,
+													  int resultSetNUmber,
+													  GeneratedMethod emptyRowFun,
+													  boolean wasRightOuterJoin,
+													  boolean oneRowRightSide,
+													  boolean noExistsRightSide,
+													  boolean rightFromSSQ,
+													  double optimizerEstimatedRowCount,
+													  double optimizerEstimatedCost,
+													  String userSuppliedOptimizerOverrides,
+													  String explainPlan)
 			throws StandardException;
 
 	NoPutResultSet getMergeLeftOuterJoinResultSet(NoPutResultSet leftResultSet,
@@ -1528,7 +1708,7 @@ public interface ResultSetFactory {
 												  double optimizerEstimatedCost,
 												  String userSuppliedOptimizerOverrides,
 												  String explainPlan)
-	throws StandardException;
+			throws StandardException;
 
 	NoPutResultSet getBroadcastLeftOuterJoinResultSet(NoPutResultSet leftResultSet,
 													  int leftNumCols,

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AbstractSparkExpressionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AbstractSparkExpressionNode.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.parser.ParserInterface;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public abstract class AbstractSparkExpressionNode implements SparkExpressionNode
+{
+    protected SparkExpressionNode left;
+    protected SparkExpressionNode right;
+
+    protected int abstractSerializationVersion = 1;
+    protected int serializationVersion = 1;
+
+    @Override
+    public void setLeftChild(SparkExpressionNode left) {
+        this.left = left;
+    }
+
+    @Override
+    public void setRightChild(SparkExpressionNode right) {
+        this.right = right;
+    }
+
+    @Override
+    public SparkExpressionNode getLeftChild() { return left; }
+
+    @Override
+    public SparkExpressionNode getRightChild() { return right; }
+
+    @Override
+    public boolean isTrue() { return false; }
+
+    @Override
+    public boolean isFalse() { return false; }
+
+    @Override
+    public Column getColumnExpression(Dataset<Row> leftDF,
+                                      Dataset<Row> rightDF,
+                                      ParserInterface parser) throws UnsupportedOperationException{
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeInt(abstractSerializationVersion);
+        out.writeObject(left);
+        out.writeObject(right);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        abstractSerializationVersion = in.readInt();
+        left = (SparkExpressionNode)in.readObject();
+        right = (SparkExpressionNode)in.readObject();
+    }
+}
+
+

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AndNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AndNode.java
@@ -48,6 +48,7 @@ public class AndNode extends BinaryLogicalOperatorNode{
     public void init(Object leftOperand,Object rightOperand){
         super.init(leftOperand,rightOperand,"and");
         this.shortCircuitValue=false;
+        this.operatorType = AND;
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryOperatorNode.java
@@ -80,6 +80,7 @@ public class BinaryOperatorNode extends OperatorNode
 	public final static int AND	= 12;
 	public final static int OR	= 13;
 	public final static int LIKE	= 14;
+	public final static int MOD	= 15;
 
 	ValueNode	leftOperand;
 	ValueNode	rightOperand;
@@ -1059,5 +1060,7 @@ public class BinaryOperatorNode extends OperatorNode
 	}
 
 	public boolean isRepeat () { return this.operatorType == REPEAT; }
+
+	public int getOperatorType() { return operatorType; }
 }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
@@ -1208,7 +1208,16 @@ public class JoinNode extends TableOperatorNode{
 
         sparkExpressionTree = null;
         SparkExpressionNode tmpTree = null;
-        if (joinPredicates != null) {
+        JoinStrategy joinStrategy =
+         ((Optimizable)rightResultSet).getTrulyTheBestAccessPath().
+                                                 getJoinStrategy();
+        JoinStrategy.JoinStrategyType joinStrategyType =
+                                      joinStrategy.getJoinStrategyType();
+        boolean eligibleForNativeSpark =
+         (joinStrategyType == JoinStrategy.JoinStrategyType.MERGE_SORT ||
+          joinStrategyType == JoinStrategy.JoinStrategyType.BROADCAST);
+
+        if (joinPredicates != null && eligibleForNativeSpark) {
             for (int i = 0; i < joinPredicates.size(); i++) {
                 tmpTree =
                   OperatorToString.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
@@ -49,11 +49,15 @@ import com.splicemachine.db.iapi.util.PropertyUtil;
 import com.splicemachine.db.impl.ast.CollectingVisitor;
 import com.splicemachine.db.impl.ast.PredicateUtils;
 import com.splicemachine.db.impl.ast.RSUtils;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.SerializationUtils;
 import org.spark_project.guava.base.Joiner;
 import org.spark_project.guava.base.Predicates;
 import org.spark_project.guava.collect.Lists;
 
 import java.util.*;
+
+import static com.splicemachine.db.impl.sql.compile.BinaryOperatorNode.AND;
 
 /**
  * A JoinNode represents a join result set for either of the basic DML
@@ -73,6 +77,7 @@ public class JoinNode extends TableOperatorNode{
     public static final int FULLOUTERJOIN=5;
     public static final int UNIONJOIN=6;
     public PredicateList joinPredicates;
+    public SparkExpressionNode sparkExpressionTree = null;
     // Splice Additions
     public int[] leftHashKeys;
     public int[] rightHashKeys;
@@ -1200,10 +1205,32 @@ public class JoinNode extends TableOperatorNode{
                                 MethodBuilder mb,
                                 int joinType,
                                 ValueNode joinClause) throws StandardException{
-		
-		
-		/* Put the predicates back into the tree */
 
+        sparkExpressionTree = null;
+        SparkExpressionNode tmpTree = null;
+        if (joinPredicates != null) {
+            for (int i = 0; i < joinPredicates.size(); i++) {
+                tmpTree =
+                  OperatorToString.
+                    opToSparkExpressionTree(joinPredicates.elementAt(i).getAndNode(),
+                                            leftResultSet.getResultSetNumber(),
+                                            rightResultSet.getResultSetNumber());
+                if (tmpTree == null) {
+                    sparkExpressionTree = null;
+                    break;
+                }
+                if (i == 0)
+                    sparkExpressionTree = tmpTree;
+                else
+                    sparkExpressionTree =
+                       SparkLogicalOperator.
+                         getNewSparkLogicalOperator(AND, sparkExpressionTree, tmpTree);
+            }
+        }
+        else
+            sparkExpressionTree = null;
+
+        /* Put the predicates back into the tree */
         if(joinPredicates!=null){
             // Pulling the equality predicate normal case from the restriction generation.
             if (rightHashKeys ==null || rightHashKeys.length != joinPredicates.size())
@@ -1234,6 +1261,7 @@ public class JoinNode extends TableOperatorNode{
 
         acb.pushGetResultSetFactoryExpression(mb);
         int nargs=getJoinArguments(acb,mb,joinClause);
+
         mb.callMethod(VMOpcode.INVOKEINTERFACE,null,joinResultSetString,ClassName.NoPutResultSet,nargs);
     }
 
@@ -1247,7 +1275,7 @@ public class JoinNode extends TableOperatorNode{
      * be overridden for other types of joins (for example, outer joins).
      */
     protected int getNumJoinArguments(){
-        return 13;
+        return 14;
     }
 
     /**
@@ -1924,6 +1952,14 @@ public class JoinNode extends TableOperatorNode{
             mb.pushNull("java.lang.String");
 
         mb.push(printExplainInformationForActivation());
+
+        if (sparkExpressionTree != null) {
+            String sparkExpressionTreeAsString =
+                    Base64.encodeBase64String(SerializationUtils.serialize(sparkExpressionTree));
+            mb.push(sparkExpressionTreeAsString);
+        }
+        else
+            mb.pushNull("java.lang.String");
 
         return numArgs;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
@@ -36,18 +36,15 @@ import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.sql.compile.OptimizablePredicate;
 import com.splicemachine.db.iapi.types.*;
-import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.system.SimpleSparkVersion;
 import com.splicemachine.system.SparkVersion;
 import org.apache.commons.lang3.mutable.MutableInt;
-
-import java.security.acl.Group;
 
 import static com.splicemachine.db.iapi.reference.Property.SPLICE_SPARK_COMPILE_VERSION;
 import static com.splicemachine.db.iapi.reference.Property.SPLICE_SPARK_VERSION;
 import static com.splicemachine.db.iapi.services.io.StoredFormatIds.*;
 import static java.lang.String.format;
-
+import static com.splicemachine.db.impl.sql.compile.SparkConstantExpression.SpecialValue;
 /**
  * Utility to get the string representation of a given operator.
  * <p/>
@@ -58,14 +55,25 @@ public class OperatorToString {
     public boolean      sparkExpression;
     public SparkVersion sparkVersion;
     public MutableInt   relationalOpDepth;
+    public SparkExpressionNode sparkExpressionTree;
+    public boolean buildExpressionTree;
+    public int leftResultSetNumber;
+    public int rightResultSetNumber;
 
     private static final SparkVersion spark_2_3_0 = new SimpleSparkVersion("2.3.0");
 
     OperatorToString(boolean    sparkExpression,
-                     MutableInt relationalOpDepth) {
+                     MutableInt relationalOpDepth,
+                     boolean    buildExpressionTree,
+                     int        leftResultSetNumber,
+                     int        rightResultSetNumber) {
         this.sparkExpression   = sparkExpression;
         this.sparkVersion      = getSparkVersion();
         this.relationalOpDepth = relationalOpDepth;
+        this.sparkExpressionTree = null;
+        this.buildExpressionTree = buildExpressionTree;
+        this.leftResultSetNumber = leftResultSetNumber;
+        this.rightResultSetNumber = rightResultSetNumber;
     }
 
     /**
@@ -129,7 +137,8 @@ public class OperatorToString {
         try {
             OperatorToString vars =
                 new OperatorToString(false,
-                                     new MutableInt(0));
+                                     new MutableInt(0),
+                                     false, 0, 0);
             return opToString2(operand, vars);
         }
         catch(StandardException e) {
@@ -151,8 +160,42 @@ public class OperatorToString {
         try {
             OperatorToString vars =
                 new OperatorToString(true,
-                                     new MutableInt(0));
+                                     new MutableInt(0),
+                                     false, 0, 0);
             retval = opToString2(operand, vars);
+
+        }
+        catch (StandardException e) {
+            if (e.getSQLState() != SQLState.LANG_DOES_NOT_IMPLEMENT)
+                throw e;
+        }
+        return retval;
+    }
+
+    /**
+     * Return a tree representation of a spark SQL expression given a Derby SQL expression,
+     * with column references indicating column names in the source DataFrame, and whether
+     * the source DataFrame is the left operation or the right operation (e.g. of a join).
+     */
+    public static SparkExpressionNode
+    opToSparkExpressionTree(ValueNode operand,
+                            int leftResultSetNumber,
+                            int rightResultSetNumber) throws StandardException {
+        SparkExpressionNode retval = null;
+
+        // Do not throw any errors encountered.  An error condition
+        // just means we can't generate a valid spark representation
+        // of the SQL expression to apply to a native spark Dataset,
+        // so should not be considered a fatal error.
+        try {
+            OperatorToString vars =
+                new OperatorToString(true,
+                                     new MutableInt(0),
+                                     true,
+                                     leftResultSetNumber,
+                                     rightResultSetNumber);
+            opToString2(operand, vars);
+            retval = vars.sparkExpressionTree;
 
         }
         catch (StandardException e) {
@@ -239,9 +282,14 @@ public class OperatorToString {
                                       OperatorToString vars) throws StandardException {
         if(operand==null){
             return "";
-        } else if (operand instanceof UntypedNullConstantNode)
+        } else if (operand instanceof UntypedNullConstantNode) {
+            if (vars.buildExpressionTree)
+                throwNotImplementedError();
             return " null ";
+        }
         else if(operand instanceof UnaryOperatorNode){
+            if (vars.buildExpressionTree)
+                throwNotImplementedError();
             UnaryOperatorNode uop=(UnaryOperatorNode)operand;
             String operatorString = uop.getOperatorString();
             if (vars.sparkExpression) {
@@ -306,13 +354,28 @@ public class OperatorToString {
             vars.relationalOpDepth.increment();
             BinaryRelationalOperatorNode bron=(BinaryRelationalOperatorNode)operand;
             try {
+                SparkExpressionNode leftExpr, rightExpr, resultExpr = null;
                 InListOperatorNode inListOp = bron.getInListOp();
-                if (inListOp != null) return opToString2(inListOp, vars);
-    
+
+                if (inListOp != null) {
+                    if (vars.buildExpressionTree)
+                        throwNotImplementedError();
+                    return opToString2(inListOp, vars);
+                }
+                String leftOperandString = opToString2(bron.getLeftOperand(), vars);
+                leftExpr = vars.sparkExpressionTree;
+                String rightOperandString = opToString2(bron.getRightOperand(), vars);
+                rightExpr = vars.sparkExpressionTree;
                 String opString =
-                        format("(%s %s %s)", opToString2(bron.getLeftOperand(), vars),
-                               bron.getOperatorString(), opToString2(bron.getRightOperand(), vars));
+                        format("(%s %s %s)", leftOperandString,
+                               bron.getOperatorString(), rightOperandString);
                 vars.relationalOpDepth.decrement();
+                if (vars.buildExpressionTree) {
+                    resultExpr =
+                        new SparkRelationalOperator(bron.getOperator(),
+                                                    leftExpr, rightExpr);
+                    vars.sparkExpressionTree = resultExpr;
+                }
                 return opString;
             }
             catch (StandardException e) {
@@ -322,6 +385,8 @@ public class OperatorToString {
                     return "PARSE_ERROR_WHILE_CONVERTING_OPERATOR";
             }
         }else if(operand instanceof BinaryListOperatorNode){
+            if (vars.buildExpressionTree)
+                throwNotImplementedError();
             vars.relationalOpDepth.increment();
             BinaryListOperatorNode blon = (BinaryListOperatorNode)operand;
             StringBuilder inList = new StringBuilder("(");
@@ -350,17 +415,29 @@ public class OperatorToString {
             vars.relationalOpDepth.decrement();
             return retval;
         }else if (operand instanceof BinaryOperatorNode) {
+
             BinaryOperatorNode bop = (BinaryOperatorNode) operand;
             ValueNode leftOperand = bop.getLeftOperand();
             ValueNode rightOperand = bop.getRightOperand();
+            SparkExpressionNode leftExpr = null, rightExpr = null, resultExpr = null;
             String leftOperandString = opToString2(leftOperand, vars);
+            if (vars.buildExpressionTree)
+                leftExpr = vars.sparkExpressionTree;
             String rightOperandString = opToString2(rightOperand, vars);
+            if (vars.buildExpressionTree)
+                rightExpr = vars.sparkExpressionTree;
 
             if (vars.sparkExpression) {
-                if (operand instanceof ConcatenationOperatorNode)
+
+                if (operand instanceof ConcatenationOperatorNode) {
+                    if (vars.buildExpressionTree)
+                        throwNotImplementedError();
                     return format("concat(%s, %s) ", opToString2(leftOperand, vars),
-                                                    opToString2(rightOperand, vars));
+                                                     opToString2(rightOperand, vars));
+                }
                 else if (operand instanceof TruncateOperatorNode) {
+                    if (vars.buildExpressionTree)
+                        throwNotImplementedError();
                     if (leftOperand.getTypeId().getTypeFormatId() == DATE_TYPE_ID) {
                         return format("trunc(%s, %s) ", opToString2(leftOperand, vars),
                                                        opToString2(rightOperand, vars));
@@ -404,14 +481,26 @@ public class OperatorToString {
                     }
                     if (doCast) {
                         if (leftOperand.getTypeServices().getTypeId().typePrecedence() >
-                            rightOperand.getTypeServices().getTypeId().typePrecedence())
+                            rightOperand.getTypeServices().getTypeId().typePrecedence()) {
                             leftOperandString = format("CAST(%s as %s) ",
-                                                        leftOperandString,
-                                                        targetType);
-                        else
+                                                       leftOperandString,
+                                                       targetType);
+                            if (vars.buildExpressionTree)
+                                leftExpr = new SparkCastNode(leftExpr, targetType);
+                        }
+                        else {
                             rightOperandString = format("CAST(%s as %s) ",
                                                          rightOperandString,
                                                          targetType);
+                            if (vars.buildExpressionTree)
+                                rightExpr = new SparkCastNode(rightExpr, targetType);
+                        }
+                    }
+                    if (vars.buildExpressionTree) {
+                        resultExpr =
+                           new SparkArithmeticOperator
+                                (bao.getOperatorString(), leftExpr, rightExpr);
+                        vars.sparkExpressionTree = resultExpr;
                     }
 
                     // Though documented as supported by spark, mod
@@ -426,17 +515,29 @@ public class OperatorToString {
                               getAllowOverflowSensitiveNativeSparkExpressions())
                         throwNotImplementedError();
                     else if (bao.getOperatorString() == "+") {
-                        if (leftOperand.getTypeId().getTypeFormatId() == DATE_TYPE_ID)
+                        if (leftOperand.getTypeId().getTypeFormatId() == DATE_TYPE_ID) {
+                            if (vars.buildExpressionTree)
+                                throwNotImplementedError();
                             return format("date_add(%s, %s) ", opToString2(leftOperand, vars),
                             opToString2(rightOperand, vars));
+                        }
+                        else if (leftOperand.getTypeId().getTypeFormatId() == TIMESTAMP_TYPE_ID)
+                            throwNotImplementedError();
                     }
                     else if (bao.getOperatorString() == "-") {
-                        if (leftOperand.getTypeId().getTypeFormatId() == DATE_TYPE_ID)
+                        if (leftOperand.getTypeId().getTypeFormatId() == DATE_TYPE_ID) {
+                            if (vars.buildExpressionTree)
+                                throwNotImplementedError();
                             return format("date_sub(%s, %s) ", opToString2(leftOperand, vars),
                             opToString2(rightOperand, vars));
+                        }
+                        else if (leftOperand.getTypeId().getTypeFormatId() == TIMESTAMP_TYPE_ID)
+                            throwNotImplementedError();
                     }
                 }
                 else if (operand.getClass() == BinaryOperatorNode.class) {
+                    if (vars.buildExpressionTree)
+                        throwNotImplementedError();
                     if (((BinaryOperatorNode) operand).isRepeat()) {
                         return format("%s(%s, %s) ", bop.getOperatorString(),
                           opToString2(bop.getLeftOperand(), vars), opToString2(bop.getRightOperand(), vars));
@@ -444,6 +545,15 @@ public class OperatorToString {
                 }
                 else if (operand instanceof TimestampOperatorNode ||
                          operand instanceof SimpleLocaleStringOperatorNode)
+                    throwNotImplementedError();
+                else if (vars.buildExpressionTree && operand instanceof BinaryLogicalOperatorNode) {
+                    BinaryLogicalOperatorNode blon = (BinaryLogicalOperatorNode) operand;
+                    resultExpr =
+                        SparkLogicalOperator.getNewSparkLogicalOperator
+                            (blon.getOperatorType(), leftExpr, rightExpr);
+                    vars.sparkExpressionTree = resultExpr;
+                }
+                else if (vars.buildExpressionTree)
                     throwNotImplementedError();
             }
 
@@ -463,18 +573,27 @@ public class OperatorToString {
                 // which could hide the overflow.
                 if (!operand.getCompilerContext().getAllowOverflowSensitiveNativeSparkExpressions())
                     throwNotImplementedError();
+
                 expressionString = format("CAST(%s as %s) ",
                                            expressionString,
                                            operand.getTypeServices().toSparkString());
+                if (vars.buildExpressionTree)
+                    vars.sparkExpressionTree =
+                        new SparkCastNode(vars.sparkExpressionTree,
+                                          operand.getTypeServices().toSparkString());
             }
             return expressionString;
         } else if (operand instanceof ArrayOperatorNode) {
+            if (vars.buildExpressionTree)
+                throwNotImplementedError();
             if (vars.sparkExpression)
                 throwNotImplementedError();
             ArrayOperatorNode array = (ArrayOperatorNode) operand;
             ValueNode op = array.operand;
             return format("%s[%d]", op == null ? "" : opToString2(op, vars), array.extractField);
         } else if (operand instanceof TernaryOperatorNode) {
+            if (vars.buildExpressionTree)
+                throwNotImplementedError();
             TernaryOperatorNode top = (TernaryOperatorNode) operand;
             ValueNode rightOp = top.getRightOperand();
             if (vars.sparkExpression) {
@@ -532,6 +651,8 @@ public class OperatorToString {
                           opToString2(top.getLeftOperand(), vars), rightOp == null ? "" : ", " + opToString2(rightOp, vars));
         }
         else if (operand instanceof ArrayConstantNode) {
+            if (vars.buildExpressionTree)
+                throwNotImplementedError();
             vars.relationalOpDepth.increment();
             if (vars.sparkExpression)
                 throwNotImplementedError();;
@@ -549,6 +670,8 @@ public class OperatorToString {
             vars.relationalOpDepth.decrement();
             return builder.toString();
         } else if (operand instanceof ListValueNode) {
+            if (vars.buildExpressionTree)
+                throwNotImplementedError();
             vars.relationalOpDepth.increment();
             if (vars.sparkExpression)
                 throwNotImplementedError();;
@@ -578,7 +701,20 @@ public class OperatorToString {
                 if (!sparkSupportedType(cr.getTypeId().getTypeFormatId(), operand))
                     throwNotImplementedError();
 
-                return format("c%d ", source.getVirtualColumnId()-1);
+                String columnString = format("c%d", source.getVirtualColumnId()-1);
+                if (vars.buildExpressionTree) {
+                    boolean leftDataFrame;
+                    int rsn =  source.getResultSetNumber();
+                    if (rsn != vars.leftResultSetNumber &&
+                        rsn != vars.rightResultSetNumber)
+                        opToString2(source.getExpression(), vars);
+                    else {
+                        leftDataFrame = (rsn == vars.leftResultSetNumber);
+                        vars.sparkExpressionTree =
+                        new SparkColumnReference(columnString, leftDataFrame);
+                    }
+                }
+                return columnString;
             }
         } else if (operand instanceof VirtualColumnNode) {
             VirtualColumnNode vcn = (VirtualColumnNode) operand;
@@ -593,9 +729,24 @@ public class OperatorToString {
                 if (!sparkSupportedType(operand.getTypeId().getTypeFormatId(), operand))
                     throwNotImplementedError();
 
-                return format("c%d ", source.getVirtualColumnId()-1);
+                String columnString = format("c%d", source.getVirtualColumnId()-1);
+                if (vars.buildExpressionTree) {
+                    boolean leftDataFrame;
+                    int rsn =  source.getResultSetNumber();
+                    if (rsn != vars.leftResultSetNumber &&
+                        rsn != vars.rightResultSetNumber)
+                        opToString2(source.getExpression(), vars);
+                    else {
+                        leftDataFrame = (rsn == vars.leftResultSetNumber);
+                        vars.sparkExpressionTree =
+                        new SparkColumnReference(columnString, leftDataFrame);
+                    }
+                }
+                return columnString;
             }
         } else if (operand instanceof SubqueryNode) {
+            if (vars.buildExpressionTree)
+                throwNotImplementedError();
             if (vars.sparkExpression)
                 throwNotImplementedError();
             SubqueryNode subq = (SubqueryNode) operand;
@@ -638,6 +789,23 @@ public class OperatorToString {
                 }
                 else
                     str = cn.getValue().getString();
+
+                if (vars.buildExpressionTree) {
+                    SpecialValue sv = SpecialValue.NONE;
+                    if (dvd == null)
+                        sv = SpecialValue.NULL;
+                    else if (cn instanceof BooleanConstantNode) {
+                        BooleanConstantNode bcn = (BooleanConstantNode) cn;
+                        if (bcn.isBooleanTrue())
+                            sv = SpecialValue.TRUE;
+                        else
+                            sv = SpecialValue.FALSE;
+                    }
+                    vars.sparkExpressionTree =
+                        new SparkConstantExpression(str, sv,
+                                                    cn.getTypeServices().
+                                                       toSparkString());
+                }
                 return str;
             } catch (StandardException se) {
                 if (vars.sparkExpression)
@@ -656,8 +824,11 @@ public class OperatorToString {
                     throwNotImplementedError();
 
                 sb.append(format("CAST(%s ", opToString2(castOperand, vars)));
+                SparkExpressionNode childExpression = vars.sparkExpressionTree;
+                String dataTypeString = null;
+
                 if (typeFormatId == LONGVARCHAR_TYPE_ID)
-                    sb.append("AS varchar(32670)) ");
+                    dataTypeString = "varchar(32670)";
                 else if (isNumericTypeFormatID(typeFormatId) &&
                          typeFormatId != DOUBLE_TYPE_ID      &&
                          !operand.getCompilerContext().
@@ -676,7 +847,16 @@ public class OperatorToString {
                     throwNotImplementedError();
                 }
                 else
-                    sb.append(format("AS %s) ", cn.getTypeServices().toSparkString()));
+                    dataTypeString = cn.getTypeServices().toSparkString();
+
+                if (vars.buildExpressionTree) {
+                    // Spark doesn't handle casting char to numeric very well.
+                    if (isNumericTypeFormatID(typeFormatId) &&
+                        !isNumericTypeFormatID(castOperand.getTypeId().getTypeFormatId()))
+                        throwNotImplementedError();
+                    vars.sparkExpressionTree = new SparkCastNode(childExpression, dataTypeString);
+                }
+                sb.append(format("AS %s) ", dataTypeString));
                 castString = sb.toString();
             }
             else
@@ -685,6 +865,8 @@ public class OperatorToString {
             return castString;
         }
         else if (operand instanceof CoalesceFunctionNode) {
+            if (vars.buildExpressionTree)
+                throwNotImplementedError();
             vars.relationalOpDepth.increment();
             StringBuilder sb = new StringBuilder();
             sb.append("coalesce(");
@@ -701,6 +883,8 @@ public class OperatorToString {
             return sb.toString();
         }
         else if (operand instanceof CurrentDatetimeOperatorNode) {
+            if (vars.buildExpressionTree)
+                throwNotImplementedError();
             CurrentDatetimeOperatorNode cdtOp = (CurrentDatetimeOperatorNode)operand;
             StringBuilder sb = new StringBuilder();
             if (cdtOp.isCurrentDate())
@@ -720,6 +904,8 @@ public class OperatorToString {
             return sb.toString();
         }
         else if (operand instanceof ConditionalNode) {
+            if (vars.buildExpressionTree)
+                throwNotImplementedError();
             vars.relationalOpDepth.increment();
             ConditionalNode cn = (ConditionalNode)operand;
             StringBuilder sb = new StringBuilder();
@@ -738,6 +924,8 @@ public class OperatorToString {
             return sb.toString();
         }
         else {
+            if (vars.buildExpressionTree)
+                throwNotImplementedError();
             if (vars.sparkExpression) {
                 if (operand instanceof JavaToSQLValueNode &&
                 ((JavaToSQLValueNode) operand).isSystemFunction()) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrNode.java
@@ -57,6 +57,7 @@ public class OrNode extends BinaryLogicalOperatorNode {
 	{
 		super.init(leftOperand, rightOperand, "or");
 		this.shortCircuitValue = true;
+		this.operatorType = OR;
 	}
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RelationalOperator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RelationalOperator.java
@@ -56,6 +56,7 @@ public interface RelationalOperator
 	int LESS_EQUALS_RELOP = 6;
 	int IS_NULL_RELOP = 7;
 	int IS_NOT_NULL_RELOP = 8;
+	int ILLEGAL_UNDEFINED_RELOP = 9;
 
 	/**
 	 * Check whether this RelationalOperator is a comparison of the given

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SparkArithmeticOperator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SparkArithmeticOperator.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.parser.ParserInterface;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+
+import static com.splicemachine.db.impl.sql.compile.BinaryOperatorNode.*;
+import static com.splicemachine.db.impl.sql.compile.RelationalOperator.*;
+
+public class SparkArithmeticOperator extends AbstractSparkExpressionNode
+{
+    // See the RelationalOperator interface for valid
+    // values of relOpKind
+    private int opKind;
+
+    public SparkArithmeticOperator()
+    {
+    }
+
+    public SparkArithmeticOperator(String operatorString,
+                                   SparkExpressionNode leftChild,
+                                   SparkExpressionNode rightChild)
+    {
+        if (operatorString.equals("+"))
+            this.opKind = PLUS;
+        else if (operatorString.equals("-"))
+            this.opKind = MINUS;
+        else if (operatorString.equals("*"))
+            this.opKind = TIMES;
+        else if (operatorString.equals("/"))
+            this.opKind = DIVIDE;
+        else
+            this.opKind = -1;
+        this.setLeftChild(leftChild);
+        this.setRightChild(rightChild);
+    }
+
+    @Override
+    public Column getColumnExpression(Dataset<Row> leftDF,
+                                      Dataset<Row> rightDF,
+                                      ParserInterface parser) throws UnsupportedOperationException {
+        Column leftExpr  = getLeftChild().getColumnExpression(leftDF, rightDF, parser);
+        Column rightExpr = getRightChild().getColumnExpression(leftDF, rightDF, parser);
+
+        if (opKind == PLUS)
+            return leftExpr.plus(rightExpr);
+        else if (opKind == MINUS)
+            return leftExpr.minus(rightExpr);
+        else if (opKind == TIMES)
+            return leftExpr.multiply(rightExpr);
+        else if (opKind == DIVIDE)
+            return leftExpr.divide(rightExpr);
+        else
+            throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("(");
+        sb.append(getLeftChild().toString());
+        if (opKind == PLUS)
+            sb.append(" + ");
+        else if (opKind == MINUS)
+            sb.append(" - ");
+        else if (opKind == TIMES)
+            sb.append(" * ");
+        else if (opKind == DIVIDE)
+            sb.append(" / ");
+        else
+            sb.append(" unknown_op ");
+        sb.append(getRightChild().toString());
+        sb.append(")");
+        return sb.toString();
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeInt(serializationVersion);
+        if (opKind < PLUS || opKind > DIVIDE)
+            throw new IOException();
+        out.writeInt(opKind);
+        super.writeExternal(out);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        serializationVersion = in.readInt();
+        opKind = in.readInt();
+        if (opKind < PLUS || opKind > DIVIDE)
+            throw new IOException();
+        super.readExternal(in);
+    }
+}
+

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SparkCastNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SparkCastNode.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+import org.apache.spark.sql.*;
+import org.apache.spark.sql.catalyst.parser.ParserInterface;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.catalyst.parser.ParseException;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import static java.lang.String.format;
+import static org.apache.spark.sql.functions.lit;
+
+public class SparkCastNode extends AbstractSparkExpressionNode
+{
+    private String                     dataTypeAsString;
+    private DataType                   dataType = null;
+
+    public SparkCastNode()
+    {
+    }
+
+    public SparkCastNode(SparkExpressionNode childExpression,
+                         String              dataTypeAsString)
+    {
+        this.dataTypeAsString   = dataTypeAsString;
+        this.setLeftChild(childExpression);
+    }
+
+    @Override
+    public boolean isTrue() { return getLeftChild().isTrue(); }
+
+    @Override
+    public boolean isFalse() { return getLeftChild().isFalse(); }
+
+    @Override
+    public Column getColumnExpression(Dataset<Row> leftDF,
+                                      Dataset<Row> rightDF,
+                                      ParserInterface parser) throws UnsupportedOperationException {
+        if (dataType == null) {
+            try {
+                dataType = parser.parseDataType(dataTypeAsString);
+            }
+            catch (ParseException e) {
+                throw new UnsupportedOperationException();
+            }
+        }
+        Column childColumnExpression =
+            getLeftChild().getColumnExpression(leftDF, rightDF, parser);
+        return childColumnExpression.cast(dataType);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("CAST(");
+        sb.append(format("%s AS ", getLeftChild().toString()));
+        sb.append(format("%s)", dataTypeAsString));
+        return sb.toString();
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeInt(serializationVersion);
+        out.writeUTF(dataTypeAsString);
+        super.writeExternal(out);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        serializationVersion = in.readInt();
+        dataTypeAsString     = in.readUTF();
+        super.readExternal(in);
+    }
+}
+

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SparkColumnReference.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SparkColumnReference.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.parser.ParserInterface;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import static com.splicemachine.db.impl.sql.compile.RelationalOperator.EQUALS_RELOP;
+import static com.splicemachine.db.impl.sql.compile.RelationalOperator.ILLEGAL_UNDEFINED_RELOP;
+
+public class SparkColumnReference extends AbstractSparkExpressionNode
+{
+    // The name of the column in the data frame.
+    private String columnName;
+
+    // Does this column refer to the left data frame, or the right?
+    private boolean leftDataFrame;
+
+    public SparkColumnReference()
+    {
+    }
+
+    public SparkColumnReference(String columnName, boolean leftDataFrame)
+    {
+        this.columnName = columnName;
+        this.leftDataFrame = leftDataFrame;
+    }
+
+    @Override
+    public Column getColumnExpression(Dataset<Row> leftDF,
+                                      Dataset<Row> rightDF,
+                                      ParserInterface parser) throws UnsupportedOperationException {
+        Dataset<Row> df = leftDataFrame ? leftDF : rightDF;
+        return df.col(columnName);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        if (leftDataFrame)
+            sb.append("leftDF.");
+        else
+            sb.append("rightDF.");
+        sb.append(columnName);
+        return sb.toString();
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeInt(serializationVersion);
+        out.writeUTF(columnName);
+        out.writeBoolean(leftDataFrame);
+        super.writeExternal(out);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        serializationVersion = in.readInt();
+        columnName = in.readUTF();
+        leftDataFrame = in.readBoolean();
+        super.readExternal(in);
+    }
+}
+

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SparkConstantExpression.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SparkConstantExpression.java
@@ -1,0 +1,141 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+import org.apache.spark.sql.*;
+import org.apache.spark.sql.catalyst.parser.ParserInterface;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.catalyst.parser.ParseException;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import static java.lang.String.format;
+import static org.apache.spark.sql.functions.lit;
+
+public class SparkConstantExpression extends AbstractSparkExpressionNode
+{
+    // The string representation of the constant expression.
+    private String        constantExpression;
+    private String        dataTypeAsString;
+    private DataType      dataType = null;
+    private SpecialValue  specialValue = SpecialValue.NONE;
+
+    public enum SpecialValue {NONE, NULL, TRUE, FALSE};
+
+    public SparkConstantExpression()
+    {
+    }
+
+    public SparkConstantExpression(String       constantExpression,
+                                   SpecialValue specialValue,
+                                   String       dataTypeAsString)
+    {
+        this.constantExpression = constantExpression;
+        this.dataTypeAsString   = dataTypeAsString;
+        this.specialValue       = specialValue;
+    }
+
+    // Is this a constant TRUE node?
+    @Override
+    public boolean isTrue() { return specialValue == SpecialValue.TRUE; }
+
+    // Is this a constant FALSE node?
+    @Override
+    public boolean isFalse() { return specialValue == SpecialValue.FALSE; }
+
+    @Override
+    public Column getColumnExpression(Dataset<Row> leftDF,
+                                      Dataset<Row> rightDF,
+                                      ParserInterface parser) throws UnsupportedOperationException {
+        if (dataType == null) {
+            try {
+                dataType = parser.parseDataType(dataTypeAsString);
+            }
+            catch (ParseException e) {
+                throw new UnsupportedOperationException();
+            }
+        }
+        if (specialValue == SpecialValue.NULL)
+            return lit(null).cast(dataType);
+        else
+            return lit(constantExpression).cast(dataType);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        if (specialValue == SpecialValue.TRUE)
+            sb.append("true");
+        else if (specialValue == SpecialValue.FALSE)
+            sb.append("false");
+        else {
+            sb.append("CAST(");
+            if (specialValue == SpecialValue.NULL)
+                sb.append("null AS ");
+            else
+                sb.append(format("%s AS ", constantExpression));
+            sb.append(format("%s)", dataTypeAsString));
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeInt(serializationVersion);
+        out.writeUTF(constantExpression);
+        out.writeUTF(dataTypeAsString);
+        out.writeUTF(specialValue.name());
+        super.writeExternal(out);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        serializationVersion = in.readInt();
+        constantExpression   = in.readUTF();
+        dataTypeAsString     = in.readUTF();
+        String enumString = in.readUTF();
+        if (enumString.equals(SpecialValue.NONE.name()))
+            specialValue = SpecialValue.NONE;
+        else if (enumString.equals(SpecialValue.NULL.name()))
+            specialValue = SpecialValue.NULL;
+        else if (enumString.equals(SpecialValue.TRUE.name()))
+            specialValue = SpecialValue.TRUE;
+        else if (enumString.equals(SpecialValue.FALSE.name()))
+            specialValue = SpecialValue.FALSE;
+        else
+            throw new IOException();
+        super.readExternal(in);
+    }
+}
+

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SparkExpressionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SparkExpressionNode.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.parser.ParserInterface;
+
+import java.io.Externalizable;
+
+/**
+  Interface for building an externalizable SQL expression tree,
+  from which a Spark Column expression can be built later on
+  to pass to Dataset.join.
+ */
+
+public interface SparkExpressionNode
+extends Externalizable
+{
+    void setLeftChild(SparkExpressionNode leftChild);
+    void setRightChild(SparkExpressionNode rightChild);
+
+    SparkExpressionNode getLeftChild();
+    SparkExpressionNode getRightChild();
+
+    // Convert the SparkExpressionNode tree into a Spark
+    // Column expression (e.g. representing a join condition).
+    Column getColumnExpression(Dataset<Row> leftDF, Dataset<Row> rightDF, ParserInterface parser) throws UnsupportedOperationException;
+
+    // Is this a constant TRUE node?
+    boolean isTrue();
+
+    // Is this a constant FALSE node?
+    boolean isFalse();
+}
+

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SparkLogicalOperator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SparkLogicalOperator.java
@@ -1,0 +1,151 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.parser.ParserInterface;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import static com.splicemachine.db.impl.sql.compile.BinaryOperatorNode.AND;
+import static com.splicemachine.db.impl.sql.compile.BinaryOperatorNode.OR;
+import static com.splicemachine.db.impl.sql.compile.RelationalOperator.EQUALS_RELOP;
+import static com.splicemachine.db.impl.sql.compile.RelationalOperator.ILLEGAL_UNDEFINED_RELOP;
+import static java.lang.String.format;
+import static org.apache.spark.sql.functions.lit;
+
+public class SparkLogicalOperator extends AbstractSparkExpressionNode
+{
+    // See the RelationalOperator interface for valid
+    // values of relOpKind
+    private int logicalOpKind;
+
+    public SparkLogicalOperator()
+    {
+    }
+
+    public SparkLogicalOperator(int logicalOpKind)
+    {
+        this.logicalOpKind = logicalOpKind;
+    }
+
+    public static SparkExpressionNode
+    getNewSparkLogicalOperator(int logicalOpKind,
+                               SparkExpressionNode leftChild,
+                               SparkExpressionNode rightChild) {
+        if (logicalOpKind == AND) {
+            if (leftChild.isTrue())
+                return rightChild;
+            if (rightChild.isTrue())
+                return leftChild;
+            if (leftChild.isFalse())
+                return leftChild;
+            if (rightChild.isFalse())
+                return rightChild;
+        }
+        else if (logicalOpKind == OR) {
+            if (leftChild.isTrue())
+                return leftChild;
+            if (rightChild.isTrue())
+                return rightChild;
+            if (leftChild.isFalse())
+                return rightChild;
+            if (rightChild.isFalse())
+                return leftChild;
+        }
+        return new SparkLogicalOperator(logicalOpKind, leftChild, rightChild);
+    }
+
+    private SparkLogicalOperator(int logicalOpKind,
+                                 SparkExpressionNode leftChild,
+                                 SparkExpressionNode rightChild)
+    {
+        this.logicalOpKind = logicalOpKind;
+        this.setLeftChild(leftChild);
+        this.setRightChild(rightChild);
+    }
+
+    @Override
+    public Column getColumnExpression(Dataset<Row> leftDF,
+                                      Dataset<Row> rightDF,
+                                      ParserInterface parser) throws UnsupportedOperationException {
+        Column leftExpr  = getLeftChild().getColumnExpression(leftDF, rightDF, parser);
+        Column rightExpr = getRightChild().getColumnExpression(leftDF, rightDF, parser);
+
+        if (logicalOpKind == AND)
+            return leftExpr.and(rightExpr);
+        else if (logicalOpKind == OR)
+            return leftExpr.or(rightExpr);
+        else
+            throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("(");
+        sb.append(getLeftChild().toString());
+        if (logicalOpKind == AND)
+            sb.append(" and ");
+        else if (logicalOpKind == OR)
+            sb.append(" or ");
+        else
+            sb.append(" unknown_op ");
+        sb.append(getRightChild().toString());
+        sb.append(")");
+        return sb.toString();
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeInt(serializationVersion);
+        if (logicalOpKind != AND && logicalOpKind != OR)
+            throw new IOException();
+        out.writeInt(logicalOpKind);
+        super.writeExternal(out);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        serializationVersion = in.readInt();
+        logicalOpKind = in.readInt();
+        if (logicalOpKind != AND && logicalOpKind != OR)
+            throw new IOException();
+        super.readExternal(in);
+    }
+}
+

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SparkRelationalOperator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SparkRelationalOperator.java
@@ -1,0 +1,138 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.parser.ParserInterface;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+
+import static com.splicemachine.db.impl.sql.compile.RelationalOperator.*;
+
+public class SparkRelationalOperator extends AbstractSparkExpressionNode
+{
+    // See the RelationalOperator interface for valid
+    // values of relOpKind
+    private int relOpKind;
+
+    public SparkRelationalOperator()
+    {
+    }
+
+    public SparkRelationalOperator(int relOpKind,
+                                   SparkExpressionNode leftChild,
+                                   SparkExpressionNode rightChild)
+    {
+        this.relOpKind = relOpKind;
+        this.setLeftChild(leftChild);
+        this.setRightChild(rightChild);
+    }
+
+    @Override
+    public Column getColumnExpression(Dataset<Row> leftDF,
+                                      Dataset<Row> rightDF,
+                                      ParserInterface parser) throws UnsupportedOperationException {
+        Column leftExpr  = getLeftChild().getColumnExpression(leftDF, rightDF, parser);
+        Column rightExpr = getRightChild().getColumnExpression(leftDF, rightDF, parser);
+
+        if (relOpKind == EQUALS_RELOP)
+            return leftExpr.equalTo(rightExpr);
+        else if (relOpKind == NOT_EQUALS_RELOP)
+            return leftExpr.notEqual(rightExpr);
+        else if (relOpKind == GREATER_THAN_RELOP)
+            return leftExpr.gt(rightExpr);
+        else if (relOpKind == GREATER_EQUALS_RELOP)
+            return leftExpr.geq(rightExpr);
+        else if (relOpKind == LESS_THAN_RELOP)
+            return leftExpr.lt(rightExpr);
+        else if (relOpKind == LESS_EQUALS_RELOP)
+            return leftExpr.leq(rightExpr);
+        else if (relOpKind == IS_NULL_RELOP)
+            return leftExpr.isNull();
+        else if (relOpKind == IS_NOT_NULL_RELOP)
+            return leftExpr.isNotNull();
+        else
+            throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(getLeftChild().toString());
+        if (relOpKind == EQUALS_RELOP)
+            sb.append(" = ");
+        else if (relOpKind == NOT_EQUALS_RELOP)
+            sb.append(" <> ");
+        else if (relOpKind == GREATER_THAN_RELOP)
+            sb.append(" > ");
+        else if (relOpKind == GREATER_EQUALS_RELOP)
+            sb.append(" >= ");
+        else if (relOpKind == LESS_THAN_RELOP)
+            sb.append(" < ");
+        else if (relOpKind == LESS_EQUALS_RELOP)
+            sb.append(" <= ");
+        else if (relOpKind == IS_NULL_RELOP)
+            sb.append(" IS NULL ");
+        else if (relOpKind == IS_NOT_NULL_RELOP)
+            sb.append(" IS NOT NULL ");
+        else
+            sb.append(" unknown_op ");
+        if (relOpKind != IS_NULL_RELOP && relOpKind != IS_NOT_NULL_RELOP)
+            sb.append(getRightChild().toString());
+        return sb.toString();
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeInt(serializationVersion);
+        if (relOpKind >= ILLEGAL_UNDEFINED_RELOP || relOpKind < EQUALS_RELOP)
+            throw new IOException();
+        out.writeInt(relOpKind);
+        super.writeExternal(out);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        serializationVersion = in.readInt();
+        relOpKind = in.readInt();
+        if (relOpKind >= ILLEGAL_UNDEFINED_RELOP || relOpKind < EQUALS_RELOP)
+            throw new IOException();
+        super.readExternal(in);
+    }
+}
+

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
@@ -315,6 +315,9 @@ public class SpliceSpark {
          */
         conf.set("spark.sql.retainGroupColumns", "true");
 
+        // Uncomment to disable WholeStageCodeGen for debugging.
+        // conf.set("spark.sql.codegen.wholeStage", "false");
+
         if (LOG.isDebugEnabled()) {
             printConfigProps(conf);
         }

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
@@ -39,6 +39,7 @@ import com.splicemachine.db.impl.sql.catalog.DDColumnDependableFinder;
 import com.splicemachine.db.impl.sql.catalog.DD_Version;
 import com.splicemachine.db.impl.sql.catalog.DDdependableFinder;
 import com.splicemachine.db.impl.sql.catalog.ManagedCache;
+import com.splicemachine.db.impl.sql.compile.*;
 import com.splicemachine.db.impl.sql.execute.*;
 import com.splicemachine.db.impl.store.access.PC_XenaVersion;
 import com.splicemachine.derby.ddl.*;
@@ -907,5 +908,12 @@ public class SpliceSparkKryoRegistrator implements KryoRegistrator, KryoPool.Kry
 
         instance.register(getClassFromString("java.util.Arrays$ArrayList"),
                           new ArraysAsListSerializer());
+
+        instance.register(SparkColumnReference.class,EXTERNALIZABLE_SERIALIZER);
+        instance.register(SparkConstantExpression.class,EXTERNALIZABLE_SERIALIZER);
+        instance.register(SparkLogicalOperator.class,EXTERNALIZABLE_SERIALIZER);
+        instance.register(SparkRelationalOperator.class,EXTERNALIZABLE_SERIALIZER);
+        instance.register(SparkArithmeticOperator.class,EXTERNALIZABLE_SERIALIZER);
+        instance.register(SparkCastNode.class,EXTERNALIZABLE_SERIALIZER);
     }
 }

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
@@ -22,6 +22,7 @@ import com.splicemachine.db.iapi.sql.ResultColumnDescriptor;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.types.SQLLongint;
+import com.splicemachine.db.impl.sql.compile.SparkExpressionNode;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.SpliceSpark;
@@ -37,6 +38,7 @@ import com.splicemachine.derby.stream.iapi.*;
 import com.splicemachine.derby.stream.output.*;
 import com.splicemachine.derby.stream.utils.ExternalTableUtils;
 import com.splicemachine.pipeline.Exceptions;
+import com.splicemachine.spark.splicemachine.ScalaUtils;
 import com.splicemachine.spark.splicemachine.ShuffleUtils;
 import com.splicemachine.utils.ByteDataInput;
 import com.splicemachine.utils.Pair;
@@ -58,6 +60,7 @@ import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.sql.*;
 import static org.apache.spark.sql.functions.*;
 
+import org.apache.spark.sql.catalyst.parser.ParserInterface;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.storage.StorageLevel;
 import scala.collection.JavaConversions;
@@ -910,10 +913,18 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
             int[] rightJoinKeys = ((JoinOperation)context.getOperation()).getRightHashKeys();
             int[] leftJoinKeys = ((JoinOperation)context.getOperation()).getLeftHashKeys();
             assert rightJoinKeys!=null && leftJoinKeys!=null && rightJoinKeys.length == leftJoinKeys.length:"Join Keys Have Issues";
-            for (int i = 0; i< rightJoinKeys.length;i++) {
-                Column joinEquality = (leftDF.col(ValueRow.getNamedColumn(leftJoinKeys[i]))
-                        .equalTo(rightDF.col(ValueRow.getNamedColumn(rightJoinKeys[i]))));
-                expr = i!=0?expr.and(joinEquality):joinEquality;
+
+            SparkExpressionNode sparkJoinPred = op.getSparkJoinPredicate();
+            if (sparkJoinPred != null) {
+                ParserInterface parser = ScalaUtils.getParser();
+                expr = sparkJoinPred.getColumnExpression(leftDF, rightDF, parser);
+            }
+            else {
+                for (int i = 0; i < rightJoinKeys.length; i++) {
+                    Column joinEquality = (leftDF.col(ValueRow.getNamedColumn(leftJoinKeys[i]))
+                    .equalTo(rightDF.col(ValueRow.getNamedColumn(rightJoinKeys[i]))));
+                    expr = i != 0 ? expr.and(joinEquality) : joinEquality;
+                }
             }
             DataSet joinedSet;
 

--- a/scala_util/src/main/scala/com/splicemachine/spark/splicemachine/ScalaUtils.scala
+++ b/scala_util/src/main/scala/com/splicemachine/spark/splicemachine/ScalaUtils.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.spark.splicemachine
+
+
+import org.apache.spark.sql.execution.SparkSqlParser
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+
+object ScalaUtils {
+
+  def getParser: ParserInterface = {
+    SparkSession.getActiveSession.map(_.sessionState.sqlParser).getOrElse {
+      new SparkSqlParser(new SQLConf)
+    }
+  }
+}

--- a/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
+++ b/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
@@ -36,6 +36,7 @@ import com.splicemachine.db.impl.sql.catalog.DDColumnDependableFinder;
 import com.splicemachine.db.impl.sql.catalog.DD_Version;
 import com.splicemachine.db.impl.sql.catalog.DDdependableFinder;
 import com.splicemachine.db.impl.sql.catalog.ManagedCache;
+import com.splicemachine.db.impl.sql.compile.*;
 import com.splicemachine.db.impl.sql.execute.*;
 import com.splicemachine.db.impl.store.access.PC_XenaVersion;
 import com.splicemachine.db.shared.common.udt.UDTBase;
@@ -948,5 +949,11 @@ public class SpliceKryoRegistry implements KryoPool.KryoRegistry{
         instance.register(DataValueDescriptor.class, 311);
         instance.register(getClassFromString("java.util.Arrays$ArrayList"),
                           new ArraysAsListSerializer(), 312);
+        instance.register(SparkColumnReference.class,EXTERNALIZABLE_SERIALIZER,313);
+        instance.register(SparkConstantExpression.class,EXTERNALIZABLE_SERIALIZER,314);
+        instance.register(SparkLogicalOperator.class,EXTERNALIZABLE_SERIALIZER,315);
+        instance.register(SparkRelationalOperator.class,EXTERNALIZABLE_SERIALIZER,316);
+        instance.register(SparkArithmeticOperator.class,EXTERNALIZABLE_SERIALIZER,317);
+        instance.register(SparkCastNode.class,EXTERNALIZABLE_SERIALIZER,318);
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
@@ -280,6 +280,44 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             double optimizerEstimatedCost,
             String userSuppliedOptimizerOverrides,
             String explainPlan) throws StandardException {
+        return
+        getNestedLoopLeftOuterJoinResultSet(
+            leftResultSet,
+            leftNumCols,
+            rightResultSet,
+            rightNumCols,
+            joinClause,
+            resultSetNumber,
+            emptyRowFun,
+            wasRightOuterJoin,
+            oneRowRightSide,
+            notExistsRightSide,
+            rightFromSSQ,
+            optimizerEstimatedRowCount,
+            optimizerEstimatedCost,
+            userSuppliedOptimizerOverrides,
+            explainPlan,
+            null);
+    }
+
+    @Override
+    public NoPutResultSet getNestedLoopLeftOuterJoinResultSet(
+            NoPutResultSet leftResultSet,
+            int leftNumCols,
+            NoPutResultSet rightResultSet,
+            int rightNumCols,
+            GeneratedMethod joinClause,
+            int resultSetNumber,
+            GeneratedMethod emptyRowFun,
+            boolean wasRightOuterJoin,
+            boolean oneRowRightSide,
+            boolean notExistsRightSide,
+            boolean rightFromSSQ,
+            double optimizerEstimatedRowCount,
+            double optimizerEstimatedCost,
+            String userSuppliedOptimizerOverrides,
+            String explainPlan,
+            String sparkExpressionTreeAsString) throws StandardException {
         try{
             SpliceLogUtils.trace(LOG, "getNestedLoopLeftOuterJoinResultSet");
             ConvertedResultSet left = (ConvertedResultSet)leftResultSet;
@@ -295,7 +333,8 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                     rightFromSSQ,
                     optimizerEstimatedRowCount,
                     optimizerEstimatedCost,
-                    userSuppliedOptimizerOverrides);
+                    userSuppliedOptimizerOverrides,
+                    sparkExpressionTreeAsString);
             op.setExplainPlan(explainPlan);
             return op;
         }catch(Exception e){
@@ -428,7 +467,8 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             double optimizerEstimatedRowCount,
             double optimizerEstimatedCost,
             String userSuppliedOptimizerOverrides,
-            String explainPlan) throws StandardException {
+            String explainPlan,
+            String sparkExpressionTreeAsString) throws StandardException {
         throw new UnsupportedOperationException("HashLeftOuterJoin operation shouldn't be called");
     }
 
@@ -948,6 +988,33 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             double optimizerEstimatedRowCount, double optimizerEstimatedCost,
             String userSuppliedOptimizerOverrides,
             String explainPlan) throws StandardException {
+        return getMergeSortLeftOuterJoinResultSet(
+             leftResultSet, leftNumCols,
+             rightResultSet, rightNumCols,
+             leftHashKeyItem, rightHashKeyItem,
+             joinClause, resultSetNumber,
+             emptyRowFun, wasRightOuterJoin,
+             oneRowRightSide, notExistsRightSide,
+             rightFromSSQ,
+             optimizerEstimatedRowCount,  optimizerEstimatedCost,
+             userSuppliedOptimizerOverrides,
+             explainPlan,
+             null);
+    }
+
+    @Override
+    public NoPutResultSet getMergeSortLeftOuterJoinResultSet(
+            NoPutResultSet leftResultSet, int leftNumCols,
+            NoPutResultSet rightResultSet, int rightNumCols,
+            int leftHashKeyItem, int rightHashKeyItem,
+            GeneratedMethod joinClause, int resultSetNumber,
+            GeneratedMethod emptyRowFun, boolean wasRightOuterJoin,
+            boolean oneRowRightSide, boolean notExistsRightSide,
+            boolean rightFromSSQ,
+            double optimizerEstimatedRowCount, double optimizerEstimatedCost,
+            String userSuppliedOptimizerOverrides,
+            String explainPlan,
+            String sparkExpressionTreeAsString) throws StandardException {
         SpliceLogUtils.trace(LOG, "getMergeSortLeftOuterJoinResultSet");
         try{
             ConvertedResultSet left = (ConvertedResultSet)leftResultSet;
@@ -963,7 +1030,8 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                     rightFromSSQ,
                     optimizerEstimatedRowCount,
                     optimizerEstimatedCost,
-                    userSuppliedOptimizerOverrides);
+                    userSuppliedOptimizerOverrides,
+                    sparkExpressionTreeAsString);
             op.setExplainPlan(explainPlan);
             return op;
         }catch(Exception e){
@@ -982,7 +1050,8 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             boolean rightFromSSQ,
             double optimizerEstimatedRowCount, double optimizerEstimatedCost,
             String userSuppliedOptimizerOverrides,
-            String explainPlan) throws StandardException {
+            String explainPlan,
+            String sparkExpressionTreeAsString) throws StandardException {
         SpliceLogUtils.trace(LOG, "getMergeSortLeftOuterJoinResultSet");
         try{
             ConvertedResultSet left = (ConvertedResultSet)leftResultSet;
@@ -998,7 +1067,8 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                     rightFromSSQ,
                     optimizerEstimatedRowCount,
                     optimizerEstimatedCost,
-                    userSuppliedOptimizerOverrides);
+                    userSuppliedOptimizerOverrides,
+                    sparkExpressionTreeAsString);
             op.setExplainPlan(explainPlan);
             return op;
         }catch(Exception e){
@@ -1020,6 +1090,38 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             double optimizerEstimatedRowCount, double optimizerEstimatedCost,
             String userSuppliedOptimizerOverrides,
             String explainPlan) throws StandardException {
+
+        return getMergeLeftOuterJoinResultSet(
+             leftResultSet,  leftNumCols,
+             rightResultSet,  rightNumCols,
+             leftHashKeyItem,  rightHashKeyItem,
+             rightHashKeyToBaseTableMapItem,
+             rightHashKeySortOrderItem,
+             joinClause,  resultSetNumber,
+             emptyRowFun,  wasRightOuterJoin,
+             oneRowRightSide,  notExistsRightSide,
+             rightFromSSQ,
+             optimizerEstimatedRowCount,  optimizerEstimatedCost,
+             userSuppliedOptimizerOverrides,
+             explainPlan,
+             null);
+    }
+
+    @Override
+    public NoPutResultSet getMergeLeftOuterJoinResultSet(
+            NoPutResultSet leftResultSet, int leftNumCols,
+            NoPutResultSet rightResultSet, int rightNumCols,
+            int leftHashKeyItem, int rightHashKeyItem,
+            int rightHashKeyToBaseTableMapItem,
+            int rightHashKeySortOrderItem,
+            GeneratedMethod joinClause, int resultSetNumber,
+            GeneratedMethod emptyRowFun, boolean wasRightOuterJoin,
+            boolean oneRowRightSide, boolean notExistsRightSide,
+            boolean rightFromSSQ,
+            double optimizerEstimatedRowCount, double optimizerEstimatedCost,
+            String userSuppliedOptimizerOverrides,
+            String explainPlan,
+            String sparkExpressionTreeAsString) throws StandardException {
         SpliceLogUtils.trace(LOG, "getMergeSortLeftOuterJoinResultSet");
         try{
             ConvertedResultSet left = (ConvertedResultSet)leftResultSet;
@@ -1037,7 +1139,8 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                     rightFromSSQ,
                     optimizerEstimatedRowCount,
                     optimizerEstimatedCost,
-                    userSuppliedOptimizerOverrides);
+                    userSuppliedOptimizerOverrides,
+                    sparkExpressionTreeAsString);
             op.setExplainPlan(explainPlan);
             return op;
         }catch(Exception e){
@@ -1057,6 +1160,34 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             double optimizerEstimatedRowCount, double optimizerEstimatedCost,
             String userSuppliedOptimizerOverrides,
             String explainPlan) throws StandardException {
+
+        return getBroadcastLeftOuterJoinResultSet(
+             leftResultSet,  leftNumCols,
+             rightResultSet,  rightNumCols,
+             leftHashKeyItem,  rightHashKeyItem,
+             joinClause,  resultSetNumber,
+             emptyRowFun,  wasRightOuterJoin,
+             oneRowRightSide,  notExistsRightSide,
+             rightFromSSQ,
+             optimizerEstimatedRowCount,  optimizerEstimatedCost,
+             userSuppliedOptimizerOverrides,
+             explainPlan,
+             null);
+    }
+
+    @Override
+    public NoPutResultSet getBroadcastLeftOuterJoinResultSet(
+            NoPutResultSet leftResultSet, int leftNumCols,
+            NoPutResultSet rightResultSet, int rightNumCols,
+            int leftHashKeyItem, int rightHashKeyItem,
+            GeneratedMethod joinClause, int resultSetNumber,
+            GeneratedMethod emptyRowFun, boolean wasRightOuterJoin,
+            boolean oneRowRightSide, boolean notExistsRightSide,
+            boolean rightFromSSQ,
+            double optimizerEstimatedRowCount, double optimizerEstimatedCost,
+            String userSuppliedOptimizerOverrides,
+            String explainPlan,
+            String sparkExpressionTreeAsString) throws StandardException {
         SpliceLogUtils.trace(LOG, "getMergeSortLeftOuterJoinResultSet");
         try{
             ConvertedResultSet left = (ConvertedResultSet)leftResultSet;
@@ -1072,7 +1203,8 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                     rightFromSSQ,
                     optimizerEstimatedRowCount,
                     optimizerEstimatedCost,
-                    userSuppliedOptimizerOverrides);
+                    userSuppliedOptimizerOverrides,
+                    sparkExpressionTreeAsString);
             op.setExplainPlan(explainPlan);
             return op;
         }catch(Exception e){
@@ -1090,6 +1222,29 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             double optimizerEstimatedRowCount, double optimizerEstimatedCost,
             String userSuppliedOptimizerOverrides,
             String explainPlan) throws StandardException {
+        return getNestedLoopJoinResultSet(
+             leftResultSet,  leftNumCols,
+             rightResultSet,  rightNumCols,
+             joinClause,  resultSetNumber,
+             oneRowRightSide,  notExistsRightSide,
+             rightFromSSQ,
+             optimizerEstimatedRowCount,  optimizerEstimatedCost,
+             userSuppliedOptimizerOverrides,
+             explainPlan,
+             null);
+    }
+
+    @Override
+    public NoPutResultSet getNestedLoopJoinResultSet(
+            NoPutResultSet leftResultSet, int leftNumCols,
+            NoPutResultSet rightResultSet, int rightNumCols,
+            GeneratedMethod joinClause, int resultSetNumber,
+            boolean oneRowRightSide, boolean notExistsRightSide,
+            boolean rightFromSSQ,
+            double optimizerEstimatedRowCount, double optimizerEstimatedCost,
+            String userSuppliedOptimizerOverrides,
+            String explainPlan,
+            String sparkExpressionTreeAsString) throws StandardException {
         SpliceLogUtils.trace(LOG, "getNestedLoopJoinResultSet");
         try{
             ConvertedResultSet left = (ConvertedResultSet)leftResultSet;
@@ -1097,7 +1252,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             JoinOperation op = new NestedLoopJoinOperation(left.getOperation(), leftNumCols,
                     right.getOperation(), rightNumCols, leftResultSet.getActivation(), joinClause, resultSetNumber,
                     oneRowRightSide, notExistsRightSide, rightFromSSQ, optimizerEstimatedRowCount,
-                    optimizerEstimatedCost, userSuppliedOptimizerOverrides);
+                    optimizerEstimatedCost, userSuppliedOptimizerOverrides, sparkExpressionTreeAsString);
             op.setExplainPlan(explainPlan);
             return op;
         }catch(Exception e){
@@ -1116,6 +1271,31 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             double optimizerEstimatedRowCount, double optimizerEstimatedCost,
             String userSuppliedOptimizerOverrides,
             String explainPlan) throws StandardException {
+        return getCrossJoinResultSet(
+             leftResultSet,  leftNumCols,
+             rightResultSet,  rightNumCols,
+             leftHashKeyItem,  rightHashKeyItem,
+             joinClause,  resultSetNumber,
+             oneRowRightSide,  notExistsRightSide,
+             rightFromSSQ,
+             optimizerEstimatedRowCount,  optimizerEstimatedCost,
+             userSuppliedOptimizerOverrides,
+             explainPlan,
+             null);
+    }
+
+    @Override
+    public NoPutResultSet getCrossJoinResultSet(
+            NoPutResultSet leftResultSet, int leftNumCols,
+            NoPutResultSet rightResultSet, int rightNumCols,
+            int leftHashKeyItem, int rightHashKeyItem,
+            GeneratedMethod joinClause, int resultSetNumber,
+            boolean oneRowRightSide, boolean notExistsRightSide,
+            boolean rightFromSSQ,
+            double optimizerEstimatedRowCount, double optimizerEstimatedCost,
+            String userSuppliedOptimizerOverrides,
+            String explainPlan,
+            String sparkExpressionTreeAsString) throws StandardException {
         SpliceLogUtils.trace(LOG, "getCrossJoinResultSet");
         try{
             ConvertedResultSet left = (ConvertedResultSet)leftResultSet;
@@ -1125,14 +1305,13 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                     leftResultSet.getActivation(),
                     joinClause, resultSetNumber,
                     oneRowRightSide, notExistsRightSide, rightFromSSQ, optimizerEstimatedRowCount,
-                    optimizerEstimatedCost, userSuppliedOptimizerOverrides);
+                    optimizerEstimatedCost, userSuppliedOptimizerOverrides, sparkExpressionTreeAsString);
             op.setExplainPlan(explainPlan);
             return op;
         }catch(Exception e){
             throw Exceptions.parseException(e);
         }
     }
-
 
     @Override
     public NoPutResultSet getMergeSortJoinResultSet(
@@ -1144,6 +1323,29 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             double optimizerEstimatedCost,
             String userSuppliedOptimizerOverrides,
             String explainPlan) throws StandardException {
+        return getMergeSortJoinResultSet(
+             leftResultSet,  leftNumCols,
+             rightResultSet,  rightNumCols,
+             leftHashKeyItem,  rightHashKeyItem,  joinClause,
+             resultSetNumber,  oneRowRightSide,
+             notExistsRightSide,  rightFromSSQ,  optimizerEstimatedRowCount,
+             optimizerEstimatedCost,
+             userSuppliedOptimizerOverrides,
+             explainPlan,
+             null);
+    }
+
+    @Override
+    public NoPutResultSet getMergeSortJoinResultSet(
+            NoPutResultSet leftResultSet, int leftNumCols,
+            NoPutResultSet rightResultSet, int rightNumCols,
+            int leftHashKeyItem, int rightHashKeyItem, GeneratedMethod joinClause,
+            int resultSetNumber, boolean oneRowRightSide,
+            boolean notExistsRightSide, boolean rightFromSSQ, double optimizerEstimatedRowCount,
+            double optimizerEstimatedCost,
+            String userSuppliedOptimizerOverrides,
+            String explainPlan,
+            String sparkExpressionTreeAsString) throws StandardException {
         SpliceLogUtils.trace(LOG, "getMergeSortJoinResultSet");
         try{
             ConvertedResultSet left = (ConvertedResultSet)leftResultSet;
@@ -1151,7 +1353,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             JoinOperation op = new MergeSortJoinOperation(left.getOperation(), leftNumCols,
                     right.getOperation(), rightNumCols, leftHashKeyItem, rightHashKeyItem, leftResultSet.getActivation(), joinClause, resultSetNumber,
                     oneRowRightSide, notExistsRightSide, rightFromSSQ, optimizerEstimatedRowCount,
-                    optimizerEstimatedCost, userSuppliedOptimizerOverrides);
+                    optimizerEstimatedCost, userSuppliedOptimizerOverrides, sparkExpressionTreeAsString);
             op.setExplainPlan(explainPlan);
             return op;
         }catch(Exception e){
@@ -1168,7 +1370,8 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             boolean notExistsRightSide, boolean rightFromSSQ, double optimizerEstimatedRowCount,
             double optimizerEstimatedCost,
             String userSuppliedOptimizerOverrides,
-            String explainPlan) throws StandardException {
+            String explainPlan,
+            String sparkExpressionTreeAsString) throws StandardException {
         SpliceLogUtils.trace(LOG, "getMergeSortJoinResultSet");
         try{
             ConvertedResultSet left = (ConvertedResultSet)leftResultSet;
@@ -1176,7 +1379,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             JoinOperation op = new HalfMergeSortJoinOperation(left.getOperation(), leftNumCols,
                     right.getOperation(), rightNumCols, leftHashKeyItem, rightHashKeyItem, leftResultSet.getActivation(), joinClause, resultSetNumber,
                     oneRowRightSide, notExistsRightSide, rightFromSSQ, optimizerEstimatedRowCount,
-                    optimizerEstimatedCost, userSuppliedOptimizerOverrides);
+                    optimizerEstimatedCost, userSuppliedOptimizerOverrides, sparkExpressionTreeAsString);
             op.setExplainPlan(explainPlan);
             return op;
         }catch(Exception e){
@@ -1197,6 +1400,35 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             double optimizerEstimatedCost,
             String userSuppliedOptimizerOverrides,
             String explainPlan) throws StandardException {
+        return getMergeJoinResultSet(
+             leftResultSet,  leftNumCols,
+             rightResultSet,  rightNumCols,
+             leftHashKeyItem,  rightHashKeyItem,
+             rightHashKeyToBaseTableMapItem,
+             rightHashKeySortOrderItem,
+             joinClause,
+             resultSetNumber,  oneRowRightSide,
+             notExistsRightSide,  rightFromSSQ,  optimizerEstimatedRowCount,
+             optimizerEstimatedCost,
+             userSuppliedOptimizerOverrides,
+             explainPlan,
+             null);
+    }
+
+    @Override
+    public NoPutResultSet getMergeJoinResultSet(
+            NoPutResultSet leftResultSet, int leftNumCols,
+            NoPutResultSet rightResultSet, int rightNumCols,
+            int leftHashKeyItem, int rightHashKeyItem,
+            int rightHashKeyToBaseTableMapItem,
+            int rightHashKeySortOrderItem,
+            GeneratedMethod joinClause,
+            int resultSetNumber, boolean oneRowRightSide,
+            boolean notExistsRightSide, boolean rightFromSSQ, double optimizerEstimatedRowCount,
+            double optimizerEstimatedCost,
+            String userSuppliedOptimizerOverrides,
+            String explainPlan,
+            String sparkExpressionTreeAsString) throws StandardException {
         SpliceLogUtils.trace(LOG, "getMergeSortJoinResultSet");
         try{
             ConvertedResultSet left = (ConvertedResultSet)leftResultSet;
@@ -1205,7 +1437,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                     right.getOperation(), rightNumCols, leftHashKeyItem, rightHashKeyItem,
                     rightHashKeyToBaseTableMapItem, rightHashKeySortOrderItem, leftResultSet.getActivation(), joinClause, resultSetNumber,
                     oneRowRightSide, notExistsRightSide, rightFromSSQ, optimizerEstimatedRowCount,
-                    optimizerEstimatedCost, userSuppliedOptimizerOverrides);
+                    optimizerEstimatedCost, userSuppliedOptimizerOverrides, sparkExpressionTreeAsString);
             op.setExplainPlan(explainPlan);
             return op;
         }catch(Exception e){
@@ -1223,6 +1455,30 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             double optimizerEstimatedCost,
             String userSuppliedOptimizerOverrides,
             String explainPlan) throws StandardException {
+
+        return getBroadcastJoinResultSet(
+             leftResultSet,  leftNumCols,
+             rightResultSet,  rightNumCols,
+             leftHashKeyItem,  rightHashKeyItem,  joinClause,
+             resultSetNumber,  oneRowRightSide,
+             notExistsRightSide,  rightFromSSQ,  optimizerEstimatedRowCount,
+             optimizerEstimatedCost,
+             userSuppliedOptimizerOverrides,
+             explainPlan,
+             null);
+    }
+
+    @Override
+    public NoPutResultSet getBroadcastJoinResultSet(
+            NoPutResultSet leftResultSet, int leftNumCols,
+            NoPutResultSet rightResultSet, int rightNumCols,
+            int leftHashKeyItem, int rightHashKeyItem, GeneratedMethod joinClause,
+            int resultSetNumber, boolean oneRowRightSide,
+            boolean notExistsRightSide, boolean rightFromSSQ, double optimizerEstimatedRowCount,
+            double optimizerEstimatedCost,
+            String userSuppliedOptimizerOverrides,
+            String explainPlan,
+            String sparkExpressionTreeAsString) throws StandardException {
         SpliceLogUtils.trace(LOG, "getBroadcastJoinResultSet");
         try{
             ConvertedResultSet left = (ConvertedResultSet)leftResultSet;
@@ -1230,7 +1486,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             JoinOperation op = new BroadcastJoinOperation(left.getOperation(), leftNumCols,
                     right.getOperation(), rightNumCols, leftHashKeyItem, rightHashKeyItem, leftResultSet.getActivation(), joinClause, resultSetNumber,
                     oneRowRightSide, notExistsRightSide, rightFromSSQ, optimizerEstimatedRowCount,
-                    optimizerEstimatedCost, userSuppliedOptimizerOverrides);
+                    optimizerEstimatedCost, userSuppliedOptimizerOverrides, sparkExpressionTreeAsString);
             op.setExplainPlan(explainPlan);
             return op;
         }catch(Exception e){

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
@@ -228,7 +228,7 @@ public class BroadcastJoinOperation extends JoinOperation{
         DataSet<ExecRow> result;
         boolean usesNativeSparkDataSet =
            (useDataset && dsp.getType().equals(DataSetProcessor.Type.SPARK) &&
-             ((restriction == null || sparkJoinPredicate != null) || (!isOuterJoin && !notExistsRightSide && !isOneRowRightSide())) &&
+             ((restriction == null || hasSparkJoinPredicate()) || (!isOuterJoin && !notExistsRightSide && !isOneRowRightSide())) &&
               !containsUnsafeSQLRealComparison());
         if (usesNativeSparkDataSet)
         {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastLeftOuterJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastLeftOuterJoinOperation.java
@@ -52,10 +52,12 @@ public class BroadcastLeftOuterJoinOperation extends BroadcastJoinOperation {
 			boolean rightFromSSQ,
 			    double optimizerEstimatedRowCount,
 			double optimizerEstimatedCost,
-			String userSuppliedOptimizerOverrides) throws StandardException {
+			String userSuppliedOptimizerOverrides,
+			String sparkExpressionTreeAsString) throws StandardException {
                 super(leftResultSet, leftNumCols, rightResultSet, rightNumCols, leftHashKeyItem, rightHashKeyItem,
                         activation, restriction, resultSetNumber, oneRowRightSide, notExistsRightSide, rightFromSSQ,
-                        optimizerEstimatedRowCount, optimizerEstimatedCost,userSuppliedOptimizerOverrides);
+                        optimizerEstimatedRowCount, optimizerEstimatedCost,userSuppliedOptimizerOverrides,
+                        sparkExpressionTreeAsString);
                 SpliceLogUtils.trace(LOG, "instantiate");
                 emptyRowFunMethodName = (emptyRowFun == null) ? null : emptyRowFun.getMethodName();
                 this.wasRightOuterJoin = wasRightOuterJoin;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/CrossJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/CrossJoinOperation.java
@@ -75,11 +75,13 @@ public class CrossJoinOperation extends JoinOperation{
                               boolean rightFromSSQ,
                               double optimizerEstimatedRowCount,
                               double optimizerEstimatedCost,
-                              String userSuppliedOptimizerOverrides) throws
+                              String userSuppliedOptimizerOverrides,
+                              String sparkExpressionTreeAsString) throws
             StandardException{
         super(leftResultSet,leftNumCols,rightResultSet,rightNumCols,
                 activation,restriction,resultSetNumber,oneRowRightSide,notExistsRightSide, rightFromSSQ,
-                optimizerEstimatedRowCount,optimizerEstimatedCost,userSuppliedOptimizerOverrides);
+                optimizerEstimatedRowCount,optimizerEstimatedCost,userSuppliedOptimizerOverrides,
+                sparkExpressionTreeAsString);
         this.leftHashKeyItem=leftHashKeyItem;
         this.rightHashKeyItem=rightHashKeyItem;
         this.sequenceId = Bytes.toLong(operationInformation.getUUIDGenerator().nextBytes());

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/HalfMergeSortJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/HalfMergeSortJoinOperation.java
@@ -68,11 +68,13 @@ public class HalfMergeSortJoinOperation extends MergeJoinOperation {
                                       boolean rightFromSSQ,
                                       double optimizerEstimatedRowCount,
                                       double optimizerEstimatedCost,
-                                      String userSuppliedOptimizerOverrides)
+                                      String userSuppliedOptimizerOverrides,
+                                      String sparkExpressionTreeAsString)
             throws StandardException {
         super(leftResultSet, leftNumCols, rightResultSet, rightNumCols, leftHashKeyItem, rightHashKeyItem,
                 -1, -1, activation, restriction,
-                resultSetNumber, oneRowRightSide, notExistsRightSide, rightFromSSQ, optimizerEstimatedRowCount, optimizerEstimatedCost, userSuppliedOptimizerOverrides);
+                resultSetNumber, oneRowRightSide, notExistsRightSide, rightFromSSQ, optimizerEstimatedRowCount,
+                optimizerEstimatedCost, userSuppliedOptimizerOverrides, sparkExpressionTreeAsString);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/HalfMergeSortLeftOuterJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/HalfMergeSortLeftOuterJoinOperation.java
@@ -60,10 +60,12 @@ public class HalfMergeSortLeftOuterJoinOperation extends HalfMergeSortJoinOperat
                                                boolean rightFromSSQ,
                                                double optimizerEstimatedRowCount,
                                                double optimizerEstimatedCost,
-                                               String userSuppliedOptimizerOverrides) throws StandardException {
+                                               String userSuppliedOptimizerOverrides,
+                                               String sparkExpressionTreeAsString) throws StandardException {
         super(leftResultSet, leftNumCols, rightResultSet, rightNumCols, leftHashKeyItem, rightHashKeyItem,
                 activation, restriction, resultSetNumber, oneRowRightSide, notExistsRightSide, rightFromSSQ,
-                optimizerEstimatedRowCount, optimizerEstimatedCost, userSuppliedOptimizerOverrides);
+                optimizerEstimatedRowCount, optimizerEstimatedCost, userSuppliedOptimizerOverrides,
+                sparkExpressionTreeAsString);
         SpliceLogUtils.trace(LOG, "instantiate");
         emptyRowFunMethodName = (emptyRowFun == null) ? null : emptyRowFun.getMethodName();
         this.wasRightOuterJoin = wasRightOuterJoin;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeJoinOperation.java
@@ -79,12 +79,13 @@ public class MergeJoinOperation extends JoinOperation {
                               boolean rightFromSSQ,
                               double optimizerEstimatedRowCount,
                               double optimizerEstimatedCost,
-                              String userSuppliedOptimizerOverrides)
+                              String userSuppliedOptimizerOverrides,
+                              String sparkExpressionTreeAsString)
             throws StandardException {
         super(leftResultSet, leftNumCols, rightResultSet, rightNumCols,
                  activation, restriction, resultSetNumber, oneRowRightSide,
                  notExistsRightSide, rightFromSSQ, optimizerEstimatedRowCount,
-                 optimizerEstimatedCost, userSuppliedOptimizerOverrides);
+                 optimizerEstimatedCost, userSuppliedOptimizerOverrides, sparkExpressionTreeAsString);
         this.leftHashKeyItem = leftHashKeyItem;
         this.rightHashKeyItem = rightHashKeyItem;
         this.rightHashKeyToBaseTableMapItem = rightHashKeyToBaseTableMapItem;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeLeftOuterJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeLeftOuterJoinOperation.java
@@ -57,11 +57,13 @@ public class MergeLeftOuterJoinOperation extends MergeJoinOperation {
                                        boolean rightFromSSQ,
                                        double optimizerEstimatedRowCount,
                                        double optimizerEstimatedCost,
-                                       String userSuppliedOptimizerOverrides) throws StandardException {
+                                       String userSuppliedOptimizerOverrides,
+                                       String sparkExpressionTreeAsString) throws StandardException {
         super(leftResultSet, leftNumCols, rightResultSet, rightNumCols, leftHashKeyItem, rightHashKeyItem,
                  rightHashKeyToBaseTableMapItem, rightHashKeySortOrderItem,
                  activation, restriction, resultSetNumber, oneRowRightSide, notExistsRightSide, rightFromSSQ,
-                 optimizerEstimatedRowCount, optimizerEstimatedCost, userSuppliedOptimizerOverrides);
+                 optimizerEstimatedRowCount, optimizerEstimatedCost, userSuppliedOptimizerOverrides,
+                 sparkExpressionTreeAsString);
         SpliceLogUtils.trace(LOG, "instantiate");
         emptyRowFunMethodName = (emptyRowFun == null) ? null : emptyRowFun.getMethodName();
         this.wasRightOuterJoin = wasRightOuterJoin;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeSortJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeSortJoinOperation.java
@@ -126,10 +126,12 @@ public class MergeSortJoinOperation extends JoinOperation {
                                   boolean rightFromSSQ,
                                   double optimizerEstimatedRowCount,
                                   double optimizerEstimatedCost,
-                                  String userSuppliedOptimizerOverrides) throws StandardException {
+                                  String userSuppliedOptimizerOverrides,
+                                  String sparkExpressionTreeAsString) throws StandardException {
         super(leftResultSet, leftNumCols, rightResultSet, rightNumCols,
                 activation, restriction, resultSetNumber, oneRowRightSide, notExistsRightSide, rightFromSSQ,
-                optimizerEstimatedRowCount, optimizerEstimatedCost, userSuppliedOptimizerOverrides);
+                optimizerEstimatedRowCount, optimizerEstimatedCost, userSuppliedOptimizerOverrides,
+                sparkExpressionTreeAsString);
         SpliceLogUtils.trace(LOG, "instantiate");
         this.leftHashKeyItem = leftHashKeyItem;
         this.rightHashKeyItem = rightHashKeyItem;
@@ -205,8 +207,9 @@ public class MergeSortJoinOperation extends JoinOperation {
                     isOuterJoin ? "outer" : "inner", notExistsRightSide, restriction != null);
                 rightDataSet1.map(new CountJoinedRightFunction(operationContext));
         DataSet<ExecRow> joined;
-        if (dsp.getType().equals(DataSetProcessor.Type.SPARK) && restriction == null && !rightFromSSQ &&
-            !containsUnsafeSQLRealComparison()){
+        if (dsp.getType().equals(DataSetProcessor.Type.SPARK)   &&
+            (restriction == null || sparkJoinPredicate != null) &&
+            !rightFromSSQ && !containsUnsafeSQLRealComparison()){
             if (isOuterJoin)
                 joined = leftDataSet2.join(operationContext,rightDataSet2, DataSet.JoinType.LEFTOUTER,false);
             else if (notExistsRightSide)

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeSortJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeSortJoinOperation.java
@@ -208,7 +208,7 @@ public class MergeSortJoinOperation extends JoinOperation {
                 rightDataSet1.map(new CountJoinedRightFunction(operationContext));
         DataSet<ExecRow> joined;
         if (dsp.getType().equals(DataSetProcessor.Type.SPARK)   &&
-            (restriction == null || sparkJoinPredicate != null) &&
+            (restriction == null || hasSparkJoinPredicate()) &&
             !rightFromSSQ && !containsUnsafeSQLRealComparison()){
             if (isOuterJoin)
                 joined = leftDataSet2.join(operationContext,rightDataSet2, DataSet.JoinType.LEFTOUTER,false);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeSortLeftOuterJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeSortLeftOuterJoinOperation.java
@@ -51,10 +51,12 @@ public class MergeSortLeftOuterJoinOperation extends MergeSortJoinOperation {
 						boolean rightFromSSQ,
 						double optimizerEstimatedRowCount,
 						double optimizerEstimatedCost,
-						String userSuppliedOptimizerOverrides) throws StandardException {
+						String userSuppliedOptimizerOverrides,
+						String sparkExpressionTreeAsString) throws StandardException {
 				super(leftResultSet, leftNumCols, rightResultSet, rightNumCols, leftHashKeyItem, rightHashKeyItem,
 								activation, restriction, resultSetNumber, oneRowRightSide, notExistsRightSide, rightFromSSQ,
-								optimizerEstimatedRowCount, optimizerEstimatedCost,userSuppliedOptimizerOverrides);
+								optimizerEstimatedRowCount, optimizerEstimatedCost,userSuppliedOptimizerOverrides,
+								sparkExpressionTreeAsString);
 				SpliceLogUtils.trace(LOG, "instantiate");
 				this.emptyRowFunMethodName = (emptyRowFun == null) ? null : emptyRowFun.getMethodName();
 				this.wasRightOuterJoin = wasRightOuterJoin;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NestedLoopJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NestedLoopJoinOperation.java
@@ -56,10 +56,11 @@ public class NestedLoopJoinOperation extends JoinOperation {
 									                                 boolean rightFromSSQ,
 																	 double optimizerEstimatedRowCount,
 																	 double optimizerEstimatedCost,
-																	 String userSuppliedOptimizerOverrides) throws StandardException {
+																	 String userSuppliedOptimizerOverrides,
+																	 String sparkExpressionTreeAsString) throws StandardException {
 				super(leftResultSet,leftNumCols,rightResultSet,rightNumCols,activation,restriction,
 								resultSetNumber,oneRowRightSide,notExistsRightSide,rightFromSSQ,optimizerEstimatedRowCount,
-								optimizerEstimatedCost,userSuppliedOptimizerOverrides);
+								optimizerEstimatedCost,userSuppliedOptimizerOverrides,sparkExpressionTreeAsString);
 				this.isHash = false;
                 init();
 		}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NestedLoopLeftOuterJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NestedLoopLeftOuterJoinOperation.java
@@ -49,10 +49,12 @@ public class NestedLoopLeftOuterJoinOperation extends NestedLoopJoinOperation {
 						boolean rightFromSSQ,
 						double optimizerEstimatedRowCount,
 						double optimizerEstimatedCost,
-						String userSuppliedOptimizerOverrides) throws StandardException {
+						String userSuppliedOptimizerOverrides,
+						String sparkExpressionTreeAsString) throws StandardException {
 				super(leftResultSet, leftNumCols, rightResultSet, rightNumCols,
-								activation, restriction, resultSetNumber,oneRowRightSide, notExistsRightSide, rightFromSSQ,
-								optimizerEstimatedRowCount, optimizerEstimatedCost,userSuppliedOptimizerOverrides);
+					activation, restriction, resultSetNumber,oneRowRightSide, notExistsRightSide, rightFromSSQ,
+					optimizerEstimatedRowCount, optimizerEstimatedCost,userSuppliedOptimizerOverrides,
+					sparkExpressionTreeAsString);
 				SpliceLogUtils.trace(LOG, "instantiate");
 				this.emptyRowFunMethodName = (emptyRowFun == null) ? null : emptyRowFun.getMethodName();
 				this.wasRightOuterJoin = wasRightOuterJoin;

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NativeSparkJoinWithInequalityPredsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NativeSparkJoinWithInequalityPredsIT.java
@@ -1,0 +1,573 @@
+/*
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.test_tools.TableCreator;
+import org.junit.*;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.spark_project.guava.collect.Lists;
+
+import java.math.BigDecimal;
+import java.sql.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static com.splicemachine.test_tools.Rows.row;
+import static com.splicemachine.test_tools.Rows.rows;
+
+/**
+ * Test native spark broadcast join and mergesort join with inequality join conditions.
+ */
+@RunWith(Parameterized.class)
+public class NativeSparkJoinWithInequalityPredsIT  extends SpliceUnitTest {
+
+    private String joinStrategy;
+    private String useSpark;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        Collection<Object[]> params = Lists.newArrayListWithCapacity(4);
+        params.add(new Object[]{"BROADCAST","true"});
+        params.add(new Object[]{"SORTMERGE","true"});
+        params.add(new Object[]{"BROADCAST","false"});
+        params.add(new Object[]{"SORTMERGE","false"});
+        return params;
+    }
+
+    public static final String CLASS_NAME = NativeSparkJoinWithInequalityPredsIT.class.getSimpleName().toUpperCase();
+    protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);
+    protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
+
+    @ClassRule
+    public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
+            .around(spliceSchemaWatcher);
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher(CLASS_NAME);
+    
+    public NativeSparkJoinWithInequalityPredsIT(String joinStrategy, String useSpark) {
+        this.joinStrategy = joinStrategy;
+        this.useSpark     = useSpark;
+    }
+    
+    public static void createData(Connection conn, String schemaName) throws Exception {
+
+        new TableCreator(conn)
+                .withCreate("create table ts_int (j int, t tinyint, s smallint, i int, l bigint, d decimal(38,0))")
+                .create();
+
+        String [] values = {
+        "(1, 127, 32767, 2147483647, 9223372036854775807, 9223372036854775807)",
+        "(1, 126, 32766, 2147483646, 9223372036854775806, 9223372036854775806)",
+        "(1, 126, 32766, 2147483646, 9223372036854775806, 9223372036854775806)",
+        "(1, 125, 32765, 2147483645, 9223372036854775805, 9223372036854775805)",
+        "(1, -128, -32768, -2147483648, -9223372036854775808, -9223372036854775808)",
+        "(1, -127, -32767, -2147483647, -9223372036854775807, -9223372036854775807)",
+        "(1, null, null, null, null, null)"
+        };
+        for (int i=0; i < values.length; i++) {
+            spliceClassWatcher.executeUpdate(format("insert into ts_int values %s", values[i]));
+        }
+
+        new TableCreator(conn)
+                .withCreate("create table ts_float (j double, f1 float(40), f2 float(45), f3 real, f4 double)")
+                .withInsert("insert into ts_float values(?, ?, ?, ?, ?)")
+                .create();
+
+        String [] values2 = {
+        "(1, 3.11111111111E+8, 3.111111111111111111E+8, 3.11111111111E+8, 3.111111111111111111E+8)",
+        "(1, 3.11111111111E+28, 3.111111111111111111E+3, 3.11111111111E+8, 3.111111111111111111E+3)",
+        "(1, 3.11111111111E+18, 3.111111111111111111E+13, 3.11111111111E+8, 3.111111111111111111E+13)",
+        "(1, 3.11111111111E+54, 3.111111111111111111E+72, 3.11111111111E+8, 3.111111111111111111E+72)",
+        "(1, null, null, null, null)"
+        };
+
+        for (int i=0; i < values2.length; i++) {
+            spliceClassWatcher.executeUpdate(format("insert into ts_float values %s", values2[i]));
+        }
+
+        new TableCreator(conn)
+                .withCreate("create table ts_datetime (j date, d date, ts timestamp, t time)")
+                .withInsert("insert into ts_datetime values(?, ?, ?, ?)")
+                .withRows(rows(
+                        row("1999-01-01", "1999-01-01", "1999-01-01 12:00:00", "12:00:00"),
+                        row("1999-01-01", "1999-01-02", "1999-01-02 12:00:00", "12:01:00"),
+                        row("1999-01-01", "1999-01-03", "1999-01-03 12:00:00", "12:03:00"),
+                        row("1999-01-01", "1999-01-04", "1999-01-04 12:00:00", "11:00:00"),
+                        row("1999-01-01", null, null, null)))
+                .create();
+
+        new TableCreator(conn)
+                .withCreate("create table ts_char (j char(1), b char(3), c varchar(2), d long varchar)")
+                .withInsert("insert into ts_char values(?, ?, ?, ?)")
+                .withRows(rows(
+                        row("1", "1", "1","1"),
+                        row("1", "2", "2","2"),
+                        row("1", "3", "3","3"),
+                        row("1", "4", "4","4"),
+                        row("1", null, null, null)))
+                .create();
+
+    }
+
+    @BeforeClass
+    public static void createDataSet() throws Exception {
+        createData(spliceClassWatcher.getOrCreateConnection(), spliceSchemaWatcher.toString());
+    }
+
+    @Test
+    public void testInt() throws Exception {
+
+        /* create table ts_int (j int, t tinyint, s smallint, i int, l bigint, d decimal(38,0)) */
+        String sqlText = null;
+        String expected = null;
+        String expectedTemplate =
+                "1 |\n" +
+                "----\n" +
+                "%s |";
+
+        String[] joins = {", ", "left outer join ", "where exists (select 1 from ", "where not exists (select 1 from "};
+        String[] whereOrOnClause = {"where", "on ", "where", "where"};
+        String[] closingParenthesis = {"", "", ")", ")"};
+        String [][] expectedCounts = {{"14","14","22","14","14"," 9","24","21","21"},
+                                      {"16","16","23","16","16","12","27","22","21"},
+                                      {" 5"," 5"," 6"," 5"," 5"," 4"," 4"," 6"," 7"},
+                                      {" 2"," 2"," 1"," 2"," 2"," 3"," 3"," 1"," 0"}};
+
+        String [] joinConditions = {"%s tab1.j = tab2.j and tab1.t > tab2.t ",
+                                    "%s tab1.j = tab2.j and (tab1.t > tab2.t or tab1.t > tab2.t - 1 and tab1.t > tab2.t + 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.t > tab2.t + 1 and tab1.t > tab2.t or tab1.t > tab2.t - 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.t > tab2.t + 1 and tab1.t > tab2.t - 1 or tab1.t > tab2.t) ",
+                                    "%s (tab1.t > tab2.t + 1 and tab1.t > tab2.t - 1 or tab1.t > tab2.t) and tab1.j = tab2.j ",
+                                    "%s tab1.j = tab2.j and ((tab1.t > tab2.t or tab1.t > tab2.t - 1) and tab1.t > tab2.t + 1) ",
+                                    "%s tab1.j = tab2.j and ((tab1.t > tab2.t or tab1.t > tab2.t * 0.9) and tab1.t > tab2.t / 1.1) ",
+                                    "%s tab1.j = tab2.j and (tab1.t > tab2.t or tab1.t is null) ",
+                                    "%s tab1.j = tab2.j and (tab1.t > tab2.t or tab2.t is null) "
+        };
+        for (int i = 0; i < joins.length; i++)
+          for (int j = 0; j < joinConditions.length; j++) {
+            sqlText = format("/* i=%d, j=%d */ select count(*) from ts_int tab1 %s ts_int tab2 " +
+            "--splice-properties useSpark=%s, joinStrategy=%s\n" +
+            "%s " +
+            "%s" +
+            "order by 1", i, j, joins[i], useSpark, joinStrategy, joinConditions[j], closingParenthesis[i]);
+            sqlText = format(sqlText, whereOrOnClause[i]);
+            expected = format(expectedTemplate, expectedCounts[i][j]);
+            testQuery(sqlText, expected, methodWatcher);
+          }
+
+       String []  joinConditions2 = {"%s tab1.j = tab2.j and tab1.s > tab2.s ",
+                                    "%s tab1.j = tab2.j and (tab1.s > tab2.s or tab1.s > tab2.s - 1 and tab1.s > tab2.s + 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.s > tab2.s + 1 and tab1.s > tab2.s or tab1.s > tab2.s - 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.s > tab2.s + 1 and tab1.s > tab2.s - 1 or tab1.s > tab2.s) ",
+                                    "%s (tab1.s > tab2.s + 1 and tab1.s > tab2.s - 1 or tab1.s > tab2.s) and tab1.j = tab2.j ",
+                                    "%s tab1.j = tab2.j and ((tab1.s > tab2.s or tab1.s > tab2.s - 1) and tab1.s > tab2.s + 1) ",
+                                    "%s tab1.j = tab2.j and ((tab1.s > tab2.s or tab1.s > tab2.s * 0.9) and tab1.s > tab2.s / 1.1) ",
+                                    "%s tab1.j = tab2.j and (tab1.s > tab2.s or tab1.s is null) ",
+                                    "%s tab1.j = tab2.j and (tab1.s > tab2.s or tab2.s is null) "
+        };
+        for (int i = 0; i < joins.length; i++)
+          for (int j = 0; j < joinConditions2.length; j++) {
+            sqlText = format("select count(*) from ts_int tab1 %s ts_int tab2 " +
+            "--splice-properties useSpark=%s, joinStrategy=%s\n" +
+            "%s " +
+            "%s" +
+            "order by 1", joins[i], useSpark, joinStrategy, joinConditions2[j], closingParenthesis[i]);
+            sqlText = format(sqlText, whereOrOnClause[i]);
+            expected = format(expectedTemplate, expectedCounts[i][j]);
+            testQuery(sqlText, expected, methodWatcher);
+          }
+
+       String []  joinConditions3 = {"%s tab1.j = tab2.j and tab1.i > tab2.i ",
+                                    "%s tab1.j = tab2.j and (tab1.i > tab2.i or tab1.i > tab2.i - 1 and tab1.i > tab2.i + 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.i > tab2.i + 1 and tab1.i > tab2.i or tab1.i > tab2.i - 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.i > tab2.i + 1 and tab1.i > tab2.i - 1 or tab1.i > tab2.i) ",
+                                    "%s (tab1.i > tab2.i + 1 and tab1.i > tab2.i - 1 or tab1.i > tab2.i) and tab1.j = tab2.j ",
+                                    "%s tab1.j = tab2.j and ((tab1.i > tab2.i or tab1.i > tab2.i - 1) and tab1.i > tab2.i + 1) ",
+                                    "%s tab1.j = tab2.j and ((tab1.i > tab2.i or tab1.i > tab2.i * 0.9) and tab1.i > tab2.i / 1.1) ",
+                                    "%s tab1.j = tab2.j and (tab1.i > tab2.i or tab1.i is null) ",
+                                    "%s tab1.j = tab2.j and (tab1.i > tab2.i or tab2.i is null) "
+        };
+        for (int i = 0; i < joins.length; i++)
+          for (int j = 0; j < joinConditions3.length; j++) {
+            sqlText = format("select count(*) from ts_int tab1 %s ts_int tab2 " +
+            "--splice-properties useSpark=%s, joinStrategy=%s\n" +
+            "%s " +
+            "%s" +
+            "order by 1", joins[i], useSpark, joinStrategy, joinConditions3[j], closingParenthesis[i]);
+            sqlText = format(sqlText, whereOrOnClause[i]);
+            expected = format(expectedTemplate, expectedCounts[i][j]);
+            testQuery(sqlText, expected, methodWatcher);
+          }
+
+       String []  joinConditions4 = {"%s tab1.j = tab2.j and tab1.l > tab2.l ",
+                                    "%s tab1.j = tab2.j and (tab1.l > tab2.l or tab1.l > tab2.l - 1 and tab1.l > tab2.l + 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.l > tab2.l + 1 and tab1.l > tab2.l or tab1.l > tab2.l - 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.l > tab2.l + 1 and tab1.l > tab2.l - 1 or tab1.l > tab2.l) ",
+                                    "%s (tab1.l > tab2.l + 1 and tab1.l > tab2.l - 1 or tab1.l > tab2.l) and tab1.j = tab2.j ",
+                                    "%s tab1.j = tab2.j and ((tab1.l > tab2.l or tab1.l > tab2.l - 1) and tab1.l > tab2.l + 1) ",
+                                    "%s tab1.j = tab2.j and ((tab1.l > tab2.l or tab1.l > tab2.l * 0.9) and tab1.l > tab2.l / 1.1) ",
+                                    "%s tab1.j = tab2.j and (tab1.l > tab2.l or tab1.l is null) ",
+                                    "%s tab1.j = tab2.j and (tab1.l > tab2.l or tab2.l is null) "
+        };
+        for (int i = 0; i < joins.length; i++)
+          for (int j = 0; j < joinConditions4.length; j++) {
+            sqlText = format("select count(*) from ts_int tab1 %s ts_int tab2 " +
+            "--splice-properties useSpark=%s, joinStrategy=%s\n" +
+            "%s " +
+            "%s" +
+            "order by 1", joins[i], useSpark, joinStrategy, joinConditions4[j], closingParenthesis[i]);
+            sqlText = format(sqlText, whereOrOnClause[i]);
+            expected = format(expectedTemplate, expectedCounts[i][j]);
+            testQuery(sqlText, expected, methodWatcher);
+          }
+
+       String []  joinConditions5 = {"%s tab1.j = tab2.j and tab1.d > tab2.d ",
+                                    "%s tab1.j = tab2.j and (tab1.d > tab2.d or tab1.d > tab2.d - 1 and tab1.d > tab2.d + 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.d > tab2.d + 1 and tab1.d > tab2.d or tab1.d > tab2.d - 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.d > tab2.d + 1 and tab1.d > tab2.d - 1 or tab1.d > tab2.d) ",
+                                    "%s (tab1.d > tab2.d + 1 and tab1.d > tab2.d - 1 or tab1.d > tab2.d) and tab1.j = tab2.j ",
+                                    "%s tab1.j = tab2.j and ((tab1.d > tab2.d or tab1.d > tab2.d - 1) and tab1.d > tab2.d + 1) ",
+                                    "%s tab1.j = tab2.j and ((tab1.d > tab2.d or tab1.d > tab2.d * 0.9) and tab1.d > tab2.d / 1.1) ",
+                                    "%s tab1.j = tab2.j and (tab1.d > tab2.d or tab1.d is null) ",
+                                    "%s tab1.j = tab2.j and (tab1.d > tab2.d or tab2.d is null) "
+        };
+        for (int i = 0; i < joins.length; i++)
+          for (int j = 0; j < joinConditions5.length; j++) {
+            sqlText = format("select count(*) from ts_int tab1 %s ts_int tab2 " +
+            "--splice-properties useSpark=%s, joinStrategy=%s\n" +
+            "%s " +
+            "%s" +
+            "order by 1", joins[i], useSpark, joinStrategy, joinConditions5[j], closingParenthesis[i]);
+            sqlText = format(sqlText, whereOrOnClause[i]);
+            expected = format(expectedTemplate, expectedCounts[i][j]);
+            testQuery(sqlText, expected, methodWatcher);
+          }
+
+       String []  joinConditions6 = {"%s tab1.j = tab2.j and tab1.d > tab2.l ",
+                                    "%s tab1.j = tab2.j and (tab1.d > tab2.l or tab1.l > tab2.d - 1 and tab1.l > tab2.d + 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.l > tab2.d + 1 and tab1.d > tab2.l or tab1.d > tab2.l - 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.d > tab2.l + 1 and tab1.l > tab2.d - 1 or tab1.l > tab2.d) ",
+                                    "%s (tab1.d > tab2.l + 1 and tab1.d > tab2.l - 1 or tab1.d > tab2.l) and tab1.j = tab2.j ",
+                                    "%s tab1.j = tab2.j and ((tab1.l > tab2.d or tab1.l > tab2.d - 1) and tab1.l > tab2.d + 1) ",
+                                    "%s tab1.j = tab2.j and ((tab1.d > tab2.l or tab1.d > tab2.l * 0.9) and tab1.l > tab2.d / 1.1) ",
+                                    "%s tab1.j = tab2.j and (tab1.d > tab2.l or tab1.d is null) ",
+                                    "%s tab1.j = tab2.j and (tab1.d > tab2.l or tab2.d is null) "
+        };
+        for (int i = 0; i < joins.length; i++)
+          for (int j = 0; j < joinConditions6.length; j++) {
+            sqlText = format("select count(*) from ts_int tab1 %s ts_int tab2 " +
+            "--splice-properties useSpark=%s, joinStrategy=%s\n" +
+            "%s " +
+            "%s" +
+            "order by 1", joins[i], useSpark, joinStrategy, joinConditions6[j], closingParenthesis[i]);
+            sqlText = format(sqlText, whereOrOnClause[i]);
+            expected = format(expectedTemplate, expectedCounts[i][j]);
+            testQuery(sqlText, expected, methodWatcher);
+          }
+    }
+
+    @Test
+    public void testFloat() throws Exception {
+
+        /* create table ts_float (j double, f1 float(40), f2 float(45), f3 real, f4 double) */
+        String sqlText = null;
+        String expected = null;
+        String expectedTemplate =
+                "1 |\n" +
+                "----\n" +
+                "%s |";
+
+        String[] joins = {", ", "left outer join ", "where exists (select 1 from ", "where not exists (select 1 from "};
+        String[] whereOrOnClause = {"where", "on ", "where", "where"};
+        String[] closingParenthesis = {"", "", ")", ")"};
+        String [][] expectedCounts = {{" 6"," 6"," 7"," 6"," 6"," 6"},
+                                      {" 8"," 8"," 8"," 8"," 8"," 8"},
+                                      {" 3"," 3"," 4"," 3"," 3"," 3"},
+                                      {" 2"," 2"," 1"," 2"," 2"," 2"}};
+
+        String [] joinConditions = {"%s tab1.j = tab2.j and tab1.f1 > tab2.f1 ",
+                                    "%s tab1.j = tab2.j and (tab1.f1 > tab2.f1 or tab1.f1 > tab2.f1 - 1 and tab1.f1 > tab2.f1 + 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.f1 > tab2.f1 + 1 and tab1.f1 > tab2.f1 or tab1.f1 > tab2.f1 - 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.f1 > tab2.f1 + 1 and tab1.f1 > tab2.f1 - 1 or tab1.f1 > tab2.f1) ",
+                                    "%s (tab1.f1 > tab2.f1 + 1 and tab1.f1 > tab2.f1 - 1 or tab1.f1 > tab2.f1) and tab1.j = tab2.j ",
+                                    "%s tab1.j = tab2.j and ((tab1.f1 > tab2.f1 or tab1.f1 > tab2.f1 - 1) and tab1.f1 > tab2.f1 + 1) "};
+
+        for (int i = 0; i < joins.length; i++)
+          for (int j = 0; j < joinConditions.length; j++) {
+            sqlText = format("/* i=%d, j=%d */ select count(*) from ts_float tab1 %s ts_float tab2 " +
+            "--splice-properties useSpark=%s, joinStrategy=%s\n" +
+            "%s " +
+            "%s"
+            , i, j, joins[i], useSpark, joinStrategy, joinConditions[j], closingParenthesis[i]);
+            sqlText = format(sqlText, whereOrOnClause[i]);
+            expected = format(expectedTemplate, expectedCounts[i][j]);
+            testQueryUnsorted(sqlText, expected, methodWatcher);
+          }
+
+        String [] joinConditions2 = {"%s tab1.j = tab2.j and tab1.f2 > tab2.f2 ",
+                                    "%s tab1.j = tab2.j and (tab1.f2 > tab2.f2 or tab1.f2 > tab2.f2 - 1 and tab1.f2 > tab2.f2 + 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.f2 > tab2.f2 + 1 and tab1.f2 > tab2.f2 or tab1.f2 > tab2.f2 - 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.f2 > tab2.f2 + 1 and tab1.f2 > tab2.f2 - 1 or tab1.f2 > tab2.f2) ",
+                                    "%s (tab1.f2 > tab2.f2 + 1 and tab1.f2 > tab2.f2 - 1 or tab1.f2 > tab2.f2) and tab1.j = tab2.j ",
+                                    "%s tab1.j = tab2.j and ((tab1.f2 > tab2.f2 or tab1.f2 > tab2.f2 - 1) and tab1.f2 > tab2.f2 + 1) "};
+        String [][] expectedCounts2 = {{" 6"," 6"," 9"," 6"," 6"," 6"},
+                                      {" 8"," 8","10"," 8"," 8"," 8"},
+                                      {" 3"," 3"," 4"," 3"," 3"," 3"},
+                                      {" 2"," 2"," 1"," 2"," 2"," 2"}};
+
+        for (int i = 0; i < joins.length; i++)
+          for (int j = 0; j < joinConditions2.length; j++) {
+            sqlText = format("/* i=%d, j=%d */ select count(*) from ts_float tab1 %s ts_float tab2 " +
+            "--splice-properties useSpark=%s, joinStrategy=%s\n" +
+            "%s " +
+            "%s" +
+            "order by 1", i, j, joins[i], useSpark, joinStrategy, joinConditions2[j], closingParenthesis[i]);
+            sqlText = format(sqlText, whereOrOnClause[i]);
+            expected = format(expectedTemplate, expectedCounts2[i][j]);
+            testQuery(sqlText, expected, methodWatcher);
+          }
+
+        String [] joinConditions3 = {"%s tab1.j = tab2.j and tab1.f3 > tab2.f3 ",
+                                    "%s tab1.j = tab2.j and (tab1.f3 > tab2.f3 or tab1.f3 > tab2.f3 - 1 and tab1.f3 > tab2.f3 + 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.f3 > tab2.f3 + 1 and tab1.f3 > tab2.f3 or tab1.f3 > tab2.f3 - 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.f3 > tab2.f3 + 1 and tab1.f3 > tab2.f3 - 1 or tab1.f3 > tab2.f3) ",
+                                    "%s (tab1.f3 > tab2.f3 + 1 and tab1.f3 > tab2.f3 - 1 or tab1.f3 > tab2.f3) and tab1.j = tab2.j ",
+                                    "%s tab1.j = tab2.j and ((tab1.f3 > tab2.f3 or tab1.f3 > tab2.f3 - 1) and tab1.f3 > tab2.f3 + 1) "};
+
+        String [][] expectedCounts3 = {{" 0"," 0","16"," 0"," 0"," 0"},
+                                      {" 5"," 5","17"," 5"," 5"," 5"},
+                                      {" 0"," 0"," 4"," 0"," 0"," 0"},
+                                      {" 5"," 5"," 1"," 5"," 5"," 5"}};
+
+        for (int i = 0; i < joins.length; i++)
+          for (int j = 0; j < joinConditions3.length; j++) {
+            sqlText = format("/* i=%d, j=%d */ select count(*) from ts_float tab1 %s ts_float tab2 " +
+            "--splice-properties useSpark=%s, joinStrategy=%s\n" +
+            "%s " +
+            "%s" +
+            "order by 1", i, j, joins[i], useSpark, joinStrategy, joinConditions3[j], closingParenthesis[i]);
+            sqlText = format(sqlText, whereOrOnClause[i]);
+            expected = format(expectedTemplate, expectedCounts3[i][j]);
+            testQuery(sqlText, expected, methodWatcher);
+          }
+
+        String [] joinConditions4 = {"%s tab1.j = tab2.j and tab1.f4 > tab2.f4 ",
+                                    "%s tab1.j = tab2.j and (tab1.f4 > tab2.f4 or tab1.f4 > tab2.f4 - 1 and tab1.f4 > tab2.f4 + 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.f4 > tab2.f4 + 1 and tab1.f4 > tab2.f4 or tab1.f4 > tab2.f4 - 1) ",
+                                    "%s tab1.j = tab2.j and (tab1.f4 > tab2.f4 + 1 and tab1.f4 > tab2.f4 - 1 or tab1.f4 > tab2.f4) ",
+                                    "%s (tab1.f4 > tab2.f4 + 1 and tab1.f4 > tab2.f4 - 1 or tab1.f4 > tab2.f4) and tab1.j = tab2.j ",
+                                    "%s tab1.j = tab2.j and ((tab1.f4 > tab2.f4 or tab1.f4 > tab2.f4 - 1) and tab1.f4 > tab2.f4 + 1) "};
+
+        String [][] expectedCounts4 = {{" 6"," 6"," 9"," 6"," 6"," 6"},
+                                      {" 8"," 8","10"," 8"," 8"," 8"},
+                                      {" 3"," 3"," 4"," 3"," 3"," 3"},
+                                      {" 2"," 2"," 1"," 2"," 2"," 2"}};
+
+        for (int i = 0; i < joins.length; i++)
+          for (int j = 0; j < joinConditions4.length; j++) {
+            sqlText = format("/* i=%d, j=%d */ select count(*) from ts_float tab1 %s ts_float tab2 " +
+            "--splice-properties useSpark=%s, joinStrategy=%s\n" +
+            "%s " +
+            "%s" +
+            "order by 1", i, j, joins[i], useSpark, joinStrategy, joinConditions4[j], closingParenthesis[i]);
+            sqlText = format(sqlText, whereOrOnClause[i]);
+            expected = format(expectedTemplate, expectedCounts4[i][j]);
+            testQuery(sqlText, expected, methodWatcher);
+          }
+    }
+
+    @Test
+    public void testDateTime() throws Exception {
+
+        /* create table ts_datetime (j date, d date, t timestamp) */
+        String sqlText = null;
+        String expected = null;
+        String expectedTemplate =
+        "1 |\n" +
+        "----\n" +
+        "%s |";
+
+        String[] joins = {", ", "left outer join ", "where exists (select 1 from ", "where not exists (select 1 from "};
+        String[] whereOrOnClause = {"where", "on ", "where", "where"};
+        String[] closingParenthesis = {"", "", ")", ")"};
+        String[][] expectedCounts = {{" 6", " 6", "10", " 6", " 6", " 3"},
+                                    {" 8", " 8", "11", " 8", " 8", " 6"},
+                                    {" 3", " 3", " 4", " 3", " 3", " 2"},
+                                    {" 2", " 2", " 1", " 2", " 2", " 3"}};
+
+        String[] joinConditions = {"%s tab1.j = tab2.j and tab1.d > tab2.d ",
+        "%s tab1.j = tab2.j and (tab1.d > tab2.d or tab1.d > tab2.d - 1 and tab1.d > tab2.d + 1) ",
+        "%s tab1.j = tab2.j and (tab1.d > tab2.d + 1 and tab1.d > tab2.d or tab1.d > tab2.d - 1) ",
+        "%s tab1.j = tab2.j and (tab1.d > tab2.d + 1 and tab1.d > tab2.d - 1 or tab1.d > tab2.d) ",
+        "%s (tab1.d > tab2.d + 1 and tab1.d > tab2.d - 1 or tab1.d > tab2.d) and tab1.j = tab2.j ",
+        "%s tab1.j = tab2.j and ((tab1.d > tab2.d or tab1.d > tab2.d - 1) and tab1.d > tab2.d + 1) "};
+
+        for (int i = 0; i < joins.length; i++)
+            for (int j = 0; j < joinConditions.length; j++) {
+                sqlText = format("/* i=%d, j=%d */ select count(*) from ts_datetime tab1 %s ts_datetime tab2 " +
+                "--splice-properties useSpark=%s, joinStrategy=%s\n" +
+                "%s " +
+                "%s"
+                , i, j, joins[i], useSpark, joinStrategy, joinConditions[j], closingParenthesis[i]);
+                sqlText = format(sqlText, whereOrOnClause[i]);
+                expected = format(expectedTemplate, expectedCounts[i][j]);
+                testQueryUnsorted(sqlText, expected, methodWatcher);
+            }
+
+        String[][] expectedCounts2 = {{" 6", " 6", "10", " 6", " 6", " 3"},
+                                    {" 8", " 8", "11", " 8", " 8", " 6"},
+                                    {" 3", " 3", " 4", " 3", " 3", " 2"},
+                                    {" 2", " 2", " 1", " 2", " 2", " 3"}};
+
+        String[] joinConditions2 = {"%s tab1.j = tab2.j and tab1.ts > tab2.ts ",
+        "%s tab1.j = tab2.j and (tab1.ts > tab2.ts or tab1.ts > tab2.ts - 1 and tab1.ts > tab2.ts + 1) ",
+        "%s tab1.j = tab2.j and (tab1.ts > tab2.ts + 1 and tab1.ts > tab2.ts or tab1.ts > tab2.ts - 1) ",
+        "%s tab1.j = tab2.j and (tab1.ts > tab2.ts + 1 and tab1.ts > tab2.ts - 1 or tab1.ts > tab2.ts) ",
+        "%s (tab1.ts > tab2.ts + 1 and tab1.ts > tab2.ts - 1 or tab1.ts > tab2.ts) and tab1.j = tab2.j ",
+        "%s tab1.j = tab2.j and ((tab1.ts > tab2.ts or tab1.ts > tab2.ts - 1) and tab1.ts > tab2.ts + 1) "};
+
+        for (int i = 0; i < joins.length; i++)
+            for (int j = 0; j < joinConditions2.length; j++) {
+                sqlText = format("/* i=%d, j=%d */ select count(*) from ts_datetime tab1 %s ts_datetime tab2 " +
+                "--splice-properties useSpark=%s, joinStrategy=%s\n" +
+                "%s " +
+                "%s"
+                , i, j, joins[i], useSpark, joinStrategy, joinConditions2[j], closingParenthesis[i]);
+                sqlText = format(sqlText, whereOrOnClause[i]);
+                expected = format(expectedTemplate, expectedCounts2[i][j]);
+                testQueryUnsorted(sqlText, expected, methodWatcher);
+            }
+
+        String[][] expectedCounts3 = {{" 6", " 6", "12", "10", " 4", " 0", " 3"},
+                                    {" 8", " 8", "13", "11", " 5", " 5", " 5"},
+                                    {" 3", " 3", " 4", " 4", " 4", " 0", " 3"},
+                                    {" 2", " 2", " 1", " 1", " 1", " 5", " 2"}};
+
+        String[] joinConditions3 = {"%s tab1.j = tab2.j and tab1.t > tab2.t ",
+        "%s tab1.j = tab2.j and (tab1.t > tab2.t or tab1.t > tab2.t and tab1.t >= tab2.t) ",
+        "%s tab1.j = tab2.j and (tab1.t >= tab2.t and tab1.t > tab2.t or tab1.t < tab2.t) ",
+        "%s tab1.j = tab2.j and (tab1.t > tab2.t and tab1.t >= tab2.t or tab1.t >= tab2.t) ",
+        "%s (tab1.t > tab2.t and tab1.t < tab2.t or tab1.t = tab2.t) and tab1.j = tab2.j ",
+        "%s tab1.j = tab2.j and ((tab1.t = tab2.t or tab1.t is null) and tab1.t > tab2.t) ",
+        "%s tab1.j = tab2.j and ((tab1.t = tab2.t or tab1.t is null) and tab1.t > TO_TIME('11:44', 'HH:mm')) ",
+        };
+
+        for (int i = 0; i < joins.length; i++)
+            for (int j = 0; j < joinConditions3.length; j++) {
+                sqlText = format("/* i=%d, j=%d */ select count(*) from ts_datetime tab1 %s ts_datetime tab2 " +
+                "--splice-properties useSpark=%s, joinStrategy=%s\n" +
+                "%s " +
+                "%s"
+                , i, j, joins[i], useSpark, joinStrategy, joinConditions3[j], closingParenthesis[i]);
+                sqlText = format(sqlText, whereOrOnClause[i]);
+                expected = format(expectedTemplate, expectedCounts3[i][j]);
+                testQueryUnsorted(sqlText, expected, methodWatcher);
+            }
+    }
+
+    @Test
+    public void testChar() throws Exception {
+
+        /* create table ts_char (j char(1), b char(3), c varchar(2), d long varchar) */
+        String sqlText = null;
+        String expected = null;
+        String expectedTemplate =
+        "1 |\n" +
+        "----\n" +
+        "%s |";
+
+        String[] joins = {", ", "left outer join ", "where exists (select 1 from ", "where not exists (select 1 from "};
+        String[] whereOrOnClause = {"where", "on ", "where", "where"};
+        String[] closingParenthesis = {"", "", ")", ")"};
+        String[][] expectedCounts = {{" 6", " 6", "10", " 6", " 6", " 3"},
+                                    {" 8", " 8", "11", " 8", " 8", " 6"},
+                                    {" 3", " 3", " 4", " 3", " 3", " 2"},
+                                    {" 2", " 2", " 1", " 2", " 2", " 3"}};
+
+        String[] joinConditions = {"%s tab1.j = tab2.j and tab1.b > tab2.b ",
+        "%s tab1.j = tab2.j and (tab1.b > tab2.b or tab1.b > tab2.b - 1 and tab1.b > tab2.b + 1) ",
+        "%s tab1.j = tab2.j and (tab1.b > tab2.b + 1 and tab1.b > tab2.b or tab1.b > tab2.b - 1) ",
+        "%s tab1.j = tab2.j and (tab1.b > tab2.b + 1 and tab1.b > tab2.b - 1 or tab1.b > tab2.b) ",
+        "%s (tab1.b > tab2.b + 1 and tab1.b > tab2.b - 1 or tab1.b > tab2.b) and tab1.j = tab2.j ",
+        "%s tab1.j = tab2.j and ((tab1.b > tab2.b or tab1.b > tab2.b - 1) and tab1.b > tab2.b + 1) "};
+
+        for (int i = 0; i < joins.length; i++)
+            for (int j = 0; j < joinConditions.length; j++) {
+                sqlText = format("/* i=%d, j=%d */ select count(*) from ts_char tab1 %s ts_char tab2 " +
+                "--splice-properties useSpark=%s, joinStrategy=%s\n" +
+                "%s " +
+                "%s"
+                , i, j, joins[i], useSpark, joinStrategy, joinConditions[j], closingParenthesis[i]);
+                sqlText = format(sqlText, whereOrOnClause[i]);
+                expected = format(expectedTemplate, expectedCounts[i][j]);
+                testQueryUnsorted(sqlText, expected, methodWatcher);
+            }
+
+        String[][] expectedCounts2 = {{" 6", " 6", "10", " 6", " 6", " 3"},
+                                    {" 8", " 8", "11", " 8", " 8", " 6"},
+                                    {" 3", " 3", " 4", " 3", " 3", " 2"},
+                                    {" 2", " 2", " 1", " 2", " 2", " 3"}};
+
+        String[] joinConditions2 = {"%s tab1.j = tab2.j and tab1.c > tab2.c ",
+        "%s tab1.j = tab2.j and (tab1.c > tab2.c or tab1.c > tab2.c - 1 and tab1.c > tab2.c + 1) ",
+        "%s tab1.j = tab2.j and (tab1.c > tab2.c + 1 and tab1.c > tab2.c or tab1.c > tab2.c - 1) ",
+        "%s tab1.j = tab2.j and (tab1.c > tab2.c + 1 and tab1.c > tab2.c - 1 or tab1.c > tab2.c) ",
+        "%s (tab1.c > tab2.c + 1 and tab1.c > tab2.c - 1 or tab1.c > tab2.c) and tab1.j = tab2.j ",
+        "%s tab1.j = tab2.j and ((tab1.c > tab2.c or tab1.c > tab2.c - 1) and tab1.c > tab2.c + 1) "};
+
+        for (int i = 0; i < joins.length; i++)
+            for (int j = 0; j < joinConditions2.length; j++) {
+                sqlText = format("/* i=%d, j=%d */ select count(*) from ts_char tab1 %s ts_char tab2 " +
+                "--splice-properties useSpark=%s, joinStrategy=%s\n" +
+                "%s " +
+                "%s"
+                , i, j, joins[i], useSpark, joinStrategy, joinConditions2[j], closingParenthesis[i]);
+                sqlText = format(sqlText, whereOrOnClause[i]);
+                expected = format(expectedTemplate, expectedCounts2[i][j]);
+                testQueryUnsorted(sqlText, expected, methodWatcher);
+            }
+
+        String[][] expectedCounts3 = {{"10", "10", "10", "10", "10", " 3"},
+                                    {"11", "11", "11", "11", "11", " 6"},
+                                    {" 4", " 4", " 4", " 4", " 4", " 2"},
+                                    {" 1", " 1", " 1", " 1", " 1", " 3"}};
+
+        String[] joinConditions3 = {"%s tab1.j = tab2.j and tab1.b > tab2.c ",
+        "%s tab1.j = tab2.j and (tab1.b > tab2.c or tab1.b > tab2.c - 1 and tab1.b > tab2.c + 1) ",
+        "%s tab1.j = tab2.j and (tab1.b > tab2.c + 1 and tab1.b > tab2.c or tab1.b > tab2.c - 1) ",
+        "%s tab1.j = tab2.j and (tab1.b > tab2.c + 1 and tab1.b > tab2.c - 1 or tab1.b > tab2.c) ",
+        "%s (tab1.b > tab2.c + 1 and tab1.b > tab2.c - 1 or tab1.b > tab2.c) and tab1.j = tab2.j ",
+        "%s tab1.j = tab2.j and ((tab1.b > tab2.c or tab1.b > tab2.c - 1) and tab1.b > tab2.c + 1) "};
+
+        for (int i = 0; i < joins.length; i++)
+            for (int j = 0; j < joinConditions3.length; j++) {
+                sqlText = format("/* i=%d, j=%d */ select count(*) from ts_char tab1 %s ts_char tab2 " +
+                "--splice-properties useSpark=%s, joinStrategy=%s\n" +
+                "%s " +
+                "%s"
+                , i, j, joins[i], useSpark, joinStrategy, joinConditions3[j], closingParenthesis[i]);
+                sqlText = format(sqlText, whereOrOnClause[i]);
+                expected = format(expectedTemplate, expectedCounts3[i][j]);
+                testQueryUnsorted(sqlText, expected, methodWatcher);
+            }
+    }
+}


### PR DESCRIPTION
Performance feature to execute joins with both equality and inequality join predicates as native spark operations, e.g.  select * from t1, t2 where t1.c1 = t2.c1 and t1.c2 <> t2.c2.  

Only broadcast join and sortmerge join are affected, as these are the only native spark joins with join predicates Splice supports.  Cross join is native spark, but in that case the join conditions are applied as a filter on the resulting DataFrame after the join is executed, so it cannot apply this optimization.  

This improves the performance of TPC-H query 21.   
See [SPLICE-2362](https://splice.atlassian.net/browse/SPLICE-2362?focusedCommentId=27913&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-27913) 