### PR TITLE
SPLICE-2385 Fix BETWEEN clause in native Spark projections.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
@@ -323,8 +323,10 @@ public class OperatorToString {
             }
         }else if(operand instanceof BinaryListOperatorNode){
             vars.relationalOpDepth.increment();
+            boolean isBetween = operand instanceof BetweenOperatorNode;
             BinaryListOperatorNode blon = (BinaryListOperatorNode)operand;
-            StringBuilder inList = new StringBuilder("(");
+            StringBuilder inList = isBetween ? new StringBuilder() :
+                                               new StringBuilder("(");
             if (!blon.isSingleLeftOperand()) {
                 ValueNodeList vnl = blon.leftOperandList;
                 inList.append("(");
@@ -338,15 +340,22 @@ public class OperatorToString {
             }
             else
                 inList.append(opToString2(blon.getLeftOperand(), vars));
-            inList.append(" ").append(blon.getOperator()).append(" (");
+            inList.append(" ").append(blon.getOperator());
+            String appendString = isBetween ? " " : " (";
+            inList.append(appendString);
             ValueNodeList rightOperandList=blon.getRightOperandList();
             boolean isFirst = true;
             for(Object qtn: rightOperandList){
                 if(isFirst) isFirst = false;
-                else inList = inList.append(",");
+                else if (isBetween)
+                    inList = inList.append(" and ");
+                else
+                    inList = inList.append(",");
                 inList = inList.append(opToString2((ValueNode)qtn, vars));
             }
-            String retval = inList.append("))").toString();
+            if (!isBetween)
+                inList.append("))");
+            String retval = inList.toString();
             vars.relationalOpDepth.decrement();
             return retval;
         }else if (operand instanceof BinaryOperatorNode) {

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictSparkExpressionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictSparkExpressionIT.java
@@ -71,36 +71,66 @@ public class ProjectRestrictSparkExpressionIT  extends SpliceUnitTest {
     @Test
     public void testLike() throws Exception {
         String expected =
-            "A |\n" +
-            "----\n" +
-            "a_ |";
+        "A |\n" +
+        "----\n" +
+        "a_ |";
 
         String query = format("select * from t1_like --SPLICE-PROPERTIES useSpark=%s\n" +
-            "where a LIKE 'a=_' ESCAPE '='", useSpark);
+        "where a LIKE 'a=_' ESCAPE '='", useSpark);
 
         testQuery(query, expected, methodWatcher);
 
         query = format("select * from t1_like --SPLICE-PROPERTIES useSpark=%s\n" +
-            "where a LIKE 'a%%' ", useSpark);
+        "where a LIKE 'a%%' ", useSpark);
 
         expected =
-            "A |\n" +
-            "----\n" +
-            " a |\n" +
-            " a |\n" +
-            "a_ |";
+        "A |\n" +
+        "----\n" +
+        " a |\n" +
+        " a |\n" +
+        "a_ |";
 
         testQuery(query, expected, methodWatcher);
 
         query = format("select * from t2_like --SPLICE-PROPERTIES useSpark=%s\n" +
-            "WHERE REGEXP_LIKE(a, '^Ste.*') ", useSpark);
+        "WHERE REGEXP_LIKE(a, '^Ste.*') ", useSpark);
 
         expected =
-            "A        |\n" +
-            "-----------------\n" +
-            "Stephen Tuvesco |\n" +
-            " Steve Mossely  |\n" +
-            " Steve Raster   |";
+        "A        |\n" +
+        "-----------------\n" +
+        "Stephen Tuvesco |\n" +
+        " Steve Mossely  |\n" +
+        " Steve Raster   |";
+
+        testQuery(query, expected, methodWatcher);
+
+    }
+
+    @Test
+    public void testBetween() throws Exception {
+        String expected =
+        "1                |\n" +
+        "----------------------------------\n" +
+        "0.024691357802469135780246913578 |\n" +
+        "2.000000000000000000000000000000 |";
+
+        String query = format("select tab1.a+tab2.a from t1 tab1, t1 tab2 --SPLICE-PROPERTIES useSpark=%s, joinStrategy=SORTMERGE\n" +
+        "where tab1.c=tab2.c and tab1.a+tab2.a between 0 and 1000", useSpark);
+
+        testQuery(query, expected, methodWatcher);
+
+    }
+
+    @Test
+    public void testIn() throws Exception {
+        String expected =
+        "1                |\n" +
+        "----------------------------------\n" +
+        "0.024691357802469135780246913578 |\n" +
+        "2.000000000000000000000000000000 |";
+
+        String query = format("select tab1.a+tab2.a from t1 tab1, t1 tab2 --SPLICE-PROPERTIES useSpark=%s, joinStrategy=SORTMERGE\n" +
+        "where tab1.c=tab2.c and tab1.a+tab2.a IN (0.024691357802469135780246913578, 2.0)", useSpark);
 
         testQuery(query, expected, methodWatcher);
 


### PR DESCRIPTION
Fixes a regression of SPLICE-2301.  The BETWEEN clause in a native spark projection is translated to Spark SQL as: BETWEEN (_expr1_,_expr2_)   ...  but should be:   BETWEEN _expr1_ AND _expr2_.