### PR TITLE
SPLICE-2387 AbstractFileFunction.getRow() instantiates too many Calendars

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
@@ -790,7 +790,7 @@ public class SpliceRegionAdmin {
 
         // return the primary key or index value in ExecRow
         ExecRow dataRow = FileFunction.getRow(read, quotedColumns, null,
-                execRow, null, timeFormat, dateFormat, timestampFormat, null, null, null);
+                execRow, new GregorianCalendar(), timeFormat, dateFormat, timestampFormat, null, null, null);
 
         // Encoded row value
         DataHash dataHash = getEncoder(td, index, execRow);

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AbstractFileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/AbstractFileFunction.java
@@ -67,7 +67,7 @@ public abstract class AbstractFileFunction<I> extends SpliceFlatMapFunction<Spli
     private String timestampFormat;
     private int[] columnIndex;
 
-    private transient Calendar calendar;
+    private transient Calendar calendar = new GregorianCalendar();
 
     @SuppressWarnings("WeakerAccess") //weaker access isn't allowed because we have to be serializable
     public AbstractFileFunction() { }
@@ -221,24 +221,18 @@ public abstract class AbstractFileFunction<I> extends SpliceFlatMapFunction<Spli
                 columnValue = value;
                 switch(type){
                     case StoredFormatIds.SQL_TIME_ID:
-                        if(calendar==null)
-                            calendar = new GregorianCalendar();
                         if (timeFormat == null || value==null){
                             ((DateTimeDataValue)dvd).setValue(value,calendar);
                         }else
                             dvd.setValue(SpliceDateFunctions.TO_TIME(value, timeFormat, timeFormatter), calendar);
                         break;
                     case StoredFormatIds.SQL_DATE_ID:
-                        if(calendar==null)
-                            calendar = new GregorianCalendar();
                         if (dateTimeFormat == null || value == null)
                             ((DateTimeDataValue)dvd).setValue(value,calendar);
                         else
                             dvd.setValue(TO_DATE(value, dateTimeFormat, dateFormatter),calendar);
                         break;
                     case StoredFormatIds.SQL_TIMESTAMP_ID:
-                        if(calendar==null)
-                            calendar = new GregorianCalendar();
                         if (timestampFormat == null || value==null)
                             ((DateTimeDataValue)dvd).setValue(value,calendar);
                         else {


### PR DESCRIPTION
Initialize _calendar_ in the default constructor.