### PR TITLE
SPLICE-2379 Spark Explain Statement

### DIFF
--- a/db-client/src/main/java/com/splicemachine/db/client/am/Statement.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Statement.java
@@ -2384,6 +2384,7 @@ public class Statement implements java.sql.Statement, StatementCallbackInterface
 
         if (firstToken.equalsIgnoreCase("select") || // captures <subselect> production
                 firstToken.equalsIgnoreCase("explain") ||
+                firstToken.equalsIgnoreCase("sparkexplain") ||
                 firstToken.equalsIgnoreCase("with") ||
                 firstToken.equalsIgnoreCase("export") ||
                 firstToken.equalsIgnoreCase("values")) // captures <values-clause> production

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Statement.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Statement.java
@@ -2385,6 +2385,9 @@ public class Statement implements java.sql.Statement, StatementCallbackInterface
         if (firstToken.equalsIgnoreCase("select") || // captures <subselect> production
                 firstToken.equalsIgnoreCase("explain") ||
                 firstToken.equalsIgnoreCase("sparkexplain") ||
+                firstToken.equalsIgnoreCase("sparkexplain_logical") ||
+                firstToken.equalsIgnoreCase("sparkexplain_optimized") ||
+                firstToken.equalsIgnoreCase("sparkexplain_analyzed") ||
                 firstToken.equalsIgnoreCase("with") ||
                 firstToken.equalsIgnoreCase("export") ||
                 firstToken.equalsIgnoreCase("values")) // captures <values-clause> production

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
@@ -655,7 +655,7 @@ public interface CompilerContext extends Context
 	 */
 	boolean isReferenced(SequenceDescriptor sd);
 
-    void setDataSetProcessorType(DataSetProcessorType type);
+    void setDataSetProcessorType(DataSetProcessorType type, boolean setDSPTypeinLCC);
 
     DataSetProcessorType getDataSetProcessorType();
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -1371,6 +1371,8 @@ public interface LanguageConnectionContext extends Context {
 
     CompilerContext.DataSetProcessorType getDataSetProcessorType();
 
+    void setDataSetProcessorType(CompilerContext.DataSetProcessorType type);
+
 	/**
 	 *
 	 * Setting the dynamic withDescriptors

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
@@ -1838,9 +1838,9 @@ public interface ResultSetFactory {
 			double optimizerEstimatedCost,
 			String explainPlan) throws StandardException;
 
-    NoPutResultSet getExplainResultSet(ResultSet source, Activation activation, int resultSetNumber) throws StandardException;
+    NoPutResultSet getExplainResultSet(ResultSet source, Activation activation, int resultSetNumber, String sparkExplainKind) throws StandardException;
 
-    NoPutResultSet getExplainResultSet(NoPutResultSet source, Activation activation, int resultSetNumber) throws StandardException;
+    NoPutResultSet getExplainResultSet(NoPutResultSet source, Activation activation, int resultSetNumber, String sparkExplainKind) throws StandardException;
 
     /**
      * Export

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ActivationClassBuilder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ActivationClassBuilder.java
@@ -186,7 +186,7 @@ public class ActivationClassBuilder	extends	ExpressionClassBuilder {
 		// if current type has already been set to Spark, we should honor it
 		if (currentType.equals(CompilerContext.DataSetProcessorType.SPARK))
 			return;
-        myCompCtx.setDataSetProcessorType(type);
+        myCompCtx.setDataSetProcessorType(type, false);
 		constructor.pushThis();
 		constructor.push(type.ordinal());
 		constructor.putField(ClassName.BaseActivation, "datasetProcessorType", "int");

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
@@ -1164,8 +1164,10 @@ public class CompilerContextImpl extends ContextImpl
     private DataSetProcessorType dataSetProcessorType = DataSetProcessorType.DEFAULT_CONTROL;
 
     @Override
-    public void setDataSetProcessorType(DataSetProcessorType type) {
+    public void setDataSetProcessorType(DataSetProcessorType type, boolean setDSPTypeinLCC) {
         dataSetProcessorType = type;
+        if (setDSPTypeinLCC)
+           lcc.setDataSetProcessorType(type);
     }
 
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExplainNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExplainNode.java
@@ -53,12 +53,40 @@ import java.util.Collection;
 public class ExplainNode extends DMLStatementNode {
 
     StatementNode node;
+    private SparkExplainKind sparkExplainKind;
+
+    public enum SparkExplainKind {
+        NONE("none"),
+        EXECUTED("executed"),
+        LOGICAL("logical"),
+        OPTIMIZED("optimized"),
+        ANALYZED("analyzed");
+
+        private final String value;
+
+        SparkExplainKind(String value) {
+            this.value = value;
+        }
+
+        public final String getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
 
     int activationKind() { return StatementNode.NEED_NOTHING_ACTIVATION; }
 
     public String statementToString() { return "Explain"; }
 
-    public void init(Object statementNode) { node = (StatementNode)statementNode; }
+    public void init(Object statementNode,
+                     Object sparkExplainKind) {
+        node = (StatementNode)statementNode;
+        this.sparkExplainKind = (SparkExplainKind)sparkExplainKind;
+    }
 
     /**
      * Used by splice. Provides direct access to the node underlying the explain node.
@@ -87,21 +115,46 @@ public class ExplainNode extends DMLStatementNode {
          * certain fixed number, then we will perform the Explain in Spark, which will be brutal and useless.
          * This forces us to use control-side execution
          */
-        getCompilerContext().setDataSetProcessorType(CompilerContext.DataSetProcessorType.FORCED_CONTROL);
+        if (!sparkExplainKind.equals(SparkExplainKind.NONE)) {
+            acb.setDataSetProcessorType(CompilerContext.DataSetProcessorType.FORCED_SPARK);
+            getCompilerContext().setDataSetProcessorType(CompilerContext.DataSetProcessorType.FORCED_SPARK, true);
+        }
+        else
+            getCompilerContext().setDataSetProcessorType(CompilerContext.DataSetProcessorType.FORCED_CONTROL, false);
+
         acb.pushGetResultSetFactoryExpression(mb);
         // parameter
         node.generate(acb, mb);
         acb.pushThisAsActivation(mb);
         int resultSetNumber = getCompilerContext().getNextResultSetNumber();
         mb.push(resultSetNumber);
-        mb.callMethod(VMOpcode.INVOKEINTERFACE,null, "getExplainResultSet", ClassName.NoPutResultSet, 3);
+        mb.push(sparkExplainKind.toString());
+        mb.callMethod(VMOpcode.INVOKEINTERFACE,null, "getExplainResultSet", ClassName.NoPutResultSet, 4);
     }
 
     @Override
     public ResultDescription makeResultDescription() {
         DataTypeDescriptor dtd = new DataTypeDescriptor(TypeId.getBuiltInTypeId(TypeId.VARCHAR_NAME), true);
         ResultColumnDescriptor[] colDescs = new GenericColumnDescriptor[1];
-        colDescs[0] = new GenericColumnDescriptor("Plan", dtd);
+        String headerString = null;
+        switch (sparkExplainKind) {
+            case EXECUTED:
+                headerString = "\nNative Spark Execution Plan";
+                break;
+            case LOGICAL :
+                headerString = "\nNative Spark Logical Plan";
+                break;
+            case OPTIMIZED :
+                headerString = "\nNative Spark Optimized Plan";
+                break;
+            case ANALYZED :
+                headerString = "\nNative Spark Analyzed Plan";
+                break;
+            default :
+                headerString = "Plan";
+                break;
+        }
+        colDescs[0] = new GenericColumnDescriptor(headerString, dtd);
         String statementType = statementToString();
 
         return getExecutionFactory().getResultDescription(colDescs, statementType );

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -65,6 +65,7 @@ import com.splicemachine.db.impl.sql.compile.ColumnDefinitionNode;
 import com.splicemachine.db.impl.sql.compile.ColumnReference;
 import com.splicemachine.db.impl.sql.compile.CreateAliasNode;
 import com.splicemachine.db.impl.sql.compile.CursorNode;
+import com.splicemachine.db.impl.sql.compile.ExplainNode.SparkExplainKind;
 import com.splicemachine.db.impl.sql.compile.FromBaseTable;
 import com.splicemachine.db.impl.sql.compile.FromList;
 import com.splicemachine.db.impl.sql.compile.FromSubquery;
@@ -3058,6 +3059,10 @@ TOKEN [IGNORE_CASE] :
 |	<DENSERANK: "dense_rank">
 |	<GET_CURRENT_CONNECTION: "getCurrentConnection">
 |	<EXPLAIN: "explain">
+|	<SPARKEXPLAIN: "sparkexplain">
+|	<SPARKEXPLAIN_LOGICAL: "sparkexplain_logical">
+|	<SPARKEXPLAIN_OPTIMIZED: "sparkexplain_optimized">
+|	<SPARKEXPLAIN_ANALYZED: "sparkexplain_analyzed">
 |	<EXPORT: "export">
 |	<EXPORT_BINARY: "export_binary">
 |	<FIRSTVALUE: "first_value">
@@ -3946,6 +3951,35 @@ explainStatement() throws StandardException :
     {
         return (ExplainNode) nodeFactory.getNode(C_NodeTypes.EXPLAIN_NODE,
                                    statementNode,
+                                   SparkExplainKind.NONE,
+                                   getContextManager());
+    }
+    | <SPARKEXPLAIN> statementNode = preparableSQLDataStatement()
+    {
+        return (ExplainNode) nodeFactory.getNode(C_NodeTypes.EXPLAIN_NODE,
+                                   statementNode,
+                                   SparkExplainKind.EXECUTED,
+                                   getContextManager());
+    }
+    | <SPARKEXPLAIN_LOGICAL> statementNode = preparableSQLDataStatement()
+    {
+        return (ExplainNode) nodeFactory.getNode(C_NodeTypes.EXPLAIN_NODE,
+                                   statementNode,
+                                   SparkExplainKind.LOGICAL,
+                                   getContextManager());
+    }
+    | <SPARKEXPLAIN_ANALYZED> statementNode = preparableSQLDataStatement()
+    {
+        return (ExplainNode) nodeFactory.getNode(C_NodeTypes.EXPLAIN_NODE,
+                                   statementNode,
+                                   SparkExplainKind.ANALYZED,
+                                   getContextManager());
+    }
+    | <SPARKEXPLAIN_OPTIMIZED> statementNode = preparableSQLDataStatement()
+    {
+        return (ExplainNode) nodeFactory.getNode(C_NodeTypes.EXPLAIN_NODE,
+                                   statementNode,
+                                   SparkExplainKind.OPTIMIZED,
                                    getContextManager());
     }
 }
@@ -16982,6 +17016,7 @@ reservedKeyword() :
 |	tok = <CALL>
 |   tok = <CURRENT_ROLE>
 |	tok = <EXPLAIN>
+|	tok = <SPARKEXPLAIN>
 |	tok = <EXPORT>
 |	tok = <LONGINT>
 |	tok = <LTRIM>

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -3702,6 +3702,11 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         return this.type;
     }
 
+    @Override
+    public void setDataSetProcessorType(CompilerContext.DataSetProcessorType type) {
+        this.type = type;
+    }
+
     public void materialize() throws StandardException {}
 
     protected Map<String,TableDescriptor> withDescriptors;

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
@@ -22,6 +22,7 @@ import com.splicemachine.db.iapi.sql.ResultColumnDescriptor;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.types.SQLLongint;
+import com.splicemachine.db.impl.sql.compile.ExplainNode;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.SpliceSpark;
@@ -1464,4 +1465,44 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
             context.popScope();
         }
     }
+
+    @Override
+    public boolean isNativeSpark() {
+        return true;
+    }
+
+    @Override
+    public List<String> buildNativeSparkExplain(ExplainNode.SparkExplainKind sparkExplainKind) {
+        if (dataset != null) {
+            String [] arrOfStr = null;
+            switch (sparkExplainKind) {
+                case LOGICAL:
+                    arrOfStr =
+                    dataset.queryExecution().logical().toString().split("\n");
+                    break;
+                case OPTIMIZED:
+                    arrOfStr =
+                    dataset.queryExecution().optimizedPlan().toString().split("\n");
+                    break;
+                case ANALYZED:
+                    arrOfStr =
+                    dataset.queryExecution().analyzed().toString().split("\n");
+                    break;
+                default:
+                    arrOfStr =
+                    dataset.queryExecution().executedPlan().toString().split("\n");
+                    break;
+            }
+
+            // Remove trailing whitespaces.
+            for (int i = 0; i < arrOfStr.length; i++) {
+                arrOfStr[i] = arrOfStr[i].replaceFirst("\\s++$", "");
+            }
+            return Arrays.asList(arrOfStr);
+        }
+        List<String> warnMsg = new ArrayList<>();
+        warnMsg.add("Spark EXPLAIN not available.\n");
+        return warnMsg;
+    }
+
 }

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
@@ -20,6 +20,7 @@ import com.splicemachine.db.iapi.sql.ResultColumnDescriptor;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.types.SQLLongint;
+import com.splicemachine.db.impl.sql.compile.ExplainNode;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.SpliceSpark;
@@ -907,4 +908,15 @@ public class SparkDataSet<V> implements DataSet<V> {
 
     @Override
     public DataSet applyNativeSparkAggregation(int[] groupByColumns, SpliceGenericAggregator[] aggregates, boolean isRollup, OperationContext operationContext) { return null; }
+
+    @Override
+    public boolean isNativeSpark() {
+        return false;
+    }
+
+    public List<String> buildNativeSparkExplain(ExplainNode.SparkExplainKind sparkExplainKind) {
+        List<String> warnMsg = new ArrayList<>();
+        warnMsg.add("Spark EXPLAIN not available.\n");
+        return warnMsg;
+    }
 }

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -993,8 +993,17 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
 
     @Override
     public List<String> getNativeSparkExplain() {
-        numLeadingSpaces.put(explainStrings.getFirst().getIndentationLevel(), 0);
-        spacesMap.put(explainStrings.getFirst().getIndentationLevel(), "");
+        int indentationLevel = 0;
+
+        finalizeTempOperationStrings();
+        for (List<IndentedString> indentedStrings:spliceOperationStrings)
+            explainStrings.addAll(indentedStrings);
+
+        if (!explainStrings.isEmpty())
+            indentationLevel = explainStrings.getFirst().getIndentationLevel();
+
+        numLeadingSpaces.put(indentationLevel, 0);
+        spacesMap.put(indentationLevel, "");
 
         int previousIndentationLevel = -1;
         int maxIndentationLevel = -1;

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -927,7 +927,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         for (String string:sparkExplain.getTextLines()) {
             newTextLines.add(string);
             int matchIndex =
-               StringUtils.indexOfAny(string, new String[]{"Scan ExistingRDD", "LogicalRDD"});
+               StringUtils.indexOfAny(string, new String[]{"Scan ExistingRDD", "FileScan", "LogicalRDD"});
             if (!spliceOperationStrings.isEmpty() && matchIndex != -1) {
                 List<IndentedString> list = spliceOperationStrings.removeLast();
                 int baseIndentationLevel = list.get(0).getIndentationLevel();
@@ -997,7 +997,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
 
         finalizeTempOperationStrings();
         for (List<IndentedString> indentedStrings:spliceOperationStrings)
-            explainStrings.addAll(indentedStrings);
+            explainStrings.addAll(0, indentedStrings);  
 
         if (!explainStrings.isEmpty())
             indentationLevel = explainStrings.getFirst().getIndentationLevel();

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/ControlOnlyDataSetProcessorFactory.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/ControlOnlyDataSetProcessorFactory.java
@@ -18,6 +18,7 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.conn.ControlExecutionLimiter;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
+import com.splicemachine.db.impl.sql.compile.ExplainNode;
 import com.splicemachine.derby.iapi.sql.execute.DataSetProcessorFactory;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.SpliceBaseOperation;
@@ -27,15 +28,20 @@ import com.splicemachine.derby.stream.iapi.DistributedDataSetProcessor;
 import com.splicemachine.derby.stream.iapi.RemoteQueryClient;
 import com.splicemachine.derby.stream.utils.ForwardingDataSetProcessor;
 import com.splicemachine.si.impl.driver.SIDriver;
+import com.splicemachine.utils.IndentedString;
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.log4j.Logger;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import static com.splicemachine.db.impl.sql.compile.ExplainNode.SparkExplainKind.NONE;
 
 /**
  * A DataSetProcessor Factory which only generates Control-Side DataSet processors. This is because memory
@@ -154,5 +160,20 @@ public class ControlOnlyDataSetProcessorFactory implements DataSetProcessorFacto
             //no-op
             return false;
         }
+
+        // Operations specific to native spark explains
+        // have no effect on non-spark queries.
+        @Override public boolean isSparkExplain() { return false; }
+        @Override public ExplainNode.SparkExplainKind getSparkExplainKind() { return NONE; }
+        @Override public void setSparkExplain(ExplainNode.SparkExplainKind newValue) {  }
+        @Override public void prependIndentedString(IndentedString indentedString) { }
+        @Override public void prependSpliceExplainString(String explainString) { }
+        @Override public void prependSparkExplainStrings(List<String> stringsToAdd) { }
+        @Override public void finalizeTempOperationStrings() { }
+        @Override public List<String> getNativeSparkExplain() { return null; }
+        @Override public int getOpDepth() { return 0; }
+        @Override public void incrementOpDepth() { }
+        @Override public void decrementOpDepth() { }
+        @Override public void resetOpDepth() { }
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/SpliceOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/execute/SpliceOperation.java
@@ -396,4 +396,13 @@ public interface SpliceOperation extends StandardCloseable, NoPutResultSet, Conv
     ScanInformation<ExecRow> getScanInformation();
 
     void setRecursiveUnionReference(NoPutResultSet recursiveUnionReference);
+
+    void handleSparkExplain(DataSet<ExecRow> dataSet,
+                            DataSet<ExecRow> childDataSet,
+                            DataSetProcessor dsp);
+
+    void handleSparkExplain(DataSet<ExecRow> dataSet,
+                            DataSet<ExecRow> leftDataSet,
+                            DataSet<ExecRow> rightDataSet,
+                            DataSetProcessor dsp);
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
@@ -1490,15 +1490,15 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
     }
 
     @Override
-    public NoPutResultSet getExplainResultSet(ResultSet source, Activation activation, int resultSetNumber) throws StandardException {
+    public NoPutResultSet getExplainResultSet(ResultSet source, Activation activation, int resultSetNumber, String sparkExplainKind) throws StandardException {
         ConvertedResultSet opSet = (ConvertedResultSet)source;
-        return new ExplainOperation(opSet.getOperation(), activation, resultSetNumber);
+        return new ExplainOperation(opSet.getOperation(), activation, resultSetNumber, sparkExplainKind);
     }
 
     @Override
-    public NoPutResultSet getExplainResultSet(NoPutResultSet source, Activation activation, int resultSetNumber) throws StandardException {
+    public NoPutResultSet getExplainResultSet(NoPutResultSet source, Activation activation, int resultSetNumber, String sparkExplainKind) throws StandardException {
         ConvertedResultSet opSet = (ConvertedResultSet)source;
-        return new ExplainOperation(opSet.getOperation(), activation, resultSetNumber);
+        return new ExplainOperation(opSet.getOperation(), activation, resultSetNumber, sparkExplainKind);
     }
 
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/AnyOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/AnyOperation.java
@@ -160,10 +160,17 @@ public class AnyOperation extends SpliceBaseOperation {
             throw new IllegalStateException("Operation is not open");
 
         // we are consuming the dataset, get a ResultDataSet
-        Iterator<ExecRow> iterator = source.getResultDataSet(dsp).toLocalIterator();
+        dsp.incrementOpDepth();
+        DataSet<ExecRow> sourceDS = source.getResultDataSet(dsp);
+        Iterator<ExecRow> iterator = sourceDS.toLocalIterator();
+        dsp.decrementOpDepth();
+        DataSet<ExecRow> ds;
         if (iterator.hasNext())
-                return dsp.singleRowDataSet(iterator.next());
-        return dsp.singleRowDataSet(getRowWithNulls());
+            ds = dsp.singleRowDataSet(iterator.next());
+        else
+            ds = dsp.singleRowDataSet(getRowWithNulls());
+        handleSparkExplain(ds, sourceDS, dsp);
+        return ds;
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
@@ -184,13 +184,6 @@ public class BroadcastJoinOperation extends JoinOperation{
             throw new IllegalStateException("Operation is not open");
 
         OperationContext operationContext = dsp.createOperationContext(this);
-        DataSet<ExecRow> leftDataSet = leftResultSet.getDataSet(dsp);
-
-//        operationContext.pushScope();
-        leftDataSet = leftDataSet.map(new CountJoinedLeftFunction(operationContext));
-        if (LOG.isDebugEnabled())
-            SpliceLogUtils.debug(LOG, "getDataSet Performing BroadcastJoin type=%s, antiJoin=%s, hasRestriction=%s",
-                isOuterJoin ? "outer" : "inner", notExistsRightSide, restriction != null);
 
         SConfiguration configuration= EngineDriver.driver().getConfiguration();
 
@@ -229,9 +222,24 @@ public class BroadcastJoinOperation extends JoinOperation{
            (useDataset && dsp.getType().equals(DataSetProcessor.Type.SPARK) &&
              (restriction ==null || (!isOuterJoin && !notExistsRightSide && !isOneRowRightSide())) &&
               !containsUnsafeSQLRealComparison());
+
+        dsp.incrementOpDepth();
+        if (usesNativeSparkDataSet)
+            dsp.finalizeTempOperationStrings();
+        DataSet<ExecRow> leftDataSet = leftResultSet.getDataSet(dsp);
+
+//        operationContext.pushScope();
+        leftDataSet = leftDataSet.map(new CountJoinedLeftFunction(operationContext));
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "getDataSet Performing BroadcastJoin type=%s, antiJoin=%s, hasRestriction=%s",
+                isOuterJoin ? "outer" : "inner", notExistsRightSide, restriction != null);
+
+        if (usesNativeSparkDataSet)
+            dsp.finalizeTempOperationStrings();
         if (usesNativeSparkDataSet)
         {
             DataSet<ExecRow> rightDataSet = rightResultSet.getDataSet(dsp);
+            dsp.decrementOpDepth();
             if (isOuterJoin)
                 result = leftDataSet.join(operationContext,rightDataSet, DataSet.JoinType.LEFTOUTER,true);
             else if (notExistsRightSide)
@@ -251,6 +259,7 @@ public class BroadcastJoinOperation extends JoinOperation{
                     usesNativeSparkDataSet = false;
                 }
             }
+            handleSparkExplain(result, leftDataSet, rightDataSet, dsp);
         }
         else {
             if (isOuterJoin) { // Outer Join with and without restriction
@@ -281,6 +290,12 @@ public class BroadcastJoinOperation extends JoinOperation{
                             result = result.filter(new JoinRestrictionPredicateFunction(operationContext));
                         }
                     }
+                }
+                if (dsp.isSparkExplain()) {
+                    // Need to call getDataSet to fully print the spark explain.
+                    DataSet<ExecRow> rightDataSet = rightResultSet.getDataSet(dsp);
+                    dsp.decrementOpDepth();
+                    handleSparkExplain(result, leftDataSet, rightDataSet, dsp);
                 }
             }
         }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/CachedOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/CachedOperation.java
@@ -144,10 +144,10 @@ public class CachedOperation extends SpliceBaseOperation {
         }
         else {
             dsp.incrementOpDepth();
-            ds = source.getDataSet(dsp);
+            DataSet dataSet = source.getDataSet(dsp);
             dsp.decrementOpDepth();
             dsp.prependSpliceExplainString(this.explainPlan);
-            return ds;
+            return dataSet;
         }
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/CachedOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/CachedOperation.java
@@ -143,7 +143,11 @@ public class CachedOperation extends SpliceBaseOperation {
             return ds;
         }
         else {
-            return source.getDataSet(dsp);
+            dsp.incrementOpDepth();
+            ds = source.getDataSet(dsp);
+            dsp.decrementOpDepth();
+            dsp.prependSpliceExplainString(this.explainPlan);
+            return ds;
         }
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/CrossJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/CrossJoinOperation.java
@@ -125,15 +125,22 @@ public class CrossJoinOperation extends JoinOperation{
             throw new IllegalStateException("Operation is not open");
 
         OperationContext operationContext = dsp.createOperationContext(this);
+        dsp.incrementOpDepth();
+        boolean usesNativeSparkDataSet = dsp.getType().equals(DataSetProcessor.Type.SPARK);
+        if (usesNativeSparkDataSet)
+            dsp.finalizeTempOperationStrings();
         DataSet<ExecRow> leftDataSet = leftResultSet.getDataSet(dsp);
+        if (usesNativeSparkDataSet)
+            dsp.finalizeTempOperationStrings();
         DataSet<ExecRow> rightDataSet = rightResultSet.getDataSet(dsp);
+        dsp.decrementOpDepth();
 
 //        operationContext.pushScope();
         leftDataSet = leftDataSet.map(new CountJoinedLeftFunction(operationContext));
 
         DataSet<ExecRow> result;
 
-        if (dsp.getType().equals(DataSetProcessor.Type.SPARK)) {
+        if (usesNativeSparkDataSet) {
             result = leftDataSet.crossJoin(operationContext, rightDataSet);
             if (restriction != null) {
                 result = result.filter(new JoinRestrictionPredicateFunction(operationContext));
@@ -152,6 +159,8 @@ public class CrossJoinOperation extends JoinOperation{
             }
         }
         result = result.map(new CountProducedFunction(operationContext), true);
+
+        handleSparkExplain(result, leftDataSet, rightDataSet, dsp);
         return result;
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DMLWriteOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DMLWriteOperation.java
@@ -351,7 +351,7 @@ public abstract class DMLWriteOperation extends SpliceBaseOperation{
         DataSet set;
         OperationContext operationContext=dsp.createOperationContext(this);
         int[] expectedUpdatecounts = null;
-        if (activation.isBatched()) {
+        if (activation.isBatched() && !dsp.isSparkExplain()) {
             /*
              If we are executing batched operations we gather all modified rows into a single dataset by collecting
              one dataset for each original batched statement and then unioning them all together
@@ -382,7 +382,9 @@ public abstract class DMLWriteOperation extends SpliceBaseOperation{
 
             set = sets.get(0);
         } else {
+            dsp.incrementOpDepth();
             set=source.getDataSet(dsp).shufflePartitions();
+            dsp.decrementOpDepth();
         }
         return Pair.newPair(set, expectedUpdatecounts);
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DeleteOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DeleteOperation.java
@@ -94,8 +94,13 @@ public class DeleteOperation extends DMLWriteOperation {
         DataSet set = pair.getFirst();
         int[] expectedUpdateCounts = pair.getSecond();
         OperationContext operationContext = dsp.createOperationContext(this);
+        operationContext.pushScope();
+        if (dsp.isSparkExplain()) {
+            dsp.prependSpliceExplainString(this.explainPlan);
+            return set;
+        }
         TxnView txn = getCurrentTransaction();
-		operationContext.pushScope();
+
         DataSetWriterBuilder dataSetWriterBuilder = null;
         try {
             if (bulkDeleteDirectory != null) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctScanOperation.java
@@ -251,6 +251,7 @@ public class DistinctScanOperation extends ScanOperation {
         if (!isOpen)
             throw new IllegalStateException("Operation is not open");
 
+        dsp.prependSpliceExplainString(this.explainPlan);
         assert currentTemplate != null: "Current Template Cannot Be Null";
         int[] execRowTypeFormatIds = new int[currentTemplate.nColumns()];
         for (int i = 0; i< currentTemplate.nColumns(); i++) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainOperation.java
@@ -21,6 +21,7 @@ import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.types.SQLVarchar;
 import com.splicemachine.db.impl.ast.PlanPrinter;
+import com.splicemachine.db.impl.sql.compile.ExplainNode;
 import com.splicemachine.db.impl.sql.compile.QueryTreeNode;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
@@ -50,6 +51,7 @@ public class ExplainOperation extends SpliceBaseOperation {
     protected static final String NAME = ExplainOperation.class.getSimpleName().replaceAll("Operation", "");
     protected SpliceOperation source;
     protected ExecRow currentTemplate;
+    private ExplainNode.SparkExplainKind sparkExplainKind;
 
     List<String> explainString = new ArrayList<>();
 
@@ -80,10 +82,23 @@ public class ExplainOperation extends SpliceBaseOperation {
      * @param resultSetNumber
      * @throws StandardException
      */
-    public ExplainOperation(SpliceOperation source, Activation activation, int resultSetNumber) throws StandardException {
+    public ExplainOperation(SpliceOperation source, Activation activation,
+                            int resultSetNumber, String sparkExplainKind) throws StandardException {
         super(activation, resultSetNumber, 0, 0);
         this.activation = activation;
         this.source = source;
+
+        if (sparkExplainKind.equals(ExplainNode.SparkExplainKind.EXECUTED.toString()))
+            this.sparkExplainKind = ExplainNode.SparkExplainKind.EXECUTED;
+        else if (sparkExplainKind.equals(ExplainNode.SparkExplainKind.LOGICAL.toString()))
+            this.sparkExplainKind = ExplainNode.SparkExplainKind.LOGICAL;
+        else if (sparkExplainKind.equals(ExplainNode.SparkExplainKind.OPTIMIZED.toString()))
+            this.sparkExplainKind = ExplainNode.SparkExplainKind.OPTIMIZED;
+        else if (sparkExplainKind.equals(ExplainNode.SparkExplainKind.ANALYZED.toString()))
+            this.sparkExplainKind = ExplainNode.SparkExplainKind.ANALYZED;
+        else
+            this.sparkExplainKind = ExplainNode.SparkExplainKind.NONE;
+
         init();
     }
 
@@ -100,6 +115,8 @@ public class ExplainOperation extends SpliceBaseOperation {
         super.init(context);
         currentTemplate = new ValueRow(1);
         currentTemplate.setRowArray(new DataValueDescriptor[]{new SQLVarchar()});
+        if (source != null)
+            source.init(context);
     }
 
     @Override
@@ -138,6 +155,11 @@ public class ExplainOperation extends SpliceBaseOperation {
     @Override
     public List<SpliceOperation> getSubOperations() {
         return Collections.singletonList(source);
+    }
+
+    @Override
+    public SpliceOperation getLeftOperation() {
+        return (SpliceOperation) source;
     }
 
     @Override
@@ -187,7 +209,20 @@ public class ExplainOperation extends SpliceBaseOperation {
         OperationContext operationContext = dsp.createOperationContext(this);
         operationContext.pushScope();
         try {
-            return dsp.createDataSet(Iterators.transform(explainString.iterator(), new Function<String, ExecRow>() {
+            DataSet<ExecRow> resultDS = null;
+            List<String> explainToDisplay = explainString;
+            if (sparkExplainKind != ExplainNode.SparkExplainKind.NONE &&
+                dsp.getType() == DataSetProcessor.Type.SPARK) {
+                dsp.setSparkExplain(sparkExplainKind);
+                dsp.resetOpDepth();
+                resultDS = source.getResultDataSet(dsp);
+
+                if (resultDS.isNativeSpark())
+                    dsp.prependSparkExplainStrings(resultDS.buildNativeSparkExplain(sparkExplainKind));
+
+                explainToDisplay = dsp.getNativeSparkExplain();
+            }
+            return dsp.createDataSet(Iterators.transform(explainToDisplay.iterator(), new Function<String, ExecRow>() {
                                                              @Nullable
                                                              @Override
                                                              public ExecRow apply(@Nullable String n) {
@@ -216,6 +251,9 @@ public class ExplainOperation extends SpliceBaseOperation {
         for (int i = 0; i < explainString.size(); ++i) {
             out.writeUTF(explainString.get(i));
         }
+        out.writeUTF(sparkExplainKind.toString());
+        if (!sparkExplainKind.equals(ExplainNode.SparkExplainKind.NONE))
+            out.writeObject(source);
     }
 
     @Override
@@ -226,5 +264,18 @@ public class ExplainOperation extends SpliceBaseOperation {
         for (int i = 0; i < size; ++i) {
             explainString.add(in.readUTF());
         }
+        String sparkExplainKindString = in.readUTF();
+        if (sparkExplainKindString.equals(ExplainNode.SparkExplainKind.EXECUTED.toString()))
+            this.sparkExplainKind = ExplainNode.SparkExplainKind.EXECUTED;
+        else if (sparkExplainKindString.equals(ExplainNode.SparkExplainKind.LOGICAL.toString()))
+            this.sparkExplainKind = ExplainNode.SparkExplainKind.LOGICAL;
+        else if (sparkExplainKindString.equals(ExplainNode.SparkExplainKind.OPTIMIZED.toString()))
+            this.sparkExplainKind = ExplainNode.SparkExplainKind.OPTIMIZED;
+        else if (sparkExplainKindString.equals(ExplainNode.SparkExplainKind.ANALYZED.toString()))
+            this.sparkExplainKind = ExplainNode.SparkExplainKind.ANALYZED;
+        else
+            this.sparkExplainKind = ExplainNode.SparkExplainKind.NONE;
+        if (!sparkExplainKind.equals(ExplainNode.SparkExplainKind.NONE))
+            source = (SpliceOperation)in.readObject();
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/LastIndexKeyOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/LastIndexKeyOperation.java
@@ -118,6 +118,7 @@ public class LastIndexKeyOperation extends ScanOperation {
         if (!isOpen)
             throw new IllegalStateException("Operation is not open");
 
+        dsp.prependSpliceExplainString(this.explainPlan);
         operationContext = dsp.createOperationContext(this);
         DataSet<ExecRow> scan = dsp.<LastIndexKeyOperation,ExecRow>newScanSet(this,tableName)
                 .tableDisplayName(tableDisplayName)

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeJoinOperation.java
@@ -146,21 +146,33 @@ public class MergeJoinOperation extends JoinOperation {
         if (!isOpen)
             throw new IllegalStateException("Operation is not open");
 
+        boolean isSparkExplain = dsp.isSparkExplain();
         OperationContext<JoinOperation> operationContext = dsp.<JoinOperation>createOperationContext(this);
+        dsp.incrementOpDepth();
         DataSet<ExecRow> left = leftResultSet.getDataSet(dsp);
-        
+        DataSet<ExecRow> right = null;
+        if (isSparkExplain) {
+            // Need to call getDataSet to fully print the spark explain.
+            right = rightResultSet.getDataSet(dsp);
+            dsp.decrementOpDepth();
+        }
         operationContext.pushScope();
         try {
             left = left.map(new CountJoinedLeftFunction(operationContext));
+            DataSet<ExecRow> joined = null;
             if (isOuterJoin)
-                return left.mapPartitions(new MergeOuterJoinFlatMapFunction(operationContext), true);
+                joined = left.mapPartitions(new MergeOuterJoinFlatMapFunction(operationContext), true);
             else {
                 if (notExistsRightSide)
-                    return left.mapPartitions(new MergeAntiJoinFlatMapFunction(operationContext), true);
+                    joined = left.mapPartitions(new MergeAntiJoinFlatMapFunction(operationContext), true);
                 else {
-                    return left.mapPartitions(new MergeInnerJoinFlatMapFunction(operationContext), true);
+                    joined = left.mapPartitions(new MergeInnerJoinFlatMapFunction(operationContext), true);
                 }
             }
+            if (isSparkExplain)
+                handleSparkExplain(joined, left, right, dsp);
+
+            return joined;
         } finally {
             operationContext.popScope();
         }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperation.java
@@ -225,6 +225,7 @@ public class MultiProbeTableScanOperation extends TableScanOperation  {
             List<DataScan> scans = scanInformation.getScans(getCurrentTransaction(), null, activation, getKeyDecodingMap());
             DataSet<ExecRow> dataSet = dsp.getEmpty();
             OperationContext<MultiProbeTableScanOperation> operationContext = dsp.<MultiProbeTableScanOperation>createOperationContext(this);
+            dsp.prependSpliceExplainString(this.explainPlan);
             int i = 0;
             List<ScanSetBuilder<ExecRow>> datasets = new ArrayList<>(scans.size());
             for (DataScan scan : scans) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NestedLoopJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NestedLoopJoinOperation.java
@@ -96,26 +96,37 @@ public class NestedLoopJoinOperation extends JoinOperation {
 		if (!isOpen)
 			throw new IllegalStateException("Operation is not open");
 
+		dsp.incrementOpDepth();
 		DataSet<ExecRow> left = leftResultSet.getDataSet(dsp);
         OperationContext<NestedLoopJoinOperation> operationContext = dsp.createOperationContext(this);
 
+        DataSet<ExecRow> right = null;
+        if (dsp.isSparkExplain()) {
+	    // Need to call getDataSet to fully print the spark explain.
+	    right = rightResultSet.getDataSet(dsp);
+	    dsp.decrementOpDepth();
+        }
         operationContext.pushScope();
+        DataSet<ExecRow> result = null;
         try {
             if (isOuterJoin)
-                return left.mapPartitions(new NLJOuterJoinFunction(operationContext), true);
+                result = left.mapPartitions(new NLJOuterJoinFunction(operationContext), true);
             else {
                 if (notExistsRightSide)
-					return left.mapPartitions(new NLJAntiJoinFunction(operationContext), true);
-				else {
-					if (oneRowRightSide)
-						return left.mapPartitions(new NLJOneRowInnerJoinFunction(operationContext), true);
-					else
-						return left.mapPartitions(new NLJInnerJoinFunction(operationContext), true);
-				}
-
-			}
+                    result = left.mapPartitions(new NLJAntiJoinFunction(operationContext), true);
+                else {
+                    if (oneRowRightSide)
+                        result = left.mapPartitions(new NLJOneRowInnerJoinFunction(operationContext), true);
+                    else
+                        result = left.mapPartitions(new NLJInnerJoinFunction(operationContext), true);
+                }
+            }
+            if (dsp.isSparkExplain()) {
+                handleSparkExplain(result, left, right, dsp);
+            }
         } finally {
             operationContext.popScope();
         }
+        return result;
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NormalizeOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NormalizeOperation.java
@@ -286,7 +286,10 @@ public class NormalizeOperation extends SpliceBaseOperation{
         if (!isOpen)
             throw new IllegalStateException("Operation is not open");
 
+        dsp.incrementOpDepth();
         DataSet<ExecRow> sourceSet=source.getDataSet(dsp);
+        dsp.decrementOpDepth();
+        dsp.prependSpliceExplainString(this.explainPlan);
         OperationContext operationContext=dsp.createOperationContext(this);
         operationContext.pushScope();
         try{

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/OnceOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/OnceOperation.java
@@ -242,7 +242,10 @@ public class OnceOperation extends SpliceBaseOperation {
 		throw new IllegalStateException("Operation is not open");
 
         // We are consuming the dataset, get a resultDataSet
+	dsp.incrementOpDepth();
         DataSet<ExecRow> raw = source.getResultDataSet(dsp).map(new CloneFunction<>(dsp.createOperationContext(this)));
+        dsp.decrementOpDepth();
+        dsp.prependSpliceExplainString(this.explainPlan);
         final Iterator<ExecRow> iterator = raw.toLocalIterator();
         ExecRow result;
         try {
@@ -251,7 +254,9 @@ public class OnceOperation extends SpliceBaseOperation {
             throw Exceptions.parseException(e);
         }
 
-        return dsp.singleRowDataSet(result);
+        DataSet<ExecRow> ds = dsp.singleRowDataSet(result);
+        handleSparkExplain(ds, raw, dsp);
+        return ds;
     }
 
 	@Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/RowOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/RowOperation.java
@@ -26,11 +26,9 @@ import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperationContext;
 import com.splicemachine.derby.impl.SpliceMethod;
-import com.splicemachine.db.iapi.types.HBaseRowLocation;
 import com.splicemachine.derby.stream.function.RowOperationFunction;
 import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
-import com.splicemachine.primitives.Bytes;
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.log4j.Logger;
 import java.io.IOException;
@@ -315,6 +313,7 @@ public class RowOperation extends SpliceBaseOperation{
 
         ExecRow execRow=new ValueRow(1);
         execRow.setColumn(1,new SQLInteger(123));
+        dsp.prependSpliceExplainString(this.explainPlan);
         return dsp.singleRowDataSet(execRow)
                 .map(new RowOperationFunction(dsp.createOperationContext(this)));
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScrollInsensitiveOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScrollInsensitiveOperation.java
@@ -272,12 +272,16 @@ public class ScrollInsensitiveOperation extends SpliceBaseOperation {
 
         OperationContext operationContext = dsp.createOperationContext(this);
         // we are returning data to the client, get a resultDataSet
+        dsp.incrementOpDepth();
         DataSet<ExecRow> sourceSet = source.getResultDataSet(dsp);
+        dsp.decrementOpDepth();
 
         dsp.setSchedulerPool("query");
         operationContext.pushScope();
         try {
-            return sourceSet.map(new ScrollInsensitiveFunction(operationContext), true);
+            DataSet<ExecRow> ds = sourceSet.map(new ScrollInsensitiveFunction(operationContext), true);
+            handleSparkExplain(ds, sourceSet, dsp);
+            return ds;
         } finally {
             operationContext.popScope();
         }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SelfReferenceOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SelfReferenceOperation.java
@@ -157,6 +157,7 @@ public class SelfReferenceOperation extends SpliceBaseOperation {
         if (!isOpen)
             throw new IllegalStateException("Operation is not open");
 
+        dsp.prependSpliceExplainString(this.explainPlan);
         return ((RecursiveUnionOperation)this.recursiveUnionReference).getSelfReference();
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SetOpOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SetOpOperation.java
@@ -165,17 +165,23 @@ public class SetOpOperation extends SpliceBaseOperation {
             throw new IllegalStateException("Operation is not open");
 
         OperationContext operationContext = dsp.createOperationContext(this);
+        dsp.incrementOpDepth();
+        DataSet<ExecRow> leftDS = leftSource.getDataSet(dsp);
+        DataSet<ExecRow> rightDS = rightSource.getDataSet(dsp);
+        dsp.decrementOpDepth();
+
+        DataSet<ExecRow> resultDS = null;
         if (this.opType==IntersectOrExceptNode.INTERSECT_OP) {
-            return leftSource.getDataSet(dsp).map(new CloneFunction<SetOpOperation>(operationContext)).intersect(
-                    rightSource.getDataSet(dsp).map(new CloneFunction<SetOpOperation>(operationContext)),
+            resultDS = leftDS.map(new CloneFunction<SetOpOperation>(operationContext)).intersect(
+                    rightDS.map(new CloneFunction<SetOpOperation>(operationContext)),
                     OperationContext.Scope.INTERSECT.displayName(),
                     operationContext,
                     true,
                     OperationContext.Scope.INTERSECT.displayName());
         }
         else if (this.opType==IntersectOrExceptNode.EXCEPT_OP) {
-            return leftSource.getDataSet(dsp).map(new CloneFunction<SetOpOperation>(operationContext)).subtract(
-                    rightSource.getDataSet(dsp).map(new CloneFunction<SetOpOperation>(operationContext)),
+            resultDS = leftDS.map(new CloneFunction<SetOpOperation>(operationContext)).subtract(
+                    rightDS.map(new CloneFunction<SetOpOperation>(operationContext)),
                     OperationContext.Scope.SUBTRACT.displayName(),
                     operationContext,
                     true,
@@ -183,6 +189,7 @@ public class SetOpOperation extends SpliceBaseOperation {
         } else {
             throw new RuntimeException("Operation Type not Supported "+opType);
         }
-
+        handleSparkExplain(resultDS, leftDS, rightDS, dsp);
+        return resultDS;
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SortOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SortOperation.java
@@ -201,8 +201,11 @@ public class SortOperation extends SpliceBaseOperation{
             throw new IllegalStateException("Operation is not open");
 
         OperationContext operationContext=dsp.createOperationContext(this);
+        dsp.incrementOpDepth();
         DataSet dataSet=source.getDataSet(dsp)
                 .map(new CloneFunction<>(operationContext));
+        dsp.decrementOpDepth();
+        DataSet sourceDataSet = dataSet;
 
         if (distinct) {
             dataSet = dataSet.distinct(OperationContext.Scope.DISTINCT.displayName(),
@@ -211,7 +214,7 @@ public class SortOperation extends SpliceBaseOperation{
 
 
         DataSet sortedValues = dataSet.orderBy(operationContext, keyColumns,descColumns,nullsOrderedLow);
-
+        handleSparkExplain(sortedValues, sourceDataSet, dsp);
         return sortedValues;
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
@@ -53,9 +53,6 @@ import java.io.*;
 import java.sql.SQLWarning;
 import java.sql.Timestamp;
 import java.util.*;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed, Externalizable{
     private static final long serialVersionUID=4l;
@@ -124,6 +121,7 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
         this.optimizerEstimatedRowCount=in.readDouble();
         this.operationInformation=(OperationInformation)in.readObject();
         isTopResultSet=in.readBoolean();
+        explainPlan = in.readUTF();
     }
 
     @Override
@@ -133,6 +131,7 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
         out.writeDouble(optimizerEstimatedRowCount);
         out.writeObject(operationInformation);
         out.writeBoolean(isTopResultSet);
+        out.writeUTF(explainPlan);
     }
 
     @Override
@@ -1007,6 +1006,36 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
     public void setRecursiveUnionReference(NoPutResultSet recursiveUnionReference) {
         for(SpliceOperation op : getSubOperations()){
             op.setRecursiveUnionReference(recursiveUnionReference);
+        }
+    }
+
+    @Override
+    public void handleSparkExplain(DataSet<ExecRow> dataSet, DataSet<ExecRow> sourceDataSet, DataSetProcessor dsp) {
+        if (dsp.isSparkExplain()) {
+            if (!dataSet.isNativeSpark()) {
+                if (sourceDataSet.isNativeSpark())
+                    dsp.prependSparkExplainStrings(sourceDataSet.
+                                                   buildNativeSparkExplain(dsp.getSparkExplainKind()));
+                dsp.prependSpliceExplainString(this.explainPlan);
+            }
+        }
+    }
+
+    @Override
+    public void handleSparkExplain(DataSet<ExecRow> dataSet,
+                                   DataSet<ExecRow> leftDataSet,
+                                   DataSet<ExecRow> rightDataSet,
+                                   DataSetProcessor dsp) {
+        if (dsp.isSparkExplain()) {
+            if (!dataSet.isNativeSpark()) {
+                if (leftDataSet.isNativeSpark())
+                    dsp.prependSparkExplainStrings(leftDataSet.
+                                                   buildNativeSparkExplain(dsp.getSparkExplainKind()));
+                if (rightDataSet.isNativeSpark())
+                    dsp.prependSparkExplainStrings(rightDataSet.
+                                                   buildNativeSparkExplain(dsp.getSparkExplainKind()));
+                dsp.prependSpliceExplainString(this.explainPlan);
+            }
         }
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
@@ -311,8 +311,14 @@ public class TableScanOperation extends ScanOperation{
             throw new IllegalStateException("Operation is not open");
 
         assert currentTemplate!=null:"Current Template Cannot Be Null";
+
+        DataSet<ExecRow> ds = getTableScannerBuilder(dsp);
+        if (ds.isNativeSpark())
+            dsp.incrementOpDepth();
         dsp.prependSpliceExplainString(this.explainPlan);
-        return getTableScannerBuilder(dsp);
+        if (ds.isNativeSpark())
+            dsp.decrementOpDepth();
+        return ds;
     }
 
     /**

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
@@ -23,7 +23,6 @@ import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.store.access.StaticCompiledOpenConglomInfo;
 import com.splicemachine.db.impl.sql.compile.ActivationClassBuilder;
 import com.splicemachine.db.impl.sql.compile.FromTable;
-import com.splicemachine.db.impl.sql.execute.BaseActivation;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperationContext;
 import com.splicemachine.derby.stream.function.SetCurrentLocatedRowAndRowKeyFunction;
@@ -312,6 +311,7 @@ public class TableScanOperation extends ScanOperation{
             throw new IllegalStateException("Operation is not open");
 
         assert currentTemplate!=null:"Current Template Cannot Be Null";
+        dsp.prependSpliceExplainString(this.explainPlan);
         return getTableScannerBuilder(dsp);
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/UnionOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/UnionOperation.java
@@ -154,13 +154,16 @@ public class UnionOperation extends SpliceBaseOperation {
 			throw new IllegalStateException("Operation is not open");
 
 		OperationContext operationContext = dsp.createOperationContext(this);
+		dsp.incrementOpDepth();
 		DataSet<ExecRow> left = leftResultSet.getDataSet(dsp);
 		DataSet<ExecRow> right = rightResultSet.getDataSet(dsp);
+		dsp.decrementOpDepth();
 		operationContext.pushScope();
 		DataSet<ExecRow> result = left
 		    .union(right, operationContext)
 		    .map(new SetCurrentLocatedRowFunction<SpliceOperation>(operationContext), true);
 		operationContext.popScope();
+		handleSparkExplain(result, left, right, dsp);
 		return result;
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateOperation.java
@@ -199,10 +199,14 @@ public class UpdateOperation extends DMLWriteOperation{
         DataSet set = pair.getFirst();
         int[] expectedUpdateCounts = pair.getSecond();
         OperationContext operationContext=dsp.createOperationContext(this);
+        operationContext.pushScope();
+        if (dsp.isSparkExplain()) {
+            dsp.prependSpliceExplainString(this.explainPlan);
+            return set;
+        }
         TxnView txn=getCurrentTransaction();
         ExecRow execRow=getExecRowDefinition();
         int[] execRowTypeFormatIds=WriteReadUtils.getExecRowTypeFormatIds(execRow);
-        operationContext.pushScope();
         try{
             DataSetWriter writer=set.updateData(operationContext)
                     .execRowDefinition(execRow)

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperation.java
@@ -292,6 +292,7 @@ public class VTIOperation extends SpliceBaseOperation {
         if (!isOpen)
             throw new IllegalStateException("Operation is not open");
 
+        dsp.prependSpliceExplainString(this.explainPlan);
         return getDataSetProvider().getDataSet(this, dsp,getAllocatedRow());
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/WindowOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/WindowOperation.java
@@ -126,14 +126,19 @@ public class WindowOperation extends SpliceBaseOperation {
 
         OperationContext<WindowOperation> operationContext = dsp.createOperationContext(this);
         operationContext.pushScopeForOp(OperationContext.Scope.WINDOW);
-        DataSet dataSet = source.getDataSet(dsp).map(new CloneFunction<>(operationContext));
+        dsp.incrementOpDepth();
+        DataSet<ExecRow> sourceDataSet = source.getDataSet(dsp);
+        dsp.decrementOpDepth();
+        DataSet<ExecRow> dataSet = sourceDataSet.map(new CloneFunction<>(operationContext));
         operationContext.popScope();
 
         try {
-            return  dataSet.windows(windowContext,operationContext,true, OperationContext.Scope.EXECUTE.displayName());
+            dataSet = dataSet.windows(windowContext,operationContext,true, OperationContext.Scope.EXECUTE.displayName());
+            handleSparkExplain(dataSet, sourceDataSet, dsp);
         } finally {
             operationContext.popScope();
         }
+        return dataSet;
     }
 
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/batchonce/BatchOnceOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/batchonce/BatchOnceOperation.java
@@ -191,9 +191,13 @@ public class BatchOnceOperation extends SpliceBaseOperation {
         if (!isOpen)
             throw new IllegalStateException("Operation is not open");
 
+        dsp.incrementOpDepth();
         DataSet set = source.getDataSet(dsp);
+        dsp.decrementOpDepth();
         OperationContext<BatchOnceOperation> operationContext = dsp.createOperationContext(this);
-        return set.mapPartitions(new BatchOnceFunction(operationContext));
+        DataSet<ExecRow> ds = set.mapPartitions(new BatchOnceFunction(operationContext));
+        handleSparkExplain(ds, set, dsp);
+        return ds;
     }
 
     protected int[] generateColumnPositions(int columnItem) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
@@ -22,6 +22,7 @@ import com.splicemachine.db.iapi.sql.conn.ControlExecutionLimiter;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.types.SQLLongint;
+import com.splicemachine.db.impl.sql.compile.ExplainNode;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.DMLWriteOperation;
@@ -80,13 +81,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.OutputStream;
 import java.nio.file.StandardOpenOption;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -774,4 +769,15 @@ public class ControlDataSet<V> implements DataSet<V> {
 
     @Override
     public DataSet applyNativeSparkAggregation(int[] groupByColumns, SpliceGenericAggregator[] aggregates, boolean isRollup, OperationContext operationContext) { return null; }
+
+    @Override
+    public boolean isNativeSpark() {
+        return false;
+    }
+
+    public List<String> buildNativeSparkExplain(ExplainNode.SparkExplainKind sparkExplainKind) {
+        List<String> warnMsg = new ArrayList<>();
+        warnMsg.add("Spark EXPLAIN not available.\n");
+        return warnMsg;
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
@@ -21,6 +21,7 @@ import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.store.access.Qualifier;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.db.impl.sql.compile.ExplainNode;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.scanner.TableScannerBuilder;
 import com.splicemachine.derby.stream.function.Partitioner;
@@ -36,6 +37,7 @@ import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.si.impl.readresolve.NoOpReadResolver;
 import com.splicemachine.si.impl.rollforward.NoopRollForward;
 import com.splicemachine.storage.Partition;
+import com.splicemachine.utils.IndentedString;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.collections.iterators.SingletonIterator;
 import org.apache.log4j.Logger;
@@ -51,10 +53,10 @@ import java.io.SequenceInputStream;
 import java.net.URISyntaxException;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.Scanner;
+import java.util.*;
 import java.util.zip.GZIPInputStream;
+
+import static com.splicemachine.db.impl.sql.compile.ExplainNode.SparkExplainKind.NONE;
 
 /**
  * Local control side DataSetProcessor.
@@ -381,4 +383,19 @@ public class ControlDataSetProcessor implements DataSetProcessor{
     public TableChecker getTableChecker(String schemaName, String tableName, DataSet table, KeyHashDecoder tableKeyDecoder, ExecRow tableKey) {
         return new ControlTableChecker(schemaName, tableName, table, tableKeyDecoder, tableKey);
     }
+
+    // Operations specific to native spark explains
+    // have no effect on control queries.
+    @Override public boolean isSparkExplain() { return false; }
+    @Override public ExplainNode.SparkExplainKind getSparkExplainKind() { return NONE; }
+    @Override public void setSparkExplain(ExplainNode.SparkExplainKind newValue) {  }
+    @Override public void prependIndentedString(IndentedString indentedString) { }
+    @Override public void prependSpliceExplainString(String explainString) { }
+    @Override public void prependSparkExplainStrings(List<String> stringsToAdd) { }
+    @Override public void finalizeTempOperationStrings() { }
+    @Override public List<String> getNativeSparkExplain() { return null; }
+    @Override public int getOpDepth() { return 0; }
+    @Override public void incrementOpDepth() { }
+    @Override public void decrementOpDepth() { }
+    @Override public void resetOpDepth() { }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
@@ -16,6 +16,7 @@ package com.splicemachine.derby.stream.iapi;
 
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
+import com.splicemachine.db.impl.sql.compile.ExplainNode;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.MultiProbeTableScanOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.framework.SpliceGenericAggregator;
@@ -367,4 +368,8 @@ public interface DataSet<V> extends //Iterable<V>,
     DataSet upgradeToSparkNativeDataSet(OperationContext operationContext) throws StandardException;
 
     DataSet applyNativeSparkAggregation(int[] groupByColumns, SpliceGenericAggregator[] aggregates, boolean isRollup, OperationContext operationContext);
+
+    List<String> buildNativeSparkExplain(ExplainNode.SparkExplainKind sparkExplainKind);
+
+    boolean isNativeSpark();
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
@@ -18,15 +18,19 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.store.access.Qualifier;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.db.impl.sql.compile.ExplainNode;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.derby.stream.function.Partitioner;
 import com.splicemachine.derby.utils.marshall.KeyHashDecoder;
+import com.splicemachine.utils.IndentedString;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
 import java.io.InputStream;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * Higher level constructs for getting datasets and manipulating the processing mechanisms.
@@ -265,4 +269,20 @@ public interface DataSetProcessor {
     Boolean isCached(long conglomerateId) throws StandardException;
 
     TableChecker getTableChecker(String schemaName, String tableName, DataSet tableDataSet, KeyHashDecoder decoder, ExecRow key);
+
+    // Operations related to native spark explain ->
+    boolean isSparkExplain();
+    ExplainNode.SparkExplainKind getSparkExplainKind();
+    void setSparkExplain(ExplainNode.SparkExplainKind newValue);
+    void prependIndentedString(IndentedString indentedString);
+    void prependSpliceExplainString(String explainString);
+    void prependSparkExplainStrings(List<String> stringsToAdd);
+    void finalizeTempOperationStrings();
+    List<String> getNativeSparkExplain();
+    int getOpDepth();
+    void incrementOpDepth();
+    void decrementOpDepth();
+    void resetOpDepth();
+    // <- End operations related to native spark explain.
+
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ForwardingDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ForwardingDataSetProcessor.java
@@ -19,14 +19,20 @@ import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.store.access.Qualifier;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.db.impl.sql.compile.ExplainNode;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.stream.function.Partitioner;
 import com.splicemachine.derby.stream.iapi.*;
 import com.splicemachine.derby.utils.marshall.KeyHashDecoder;
+import com.splicemachine.utils.IndentedString;
 import org.apache.spark.sql.types.StructType;
 
 import java.io.InputStream;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
+
+import static com.splicemachine.db.impl.sql.compile.ExplainNode.SparkExplainKind.NONE;
 
 /**
  * @author Scott Fines
@@ -195,5 +201,19 @@ public abstract class ForwardingDataSetProcessor implements DataSetProcessor{
         return delegate.getTableChecker(schemaName, tableName, tableDataSet, decoder, key);
     }
 
+    // Operations specific to native spark explains
+    // have no effect on non-spark queries.
+    @Override public boolean isSparkExplain() { return false; }
+    @Override public ExplainNode.SparkExplainKind getSparkExplainKind() { return NONE; }
+    @Override public void setSparkExplain(ExplainNode.SparkExplainKind newValue) {  }
+    @Override public void prependIndentedString(IndentedString indentedString) { }
+    @Override public void prependSpliceExplainString(String explainString) { }
+    @Override public void prependSparkExplainStrings(List<String> stringsToAdd) { }
+    @Override public void finalizeTempOperationStrings() { }
+    @Override public List<String> getNativeSparkExplain() { return null; }
+    @Override public int getOpDepth() { return 0; }
+    @Override public void incrementOpDepth() { }
+    @Override public void decrementOpDepth() { }
+    @Override public void resetOpDepth() { }
 }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsOperation.java
@@ -36,7 +36,6 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
-import com.splicemachine.db.iapi.types.SQLDecimal;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.DerbyOperationInformation;
@@ -103,6 +102,7 @@ public class StatisticsOperation extends SpliceBaseOperation {
         if (!isOpen)
             throw new IllegalStateException("Operation is not open");
 
+        dsp.prependSpliceExplainString(this.explainPlan);
         dsp.setSchedulerPool("admin");
         try {
             DataSet statsDataSet;

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
@@ -142,6 +142,47 @@ public class ExplainPlanIT extends SpliceUnitTest  {
             ++count;
         }
         Assert.assertTrue(count>0);
+        rs.close();
+
+        rs  = methodWatcher.executeQuery(
+                String.format("sparkexplain select * from %s", this.getTableReference(TABLE_NAME)));
+
+        count = 0;
+        while (rs.next()) {
+            ++count;
+        }
+        Assert.assertTrue(count>0);
+        rs.close();
+
+        rs  = methodWatcher.executeQuery(
+                String.format("sparkexplain_analyzed select * from %s", this.getTableReference(TABLE_NAME)));
+
+        count = 0;
+        while (rs.next()) {
+            ++count;
+        }
+        Assert.assertTrue(count>0);
+        rs.close();
+
+        rs  = methodWatcher.executeQuery(
+                String.format("sparkexplain_logical select * from %s", this.getTableReference(TABLE_NAME)));
+
+        count = 0;
+        while (rs.next()) {
+            ++count;
+        }
+        Assert.assertTrue(count>0);
+        rs.close();
+
+        rs  = methodWatcher.executeQuery(
+                String.format("sparkexplain_optimized select * from %s", this.getTableReference(TABLE_NAME)));
+
+        count = 0;
+        while (rs.next()) {
+            ++count;
+        }
+        Assert.assertTrue(count>0);
+        rs.close();
     }
 
     @Test
@@ -154,6 +195,17 @@ public class ExplainPlanIT extends SpliceUnitTest  {
             ++count;
         }
         Assert.assertTrue(count>0);
+        rs.close();
+
+        rs  = methodWatcher.executeQuery(
+                String.format("sparkexplain update %s set i = 0 where i = 1", this.getTableReference(TABLE_NAME)));
+
+        count = 0;
+        while (rs.next()) {
+            ++count;
+        }
+        Assert.assertTrue(count>0);
+        rs.close();
     }
 
     @Test
@@ -166,6 +218,17 @@ public class ExplainPlanIT extends SpliceUnitTest  {
             ++count;
         }
         Assert.assertTrue(count>0);
+        rs.close();
+
+        rs  = methodWatcher.executeQuery(
+                String.format("sparkexplain delete from %s where i = 1", this.getTableReference(TABLE_NAME)));
+
+        count = 0;
+        while (rs.next()) {
+            ++count;
+        }
+        Assert.assertTrue(count>0);
+        rs.close();
     }
 
     @Test
@@ -184,6 +247,23 @@ public class ExplainPlanIT extends SpliceUnitTest  {
             ++count2;
         }
         Assert.assertTrue(count1 == count2);
+        rs.close();
+
+        rs  = methodWatcher.executeQuery(
+                String.format("-- some comments \n sparkexplain\nupdate %s set i = 0 where i = 1", this.getTableReference(TABLE_NAME)));
+        count1 = 0;
+        while (rs.next()) {
+            ++count1;
+        }
+        rs.close();
+        rs  = methodWatcher.executeQuery(
+                String.format("-- some comments \n sparkexplain\nupdate %s set i = 0 where i = 1", this.getTableReference(TABLE_NAME)));
+        count2 = 0;
+        while (rs.next()) {
+            ++count2;
+        }
+        Assert.assertTrue(count1 == count2);
+        rs.close();
     }
 
     @Test

--- a/utilities/src/main/java/com/splicemachine/utils/IndentedString.java
+++ b/utilities/src/main/java/com/splicemachine/utils/IndentedString.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.utils;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.LinkedList;
+import java.util.List;
+
+public class IndentedString implements Externalizable {
+    //private static final long serialVersionUID = 4L;
+    private static final int classVersion = 1;
+    int          indentationLevel;
+    List<String> textLines;
+
+    public IndentedString() {
+
+    }
+
+    public IndentedString(int indentationLevel, String textLine) {
+        this.indentationLevel = indentationLevel;
+        this.textLines = new LinkedList<>();
+        this.textLines.add(textLine);
+    }
+
+    public IndentedString(int indentationLevel, List<String> textLines) {
+        this.indentationLevel = indentationLevel;
+        this.textLines = textLines;
+    }
+
+    public int getIndentationLevel() { return indentationLevel; }
+    public void setIndentationLevel(int newLevel) { indentationLevel = newLevel; }
+
+    public List<String> getTextLines() { return textLines; }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeInt(classVersion);
+        out.writeInt(indentationLevel);
+        out.writeInt(this.textLines.size());
+        for (String s:this.textLines)
+            out.writeUTF(s);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException{
+        int classVersion = in.readInt();
+        indentationLevel = in.readInt();
+        int numItems = in.readInt();
+        textLines = new LinkedList<>();
+        for (int i = 0; i < numItems; i++) {
+            textLines.add(in.readUTF());
+        }
+    }
+}


### PR DESCRIPTION
Add a SPARKEXPLAIN statement, similar to EXPLAIN, which prints the query execution plan, but in the case of SPARKEXPLAIN the Splice operations which are executed natively in Spark are replaced with text describing the Spark execution plan.

Note that the Splice SubqueryNode (and all child operations under that node) are not currently printed in the spark explain.  Another Jira will add support for SubqueryNode.

For more details and example output, see [SPLICE-2379](https://splice.atlassian.net/browse/SPLICE-2379?focusedCommentId=27918&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-27918)