### PR TITLE
DB-8770 Inherit decimal scale from the input parameter in PreparedStatement.setObject

### DIFF
--- a/db-client/src/main/java/com/splicemachine/db/client/am/PreparedStatement.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/PreparedStatement.java
@@ -31,6 +31,7 @@ import com.splicemachine.db.shared.common.reference.SQLState;
 import com.splicemachine.db.shared.common.sanity.SanityManager;
 import java.io.InputStream;
 import java.io.Reader;
+import java.math.BigDecimal;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1537,7 +1538,10 @@ public class PreparedStatement extends Statement
                     agent_.logWriter_.traceEntry(this, "setObject", parameterIndex, x, targetJdbcType);
                 }
                 checkForClosedStatement();
-                setObjectX(parameterIndex, x, targetJdbcType, 0);
+                int scale = 0;
+                if (x instanceof BigDecimal)
+                    scale = ((BigDecimal)x).scale();
+                setObjectX(parameterIndex, x, targetJdbcType, scale);
             }
         }
         catch ( SqlException se )

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DecimalIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DecimalIT.java
@@ -17,8 +17,10 @@ package com.splicemachine.db.impl.sql.compile;
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.test.SerialTest;
 import com.splicemachine.test_tools.TableCreator;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
@@ -37,6 +39,7 @@ import static com.splicemachine.test_tools.Rows.rows;
 /**
  * Test decimal precision extension from 31 digits to 38 digits.
  */
+@Category(value = {SerialTest.class})
 @RunWith(Parameterized.class)
 public class DecimalIT  extends SpliceUnitTest {
     
@@ -128,6 +131,9 @@ public class DecimalIT  extends SpliceUnitTest {
                         row(new BigDecimal(".00000001234567890123456789012345678901"), 15)))
                 .create();
 
+        new TableCreator(conn)
+                .withCreate("create table preparedDecimal (a dec(38,5))")
+                .create();
     }
 
     @BeforeClass
@@ -608,5 +614,30 @@ public class DecimalIT  extends SpliceUnitTest {
                 "1234567.8901234567890123456789012345678 | 1 |";
 
         testQueryUnsorted(sqlText, expected, methodWatcher);
+    }
+
+    @Test
+    public void testPreparedStatementRetainsFractionalDigits() throws Exception {
+
+        PreparedStatement statement = spliceClassWatcher.prepareStatement(String.format("delete from %s.%s", CLASS_NAME, "preparedDecimal"));
+        statement.executeUpdate();
+	statement.close();
+
+        statement = spliceClassWatcher.prepareStatement(String.format("insert into %s.%s values (?)", CLASS_NAME, "preparedDecimal"));
+        BigDecimal bd = new BigDecimal("14.51");
+        statement.setObject(1, bd, Types.DECIMAL);
+        statement.executeUpdate();
+	statement.close();
+
+        String
+        sqlText = format("select a from preparedDecimal --splice-properties useSpark=%s", useSpark);
+
+        String
+        expected =
+                "A    |\n" +
+                "----------\n" +
+                "14.51000 |";
+
+        testQuery(sqlText, expected, methodWatcher);
     }
 }


### PR DESCRIPTION
JDBC programs that use  "void setObject(int parameterIndex, Object x, int targetSqlType)"
to specify a Decimal input parameter to a prepared statement end up getting Decimal values with the  fractional digits truncated.
The spec says a scale of 0 is implied:
https://docs.oracle.com/javase/7/docs/api/java/sql/PreparedStatement.html#setObject(int,%20java.lang.Object,%20int)

This should probably be a default for data types that have no scale (such as Double).
This Jira changes the behavior to retain the scale from the Decimal source object, e.g.
        BigDecimal bd = new BigDecimal("14.51");
        statement.setObject(1, bd, Types.DECIMAL);
... will create a Decimal input parameter of 14.51, where previously the value 14 was created.
Source data types such as Double, which have no specific scale, still need to specify the scale via this method:

https://docs.oracle.com/javase/7/docs/api/java/sql/PreparedStatement.html#setObject(int,%20java.lang.Object,%20int,%20int)
