### PR TITLE
DB-8806 and oth.: improve OLTP performance

### DIFF
--- a/hbase_storage/src/main/java/com/splicemachine/hbase/SpliceRpcSchedulerFactory.java
+++ b/hbase_storage/src/main/java/com/splicemachine/hbase/SpliceRpcSchedulerFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.hbase;
+
+import com.google.protobuf.Message;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.Abortable;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.ipc.*;
+import org.apache.hadoop.hbase.protobuf.generated.RPCProtos;
+import org.apache.hadoop.hbase.regionserver.SimpleRpcSchedulerFactory;
+import org.apache.hadoop.hbase.security.User;
+
+public class SpliceRpcSchedulerFactory extends SimpleRpcSchedulerFactory {
+
+    @Override
+    public RpcScheduler create(Configuration conf, PriorityFunction priority, Abortable server) {
+        return new SimpleRpcScheduler(
+                conf,
+                conf.getInt(HConstants.REGION_SERVER_HANDLER_COUNT,
+                        HConstants.DEFAULT_REGION_SERVER_HANDLER_COUNT),
+                conf.getInt(HConstants.REGION_SERVER_HIGH_PRIORITY_HANDLER_COUNT,
+                        HConstants.DEFAULT_REGION_SERVER_HIGH_PRIORITY_HANDLER_COUNT),
+                conf.getInt(HConstants.REGION_SERVER_REPLICATION_HANDLER_COUNT,
+                        HConstants.DEFAULT_REGION_SERVER_REPLICATION_HANDLER_COUNT),
+                new SplicePriorityFunction(priority),
+                server,
+                HConstants.QOS_THRESHOLD);
+    }
+
+    class SplicePriorityFunction implements PriorityFunction {
+
+        PriorityFunction delegate;
+
+        SplicePriorityFunction(PriorityFunction priority) {
+            delegate = priority;
+        }
+
+        public int getPriority(RPCProtos.RequestHeader header, Message param, User user) {
+            if (header.hasPriority()) {
+                return header.getPriority();
+            }
+            return delegate.getPriority(header, param, user);
+        }
+
+        public long getDeadline(RPCProtos.RequestHeader header, Message param) {
+            return delegate.getDeadline(header, param);
+        }
+    }
+}

--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.master.cleaner.TimeToLiveHFileCleaner;
 import org.apache.hadoop.hbase.regionserver.DefaultStoreEngine;
+import org.apache.hadoop.hbase.regionserver.RpcSchedulerFactory;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionPolicy;
 import org.apache.hadoop.hbase.regionserver.compactions.Compactor;
 import org.apache.hadoop.hbase.security.access.AccessController;
@@ -214,6 +215,7 @@ class SpliceTestPlatformConfig {
         //
         // Threads, timeouts
         //
+        config.setClass("hbase.region.server.rpc.scheduler.factory.class", SpliceRpcSchedulerFactory.class, RpcSchedulerFactory.class);
         config.setLong("hbase.rpc.timeout", MINUTES.toMillis(5));
         config.setInt("hbase.client.max.perserver.tasks",50);
         config.setInt("hbase.client.ipc.pool.size",10);

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SIConfigurations.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SIConfigurations.java
@@ -155,7 +155,7 @@ public class SIConfigurations implements ConfigurationDefault {
 
     // Threads processing first queue
     public static final String ROLLFORWARD_FIRST_THREADS = "splice.txn.rollforward.firstQueueThreads";
-    public static final int DEFAULT_ROLLFORWARD_FIRST_THREADS = 10;
+    public static final int DEFAULT_ROLLFORWARD_FIRST_THREADS = 25;
 
     // Threads processing second queue
     public static final String ROLLFORWARD_SECOND_THREADS = "splice.txn.rollforward.secondQueueThreads";

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SIConfigurations.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SIConfigurations.java
@@ -30,7 +30,7 @@ public class SIConfigurations implements ConfigurationDefault {
     public static final byte[] CONGLOMERATE_TABLE_NAME_BYTES = Bytes.toBytes(CONGLOMERATE_TABLE_NAME);
 
     public static final String completedTxnCacheSize="splice.txn.completedTxns.cacheSize";
-    private static final int DEFAULT_COMPLETED_TRANSACTION_CACHE_SIZE=1<<17; // want to hold lots of completed transactions
+    private static final int DEFAULT_COMPLETED_TRANSACTION_CACHE_SIZE=1<<20; // want to hold lots of completed transactions
 
     public static final String completedTxnConcurrency="splice.txn.completedTxns.concurrency";
     private static final int DEFAULT_COMPLETED_TRANSACTION_CONCURRENCY=64;

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
@@ -72,7 +72,7 @@ public class SimpleTxnFilter implements TxnFilter{
                            TxnSupplier baseSupplier,
                            boolean ignoreNewerTransactions) {
         assert readResolver!=null;
-        this.transactionStore = new ActiveTxnCacheSupplier(baseSupplier,1024); //TODO -sf- configure
+        this.transactionStore = new ActiveTxnCacheSupplier(baseSupplier, 100); //TODO -sf- configure
         this.tableName=tableName;
         this.myTxn=myTxn;
         this.readResolver=readResolver;

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
@@ -42,12 +42,13 @@ public class SimpleTxnFilter implements TxnFilter{
     private final TxnSupplier transactionStore;
     private final TxnView myTxn;
     private final ReadResolver readResolver;
+    private IgnoreTxnSupplier ignoreTxnSupplier = null;
     //per row fields
     private final LongHashSet visitedTxnIds=new LongHashSet();
     private Long tombstonedTxnRow = null;
     private Long antiTombstonedTxnRow = null;
     private final ByteSlice rowKey=new ByteSlice();
-    private final String tableName;
+
     /*
      * The most common case for databases is insert-only--that is, that there
      * are few updates and deletes relative to the number of inserts. As a result,
@@ -58,7 +59,23 @@ public class SimpleTxnFilter implements TxnFilter{
      * this variable first. That way, we avoid potentially expensive locking through the
      * transaction supplier.
      */
-    private TxnView currentTxn;
+    private static int MAX_CACHED = 8;
+    private TxnView[] localCache = new TxnView[MAX_CACHED];
+    private int cacheIdx = 0;
+
+    private void cacheLocally(TxnView txn) {
+        localCache[cacheIdx] = txn;
+        cacheIdx = (cacheIdx + 1) & (MAX_CACHED - 1);
+    }
+
+    private TxnView checkLocally(long txnId) {
+        for (TxnView txn : localCache) {
+            if (txn != null && txn.getTxnId() == txnId) {
+                return txn;
+            }
+        }
+        return null;
+    }
 
     /**
      * In some cases we can safely ignore any data with a txnId greater than our
@@ -73,10 +90,13 @@ public class SimpleTxnFilter implements TxnFilter{
                            boolean ignoreNewerTransactions) {
         assert readResolver!=null;
         this.transactionStore = new ActiveTxnCacheSupplier(baseSupplier, 100); //TODO -sf- configure
-        this.tableName=tableName;
         this.myTxn=myTxn;
         this.readResolver=readResolver;
         this.ignoreNewerTransactions = ignoreNewerTransactions;
+        SIDriver driver = SIDriver.driver();
+        if (driver != null) {
+            ignoreTxnSupplier = driver.getIgnoreTxnSupplier();
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -209,11 +229,6 @@ public class SimpleTxnFilter implements TxnFilter{
 		 * it matches, then we can see it.
 		 */
         long timestamp=data.version();//dataStore.getOpFactory().getTimestamp(data);
-        SIDriver driver = SIDriver.driver();
-        IgnoreTxnSupplier ignoreTxnSupplier = null;
-        if (driver != null) {
-            ignoreTxnSupplier = driver.getIgnoreTxnSupplier();
-        }
         if (ignoreTxnSupplier != null && ignoreTxnSupplier.shouldIgnore(timestamp))
             return DataFilter.ReturnCode.SKIP;
         if(tombstonedTxnRow != null && timestamp<= tombstonedTxnRow)
@@ -238,13 +253,15 @@ public class SimpleTxnFilter implements TxnFilter{
         return toCompare != null ? myTxn.canSee(toCompare) : false;
     }
 
-    private TxnView fetchTransaction(long txnId) throws IOException{
-        TxnView toCompare=currentTxn;
-        if(currentTxn==null || currentTxn.getTxnId()!=txnId){
-            toCompare=transactionStore.getTransaction(txnId);
-            currentTxn=toCompare;
+    private TxnView fetchTransaction(long txnId) throws IOException {
+        TxnView txn = checkLocally(txnId);
+        if (txn == null) {
+            txn = transactionStore.getTransaction(txnId);
+            if (txn != null) {
+                cacheLocally(txn);
+            }
         }
-        return toCompare;
+        return txn;
     }
 
     private void addToAntiTombstoneCache(DataCell data) throws IOException{
@@ -273,30 +290,10 @@ public class SimpleTxnFilter implements TxnFilter{
     }
 
     private void ensureTransactionIsCached(DataCell data) throws IOException{
-        long txnId=data.version();//this.dataStore.getOpFactory().getTimestamp(data);
-        visitedTxnIds.add(txnId);
-        if(!transactionStore.transactionCached(txnId)){
-			/*
-			 * We do not have a cache entry for this transaction, so we want
-			 * to add it in. We have two possible scenarios:
-			 *
-			 * 1. The transaction is marked as "failed"--i.e. it's been rolled back
-			 * 2. The transaction has a commit timestamp.
-			 *
-			 * In case #1, we only care about the txnId, which we already have,
-			 * and in case #2, we only care about the commit timestamp (none of the read
-			 * isolation levels require information about the begin timestamp).
-			 *
-			 * This version of SI will physically remove entries associated
-			 * with rolled-back values, so case #1 isn't likely to happen--however,
-			 * older installations of SpliceMachine used the commit timestamp to indicate
-			 * a failure, so we have to check for it.
-			 */
-
-            long commitTs=data.valueAsLong();//dataStore.getOpFactory().getValueToLong(data);
-            TxnView toCache=new CommittedTxn(txnId,commitTs);//since we don't care about the begin timestamp, just use the TxnId
-            transactionStore.cache(toCache);
-            currentTxn=toCache;
+        long txnId = data.version();
+        if (checkLocally(txnId) == null) {
+            long commitTs = data.valueAsLong();
+            cacheLocally(new CommittedTxn(txnId, commitTs));
         }
     }
 

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/server/SITransactor.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/server/SITransactor.java
@@ -190,7 +190,7 @@ public class SITransactor implements Transactor{
             constraintState = new SimpleTxnFilter(null, txn, NoOpReadResolver.INSTANCE, txnSupplier);
             supplier = constraintState.getTxnSupplier();
         } else {
-            supplier = new ActiveTxnCacheSupplier(txnSupplier, 1024);
+            supplier = new ActiveTxnCacheSupplier(txnSupplier, 100);
         }
         @SuppressWarnings("unchecked") final LongHashSet[] conflictingChildren=new LongHashSet[mutations.size()];
 

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/store/CompletedTxnCacheSupplier.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/store/CompletedTxnCacheSupplier.java
@@ -14,6 +14,8 @@
 
 package com.splicemachine.si.impl.store;
 
+import com.splicemachine.hash.Hash32;
+import com.splicemachine.hash.HashFunctions;
 import com.splicemachine.si.api.txn.TaskId;
 import com.splicemachine.si.api.txn.Txn;
 import com.splicemachine.si.api.txn.TxnSupplier;
@@ -33,16 +35,16 @@ import java.io.IOException;
 public class CompletedTxnCacheSupplier implements TxnSupplier{
     private TxnView[] cache;
     private final TxnSupplier delegate;
+    private Hash32 hashFunction;
 
     public CompletedTxnCacheSupplier(TxnSupplier delegate, int maxSize, int concurrencyLevel) {
         cache = new TxnView[Integer.highestOneBit(maxSize)];    // ensure power of 2
         this.delegate = delegate;
+        hashFunction = HashFunctions.utilHash();
     }
 
     private int idx(long val) {
-        int hashCode = Long.hashCode(val);
-        hashCode ^= (hashCode >>> 20) ^ (hashCode >>> 12);
-        return (hashCode ^ (hashCode >>> 7) ^ (hashCode >>> 4)) & (cache.length - 1);
+        return hashFunction.hash(val) & (cache.length - 1);
     }
 
     private int idx2(long val, int idx) {

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/store/CompletedTxnCacheSupplier.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/store/CompletedTxnCacheSupplier.java
@@ -14,15 +14,12 @@
 
 package com.splicemachine.si.impl.store;
 
-import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
 import com.splicemachine.si.api.txn.TaskId;
 import com.splicemachine.si.api.txn.Txn;
 import com.splicemachine.si.api.txn.TxnSupplier;
 import com.splicemachine.si.api.txn.TxnView;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * TxnSupplier which caches transaction which have "Completed"--i.e. which have entered the COMMITTED or ROLLEDBACK
@@ -34,72 +31,84 @@ import java.util.concurrent.atomic.AtomicLong;
  *         Date: 6/18/14
  */
 public class CompletedTxnCacheSupplier implements TxnSupplier{
-    private ConcurrentLinkedHashMap<Long, TxnView> cache; // autobox for now
+    private TxnView[] cache;
     private final TxnSupplier delegate;
-    private final AtomicLong hits=new AtomicLong();
-    private final AtomicLong requests=new AtomicLong();
 
-    public CompletedTxnCacheSupplier(TxnSupplier delegate,int maxSize,int concurrencyLevel){
-        cache=new ConcurrentLinkedHashMap.Builder<Long, TxnView>()
-                .maximumWeightedCapacity(maxSize)
-                .concurrencyLevel(concurrencyLevel)
-                .build();
-        this.delegate=delegate;
+    public CompletedTxnCacheSupplier(TxnSupplier delegate, int maxSize, int concurrencyLevel) {
+        cache = new TxnView[Integer.highestOneBit(maxSize)];    // ensure power of 2
+        this.delegate = delegate;
     }
 
-    public int getMaxSize(){
-        return cache.size();
+    private int idx(long val) {
+        int hashCode = Long.hashCode(val);
+        hashCode ^= (hashCode >>> 20) ^ (hashCode >>> 12);
+        return (hashCode ^ (hashCode >>> 7) ^ (hashCode >>> 4)) & (cache.length - 1);
+    }
+
+    private int idx2(long val, int idx) {
+        return (int)(val + idx) & (cache.length - 1);
+    }
+
+    private TxnView get(long key) {
+        int idx = idx(key);
+        TxnView txn = cache[idx];   // safe to do without synchronization (JLS 17.7)
+        if (txn != null && txn.getTxnId() == key) return txn;
+        idx = idx2(key, idx);
+        txn = cache[idx];
+        return txn != null && txn.getTxnId() == key ? txn : null;
+    }
+
+    private void put(long key, TxnView txn) {
+        int idx = idx(key);
+        cache[idx] = txn;           // safe to do without synchronization (JLS 17.7)
+        idx = idx2(key, idx);
+        cache[idx] = txn;
     }
 
     @Override
     public TxnView getTransaction(long txnId) throws IOException{
-        if(txnId==-1)
-            return Txn.ROOT_TRANSACTION;
-        return getTransaction(txnId,false);
+        return getTransaction(txnId, false);
     }
 
     @Override
-    @SuppressFBWarnings("SF_SWITCH_NO_DEFAULT") //intentional
-    public TxnView getTransaction(long txnId,boolean getDestinationTables) throws IOException{
-        if(txnId==-1)
+    public TxnView getTransaction(long txnId, boolean getDestinationTables) throws IOException {
+        if (txnId == -1) {
             return Txn.ROOT_TRANSACTION;
-        requests.incrementAndGet();
-        TxnView txn=cache.get(txnId); // autobox until Cliff C merge
-        if(txn!=null){
-            hits.incrementAndGet();
-            return txn;
         }
-        //bummer, we aren't in the cache, need to check the delegate
-        TxnView transaction=delegate.getTransaction(txnId,getDestinationTables);
-        if(transaction==null) //noinspection ConstantConditions
-            return transaction; //don't cache read-only transactions;
+        TxnView transaction = get(txnId);
+        if (transaction != null) {
+            return transaction;
+        }
 
-        switch(transaction.getEffectiveState()){
-            case COMMITTED:
-            case ROLLEDBACK:
-                cache.put(transaction.getTxnId(),transaction); // Cache for Future Use
+        // Not in the cache, need to check the delegate
+        transaction = delegate.getTransaction(txnId, getDestinationTables);
+        if (transaction != null) {
+            switch (transaction.getEffectiveState()) {
+                case COMMITTED:
+                case ROLLEDBACK:
+                    put(transaction.getTxnId(), transaction); // Cache for Future Use
+                    break;
+                default:
+                    break;
+            }
         }
         return transaction;
     }
 
     @Override
-    public boolean transactionCached(long txnId){
-        return cache.get(txnId)!=null;
+    public boolean transactionCached(long txnId) {
+        return get(txnId) != null;
     }
 
     @Override
-    public void cache(TxnView toCache){
-        if(toCache.getState()==Txn.State.ACTIVE) return; //cannot cache incomplete transactions
-        cache.put(toCache.getTxnId(),toCache);
+    public void cache(TxnView toCache) {
+        if (toCache.getState() == Txn.State.ACTIVE) return; //cannot cache incomplete transactions
+        put(toCache.getTxnId(), toCache);
     }
 
     @Override
-    public TxnView getTransactionFromCache(long txnId){
-        requests.incrementAndGet();
-        TxnView txn=cache.get(txnId);
-        if(txn!=null)
-            hits.incrementAndGet();
-        return txn;
+    public TxnView getTransactionFromCache(long txnId) {
+        return get(txnId);
     }
 
     @Override

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/AbstractTxn.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/AbstractTxn.java
@@ -112,12 +112,14 @@ public abstract class AbstractTxn extends AbstractTxnView implements Txn {
             if (!other.subtransactionsAllowed)
                 return false;
             boolean nonRolledbackChild = false;
-            for (Txn c : other.children) {
-                if (c.getState() == State.ACTIVE) {
-                    if (nonRolledbackChild) {
-                        return false;
+            if (!children.isEmpty()) {
+                for (Txn c : other.children) {
+                    if (c.getState() == State.ACTIVE) {
+                        if (nonRolledbackChild) {
+                            return false;
+                        }
+                        nonRolledbackChild = true;
                     }
-                    nonRolledbackChild = true;
                 }
             }
             if (other.parentReference != null) {
@@ -133,9 +135,11 @@ public abstract class AbstractTxn extends AbstractTxnView implements Txn {
         if (counter != null && counter.get() >= SIConstants.SUBTRANSANCTION_ID_MASK) {
             return false;
         }
-        for (Txn c : children) {
-            if (c.getState() == State.ACTIVE) {
-                return false;
+        if (!children.isEmpty()) {
+            for (Txn c : children) {
+                if (c.getState() == State.ACTIVE) {
+                    return false;
+                }
             }
         }
         if (parentReference != null)
@@ -154,9 +158,11 @@ public abstract class AbstractTxn extends AbstractTxnView implements Txn {
     @Override
     public boolean canSee(TxnView otherTxn) {
         // Protects against reading data written by the "self-insert transaction"
-        for (Txn c : children) {
-            if (c.getTxnId() == otherTxn.getTxnId() && c.getState() == State.ACTIVE) {
-                return false;
+        if (!children.isEmpty()) {
+            for (Txn c : children) {
+                if (c.getTxnId() == otherTxn.getTxnId() && c.getState() == State.ACTIVE) {
+                    return false;
+                }
             }
         }
         return super.canSee(otherTxn);


### PR DESCRIPTION
DB-8796 High GC overhead during OLTP workload
DB-8806 CompletedTxnCache is expensive
DB-8789 Apparent deadlock during OLTP workload

Greatly reduces overhead from getTransaction() RPCs - a bottleneck for OLTP workloads like TPC-C and HTAP.
Introduces RPC priorities and a new _SpliceRpcSchedulerFactory_ to enable them (but not a Splice scheduler yet).