### PR TITLE
DB-8132 return first available union branch first

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
@@ -71,8 +71,6 @@ import java.util.*;
 import java.util.concurrent.Future;
 import java.util.zip.GZIPOutputStream;
 
-import static org.apache.spark.sql.functions.broadcast;
-import static org.apache.spark.sql.functions.col;
 
 /**
  *
@@ -430,6 +428,19 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
         } finally {
             if (pushScope) SpliceSpark.popScope();
         }
+    }
+
+    @Override
+    public DataSet<V> union(List<DataSet<V>> dataSetList, OperationContext operationContext) {
+        DataSet<V> toReturn = null;
+        for (DataSet<V> aSet: dataSetList) {
+            if (toReturn == null)
+                toReturn = aSet;
+            else
+                toReturn = aSet.union(aSet, operationContext, RDDName.UNION.displayName(), false, null);
+        }
+
+        return toReturn;
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
@@ -216,6 +216,8 @@ public interface DataSet<V> extends //Iterable<V>,
 
     DataSet<V> union(DataSet<V> dataSet, OperationContext operationContext);
 
+    DataSet<V> union(List<DataSet<V>> dataSetList, OperationContext operationContext);
+
     DataSet<V> orderBy(OperationContext operationContext, int[] keyColumns, boolean[] descColumns, boolean[] nullsOrderedLow);
 
     DataSet<V> parallelProbe(List<ScanSetBuilder<ExecRow>> dataSets, OperationContext<MultiProbeTableScanOperation> operationContext) throws StandardException;

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DecimalIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DecimalIT.java
@@ -381,7 +381,7 @@ public class DecimalIT  extends SpliceUnitTest {
         "-0.12345678901234567890123456789012345678 |\n" +
         "                 -1E-38                   |";
 
-        testQueryUnsorted(sqlText, expected, methodWatcher);
+        testQuery(sqlText, expected, methodWatcher);
 
         sqlText = format("values 12345678901234567890123456789012345678, -0.12345678901234567890123456789012345678, -.00000000000000000000000000000000000001", useSpark);
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/IndexIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/IndexIT.java
@@ -519,7 +519,7 @@ public class IndexIT extends SpliceUnitTest{
         methodWatcher.executeUpdate(String.format("insert into %s.%s values 6,7,8,9,10,11", SCHEMA_NAME,A_TABLE_NAME));
 
         // query base table directly
-        String sqlText = String.format("select * from %s.%s --SPLICE-PROPERTIES index=%s",SCHEMA_NAME,A_TABLE_NAME, "NULL");
+        String sqlText = String.format("select * from %s.%s --SPLICE-PROPERTIES index=%s\n order by 1",SCHEMA_NAME,A_TABLE_NAME, "NULL");
         rs = methodWatcher.executeQuery(sqlText);
         String expected =
             "I |\n" +

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/OuterJoinOrderByEliminationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/OuterJoinOrderByEliminationIT.java
@@ -384,9 +384,27 @@ public class OuterJoinOrderByEliminationIT extends SpliceUnitTest {
                 " 1 | 2 | 1 | 1 |\n" +
                 " 2 | 2 | 2 | 2 |\n" +
                 " 9 | 9 | 9 | 9 |";
+        // With DB-8132, the order between the union-all branch is not preserved, so we have an alternative
+        // exepcted result
+        String expected1 = "1 | 2 | 3 | 4 |\n" +
+                "----------------\n" +
+                " 9 | 9 | 9 | 9 |\n" +
+                " 1 | 1 | 1 | 1 |\n" +
+                " 1 | 1 | 1 | 1 |\n" +
+                " 1 | 1 | 1 | 1 |\n" +
+                " 1 | 1 | 1 | 1 |\n" +
+                " 1 | 2 | 1 | 1 |\n" +
+                " 1 | 2 | 1 | 1 |\n" +
+                " 1 | 2 | 1 | 1 |\n" +
+                " 1 | 2 | 1 | 1 |\n" +
+                " 2 | 2 | 2 | 2 |";
+
 
         rs = methodWatcher.executeQuery(sqlText);
-        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        String actual = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+        Assert.assertTrue("result mismatch, actual is: "+actual,
+                actual != null && (expected.equals(actual) || expected1.equals(actual)));
+
         rs.close();
         if (!joinStrategy.equals("SORTMERGE"))
             queryDoesNotContainString("explain " + sqlText, "OrderBy", methodWatcher);

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/complextypes/SQLArrayIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/complextypes/SQLArrayIT.java
@@ -73,12 +73,12 @@ public class SQLArrayIT extends SpliceUnitTest {
     @Test
     public void testInsertSelectValues() throws Exception {
         methodWatcher.executeUpdate("insert into ARRAY_ONE values ([1,1,1]),(null),([2,1])");
-        ResultSet rs = methodWatcher.executeQuery("select col1, col1[0], col1[1], col1[2] from ARRAY_ONE");
-        assertEquals("COL1    |  2  |  3  |  4  |\n" +
+        ResultSet rs = methodWatcher.executeQuery("select cast(col1  as varchar(30)), col1[0], col1[1], col1[2] from ARRAY_ONE");
+        assertEquals("1     |  2  |  3  |  4  |\n" +
                 "-----------------------------\n" +
-                "  NULL    |  2  |  1  |NULL |\n" +
                 "  NULL    |NULL |NULL |NULL |\n" +
-                "[1, 1, 1] |  1  |  1  |  1  |", TestUtils.FormattedResult.ResultFactory.toString(rs));
+                "[1, 1, 1] |  1  |  1  |  1  |\n" +
+                " [2, 1]   |  2  |  1  |NULL |", TestUtils.FormattedResult.ResultFactory.toString(rs));
     }
 
     @Test

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/RecursiveWithStatementIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/RecursiveWithStatementIT.java
@@ -129,7 +129,7 @@ public class RecursiveWithStatementIT extends SpliceUnitTest {
                 "union all\n" +
                 "select a2, level+1 as level\n" +
                 "from dt where level<10)\n" +
-                "select * from dt order by a2", this.useSparkString);
+                "select * from dt order by a2, level", this.useSparkString);
 
         ResultSet rs = methodWatcher.executeQuery(sqlText);
 
@@ -553,7 +553,7 @@ public class RecursiveWithStatementIT extends SpliceUnitTest {
                     "union all\n" +
                     "select a2, level+1 as level\n" +
                     "from dt where level<%d)\n" +
-                    "select * from dt order by a2";
+                    "select * from dt order by a2, level";
             String sqlText = format(sqlTemplate, this.useSparkString, 15);
 
             try {

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TernaryOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TernaryOperationIT.java
@@ -15,8 +15,11 @@
 package com.splicemachine.derby.impl.sql.execute.operations;
 
 import com.splicemachine.db.iapi.reference.SQLState;
-import com.splicemachine.derby.test.framework.*;
-
+import com.splicemachine.derby.test.framework.SpliceDataWatcher;
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceTableWatcher;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.homeless.TestUtils;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -27,12 +30,10 @@ import org.junit.runner.Description;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.SQLDataException;
 import java.sql.SQLSyntaxErrorException;
 import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 
 /**
@@ -302,19 +303,15 @@ public class TernaryOperationIT {
         String sql = "select right(name, cut) from ta";
         rs = methodWatcher.executeQuery(sql);
 
+        String expected_result = "1    |\n" +
+                "----------\n" +
+                "  NULL   |\n" +
+                "  NULL   |\n" +
+                "hey dude |\n" +
+                "  world  |";
+        assertEquals(expected_result, TestUtils.FormattedResult.ResultFactory.toString(rs));
+
         methodWatcher.execute("drop table ta");
-
-        List<String> expected = new ArrayList<>(2);
-        expected.add("world");
-        expected.add("hey dude");
-        expected.add(null);
-        expected.add(null);
-
-        for (String s: expected) {
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(s, rs.getString(1));
-        }
-        Assert.assertFalse(rs.next());
     }
 
     @Test
@@ -330,19 +327,14 @@ public class TernaryOperationIT {
         String sql = "select left(name, cut) from ta";
         rs = methodWatcher.executeQuery(sql);
 
+        String expected_result = "1    |\n" +
+                "----------\n" +
+                "  NULL   |\n" +
+                "  NULL   |\n" +
+                "  hello  |\n" +
+                "hey dude |";
+        assertEquals(expected_result, TestUtils.FormattedResult.ResultFactory.toString(rs));
         methodWatcher.execute("drop table ta");
-
-        List<String> expected = new ArrayList<>(2);
-        expected.add("hello");
-        expected.add("hey dude");
-        expected.add(null);
-        expected.add(null);
-
-        for (String s: expected) {
-            Assert.assertTrue(rs.next());
-            Assert.assertEquals(s, rs.getString(1));
-        }
-        Assert.assertFalse(rs.next());
     }
 
     @Test

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UnionOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UnionOperationIT.java
@@ -377,6 +377,18 @@ public class UnionOperationIT {
         }
     }
 
+
+    @Test
+    public void testUnionAllReturnFirstAvailableBranchFirst() throws Exception {
+        String sqlText = "select * from (select A.name from ST_EARTH as A, ST_EARTH as B, ST_MARS as C where A.name=B.name and B.name=C.name union all values ('from_values')) dt {limit 1}";
+        ResultSet rs = methodWatcher.executeQuery(sqlText);
+        String expected =
+                "1      |\n" +
+                        "-------------\n" +
+                        "from_values |";
+        assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+
+    }
     /* ****************************************************************************************************************/
     /*private helper methods*/
     private void insert(Statement s, long times, String sql) throws Exception {

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UnionOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UnionOperationIT.java
@@ -380,7 +380,9 @@ public class UnionOperationIT {
 
     @Test
     public void testUnionAllReturnFirstAvailableBranchFirst() throws Exception {
-        String sqlText = "select * from (select A.name from ST_EARTH as A, ST_EARTH as B, ST_MARS as C where A.name=B.name and B.name=C.name union all values ('from_values')) dt {limit 1}";
+        String sqlText = "select * from (select A.name from ST_EARTH as A, ST_EARTH as B, ST_MARS as C " +
+                "where A.name=B.name and B.name=C.name and C.name in (select D.name from ST_MARS as D, ST_MARS as E where D.name=E.name and D.name=C.name) " +
+                "union all values ('from_values')) dt {limit 1}";
         ResultSet rs = methodWatcher.executeQuery(sqlText);
         String expected =
                 "1      |\n" +

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Exists_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Exists_IT.java
@@ -607,7 +607,7 @@ public class Subquery_Flattening_Exists_IT {
         int deleteCount = methodWatcher.executeUpdate("delete from YY where exists (select 1 from ZZ where y1=z1)");
         assertEquals(5, deleteCount);
         // verify that only expected rows remain in target table
-        assertEquals("[1, 3, 5, 7, 9]", methodWatcher.queryList("select y1 from YY").toString());
+        assertEquals("[1, 3, 5, 7, 9]", methodWatcher.queryList("select y1 from YY order by 1").toString());
     }
 
 

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_NotExists_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_NotExists_IT.java
@@ -714,7 +714,7 @@ public class Subquery_Flattening_NotExists_IT {
         int deleteCount = methodWatcher.executeUpdate("delete from YY where not exists (select 1 from ZZ where y1=z1)");
         assertEquals(5, deleteCount);
         // verify that only expected rows remain in target table
-        assertEquals("[2, 4, 6, 8, 10]", methodWatcher.queryList("select y1 from YY").toString());
+        assertEquals("[2, 4, 6, 8, 10]", methodWatcher.queryList("select y1 from YY order by 1").toString());
     }
 
 

--- a/splice_machine/src/test/test-data/expressions/SparkExpressionTables.sql
+++ b/splice_machine/src/test/test-data/expressions/SparkExpressionTables.sql
@@ -45,10 +45,10 @@ insert into ts_int values
 create index ix_int on ts_int(l, i);
 
 create table ts_decimal (a dec(11,1), b int);
-insert into ts_decimal values
+insert into ts_decimal select * from (values
                         (9999999999.7, 1),
                         (9999999999.9, 1),
-                        (9999999999.9, 1);
+                        (9999999999.9, 1)) dt order by 1;
 
 create table ts_double (a double, b double, c int);
 insert into ts_double values (1.79769E+308, 1.49769E+308, 1);


### PR DESCRIPTION
For union-all operation that takes control execution, instead of always returning rows from the first union branch, return from the branch whose rows become available first.