### PR TITLE
DB-8167 Stagger region load refreshes

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/hbase/HBaseRegionLoads.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/HBaseRegionLoads.java
@@ -106,6 +106,14 @@ public class HBaseRegionLoads implements PartitionLoadWatcher{
             SConfiguration configuration=SIDriver.driver().getConfiguration();
             long updateInterval = configuration.getRegionLoadUpdateInterval();
             long initialDelay = new Random().nextInt((int) updateInterval); // avoid refreshes from all RSs at once
+
+            // initialize an empty cache
+            cache.set(new HashMap<>());
+
+            // schedule first update right away
+            updateService.execute(updater);
+
+            // schedule remaining updates staggered
             updateService.scheduleWithFixedDelay(updater,initialDelay,updateInterval,TimeUnit.SECONDS);
         }
     }

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/HBaseRegionLoads.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/HBaseRegionLoads.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
@@ -104,7 +105,8 @@ public class HBaseRegionLoads implements PartitionLoadWatcher{
 
             SConfiguration configuration=SIDriver.driver().getConfiguration();
             long updateInterval = configuration.getRegionLoadUpdateInterval();
-            updateService.scheduleAtFixedRate(updater,0l,updateInterval,TimeUnit.SECONDS);
+            long initialDelay = new Random().nextInt((int) updateInterval); // avoid refreshes from all RSs at once
+            updateService.scheduleWithFixedDelay(updater,initialDelay,updateInterval,TimeUnit.SECONDS);
         }
     }
 


### PR DESCRIPTION
My previous PR had a problem because the cache wasn't initialized for a long time, functions like tableLoad() could try to .put() values into a null map.

Now I initialize the cache to an empty Map and schedule the first update right away, the rest will continue to be staggered.