### PR TITLE
DB-8110 When clause for triggers

### DIFF
--- a/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAConnThread.java
+++ b/db-drda/src/main/java/com/splicemachine/db/impl/drda/DRDAConnThread.java
@@ -6508,6 +6508,25 @@ class DRDAConnThread extends Thread {
 		do {
 			if ( se instanceof EmbedSQLException)
 			{
+				StringBuilder sb = new StringBuilder();
+				Throwable t = se.getCause();
+				Throwable last = t;
+				while (t != null && t != t.getCause()) {
+					last = t;
+					t = t.getCause();
+				}
+				if (last instanceof StandardException) {
+					StandardException e = (StandardException) last;
+					if (e.isSignal()) {
+						sb.append(e.getLocalizedMessage());
+						// Can't have a zero-length message.
+						if (sb.toString().length() == 0)
+							sb.append(" ");
+						sqlerrmc += sb.toString();
+						se = null;
+						continue;
+					}
+				}
 				String messageId = ((EmbedSQLException)se).getMessageId();
 				// arguments are variable part of a message
 				Object[] args = ((EmbedSQLException)se).getArguments();

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/ast/ISpliceVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/ast/ISpliceVisitor.java
@@ -218,5 +218,7 @@ public interface ISpliceVisitor {
     Visitable visit(ListValueNode node) throws StandardException;
     Visitable visit(GroupingFunctionNode node) throws StandardException;
     Visitable visit(SelfReferenceNode node) throws StandardException;
+    Visitable visit(SignalNode node) throws StandardException;
+    Visitable visit(SetNode node) throws StandardException;
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/error/StandardException.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/error/StandardException.java
@@ -70,6 +70,7 @@ public class StandardException extends Exception
 	private String textMessage;
 	private String sqlState;
 	private transient int report;
+	private boolean isSignal = false;
 
 	/*
 	** End of constructors
@@ -79,7 +80,8 @@ public class StandardException extends Exception
 		
 	}
 	
-	
+	public void setIsSignal(boolean isSignal) { this.isSignal = isSignal; }
+	public boolean isSignal() { return isSignal; }
 	
 	public String getTextMessage() {
 		return textMessage;
@@ -208,6 +210,13 @@ public class StandardException extends Exception
 
 		if (messageID.length() == 5)
 			return messageID;
+		else if (messageID.length() < 5) {
+			StringBuilder sb = new StringBuilder();
+			for (int i = 0; i < 5-messageID.length(); i++)
+				sb.append(' ');
+			sb.append(messageID);
+			return sb.toString();
+		}
 		return messageID.substring(0, 5);
 	}
 
@@ -253,6 +262,7 @@ public class StandardException extends Exception
 			break;
 
 		default:
+	              if (messageID.length() >= 7)
 			switch (messageID.charAt(6)) {
 			case 'M':
 				lseverity = ExceptionSeverity.SYSTEM_SEVERITY;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/C_NodeTypes.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/C_NodeTypes.java
@@ -277,9 +277,11 @@ int CREATE_INDEX_NODE = 146;
 	int GROUP_USER_NODE = 266;
 	int SELF_REFERENCE_NODE = 267;
 	int DIGITS_OPERATOR_NODE = 268;
+	int SIGNAL_NODE = 269;
+	int SET_NODE = 270;
 
 	// Final value in set, keep up to date!
-	int FINAL_VALUE = DIGITS_OPERATOR_NODE;
+	int FINAL_VALUE = SET_NODE;
 
     /**
      * Extensions to this interface can use nodetypes > MAX_NODE_TYPE with out fear of collision

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Parser.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Parser.java
@@ -69,6 +69,16 @@ public interface Parser
 		throws StandardException;
 
 	/**
+	* Parse an SQL fragment that represents a {@code <search condition>}.
+	*
+	* @param sqlFragment the SQL fragment to parse
+	* @return a parse tree representing the search condition
+	* @throws StandardException if the SQL fragment could not be parsed
+	*/
+	Visitable parseSearchCondition(String sqlFragment)
+		throws StandardException;
+
+	/**
 	 * Returns the current SQL text string that is being parsed.
 	 *
 	 * @return	Current SQL text string.

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/CatalogRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/CatalogRowFactory.java
@@ -270,7 +270,7 @@ public abstract	class CatalogRowFactory
 	 *
 	 * @return The number of columns in the heap.
 	 */
-	public final int getHeapColumnCount()
+	public int getHeapColumnCount()
 	{
 		return columnCount;
 	}
@@ -281,6 +281,28 @@ public abstract	class CatalogRowFactory
 	public  ExecRow makeEmptyRow() throws StandardException
 	{
  		return	this.makeRow(null, null);
+	}
+
+	/**
+	* <p>
+	* Create an empty row for this conglomerate, in the format that would
+	* be used in a database that was created with, or hard upgraded to,
+	* the currently running version. That is, even if the database is only
+	* soft-upgraded, this method should return a row in the new format.
+	* </p>
+	*
+	* <p>
+	* This method is for use in code that creates the catalogs, or that
+	* upgrades the format of the catalogs to the newest version. Other code
+	* should call {@link #makeEmptyRow()}, which returns a row in the format
+	* used in the old database version if the database is soft-upgraded.
+	* </p>
+	*
+	* @return an empty row
+	* @throws StandardException if an error happens when creating the row
+	*/
+	public ExecRow makeEmptyRowForCurrentVersion() throws StandardException {
+	    return makeEmptyRow();
 	}
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDescriptorGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDescriptorGenerator.java
@@ -373,6 +373,7 @@ public class DataDescriptorGenerator
 	 * @param referencingNew whether or not NEW appears in REFERENCING clause
 	 * @param oldReferencingName old referencing table name, if any, that appears in REFERCING clause
 	 * @param newReferencingName new referencing table name, if any, that appears in REFERCING clause
+	 * @param whenClauseText the SQL text of the WHEN clause (may be null)
 	 *
 	 * @exception StandardException on error
 	 */
@@ -395,7 +396,8 @@ public class DataDescriptorGenerator
 		boolean				referencingOld,
 		boolean				referencingNew,
 		String				oldReferencingName,
-		String				newReferencingName
+		String				newReferencingName,
+                String                          whenClauseText
 	) throws StandardException
 	{
 		return new TriggerDescriptor(
@@ -417,7 +419,8 @@ public class DataDescriptorGenerator
 					referencingOld,
 					referencingNew,
 					oldReferencingName,
-					newReferencingName
+					newReferencingName,
+                                        whenClauseText
 					);
 	}
 		

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -1158,6 +1158,20 @@ public interface DataDictionary{
      */
     TriggerDescriptor getTriggerDescriptor(String name,SchemaDescriptor sd) throws StandardException;
 
+    int[] examineTriggerNodeAndCols(
+			Visitable actionStmt,
+			String oldReferencingName,
+			String newReferencingName,
+			String triggerDefinition,
+			int[] referencedCols,
+			int[] referencedColsInTriggerAction,
+			int actionOffset,
+			TableDescriptor triggerTableDescriptor,
+			TriggerEventDML triggerEventMask,
+                        boolean createTriggerTime,
+                        List<int[]> replacements
+			) throws StandardException;
+
     /**
      * This method does the job of transforming the trigger action plan text
      * as shown below.
@@ -1270,7 +1284,9 @@ public interface DataDictionary{
                                   int actionOffset,
                                   TableDescriptor triggerTableDescriptor,
                                   TriggerEventDML triggerEventMask,
-                                  boolean createTriggerTime) throws StandardException;
+                                  boolean createTriggerTime,
+                                  List<int[]> replacements,
+                                  int[] cols) throws StandardException;
 
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TriggerDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TriggerDescriptor.java
@@ -370,7 +370,7 @@ public class TriggerDescriptor extends TupleDescriptor implements UniqueSQLObjec
                 // The WHEN clause is not a full SQL statement, just a search
                 // condition, so we need to turn it into a statement in order
                 // to create an SPS.
-                newText = "VALUES " + newText;
+                newText = "VALUES ( " + newText + " )";
             }
             sps.setText(newText);
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TriggerDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TriggerDescriptor.java
@@ -96,6 +96,7 @@ public class TriggerDescriptor extends TupleDescriptor implements UniqueSQLObjec
     private Timestamp creationTimestamp;
     private UUID triggerSchemaId;
     private UUID triggerTableId;
+    private String whenClauseText;
 
 
     /**
@@ -127,6 +128,8 @@ public class TriggerDescriptor extends TupleDescriptor implements UniqueSQLObjec
      * @param referencingNew                whether or not NEW appears in REFERENCING clause
      * @param oldReferencingName            old referencing table name, if any, that appears in REFERCING clause
      * @param newReferencingName            new referencing table name, if any, that appears in REFERCING clause
+     * @param whenClauseText                the SQL text of the WHEN clause, or {@code null}
+     *                                      if there is no WHEN clause
      */
     public TriggerDescriptor(
             DataDictionary dataDictionary,
@@ -147,7 +150,8 @@ public class TriggerDescriptor extends TupleDescriptor implements UniqueSQLObjec
             boolean referencingOld,
             boolean referencingNew,
             String oldReferencingName,
-            String newReferencingName) {
+            String newReferencingName,
+            String whenClauseText) {
         super(dataDictionary);
         this.id = id;
         this.sd = sd;
@@ -169,6 +173,7 @@ public class TriggerDescriptor extends TupleDescriptor implements UniqueSQLObjec
         this.newReferencingName = newReferencingName;
         this.triggerSchemaId = sd.getUUID();
         this.triggerTableId = td.getUUID();
+        this.whenClauseText = whenClauseText;
     }
     
     /**
@@ -276,7 +281,30 @@ public class TriggerDescriptor extends TupleDescriptor implements UniqueSQLObjec
      * @return the trigger action sps
      */
     public SPSDescriptor getActionSPS(LanguageConnectionContext lcc) throws StandardException {
-        if (actionSPS == null) {
+
+        return getSPS(lcc, false /* isWhenClause */);
+
+    }
+
+    /**
+     * Get the SPS for the triggered SQL statement or the WHEN clause.
+     *
+     * @param lcc the LanguageConnectionContext to use
+     * @param isWhenClause {@code true} if the SPS for the WHEN clause is
+     *   requested, {@code false} if it is the triggered SQL statement
+     * @return the requested SPS
+     * @throws StandardException if an error occurs
+     */
+    private SPSDescriptor getSPS(LanguageConnectionContext lcc,
+                                 boolean isWhenClause)
+            throws StandardException
+    {
+        DataDictionary dd = getDataDictionary();
+        SPSDescriptor sps = isWhenClause ? whenSPS : actionSPS;
+        UUID spsId = isWhenClause ? whenSPSId : actionSPSId;
+        String originalSQL = isWhenClause ? whenClauseText : triggerDefinition;
+
+        if (sps == null) {
             //bug 4821 - do the sysstatement look up in a nested readonly
             //transaction rather than in the user transaction. Because of
             //this, the nested compile transaction which is attempting to
@@ -287,7 +315,7 @@ public class TriggerDescriptor extends TupleDescriptor implements UniqueSQLObjec
             // fail for row trigger that were executing on remote nodes with SpliceTransactionView with which we
             // cannot begin a new txn.
             //  lcc.beginNestedTransaction(true);
-            actionSPS = getDataDictionary().getSPSDescriptor(actionSPSId);
+            sps = dd.getSPSDescriptor(spsId);
             // lcc.commitNestedTransaction();
         }
 
@@ -305,29 +333,52 @@ public class TriggerDescriptor extends TupleDescriptor implements UniqueSQLObjec
         //will then get updated into SYSSTATEMENTS table.
         boolean usesReferencingClause = referencedColsInTriggerAction != null;
 
-        if ((!actionSPS.isValid() || (actionSPS.getPreparedStatement() == null)) && isRow && usesReferencingClause) {
-            SchemaDescriptor compSchema = getDataDictionary().getSchemaDescriptor(triggerSchemaId, null);
+        if ((!sps.isValid() || (sps.getPreparedStatement() == null)) && isRow && usesReferencingClause) {
+            SchemaDescriptor compSchema = dd.getSchemaDescriptor(triggerSchemaId, null);
             CompilerContext newCC = lcc.pushCompilerContext(compSchema);
             Parser pa = newCC.getParser();
-            Visitable stmtnode = pa.parseStatement(triggerDefinition);
+            Visitable stmtnode =
+                    isWhenClause ? pa.parseSearchCondition(originalSQL)
+                                 : pa.parseStatement(originalSQL);
             lcc.popCompilerContext(newCC);
+            int[] cols;
+            cols = dd.examineTriggerNodeAndCols(stmtnode,
+					oldReferencingName,
+					newReferencingName,
+					originalSQL,
+					referencedCols,
+					referencedColsInTriggerAction,
+                                        0,
+					getTableDescriptor(),
+					null,
+                                        false,
+                                        null);
 
-            actionSPS.setText(getDataDictionary().getTriggerActionString(stmtnode,
-                    oldReferencingName,
-                    newReferencingName,
-                    triggerDefinition,
-                    referencedCols,
-                    referencedColsInTriggerAction,
-                    0,
-                    getTableDescriptor(),
-                    null,
-                    false
-            ));
+            String newText = dd.getTriggerActionString(stmtnode,
+					oldReferencingName,
+					newReferencingName,
+                                        originalSQL,
+					referencedCols,
+					referencedColsInTriggerAction,
+					0,
+					getTableDescriptor(),
+					null,
+                                        false,
+                                        null,
+                                        cols);
+            if (isWhenClause) {
+                // The WHEN clause is not a full SQL statement, just a search
+                // condition, so we need to turn it into a statement in order
+                // to create an SPS.
+                newText = "VALUES " + newText;
+            }
+            sps.setText(newText);
+
             //By this point, we are finished transforming the trigger action if
             //it has any references to old/new transition variables.
         }
 
-        return actionSPS;
+        return sps;
     }
 
     /**
@@ -338,13 +389,23 @@ public class TriggerDescriptor extends TupleDescriptor implements UniqueSQLObjec
     }
 
     /**
+     * Get the SQL text of the WHEN clause.
+     * @return SQL text for the WHEN clause, or {@code null} if there is
+     *   no WHEN clause
+     */
+    public String getWhenClauseText() {
+        return whenClauseText;
+    }
+
+    /**
      * Get the trigger when clause sps
      */
-    public SPSDescriptor getWhenClauseSPS() throws StandardException {
-        if (whenSPS == null) {
-            whenSPS = getDataDictionary().getSPSDescriptor(whenSPSId);
+    public SPSDescriptor getWhenClauseSPS(LanguageConnectionContext lcc) throws StandardException {
+        if (whenSPSId == null) {
+            // This trigger doesn't have a WHEN clause.
+            return null;
         }
-        return whenSPS;
+        return getSPS(lcc, true /* isWhenClause */);
     }
 
     /**
@@ -702,6 +763,7 @@ public class TriggerDescriptor extends TupleDescriptor implements UniqueSQLObjec
         referencingNew = in.readBoolean();
         oldReferencingName = (String) in.readObject();
         newReferencingName = (String) in.readObject();
+        whenClauseText = (String) in.readObject();
 
     }
 
@@ -763,6 +825,7 @@ public class TriggerDescriptor extends TupleDescriptor implements UniqueSQLObjec
         out.writeBoolean(referencingNew);
         out.writeObject(oldReferencingName);
         out.writeObject(newReferencingName);
+        out.writeObject(whenClauseText);
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
@@ -2076,4 +2076,12 @@ public interface ResultSetFactory {
 											  String explainPlan,
 											  int iterationLimit) throws StandardException;
 
+	NoPutResultSet getSignalResultSet(Activation activation,
+	                                  String sqlState,
+	                                  GeneratedMethod errorTextGenerator) throws StandardException;
+
+        NoPutResultSet getSetResultSet(Activation activation,
+                                       String getColumnDVDsMethodNames,
+                                       GeneratedMethod getNewDVDsMethod) throws StandardException;
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/AbstractSpliceVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/AbstractSpliceVisitor.java
@@ -900,4 +900,14 @@ public abstract class AbstractSpliceVisitor implements ISpliceVisitor {
     public Visitable visit(SelfReferenceNode node) throws StandardException {
         return defaultVisit(node);
     }
+
+    @Override
+    public Visitable visit(SignalNode node) throws StandardException {
+        return defaultVisit(node);
+    }
+
+    @Override
+    public Visitable visit(SetNode node) throws StandardException {
+        return defaultVisit(node);
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayConstantNode.java
@@ -358,11 +358,12 @@ public class ArrayConstantNode extends ValueNode {
 								PredicateList outerPredicateList)
 			throws StandardException
 	{
-		argumentsList.preprocess(
-				numTables,
-				outerFromList,
-				outerSubqueryList,
-				outerPredicateList);
+		if (argumentsList != null)
+			argumentsList.preprocess(
+					numTables,
+					outerFromList,
+					outerSubqueryList,
+					outerPredicateList);
 
 		return this;
 	}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/C_NodeNames.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/C_NodeNames.java
@@ -352,6 +352,10 @@ public interface C_NodeNames
 
 	String SELF_REFERENCE_NODE_NAME = "com.splicemachine.db.impl.sql.compile.SelfReferenceNode";
 
+	String SIGNAL_NAME = "com.splicemachine.db.impl.sql.compile.SignalNode";
+
+	String SET_NAME = "com.splicemachine.db.impl.sql.compile.SetNode";
+
 	// WARNING: WHEN ADDING NODE TYPES HERE, YOU MUST ALSO ADD
     // THEM TO tools/jar/DBMSnodes.properties
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConcatenationOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConcatenationOperatorNode.java
@@ -53,6 +53,8 @@ import java.sql.Types;
 
 import java.util.List;
 
+import static com.splicemachine.db.iapi.reference.Limits.DB2_VARCHAR_MAXWIDTH;
+
 /**
  * This node represents a concatenation comparison operator
  * 
@@ -241,9 +243,10 @@ public class ConcatenationOperatorNode extends BinaryOperatorNode {
 		TypeCompiler tc = leftOperand.getTypeCompiler();
 		if (!(leftOperand.getTypeId().isStringTypeId() || leftOperand
 				.getTypeId().isBitTypeId())) {
+			int leftWidth = (tc instanceof UserDefinedTypeCompiler) ? DB2_VARCHAR_MAXWIDTH :
+			                 tc.getCastToCharWidth(leftOperand.getTypeServices());
 			DataTypeDescriptor dtd = DataTypeDescriptor.getBuiltInDataTypeDescriptor(
-					Types.VARCHAR, true, tc
-					.getCastToCharWidth(leftOperand							.getTypeServices()));	
+					Types.VARCHAR, true, leftWidth);
 
 			leftOperand = (ValueNode) getNodeFactory().getNode(
 					C_NodeTypes.CAST_NODE,
@@ -260,10 +263,10 @@ public class ConcatenationOperatorNode extends BinaryOperatorNode {
 		tc = rightOperand.getTypeCompiler();
 		if (!(rightOperand.getTypeId().isStringTypeId() || rightOperand
 				.getTypeId().isBitTypeId())) {
+			int rightWidth = (tc instanceof UserDefinedTypeCompiler) ? DB2_VARCHAR_MAXWIDTH :
+			                 tc.getCastToCharWidth(rightOperand.getTypeServices());
 			DataTypeDescriptor dtd = DataTypeDescriptor.getBuiltInDataTypeDescriptor(
-					Types.VARCHAR, true, tc
-							.getCastToCharWidth(rightOperand
-									.getTypeServices()));
+					Types.VARCHAR, true, rightWidth);
 
 			rightOperand = (ValueNode) getNodeFactory().getNode(
 					C_NodeTypes.CAST_NODE,

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
@@ -656,7 +656,7 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 
 	// It is expected that a DVD to move into the array has been pushed to the stack
 	// before this method is called.
-	protected void setDVDItemInArray(MethodBuilder mb, LocalField arrayField, int index,
+	public static void setDVDItemInArray(MethodBuilder mb, LocalField arrayField, int index,
 								     int constIdx, int numValsInSet) throws StandardException {
 		if (mb != null) {
 			if (numValsInSet > 1) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OffsetOrderVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OffsetOrderVisitor.java
@@ -1,0 +1,120 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+import java.util.Comparator;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.compile.Visitable;
+import com.splicemachine.db.iapi.sql.compile.Visitor;
+import com.splicemachine.db.shared.common.sanity.SanityManager;
+
+/**
+ * Get all nodes of a certain type in a query tree, and return them in
+ * the order in which they appear in the original SQL text. This visitor
+ * is useful when rewriting SQL queries by replacing certain tokens in
+ * the original query.
+ *
+ * @param <T> the type of nodes to collect
+ */
+class OffsetOrderVisitor<T extends QueryTreeNode> implements Visitor {
+
+    /** Comparator that orders nodes by ascending begin offset. */
+    private static final Comparator<QueryTreeNode>
+            COMPARATOR = new Comparator<QueryTreeNode>() {
+        public int compare(QueryTreeNode node1, QueryTreeNode node2) {
+            return node1.getBeginOffset() - node2.getBeginOffset();
+        }
+    };
+
+    private final Class<T> nodeClass;
+    private final TreeSet<T> nodes = new TreeSet<T>(COMPARATOR);
+    private final int lowOffset;
+    private final int highOffset;
+
+    /**
+     * Create a new {@code OffsetOrderVisitor} that collects nodes of the
+     * specified type. The nodes must have begin offset and end offset in
+     * the range given by the {@code low} and {@code high} parameters.
+     *
+     * @param nodeClass the type of nodes to collect
+     * @param low the lowest begin offset to accept (inclusive)
+     * @param high the highest end offset to accept (exclusive)
+     */
+    OffsetOrderVisitor(Class<T> nodeClass, int low, int high) {
+        this.nodeClass = nodeClass;
+        this.lowOffset = low;
+        this.highOffset = high;
+
+        if (SanityManager.DEBUG) {
+            // We should only collect nodes with non-negative offset. Nodes
+            // with negative offset are synthetic and did not exist as tokens
+            // in the original query text.
+            SanityManager.ASSERT(lowOffset >= 0 && highOffset >= 0,
+                                 "offsets should be non-negative");
+        }
+    }
+
+    @Override
+    public Visitable visit(Visitable node, QueryTreeNode parent) throws StandardException {
+        if (nodeClass.isInstance(node)) {
+            T qtn = nodeClass.cast(node);
+            if (qtn.getBeginOffset() >= lowOffset
+                    && qtn.getEndOffset() < highOffset) {
+                nodes.add(qtn);
+            }
+        }
+
+        return node;
+    }
+
+    @Override
+    public boolean visitChildrenFirst(Visitable node) {
+        return false;
+    }
+
+    @Override
+    public boolean stopTraversal() {
+        return false;
+    }
+
+    @Override
+    public boolean skipChildren(Visitable node) throws StandardException {
+        return false;
+    }
+
+    SortedSet<T> getNodes() {
+        return nodes;
+    }
+}
+

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
@@ -778,8 +778,13 @@ public class ResultColumn extends ValueNode
 			fromList.isJoinColumnForRightOuterJoin(this);
 		}
 
-		setExpression( expression.bindExpression(fromList, subqueryList,
-				aggregateVector) );
+		ValueNode newExpression =
+		    expression.bindExpression(fromList, subqueryList, aggregateVector);
+
+		if (newExpression instanceof BinaryLogicalOperatorNode ||
+		    newExpression instanceof UnaryLogicalOperatorNode)
+		    newExpression = SelectNode.normExpressions(newExpression);
+		setExpression( newExpression );
 
 		if (expression instanceof ColumnReference)
 		{
@@ -1716,6 +1721,8 @@ public class ResultColumn extends ValueNode
 		if (expression != null) {
 			setExpression( (ValueNode)expression.accept(v, this));
 		}
+		if (v instanceof OffsetOrderVisitor && reference != null)
+			reference = (ColumnReference)reference.accept(v, this);
 	}
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowResultSetNode.java
@@ -375,13 +375,19 @@ public class RowResultSetNode extends FromTable {
 
 	public ResultSetNode preprocess(int numTables, GroupByList gbl, FromList fromList) throws StandardException {
 
+		SubqueryList subqueryList =
+		  (SubqueryList) getNodeFactory().getNode( C_NodeTypes.SUBQUERY_LIST, getContextManager());
+		PredicateList predicateList = (PredicateList) getNodeFactory().getNode( C_NodeTypes.PREDICATE_LIST, getContextManager());
+                FromList localFromList = fromList == null ?
+		    (FromList) getNodeFactory().getNode( C_NodeTypes.FROM_LIST,
+							 getNodeFactory().doJoinOrderOptimization(),
+							 getContextManager()) : fromList;
+
+                assignResultSetNumber();
+		resultColumns.preprocess(numTables, localFromList, subqueryList, predicateList);
+
 		if (!subquerys.isEmpty()) {
-			subquerys.preprocess(numTables,
-					(FromList) getNodeFactory().getNode( C_NodeTypes.FROM_LIST,
-							getNodeFactory().doJoinOrderOptimization(),
-							getContextManager()),
-					(SubqueryList) getNodeFactory().getNode( C_NodeTypes.SUBQUERY_LIST, getContextManager()),
-					(PredicateList) getNodeFactory().getNode( C_NodeTypes.PREDICATE_LIST, getContextManager()));
+			subquerys.preprocess(numTables, localFromList, subqueryList, predicateList);
 		}
 
 		/* Allocate a dummy referenced table map */ 
@@ -877,7 +883,17 @@ public class RowResultSetNode extends FromTable {
 	}
 
 
+    @Override
+    public void assignResultSetNumber() throws StandardException{
+        super.assignResultSetNumber();
 
+	/* Set the point of attachment in all subqueries attached
+	 * to this node.
+	 */
+        if(subquerys!=null && !subquerys.isEmpty()){
+            subquerys.setPointOfAttachment(resultSetNumber);
+        }
+    }
 
     @Override
     public String printExplainInformation(String attrDelim, int order) throws StandardException {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetNode.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.ClassName;
+import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.services.classfile.VMOpcode;
+import com.splicemachine.db.iapi.services.compiler.LocalField;
+import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.io.FormatableArrayHolder;
+import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
+import com.splicemachine.db.iapi.sql.compile.RowOrdering;
+import com.splicemachine.db.iapi.sql.compile.Visitor;
+import com.splicemachine.db.iapi.sql.conn.Authorizer;
+import com.splicemachine.db.iapi.sql.conn.SessionProperties;
+import com.splicemachine.db.iapi.sql.execute.ConstantAction;
+import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+import com.splicemachine.db.iapi.types.TypeId;
+import com.splicemachine.utils.Pair;
+
+import java.lang.reflect.Modifier;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Vector;
+
+import static com.splicemachine.db.iapi.types.TypeId.VARCHAR_NAME;
+
+/**
+ * Created by msirek on Nov. 21, 2019.
+ */
+public class SetNode extends MiscellaneousStatementNode {
+    protected ValueNodeList assignedColumnsList;
+    protected ValueNodeList newValuesList;
+
+    /**
+     * Initializer for a SignalNode
+     *
+     * @param columnList The specification of column values to alter.
+     */
+    public void init(Object columnList, Object newValuesList) throws StandardException {
+        assignedColumnsList = (ValueNodeList) columnList;
+        this.newValuesList = (ValueNodeList) newValuesList;
+    }
+
+    /**
+     * Convert this object to a String.  See comments in QueryTreeNode.java
+     * for how this should be done for tree printing.
+     *
+     * @return This object as a String
+     */
+    public String toString() {
+        if (SanityManager.DEBUG) {
+            return super.toString() + "Set: " + commonString();
+        } else {
+            return "";
+        }
+    }
+
+    private String commonString() {
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < assignedColumnsList.size(); i++) {
+            sb.append(String.format("%s = %s", assignedColumnsList.elementAt(i), newValuesList.elementAt(i)));
+            if (i != assignedColumnsList.size() - 1)
+                sb.append(", ");
+        }
+        return sb.toString();
+    }
+
+    public String statementToString() {
+        return "SET " + commonString();
+    }
+
+    public void bindStatement() throws StandardException {
+        // We just need select privilege on the expressions
+        getCompilerContext().pushCurrentPrivType(Authorizer.SELECT_PRIV);
+
+        FromList fromList = (FromList) getNodeFactory().getNode(
+        C_NodeTypes.FROM_LIST,
+        getNodeFactory().doJoinOrderOptimization(),
+        getContextManager());
+
+        assignedColumnsList.bindExpression(fromList, null, null);
+        newValuesList.bindExpression(fromList, null, null);
+
+        getCompilerContext().popCurrentPrivType();
+    }
+
+    /**
+     * Accept the visitor for all visitable children of this node.
+     *
+     * @param v the visitor
+     */
+    @Override
+    public void acceptChildren(Visitor v) throws StandardException {
+        super.acceptChildren(v);
+        if (assignedColumnsList != null) {
+            assignedColumnsList.accept(v, this);
+        }
+        if (newValuesList != null) {
+            newValuesList.accept(v, this);
+        }
+    }
+
+
+    private LocalField generateListAsArray(ExpressionClassBuilder acb,
+                                           MethodBuilder mb) throws StandardException {
+        int listSize = newValuesList.size();
+        LocalField arrayField = acb.newFieldDeclaration(
+        Modifier.PRIVATE, ClassName.DataValueDescriptor + "[]");
+
+        /* Assign the initializer to the DataValueDescriptor[] field */
+        MethodBuilder cb = acb.getConstructor();
+        cb.pushNewArray(ClassName.DataValueDescriptor, listSize);
+        cb.setField(arrayField);
+
+
+        /* Set the array elements that are constant */
+        MethodBuilder nonConstantMethod = null;
+        MethodBuilder currentConstMethod = cb;
+
+        for (int index = 0; index < listSize; index++) {
+            ValueNode dataLiteral = (ValueNode) newValuesList.elementAt(index);
+            MethodBuilder setArrayMethod = null;
+            int numConstants = 0;
+
+            if (dataLiteral instanceof ConstantNode) {
+                numConstants++;
+
+                /*if too many statements are added  to a  method,
+                 *size of method can hit  65k limit, which will
+                 *lead to the class format errors at load time.
+                 *To avoid this problem, when number of statements added
+                 *to a method is > 2048, remaing statements are added to  a new function
+                 *and called from the function which created the function.
+                 *See Beetle 5135 or 4293 for further details on this type of problem.
+                 */
+                if (currentConstMethod.statementNumHitLimit(numConstants)) {
+                    MethodBuilder genConstantMethod = acb.newGeneratedFun("void", Modifier.PRIVATE);
+                    currentConstMethod.pushThis();
+                    currentConstMethod.callMethod(VMOpcode.INVOKEVIRTUAL,
+                    (String) null,
+                    genConstantMethod.getName(),
+                    "void", 0);
+                    //if it is a generate function, close the metod.
+                    if (currentConstMethod != cb) {
+                        currentConstMethod.methodReturn();
+                        currentConstMethod.complete();
+                    }
+                    currentConstMethod = genConstantMethod;
+                }
+                setArrayMethod = currentConstMethod;
+            } else {
+                if (nonConstantMethod == null)
+                    nonConstantMethod = acb.newGeneratedFun("void", Modifier.PROTECTED);
+                setArrayMethod = nonConstantMethod;
+
+            }
+
+            // Build the DVD to add to the DVD array, pushing it to the stack
+            // cast as a DataValueDescriptor.
+            dataLiteral.generateExpression(acb, setArrayMethod);
+            setArrayMethod.upCast(ClassName.DataValueDescriptor);
+
+            // Move the built DVD into the DVD array, using the proper
+            // constant or non-constant method.
+            InListOperatorNode.setDVDItemInArray(setArrayMethod, arrayField, index, 0, 1);
+
+        }
+
+        // if a generated function was created to reduce the size of the methods close the functions.
+        if (currentConstMethod != cb) {
+            currentConstMethod.methodReturn();
+            currentConstMethod.complete();
+        }
+
+        if (nonConstantMethod != null) {
+            nonConstantMethod.methodReturn();
+            nonConstantMethod.complete();
+            mb.pushThis();
+            mb.callMethod(VMOpcode.INVOKEVIRTUAL, (String) null, nonConstantMethod.getName(), "void", 0);
+        }
+
+        return arrayField;
+    }
+
+    private void generateInListValues(ExpressionClassBuilder acb, MethodBuilder mb) throws StandardException {
+
+        MethodBuilder getNewDVDsMethod = acb.newExprFun();
+        LocalField newDVDsArray = generateListAsArray(acb, getNewDVDsMethod);
+
+        getNewDVDsMethod.getField(newDVDsArray);
+        getNewDVDsMethod.methodReturn();
+        getNewDVDsMethod.complete();
+        acb.pushMethodReference(mb, getNewDVDsMethod);
+
+    }
+
+    /**
+     * Generate code, need to push parameters
+     *
+     * @param acb The ActivationClassBuilder for the class being built
+     * @param mb  the method  for the execute() method to be built
+     * @throws StandardException Thrown on error
+     */
+
+    public void generate(ActivationClassBuilder acb,
+                         MethodBuilder mb)
+    throws StandardException {
+
+        acb.pushGetResultSetFactoryExpression(mb);
+
+        acb.pushThisAsActivation(mb);
+        StringBuilder sb = new StringBuilder();
+        if (assignedColumnsList != null) {
+
+            MethodBuilder userExprFun = null;
+            for (int i = 0; i < assignedColumnsList.size(); i++) {
+                userExprFun = acb.newUserExprFun();
+
+                assignedColumnsList.elementAt(i).generate(acb, userExprFun);
+                userExprFun.methodReturn();
+                userExprFun.complete();
+                sb.append(userExprFun.getName());
+                if (i != assignedColumnsList.size() - 1)
+                    sb.append(".");
+            }
+        } else
+            throw new RuntimeException();
+        mb.push(sb.toString());
+        generateInListValues(acb, mb);
+
+        mb.callMethod(VMOpcode.INVOKEINTERFACE, (String) null, "getSetResultSet",
+        ClassName.NoPutResultSet, 3);
+    }
+
+    /**
+     * Returns the type of activation this class
+     * generates.
+     *
+     * @return NEED_NOTHING_ACTIVATION
+     */
+    int activationKind() {
+        return StatementNode.NEED_NOTHING_ACTIVATION;
+    }
+
+}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SignalNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SignalNode.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.ClassName;
+import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.services.classfile.VMOpcode;
+import com.splicemachine.db.iapi.services.compiler.LocalField;
+import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
+import com.splicemachine.db.iapi.sql.compile.Visitor;
+import com.splicemachine.db.iapi.sql.conn.Authorizer;
+import com.splicemachine.db.iapi.sql.conn.SessionProperties;
+import com.splicemachine.db.iapi.sql.execute.ConstantAction;
+import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+import com.splicemachine.db.iapi.types.TypeId;
+import com.splicemachine.utils.Pair;
+
+import java.lang.reflect.Modifier;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Vector;
+
+import static com.splicemachine.db.iapi.types.TypeId.VARCHAR_NAME;
+
+/**
+ * Created by msirek on Nov. 18, 2019.
+ */
+public class SignalNode extends MiscellaneousStatementNode {
+    protected String sqlState;
+    protected ValueNode errorText;
+
+    /**
+     * Initializer for a SignalNode
+     *
+     * @param sqlState	The error code to return.
+
+     *
+     */
+    public void init(Object sqlState, Object errorText) throws StandardException
+    {
+        this.sqlState = (String)sqlState;
+        this.errorText = (ValueNode)errorText;
+    }
+
+    /**
+     * Convert this object to a String.  See comments in QueryTreeNode.java
+     * for how this should be done for tree printing.
+     *
+     * @return	This object as a String
+     */
+    public String toString()
+    {
+        if (SanityManager.DEBUG)
+        {
+            String errMsg = errorText != null ? OperatorToString.opToString(errorText) : null;
+            String errorTextString =
+                (errMsg != null && errMsg.length() != 0) ?
+                      ", " + OperatorToString.opToString(errorText) : "";
+            return super.toString() + "Signal: " + (sqlState == null? "null" : sqlState) + errorTextString ;
+        }
+        else
+        {
+            return "";
+        }
+    }
+
+    public String statementToString()
+    {
+        return "SIGNAL " + sqlState;
+    }
+
+    public void bindStatement() throws StandardException {
+        // We just need select privilege on the expressions
+        getCompilerContext().pushCurrentPrivType(Authorizer.SELECT_PRIV);
+
+        FromList fromList = (FromList) getNodeFactory().getNode(
+        C_NodeTypes.FROM_LIST,
+        getNodeFactory().doJoinOrderOptimization(),
+        getContextManager());
+
+
+        if (errorText != null)
+            errorText = errorText.bindExpression(fromList, null,  null);
+        getCompilerContext().popCurrentPrivType();
+    }
+
+    /**
+     * Accept the visitor for all visitable children of this node.
+     *
+     * @param v the visitor
+     */
+    @Override
+    public void acceptChildren(Visitor v) throws StandardException {
+        super.acceptChildren(v);
+        if (errorText != null) {
+            errorText.accept(v, this);
+        }
+    }
+
+    /**
+     * Generate code, need to push parameters
+     *
+     * @param acb	The ActivationClassBuilder for the class being built
+     * @param mb the method  for the execute() method to be built
+     *
+     * @exception StandardException		Thrown on error
+     */
+
+    public void generate(ActivationClassBuilder acb,
+                         MethodBuilder mb)
+            throws StandardException
+    {
+        acb.pushGetResultSetFactoryExpression(mb);
+
+        acb.pushThisAsActivation(mb);
+        mb.push(this.sqlState);
+
+        if (errorText == null){
+            mb.pushNull(ClassName.GeneratedMethod);
+        }
+        else {
+            // this sets up the method and the static field.
+            // generates:
+            // 	Object userExprFun { }
+            MethodBuilder userExprFun=acb.newUserExprFun();
+
+            errorText.generateExpression(acb,userExprFun);
+            userExprFun.methodReturn();
+
+            // we are done modifying userExprFun, complete it.
+            userExprFun.complete();
+            acb.pushMethodReference(mb, userExprFun);
+        }
+
+        mb.callMethod(VMOpcode.INVOKEINTERFACE, (String) null, "getSignalResultSet",
+                ClassName.NoPutResultSet, 3);
+    }
+
+    /**
+     * Returns the type of activation this class
+     * generates.
+     *
+     * @return  NEED_NOTHING_ACTIVATION
+     *
+     */
+    int activationKind()
+    {
+        return StatementNode.NEED_NOTHING_ACTIVATION;
+    }
+}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
@@ -369,7 +369,7 @@ public class SubqueryNode extends ValueNode{
 		 * attachment as -1.
 		 */
         if(!isMaterializable()){
-            this.pointOfAttachment=pointOfAttachment;
+                this.pointOfAttachment=pointOfAttachment;
         }
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableName.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableName.java
@@ -34,6 +34,7 @@ package com.splicemachine.db.impl.sql.compile;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.util.IdUtil;
 
 /**
  * A TableName represents a qualified name, externally represented as a schema name
@@ -144,6 +145,14 @@ public class TableName extends QueryTreeNode
 			return schemaName + "." + tableName;
 		else
 			return tableName;
+	}
+
+	/**
+	* Get the full SQL name of this object, properly quoted and escaped.
+	*/
+	public  String  getFullSQLName()
+	{
+	    return IdUtil.mkQualifiedName( schemaName, tableName );
 	}
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -48,6 +48,7 @@ PARSER_BEGIN(SQLParser)
 
 package com.splicemachine.db.impl.sql.compile;
 
+import org.apache.commons.lang3.mutable.MutableInt;
 import com.splicemachine.db.iapi.sql.Statement;
 import com.splicemachine.db.iapi.sql.StatementType;
 
@@ -2902,6 +2903,7 @@ TOKEN [IGNORE_CASE] :
 |   <ACCESS: "access">
 |	<ACTION: "action">
 |	<ALWAYS: "always">
+|   <ATOMIC: "atomic">
 |   <AUTO: "auto">
 |	<B: "b">
 |	<BLOB: "blob">
@@ -3515,8 +3517,32 @@ Statement( String statementSQLText, Object[] paramDefaults) throws StandardExcep
 {
 	statementNode = StatementPart(null) <EOF>
 	{
+        statementNode.setBeginOffset(0);
+        statementNode.setEndOffset(statementSQLText.length() - 1);
 		return statementNode;
 	}
+}
+
+/**
+ * Parse a search condition.
+ *
+ * @param sqlFragment a fragment of an SQL statement, representing a
+ *                    search condition
+ * @return a {@code ValueNode} representing the search condition
+ */
+ValueNode
+SearchCondition(String sqlFragment) throws StandardException :
+{
+    ValueNode valueNode;
+    initStatement(sqlFragment, null);
+}
+{
+    valueNode = valueExpression() <EOF>
+    {
+        valueNode.setBeginOffset(0);
+        valueNode.setEndOffset(sqlFragment.length() - 1);
+        return valueNode;
+    }
 }
 
 StatementNode
@@ -13228,6 +13254,28 @@ viewColumnList() throws StandardException :
 	}
 }
 
+
+QueryTreeNode
+triggerActions(Token[] tokenHolder, MutableInt endOffset) throws StandardException :
+{
+    QueryTreeNode actionNode = null;
+    Token endPosition;
+}
+{
+	<BEGIN> <ATOMIC> actionNode = proceduralStatement(tokenHolder)
+	endPosition = <SEMICOLON>
+	<END>
+	{
+	    endOffset.setValue(endPosition.beginOffset - 1);
+		return actionNode;
+	}
+|
+	actionNode = proceduralStatement(tokenHolder)
+	{
+		return actionNode;
+	}
+}
+
 StatementNode
 triggerDefinition() throws StandardException :
 {
@@ -13243,10 +13291,16 @@ triggerDefinition() throws StandardException :
 	int					actionEnd;
 	TriggerEventDML		triggerEvent;
 	QueryTreeNode		actionNode;
+	ValueNode           whenClause = null;
+    Token               whenOpen = null;
+    Token               whenClose = null;
+    int                 whenOffset = 0;
+    int                 whenEnd = 0;
 	ResultColumnList	triggerColumns = (ResultColumnList) nodeFactory.getNode(
 											C_NodeTypes.RESULT_COLUMN_LIST,
 											getContextManager());
 	Vector				refClause = null;
+	MutableInt	        endOffset = new MutableInt(-1);
 }
 {
 	<TRIGGER> triggerName = qualifiedName(Limits.MAX_IDENTIFIER_LENGTH)
@@ -13256,12 +13310,15 @@ triggerDefinition() throws StandardException :
 		[ refClause = triggerReferencingClause() ]		// REFERENCING OLD/NEW AS
 		[ <FOR> <EACH> isRow = rowOrStatement() ]
 		[ <MODE> <DB2SQL> ]
+        [ <WHEN> whenOpen = <LEFT_PAREN> whenClause = valueExpression() whenClose = <RIGHT_PAREN> ]
 		//we are not top level statement
-		actionNode = proceduralStatement(tokenHolder)
+		actionNode = triggerActions(tokenHolder, endOffset)
 		// the trigger body
 	{
-		actionEnd = getToken(0).endOffset;
+		actionEnd = endOffset.intValue() != -1 ? endOffset.intValue() : getToken(0).endOffset;
 		actionBegin = tokenHolder[0].beginOffset;
+        actionNode.setBeginOffset(actionBegin);
+        actionNode.setEndOffset(actionEnd);
 
 		// No DML in action node for BEFORE triggers.
 		if (isBefore.booleanValue() && (actionNode instanceof DMLModStatementNode)) {
@@ -13274,10 +13331,26 @@ triggerDefinition() throws StandardException :
 		// no params in trigger action
  		HasNodeVisitor visitor = new HasNodeVisitor(ParameterNode.class);
 		actionNode.accept(visitor);
+        if (whenClause != null) {
+            whenClause.accept(visitor);
+        }
 		if (visitor.hasNode())
 		{
 			throw StandardException.newException(SQLState.LANG_NO_PARAMS_IN_TRIGGER_ACTION);
 		}
+
+        String actionText = StringUtil.slice(
+                statementSQLText, actionBegin, actionEnd, false);
+
+        String whenText = null;
+        if (whenClause != null) {
+            whenOffset = whenOpen.endOffset + 1;
+            whenEnd = whenClose.beginOffset - 1;
+            whenClause.setBeginOffset(whenOffset);
+            whenClause.setEndOffset(whenEnd);
+            whenText = StringUtil.slice(statementSQLText,
+                                        whenOffset, whenEnd, false);
+        }
 
 		return (StatementNode) nodeFactory.getNode(
 								C_NodeTypes.CREATE_TRIGGER_NODE,
@@ -13289,14 +13362,11 @@ triggerDefinition() throws StandardException :
 								isRow,
 								Boolean.TRUE, 				// enabled
 								refClause,			// referencing clause
-								null,// when clause node
-								null, 		// when clause text
-								ReuseFactory.getInteger(0),
-											// when clause begin offset
+                                whenClause,  // when clause node
+                                whenText,    // when clause text
+								ReuseFactory.getInteger(whenOffset),  // when clause begin offset
 								actionNode,
-								StringUtil.slice(statementSQLText,
-									actionBegin,
-									actionEnd,false),
+								actionText,
 								ReuseFactory.getInteger(actionBegin),
 								getContextManager());
 	}
@@ -13332,6 +13402,11 @@ beforeOrAfter() :
 {}
 {
 	<BEFORE>
+	{
+		return Boolean.TRUE;
+	}
+|
+	<NO> <CASCADE> <BEFORE>
 	{
 		return Boolean.TRUE;
 	}
@@ -17050,6 +17125,7 @@ nonReservedKeyword()  :
 	|	tok = <AFTER>
 	|	tok = <AGGREGATE>
 	|	tok = <ALWAYS>
+    |	tok = <ATOMIC>
 	|   tok = <AUTO>
 	|   tok = <B>
 	|	tok = <BEFORE>

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -175,6 +175,7 @@ import com.splicemachine.utils.ModifiableBoolean;
 import java.sql.Types;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Properties;
 import java.util.StringTokenizer;
@@ -1660,13 +1661,13 @@ public class SQLParser
 	 *
 	 * @return	TRUE iff the next set of tokens is the java class name
 	 */
-	boolean javaClassFollows()
+	boolean javaClassFollows(int startingToken)
 	{
 		boolean retval = false;
 
 		// Look at every other token. Ignore the identifiers, because
 		// they are hard to test for.
-		for (int i = 2; true; i += 2)
+		for (int i = 2+startingToken; true; i += 2)
 		{
 			int tokKind = getToken(i).kind;
 
@@ -2952,6 +2953,7 @@ TOKEN [IGNORE_CASE] :
 |	<LOGGED: "logged">
 |   <LOGICAL: "logical">
 |	<MAXVALUE: "maxvalue">
+|   <MESSAGE_TEXT: "message_text">
 |	<MINVALUE: "minvalue">
 |   <MOD: "mod">
 |	<MODIFIES: "modifies">
@@ -2981,6 +2983,7 @@ TOKEN [IGNORE_CASE] :
 |	<RETURNS: "returns">
 |	<ROLLUP: "rollup">
 |	<ROW: "row">
+|   <SIGNAL: "signal">
 |	<FORMAT: "format">
 |	<DELIMITED: "delimited">
 |	<FIELDS: "fields">
@@ -3553,6 +3556,8 @@ proceduralStatement(Token[] tokenHolder) throws StandardException :
 }
 {
 (
+	statementNode = signalStatement()
+|
 	statementNode = insertStatement()
 |
 	statementNode = preparableUpdateStatement()
@@ -3622,6 +3627,7 @@ StatementPart(Token[] tokenHolder) throws StandardException :
         statementNode = spsAlterStatement() |
         statementNode = declareTemporaryTableDeclaration() |
         statementNode = preparableSQLDataStatement() |
+        statementNode = setStatement(new Token[1]) |
         statementNode = spsSetStatement() |
 		statementNode = truncateTableStatement() |
 		statementNode = grantStatement() |
@@ -3631,7 +3637,8 @@ StatementPart(Token[] tokenHolder) throws StandardException :
 		statementNode = exportStatement() |
 		statementNode = binaryExportStatement() |
 		statementNode = pinStatement() |
-		statementNode = dropPinStatement()
+		statementNode = dropPinStatement() |
+		statementNode = signalStatement()
     )
     {
         return statementNode;
@@ -7004,7 +7011,7 @@ primary() throws StandardException :
 {
 
 	//Look ahead required here to tell a java class from a identifier
-	LOOKAHEAD( { javaClassFollows() } )
+	LOOKAHEAD( { javaClassFollows(0) } )
 	value = staticClassReference()
 	{
 		return value;
@@ -13255,14 +13262,30 @@ viewColumnList() throws StandardException :
 }
 
 
+StatementNode
+actionStatement(Token[] tokenHolder, HashSet<String> hs) throws StandardException :
+{
+	StatementNode statementNode;
+}
+{
+(
+    statementNode =  setStatementInCreateTrigger(tokenHolder, hs)
+|
+	statementNode =  proceduralStatement(tokenHolder)
+)
+	{
+		return statementNode;
+	}
+}
+
 QueryTreeNode
-triggerActions(Token[] tokenHolder, MutableInt endOffset) throws StandardException :
+triggerActions(Token[] tokenHolder, MutableInt endOffset, HashSet<String> hs) throws StandardException :
 {
     QueryTreeNode actionNode = null;
     Token endPosition;
 }
 {
-	<BEGIN> <ATOMIC> actionNode = proceduralStatement(tokenHolder)
+	<BEGIN> <ATOMIC> actionNode = actionStatement(tokenHolder, hs)
 	endPosition = <SEMICOLON>
 	<END>
 	{
@@ -13270,7 +13293,7 @@ triggerActions(Token[] tokenHolder, MutableInt endOffset) throws StandardExcepti
 		return actionNode;
 	}
 |
-	actionNode = proceduralStatement(tokenHolder)
+	actionNode = actionStatement(tokenHolder, hs)
 	{
 		return actionNode;
 	}
@@ -13301,18 +13324,19 @@ triggerDefinition() throws StandardException :
 											getContextManager());
 	Vector				refClause = null;
 	MutableInt	        endOffset = new MutableInt(-1);
+	HashSet<String>     hs = new HashSet<String>();
 }
 {
 	<TRIGGER> triggerName = qualifiedName(Limits.MAX_IDENTIFIER_LENGTH)
 	    isBefore = beforeOrAfter()
 		triggerEvent = triggerEvent(triggerColumns)		// { INSERT | DELETE | UPDATE [ colList	] }
 		<ON> tableName = qualifiedName(Limits.MAX_IDENTIFIER_LENGTH)
-		[ refClause = triggerReferencingClause() ]		// REFERENCING OLD/NEW AS
+		[ refClause = triggerReferencingClause(hs, triggerEvent) ]		// REFERENCING OLD/NEW AS
 		[ <FOR> <EACH> isRow = rowOrStatement() ]
 		[ <MODE> <DB2SQL> ]
         [ <WHEN> whenOpen = <LEFT_PAREN> whenClause = valueExpression() whenClose = <RIGHT_PAREN> ]
 		//we are not top level statement
-		actionNode = triggerActions(tokenHolder, endOffset)
+		actionNode = triggerActions(tokenHolder, endOffset, hs)
 		// the trigger body
 	{
 		actionEnd = endOffset.intValue() != -1 ? endOffset.intValue() : getToken(0).endOffset;
@@ -13338,6 +13362,8 @@ triggerDefinition() throws StandardException :
 		{
 			throw StandardException.newException(SQLState.LANG_NO_PARAMS_IN_TRIGGER_ACTION);
 		}
+		if (actionNode instanceof SetNode && !isBefore)
+		    throw StandardException.newException(SQLState.LANG_UNSUPPORTED_TRIGGER_STMT, "SET", "AFTER");
 
         String actionText = StringUtil.slice(
                 statementSQLText, actionBegin, actionEnd, false);
@@ -13450,19 +13476,19 @@ rowOrStatement() :
 }
 
 Vector
-triggerReferencingClause() throws StandardException :
+triggerReferencingClause(HashSet<String> hs, TriggerEventDML triggerEvent) throws StandardException :
 {
 	Vector vector = new Vector();
 }
 {
-	<REFERENCING> triggerReferencingExpression(vector) ( triggerReferencingExpression(vector) )*
+	<REFERENCING> triggerReferencingExpression(vector, hs, triggerEvent) ( triggerReferencingExpression(vector, hs, triggerEvent) )*
 	{
 		return vector;
 	}
 }
 
 void
-triggerReferencingExpression(Vector vector) throws StandardException :
+triggerReferencingExpression(Vector vector, HashSet<String> hs, TriggerEventDML triggerEvent) throws StandardException :
 {
 	String	identifier;
 	boolean isNew = true;
@@ -13482,6 +13508,15 @@ triggerReferencingExpression(Vector vector) throws StandardException :
 	<AS> identifier = identifier(Limits.MAX_IDENTIFIER_LENGTH, true)
 	{
 		vector.addElement(new TriggerReferencingStruct(isRow, isNew, identifier));
+		if (!isNew)
+		    hs.add(identifier);
+		else {
+		    if (triggerEvent.getId() == TriggerEventDML.DELETE.getId()) {
+                throw StandardException.newException(
+                                        SQLState.LANG_TRIGGER_BAD_REF_MISMATCH,
+                                        "DELETE", "OLD");
+            }
+		}
 	}
 }
 
@@ -14689,6 +14724,167 @@ setSessionPropertyStatement() throws StandardException :
                                         getContextManager());
     }
 }
+
+ValueNode
+optionalErrorText() throws StandardException :
+{
+    ValueNode errorText = null;
+}
+{
+	<LEFT_PAREN> errorText = valueExpression() <RIGHT_PAREN>
+	{
+		return errorText;
+	}
+|
+	<SET> <MESSAGE_TEXT> <EQUALS_OPERATOR> errorText = valueExpression()
+	{
+		return errorText;
+	}
+|
+	{
+		return errorText;
+	}
+}
+
+/*
+ * <A NAME="signalStatement">signalStatement</A>
+ */
+StatementNode
+signalStatement() throws StandardException :
+{
+        CharConstantNode errorCode;
+        ValueNode errorText = null;
+}
+{
+	<SIGNAL> <SQLSTATE> errorCode = stringLiteral()
+	errorText = optionalErrorText()
+	{
+        return (StatementNode) nodeFactory.getNode(
+                                        C_NodeTypes.SIGNAL_NODE,
+                                        errorCode.getString(),
+                                        errorText,
+                                        getContextManager());
+	}
+}
+
+/*
+ * <A NAME="setClauseValueList">setClauseValueList</A>
+ */
+void
+setClauseValueList(ValueNodeList assignedColumnsList, ValueNodeList newValuesList, HashSet<String> hs) throws StandardException :
+{
+
+}
+{
+	setClauseItem(assignedColumnsList, newValuesList, hs) ( <COMMA> setClauseItem(assignedColumnsList, newValuesList, hs) ) *
+	{
+
+	}
+}
+
+/*
+ * <A NAME="columnRefOrUDF">columnRefOrUDF</A>
+ */
+ValueNode
+columnRefOrUDF() throws StandardException :
+{
+	ValueNode	 valueNode;
+}
+{
+	//Look ahead required here to tell a java class from a identifier
+	LOOKAHEAD( { javaClassFollows(0) } )
+	valueNode = primaryExpressionXX()
+	{
+	    return valueNode;
+	}
+|
+	valueNode = columnReference()
+	{
+	    return valueNode;
+	}
+}
+
+/*
+ * <A NAME="setClauseItem">setClauseItem</A>
+ */
+void
+setClauseItem(ValueNodeList	assignedColumnsList, ValueNodeList newValuesList, HashSet<String> hs) throws StandardException :
+{
+	ValueNode	 columnAccessRoutine;
+	ValueNode	 valueNode;
+}
+{
+	columnAccessRoutine = columnRefOrUDF() <EQUALS_OPERATOR> valueNode = valueExpression()
+	{
+        if (hs != null &&
+            columnAccessRoutine instanceof ColumnReference) {
+            ColumnReference cr = (ColumnReference) columnAccessRoutine;
+            String tableName = cr.getTableName();
+            if (tableName != null && hs.contains(tableName)) {
+                throw StandardException.newException(
+                                        SQLState.LANG_TRIGGER_BAD_REF_MISMATCH,
+                                        "SET", "NEW");
+            }
+        }
+	    assignedColumnsList.addValueNode(columnAccessRoutine);
+	    newValuesList.addValueNode(valueNode);
+	}
+}
+
+
+/*
+ * <A NAME="setStatement">setStatement</A>
+ */
+StatementNode
+setStatement(Token[] tokenHolder) throws StandardException :
+{
+        ResultColumnList columnList = null;
+        tokenHolder[0] = getToken(1);
+        ValueNodeList	assignedColumnsList = (ValueNodeList) nodeFactory.getNode(
+                                                    C_NodeTypes.VALUE_NODE_LIST,
+                                                    getContextManager());
+        ValueNodeList	newValuesList = (ValueNodeList) nodeFactory.getNode(
+                                                    C_NodeTypes.VALUE_NODE_LIST,
+                                                    getContextManager());
+}
+{
+  LOOKAHEAD( { javaClassFollows(1) } )
+  <SET> setClauseValueList(assignedColumnsList, newValuesList, null)
+  {
+        return (StatementNode) nodeFactory.getNode(
+                                        C_NodeTypes.SET_NODE,
+                                        assignedColumnsList,
+                                        newValuesList,
+                                        getContextManager());
+  }
+}
+
+/*
+ * <A NAME="setStatementInCreateTrigger">setStatementInCreateTrigger</A>
+ */
+StatementNode
+setStatementInCreateTrigger(Token[] tokenHolder, HashSet<String> hs) throws StandardException :
+{
+        ResultColumnList columnList = null;
+        tokenHolder[0] = getToken(1);
+        ValueNodeList	assignedColumnsList = (ValueNodeList) nodeFactory.getNode(
+                                                    C_NodeTypes.VALUE_NODE_LIST,
+                                                    getContextManager());
+        ValueNodeList	newValuesList = (ValueNodeList) nodeFactory.getNode(
+                                                    C_NodeTypes.VALUE_NODE_LIST,
+                                                    getContextManager());
+}
+{
+  <SET> setClauseValueList(assignedColumnsList, newValuesList, hs)
+  {
+        return (StatementNode) nodeFactory.getNode(
+                                        C_NodeTypes.SET_NODE,
+                                        assignedColumnsList,
+                                        newValuesList,
+                                        getContextManager());
+  }
+}
+
 
 List sessionPropertyList() throws StandardException :
 {
@@ -17220,6 +17416,7 @@ nonReservedKeyword()  :
 	|	tok = <LOGGED>
 	|	tok = <LONG>
 	|	tok = <MAXVALUE>
+	|	tok = <MESSAGE_TEXT>
 	|	tok = <MINVALUE>
 	|	tok = <MESSAGE_LOCALE>
 	|	tok = <METHOD>
@@ -17293,6 +17490,7 @@ nonReservedKeyword()  :
 	|	tok = <SERIALIZABLE>
 	|	tok = <SETS>
 	|	tok = <SHARE>
+    |	tok = <SIGNAL>
 	|   tok = <SPECIFIC>
 	|   tok = <SPLITKEYS>
 	|	tok = <SQLID>

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericConstantActionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericConstantActionFactory.java
@@ -821,6 +821,7 @@ public abstract class GenericConstantActionFactory {
 	 * @param referencedColsInTriggerAction	what columns does the trigger 
 	 *						action reference through old/new transition variables
 	 *						(may be null)
+         * @param originalWhenText The original user text of the WHEN clause (may be null)
 	 * @param originalActionText The original user text of the trigger action
 	 * @param referencingOld whether or not OLD appears in REFERENCING clause
 	 * @param referencingNew whether or not NEW appears in REFERENCING clause
@@ -843,6 +844,7 @@ public abstract class GenericConstantActionFactory {
 		Timestamp			creationTimestamp,
 		int[]				referencedCols,
 		int[]				referencedColsInTriggerAction,
+		String				originalWhenText,
 		String				originalActionText,
 		boolean				referencingOld,
 		boolean				referencingNew,

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericConstantActionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericConstantActionFactory.java
@@ -42,8 +42,10 @@ import com.splicemachine.db.iapi.sql.execute.ConstantAction;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.store.access.StaticCompiledOpenConglomInfo;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.types.RowLocation;
 import com.splicemachine.db.impl.sql.compile.TableName;
+import com.splicemachine.db.impl.sql.compile.ValueNode;
 
 import java.sql.Timestamp;
 import java.util.List;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericTriggerExecutor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericTriggerExecutor.java
@@ -212,7 +212,7 @@ public abstract class GenericTriggerExecutor {
                 ** statement context(SC) and the trigger execution context
                 ** (TEC) in language connection context(LCC) properly (e.g.:  
                 ** "Maximum depth triggers exceeded" exception); otherwise, 
-             boolean   ** this will leave old TECs lingering and may result in
+                ** this will leave old TECs lingering and may result in
                 ** subsequent statements within the same connection to throw 
                 ** the same exception again prematurely.  
                 **    

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericTriggerExecutor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericTriggerExecutor.java
@@ -32,6 +32,7 @@
 package com.splicemachine.db.impl.sql.execute;
 
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.dictionary.SPSDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.TriggerDescriptor;
 import com.splicemachine.db.iapi.sql.execute.CursorResultSet;
@@ -42,6 +43,9 @@ import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.conn.StatementContext;
 
 import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.sql.execute.ExecRow;
+import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.db.iapi.types.SQLBoolean;
 import com.splicemachine.db.impl.sql.GenericPreparedStatement;
 
 /**
@@ -59,8 +63,12 @@ public abstract class GenericTriggerExecutor {
     private SPSDescriptor whenClause;
     private SPSDescriptor action;
 
-    private ExecPreparedStatement ps;
-    private Activation spsActivation;
+    // Cached prepared statement and activation for WHEN clause and
+    // trigger action.
+    private ExecPreparedStatement   whenPS;
+    private Activation              spsWhenActivation;
+    private ExecPreparedStatement   actionPS;
+    private Activation              spsActionActivation;
 
     /**
      * Constructor
@@ -91,15 +99,15 @@ public abstract class GenericTriggerExecutor {
                               CursorResultSet rs,
                               int[] colsReadFromTable) throws StandardException;
 
-    protected SPSDescriptor getWhenClause() throws StandardException {
+    private SPSDescriptor getWhenClause() throws StandardException {
         if (!whenClauseRetrieved) {
             whenClauseRetrieved = true;
-            whenClause = triggerd.getWhenClauseSPS();
+            whenClause = triggerd.getWhenClauseSPS(lcc);
         }
         return whenClause;
     }
 
-    protected SPSDescriptor getAction() throws StandardException {
+    private SPSDescriptor getAction() throws StandardException {
         if (!actionRetrieved) {
             actionRetrieved = true;
             action = triggerd.getActionSPS(lcc);
@@ -108,11 +116,29 @@ public abstract class GenericTriggerExecutor {
     }
 
     /**
-     * Execute the given stored prepared statement.  We just grab the prepared statement from the spsd,
+     * Execute the given stored prepared statement.  We
+     * just grab the prepared statement from the spsd,
      * get a new activation holder and let er rip.
+     *
+     * @param sps the SPS to execute
+     * @param isWhen {@code true} if the SPS is for the WHEN clause,
+     *               {@code false} otherwise
+     * @return {@code true} if the SPS is for a WHEN clause and it evaluated
+     *         to {@code TRUE}, {@code false} otherwise
+     * @exception StandardException on error
      */
-    protected void executeSPS(SPSDescriptor sps) throws StandardException {
+    protected boolean executeSPS(SPSDescriptor sps, boolean isWhen) throws StandardException {
         boolean recompile = false;
+        boolean whenClauseWasTrue = false;
+
+        // The prepared statement and the activation may already be available
+        // if the trigger has been fired before in the same statement. (Only
+        // happens with row triggers that are triggered by a statement that
+        // touched multiple rows.) The WHEN clause and the trigger action have
+        // their own prepared statement and activation. Fetch the correct set.
+        ExecPreparedStatement ps = isWhen ? whenPS : actionPS;
+        Activation spsActivation = isWhen
+                ? spsWhenActivation : spsActionActivation;
 
         while (true) {
             /*
@@ -120,8 +146,11 @@ public abstract class GenericTriggerExecutor {
             ** way a row trigger doesn't do any unnecessary
             ** setup work.
             */
-            if (ps == null || recompile) {
-                compile(sps);
+            if (ps == null || spsActivation == null || recompile) {
+
+                compile(sps, ps, isWhen);
+                spsActivation = isWhen ? spsWhenActivation : spsActionActivation;
+                ps = isWhen ? whenPS : actionPS;
             }
 
             // save the active statement context for exception handling purpose
@@ -143,7 +172,31 @@ public abstract class GenericTriggerExecutor {
                 // timeout to its parent statement's timeout settings.
                 ((GenericPreparedStatement)ps).setNeedsSavepoint(false);
                 ResultSet rs = ps.executeSubStatement(activation, spsActivation, false, 0L);
-                if (rs.returnsRows()) {
+                if (isWhen)
+                {
+                    // This is a WHEN clause. Expect a single BOOLEAN value
+                    // to be returned.
+                    ExecRow row = rs.getNextRow();
+                    if (SanityManager.DEBUG && row.nColumns() != 1) {
+                        SanityManager.THROWASSERT(
+                            "Expected WHEN clause to have exactly "
+                            + "one column, found: " + row.nColumns());
+                    }
+
+                    DataValueDescriptor value = row.getColumn(1);
+                    if (SanityManager.DEBUG) {
+                        SanityManager.ASSERT(value instanceof SQLBoolean);
+                    }
+
+                    whenClauseWasTrue =
+                            !value.isNull() && value.getBoolean();
+
+                    if (SanityManager.DEBUG) {
+                        SanityManager.ASSERT(rs.getNextRow() == null,
+                                "WHEN clause returned more than one row");
+                    }
+                }
+                else if (rs.returnsRows()) {
                     // Fetch all the data to ensure that functions in the select list or values statement will
                     // be evaluated and side effects will happen. Why else would the trigger action return
                     // rows, but for side effects?
@@ -159,7 +212,7 @@ public abstract class GenericTriggerExecutor {
                 ** statement context(SC) and the trigger execution context
                 ** (TEC) in language connection context(LCC) properly (e.g.:  
                 ** "Maximum depth triggers exceeded" exception); otherwise, 
-                ** this will leave old TECs lingering and may result in 
+             boolean   ** this will leave old TECs lingering and may result in
                 ** subsequent statements within the same connection to throw 
                 ** the same exception again prematurely.  
                 **    
@@ -200,7 +253,7 @@ public abstract class GenericTriggerExecutor {
             }
 
             /* Done with execution without any recompiles */
-            break;
+            return whenClauseWasTrue;
         }
     }
 
@@ -215,10 +268,29 @@ public abstract class GenericTriggerExecutor {
      * goes away post Lassen we can consider removing this method. Or maybe someone can find a better way.
      */
     public void forceCompile() throws StandardException {
-        compile(getAction());
+
+        if (getWhenClause() != null) {
+            if (spsWhenActivation == null)
+                spsWhenActivation = activation;
+            compile(getWhenClause(), whenPS, true);
+        }
+        if (getAction() != null) {
+            if (spsActionActivation == null)
+                spsActionActivation = activation;
+            compile(getAction(), actionPS, false);
+        }
     }
 
-    private void compile(SPSDescriptor sps) throws StandardException {
+    private void compile(SPSDescriptor sps,
+                         ExecPreparedStatement ps,
+                         boolean isWhen) throws StandardException {
+
+        // The SPS activation will set its parent activation from
+        // the statement context. Reset it to the original parent
+        // activation first so that it doesn't use the activation of
+        // the previously executed SPS as parent. DERBY-6348.
+        lcc.getStatementContext().setActivation(activation);
+
         ps = sps.getPreparedStatement();
         /*
          * We need to clone the prepared statement so we don't
@@ -226,9 +298,10 @@ public abstract class GenericTriggerExecutor {
          * during the course of execution.
          */
         ps = ps.getClone();
+
         // it should be valid since we've just prepared for it
         ps.setValid();
-        spsActivation = ps.getActivation(lcc, false);
+        Activation spsActivation = ps.getActivation(lcc, false);
 
         /*
          * Normally, we want getSource() for an sps invocation
@@ -238,16 +311,53 @@ public abstract class GenericTriggerExecutor {
          */
         ps.setSource(sps.getText());
         ps.setSPSAction();
+
+        // Cache the prepared statement and activation in case the
+        // trigger fires multiple times.
+        if (isWhen) {
+            whenPS = ps;
+            spsWhenActivation = spsActivation;
+        } else {
+            actionPS = ps;
+            spsActionActivation = spsActivation;
+        }
     }
 
     /**
      * Cleanup after executing an sps.
      */
     protected void clearSPS() throws StandardException {
-        if (spsActivation != null) {
-            spsActivation.close();
+        if (spsActionActivation != null) {
+            spsActionActivation.close();
         }
-        ps = null;
-        spsActivation = null;
+        actionPS = null;
+        spsActionActivation = null;
+
+        if (spsWhenActivation != null) {
+            spsWhenActivation.close();
+        }
+        whenPS = null;
+        spsWhenActivation = null;
+    }
+
+    /**
+     * <p>
+     * Execute the WHEN clause SPS and the trigger action SPS.
+     * </p>
+     *
+     * <p>
+     * If there is no WHEN clause, the trigger action should always be
+     * executed. If there is a WHEN clause, the trigger action should only
+     * be executed if the WHEN clause returns TRUE.
+     * </p>
+     *
+     * @throws StandardException if trigger execution fails
+     */
+    final void executeWhenClauseAndAction() throws StandardException {
+        SPSDescriptor whenClauseDescriptor = getWhenClause();
+        if (whenClauseDescriptor == null ||
+                executeSPS(whenClauseDescriptor, true)) {
+            executeSPS(getAction(), false);
+        }
     }
 } 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/RowTriggerExecutor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/RowTriggerExecutor.java
@@ -79,7 +79,7 @@ public class RowTriggerExecutor extends GenericTriggerExecutor {
                 tec.updateAICounters();
             }
 
-            executeSPS(getAction());
+            executeWhenClauseAndAction();
 
                 /*
                   For BEFORE ROW triggers, update the ai values after the SPS

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/StatementTriggerExecutor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/StatementTriggerExecutor.java
@@ -76,7 +76,7 @@ public class StatementTriggerExecutor extends GenericTriggerExecutor {
         tec.setTriggeringResultSet(rs);
 
         try {
-            executeSPS(getAction());
+            executeWhenClauseAndAction();
         } finally {
             clearSPS();
             tec.clearTrigger();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerExecutionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerExecutionContext.java
@@ -553,7 +553,7 @@ public class TriggerExecutionContext implements ExecutionStmtValidator, External
                 int index = 0;
                 for (int j = heapList.anySetBit(); j >= 0; j = heapList.anySetBit(j)) {
                     if (j == i) {
-                        result.setColumn(pos++, resultSet.getColumn(sourceIndex + index).cloneValue(false));
+                        result.setColumn(pos++, resultSet.getColumn(sourceIndex + index));
                     }
                     index++;
                 }

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/StatementFinder.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/StatementFinder.java
@@ -92,6 +92,45 @@ public class StatementFinder {
 	private static final char SLASH = '/';
 	private static final char ASTERISK = '*';
 
+
+	private static final char LITTLE_A = 'a';
+	private static final char LITTLE_T = 't';
+	private static final char LITTLE_O = 'o';
+	private static final char LITTLE_M = 'm';
+	private static final char LITTLE_I = 'i';
+	private static final char LITTLE_C = 'c';
+
+	private static final char LITTLE_E = 'e';
+	private static final char LITTLE_N = 'n';
+	private static final char LITTLE_D = 'd';
+
+	private static final char BIG_A = 'A';
+	private static final char BIG_T = 'T';
+	private static final char BIG_O = 'O';
+	private static final char BIG_M = 'M';
+	private static final char BIG_I = 'I';
+	private static final char BIG_C = 'C';
+
+	private static final char BIG_E = 'E';
+	private static final char BIG_N = 'N';
+	private static final char BIG_D = 'D';
+
+
+	// state variables
+	private static final int NOT_IN_BEGIN_BLOCK = 0;
+	private static final int IN_BEGIN_BLOCK = 1;
+
+        private static final int NOTHING_SEEN = 0;
+        private static final int E_SEEN = 1;
+        private static final int EN_SEEN = 2;
+
+        private static final int A_SEEN = 3;
+        private static final int AT_SEEN = 4;
+	private static final int ATO_SEEN = 5;
+	private static final int ATOM_SEEN = 6;
+	private static final int ATOMI_SEEN = 7;
+
+
 	/**
 		The constructor does not assume the stream is data input
 		or buffered, so it will wrap it appropriately.
@@ -153,6 +192,8 @@ public class StatementFinder {
 	public String nextStatement() {
 		boolean haveSemi = false;
 		char nextChar;
+		int triggerState = NOT_IN_BEGIN_BLOCK;
+		int triggerParseState = NOTHING_SEEN;
 
 		// initialize fields for getting the next statement
 		statement.setLength(0);
@@ -187,20 +228,88 @@ public class StatementFinder {
 				continuedStatement=true;
 
 			switch(nextChar) {
+				case LITTLE_A:
+				case BIG_A:
+					if (triggerParseState == NOTHING_SEEN)
+						triggerParseState = A_SEEN;
+					else
+						triggerParseState = NOTHING_SEEN;
+					break;
+				case LITTLE_T:
+				case BIG_T:
+					if (triggerParseState == A_SEEN)
+						triggerParseState = AT_SEEN;
+					else
+						triggerParseState = NOTHING_SEEN;
+					break;
+				case LITTLE_O:
+				case BIG_O:
+					if (triggerParseState == AT_SEEN)
+						triggerParseState = ATO_SEEN;
+					else
+						triggerParseState = NOTHING_SEEN;
+					break;
+				case LITTLE_M:
+				case BIG_M:
+					if (triggerParseState == ATO_SEEN)
+						triggerParseState = ATOM_SEEN;
+					else
+						triggerParseState = NOTHING_SEEN;
+					break;
+				case LITTLE_I:
+				case BIG_I:
+					if (triggerParseState == ATOM_SEEN)
+						triggerParseState = ATOMI_SEEN;
+					else
+						triggerParseState = NOTHING_SEEN;
+					break;
+				case LITTLE_C:
+				case BIG_C:
+					if (triggerParseState == ATOMI_SEEN)
+						triggerState = IN_BEGIN_BLOCK;
+					triggerParseState = NOTHING_SEEN;
+					break;
+				case LITTLE_E:
+				case BIG_E:
+					if (triggerState == IN_BEGIN_BLOCK && triggerParseState == NOTHING_SEEN)
+						triggerParseState = E_SEEN;
+					else
+						triggerParseState = NOTHING_SEEN;
+					break;
+				case LITTLE_N:
+				case BIG_N:
+					if (triggerState == IN_BEGIN_BLOCK && triggerParseState == E_SEEN)
+						triggerParseState = EN_SEEN;
+					else
+						triggerParseState = NOTHING_SEEN;
+					break;
+				case LITTLE_D:
+				case BIG_D:
+					if (triggerState == IN_BEGIN_BLOCK && triggerParseState == EN_SEEN) {
+						triggerState = NOT_IN_BEGIN_BLOCK;
+					}
+					triggerParseState = NOTHING_SEEN;
+					break;
 				case MINUS:
 					readSingleLineComment(nextChar);
+					triggerParseState = NOTHING_SEEN;
 					break;
 				case SLASH:
-				    readBracketedComment();
-				    break;
+					readBracketedComment();
+					triggerParseState = NOTHING_SEEN;
+					break;
 				case SINGLEQUOTE:
 				case DOUBLEQUOTE:
 					readString(nextChar);
+					triggerParseState = NOTHING_SEEN;
 					break;
 				case SEMICOLON:
-					haveSemi = true;
-					state = END_OF_STATEMENT;
-					continuedStatement=false;
+					if (triggerState == NOT_IN_BEGIN_BLOCK || peekChar() == SEMICOLON) {
+						haveSemi = true;
+						state = END_OF_STATEMENT;
+						continuedStatement = false;
+					}
+					triggerParseState = NOTHING_SEEN;
 					break;
 				case NEWLINE:
 				case RETURN:
@@ -214,6 +323,7 @@ public class StatementFinder {
 						}
 					}
 				default:
+					triggerParseState = NOTHING_SEEN;
 					// keep going, just a normal character
 					break;
 			}

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
@@ -915,5 +915,7 @@ public class SpliceSparkKryoRegistrator implements KryoRegistrator, KryoPool.Kry
         instance.register(SparkRelationalOperator.class,EXTERNALIZABLE_SERIALIZER);
         instance.register(SparkArithmeticOperator.class,EXTERNALIZABLE_SERIALIZER);
         instance.register(SparkCastNode.class,EXTERNALIZABLE_SERIALIZER);
+        instance.register(SignalOperation.class,EXTERNALIZABLE_SERIALIZER);
+        instance.register(SetOperation.class,EXTERNALIZABLE_SERIALIZER);
     }
 }

--- a/splice_machine/pom.xml
+++ b/splice_machine/pom.xml
@@ -148,6 +148,18 @@
             <artifactId>derbyclient</artifactId>
             <version>10.9.1.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.splicemachine</groupId>
+            <artifactId>db-tools-testing</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.splicemachine</groupId>
+            <artifactId>db-testing</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
+++ b/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
@@ -955,5 +955,7 @@ public class SpliceKryoRegistry implements KryoPool.KryoRegistry{
         instance.register(SparkRelationalOperator.class,EXTERNALIZABLE_SERIALIZER,316);
         instance.register(SparkArithmeticOperator.class,EXTERNALIZABLE_SERIALIZER,317);
         instance.register(SparkCastNode.class,EXTERNALIZABLE_SERIALIZER,318);
+        instance.register(SignalOperation.class,EXTERNALIZABLE_SERIALIZER,319);
+        instance.register(SetOperation.class,EXTERNALIZABLE_SERIALIZER,320);
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -74,9 +74,7 @@ public class SpliceCatalogUpgradeScripts{
         // Two system procedures are moved, so we need to run base script to update all system procedures
         scripts.put(new Splice_DD_Version(sdd,3,1,0, 1928), new UpgradeScriptBase(sdd,tc));
         scripts.put(new Splice_DD_Version(sdd,3,1,0, 1933), new UpgradeScriptToUpdateViewForSYSCONGLOMERATEINSCHEMAS(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1937), new UpgradeScriptForTriggerWhenClause(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,3,0,0, 1937), new UpgradeScriptForTriggerWhenClause(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,2,8,0, 1937), new UpgradeScriptForTriggerWhenClause(sdd,tc));
+        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1938), new UpgradeScriptForTriggerWhenClause(sdd,tc));
     }
 
     public void run() throws StandardException{

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -74,6 +74,9 @@ public class SpliceCatalogUpgradeScripts{
         // Two system procedures are moved, so we need to run base script to update all system procedures
         scripts.put(new Splice_DD_Version(sdd,3,1,0, 1928), new UpgradeScriptBase(sdd,tc));
         scripts.put(new Splice_DD_Version(sdd,3,1,0, 1933), new UpgradeScriptToUpdateViewForSYSCONGLOMERATEINSCHEMAS(sdd,tc));
+        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1937), new UpgradeScriptForTriggerWhenClause(sdd,tc));
+        scripts.put(new Splice_DD_Version(sdd,3,0,0, 1937), new UpgradeScriptForTriggerWhenClause(sdd,tc));
+        scripts.put(new Splice_DD_Version(sdd,2,8,0, 1937), new UpgradeScriptForTriggerWhenClause(sdd,tc));
     }
 
     public void run() throws StandardException{

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForDroppedConglomerates.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForDroppedConglomerates.java
@@ -43,7 +43,7 @@ public class UpgradeScriptForDroppedConglomerates extends UpgradeScriptBase {
         try {
             LOG.info("Creating " + HBaseConfiguration.DROPPED_CONGLOMERATES_TABLE_NAME);
             SIDriver.driver().getTableFactory().getAdmin().newPartition().withName(HBaseConfiguration.DROPPED_CONGLOMERATES_TABLE_NAME).create();
-        } catch (IOException e) {
+        } catch (Exception e) {
             LOG.warn("Exception while creating while creating " + HBaseConfiguration.DROPPED_CONGLOMERATES_TABLE_NAME + ", does it already exist?", e);
         }
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForTriggerWhenClause.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForTriggerWhenClause.java
@@ -1,0 +1,61 @@
+package com.splicemachine.derby.impl.sql.catalog.upgrade;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.dictionary.CatalogRowFactory;
+import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
+import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
+import com.splicemachine.db.iapi.store.access.AccessFactory;
+import com.splicemachine.db.iapi.store.access.ConglomerateController;
+import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.db.impl.sql.catalog.SYSTRIGGERSRowFactory;
+import com.splicemachine.db.impl.sql.catalog.TabInfoImpl;
+import com.splicemachine.derby.impl.sql.catalog.SpliceDataDictionary;
+import com.splicemachine.derby.impl.store.access.SpliceAccessManager;
+import com.splicemachine.derby.impl.store.access.hbase.HBaseController;
+import com.splicemachine.utils.SpliceLogUtils;
+
+/**
+ * Created by msirek on 11/5/19.
+ */
+public class UpgradeScriptForTriggerWhenClause extends UpgradeScriptBase {
+    public UpgradeScriptForTriggerWhenClause(SpliceDataDictionary sdd, TransactionController tc) {
+        super(sdd, tc);
+    }
+
+    @Override
+    protected void upgradeSystemTables() throws StandardException {
+        ConglomerateController heapCC = null;
+        try {
+            TabInfoImpl tII = sdd.getNonCoreTIByNumber(DataDictionary.SYSTRIGGERS_CATALOG_NUM);
+            TableDescriptor td =
+               sdd.getTableDescriptor( tII.getCatalogRowFactory().getCatalogName(),
+                                       sdd.getSystemSchemaDescriptor(), tc );
+            long conglomID = td.getHeapConglomerateId();
+            heapCC=tc.openConglomerate(conglomID,
+                                       false,0,
+                                       TransactionController.MODE_RECORD,
+                                       TransactionController.ISOLATION_REPEATABLE_READ);
+            // If upgrade has already been done, and we somehow got here again by
+            // mistake, don't re-add the WHENCLAUSETEXT column to the systriggers
+            // conglomerate descriptor.
+            if (heapCC instanceof HBaseController) {
+                HBaseController hCC = (HBaseController)heapCC;
+                if (hCC.getConglomerate().getFormat_ids().length >=
+                    SYSTRIGGERSRowFactory.SYSTRIGGERS_COLUMN_COUNT) {
+                    return;
+                }
+            }
+            heapCC.close();
+            heapCC = null;
+            sdd.upgrade_addColumns(tII.getCatalogRowFactory(), new int[]{18}, tc);
+            SpliceLogUtils.info(LOG, "Catalog upgraded: updated system table sys.systriggers");
+        }
+        catch (Exception e) {
+            SpliceLogUtils.info(LOG, "Attempt to upgrade sys.systriggers failed.  Please check if it has already been upgraded and contains the correct number of columns: 18.");
+        }
+        finally {
+            if (heapCC != null)
+                heapCC.close();
+        }
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceNodeFactoryImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceNodeFactoryImpl.java
@@ -649,6 +649,12 @@ public class SpliceNodeFactoryImpl extends NodeFactory implements ModuleControl,
 			case C_NodeTypes.DIGITS_OPERATOR_NODE:
 				return C_NodeNames.UNARY_OPERATOR_NODE_NAME;
 
+			case C_NodeTypes.SIGNAL_NODE:
+				return C_NodeNames.SIGNAL_NAME;
+
+			case C_NodeTypes.SET_NODE:
+				return C_NodeNames.SET_NAME;
+
 			// WARNING: WHEN ADDING NODE TYPES HERE, YOU MUST ALSO ADD
 		  // THEM TO tools/jar/DBMSnodes.properties
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericConstantActionFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericConstantActionFactory.java
@@ -25,6 +25,7 @@ import com.splicemachine.db.iapi.sql.execute.ConstantAction;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.store.access.StaticCompiledOpenConglomInfo;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.types.RowLocation;
 import com.splicemachine.db.impl.sql.compile.TableName;
 import com.splicemachine.db.impl.sql.execute.*;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericConstantActionFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericConstantActionFactory.java
@@ -459,14 +459,17 @@ public abstract class SpliceGenericConstantActionFactory extends GenericConstant
             TableDescriptor triggerTable,UUID whenSPSId,String whenText,
             UUID actionSPSId,String actionText,UUID spsCompSchemaId,
             Timestamp creationTimestamp,int[] referencedCols,
-            int[] referencedColsInTriggerAction,String originalActionText,
+            int[] referencedColsInTriggerAction,
+            String originalWhenText,
+            String originalActionText,
             boolean referencingOld,boolean referencingNew,
             String oldReferencingName,String newReferencingName){
         SpliceLogUtils.trace(LOG,"getCreateTriggerConstantAction for trigger {%s.%s}",triggerSchemaName,triggerName);
         return new CreateTriggerConstantOperation(triggerSchemaName,triggerName,
                 eventMask,isBefore,isRow,isEnabled,triggerTable,whenSPSId,
                 whenText,actionSPSId,actionText,spsCompSchemaId,creationTimestamp,
-                referencedCols,referencedColsInTriggerAction,originalActionText,
+                referencedCols,referencedColsInTriggerAction,
+                originalWhenText, originalActionText,
                 referencingOld,referencingNew,oldReferencingName,newReferencingName);
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
@@ -1876,6 +1876,36 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
     }
 
     @Override
+    public NoPutResultSet getSignalResultSet(Activation activation,
+                                             String sqlState,
+                                             GeneratedMethod errorTextGenerator) throws StandardException {
+        SpliceLogUtils.trace(LOG, "getSignalResultSet");
+        try {
+            SignalOperation top =
+                new SignalOperation(activation, sqlState, errorTextGenerator);
+            top.markAsTopResultSet();
+            return top;
+        } catch(Exception e) {
+            throw Exceptions.parseException(e);
+        }
+    }
+
+    @Override
+    public NoPutResultSet getSetResultSet(Activation activation,
+                                          String getColumnDVDsMethodNames,
+                                          GeneratedMethod getNewDVDsMethod) throws StandardException {
+        SpliceLogUtils.trace(LOG, "getSignalResultSet");
+        try {
+            SetOperation top =
+                new SetOperation(activation, getColumnDVDsMethodNames, getNewDVDsMethod);
+            top.markAsTopResultSet();
+            return top;
+        } catch(Exception e) {
+            throw Exceptions.parseException(e);
+        }
+    }
+
+    @Override
     public ResultSet getInsertVTIResultSet(NoPutResultSet source, NoPutResultSet vtiRS, double optimizerEstimatedRowCount, double optimizerEstimatedCost) throws StandardException {
         throw new RuntimeException("Not Implemented");
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
@@ -1894,7 +1894,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
     public NoPutResultSet getSetResultSet(Activation activation,
                                           String getColumnDVDsMethodNames,
                                           GeneratedMethod getNewDVDsMethod) throws StandardException {
-        SpliceLogUtils.trace(LOG, "getSignalResultSet");
+        SpliceLogUtils.trace(LOG, "getSetResultSet");
         try {
             SetOperation top =
                 new SetOperation(activation, getColumnDVDsMethodNames, getNewDVDsMethod);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTriggerConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTriggerConstantOperation.java
@@ -323,7 +323,7 @@ public class CreateTriggerConstantOperation extends DDLSingleTableConstantOperat
         if (whenText != null) {
             // The WHEN clause is just a search condition and not a full
             // SQL statement. Turn in into a VALUES statement.
-            String whenValuesStmt = "VALUES " + whenText;
+            String whenValuesStmt = "VALUES ( " + whenText + " )";
             whenspsd = createSPS(lcc, ddg, dd, tc, tmpTriggerId, triggerSd,
                     whenSPSId, spsCompSchemaId, whenValuesStmt, true, triggerTable);
         }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTriggerConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTriggerConstantOperation.java
@@ -57,9 +57,10 @@ public class CreateTriggerConstantOperation extends DDLSingleTableConstantOperat
     private final boolean isEnabled;
     private final boolean referencingOld;
     private final boolean referencingNew;
-    private final UUID whenSPSId;
+    private       UUID   whenSPSId;
     private final String whenText;
     private final String actionText;
+    private final String originalWhenText;
     private final String originalActionText;
     private final String oldReferencingName;
     private final String newReferencingName;
@@ -120,6 +121,7 @@ public class CreateTriggerConstantOperation extends DDLSingleTableConstantOperat
             Timestamp creationTimestamp,
             int[] referencedCols,
             int[] referencedColsInTriggerAction,
+            String originalWhenText,
             String originalActionText,
             boolean referencingOld,
             boolean referencingNew,
@@ -143,6 +145,7 @@ public class CreateTriggerConstantOperation extends DDLSingleTableConstantOperat
         this.referencedCols = referencedCols;
         this.referencedColsInTriggerAction = referencedColsInTriggerAction;
         this.originalActionText = originalActionText;
+        this.originalWhenText = originalWhenText;
         this.referencingOld = referencingOld;
         this.referencingNew = referencingNew;
         this.oldReferencingName = oldReferencingName;
@@ -275,6 +278,10 @@ public class CreateTriggerConstantOperation extends DDLSingleTableConstantOperat
         actionSPSId = (actionSPSId == null) ?
                 dd.getUUIDFactory().createUUID() : actionSPSId;
 
+        if (whenSPSId == null && whenText != null) {
+            whenSPSId = dd.getUUIDFactory().createUUID();
+        }
+
         DataDescriptorGenerator ddg = dd.getDataDescriptorGenerator();
 
         /*
@@ -292,8 +299,7 @@ public class CreateTriggerConstantOperation extends DDLSingleTableConstantOperat
                         isRow,
                         isEnabled,
                         triggerTable,
-                        null,
-//                        whenspsd == null ? null : whenspsd.getUUID(),
+                        whenSPSId,
                         actionSPSId,
                         creationTimestamp == null ? new Timestamp(System.currentTimeMillis()) : creationTimestamp,
                         referencedCols,
@@ -302,7 +308,8 @@ public class CreateTriggerConstantOperation extends DDLSingleTableConstantOperat
                         referencingOld,
                         referencingNew,
                         oldReferencingName,
-                        newReferencingName);
+                        newReferencingName,
+                        originalWhenText);
 
 
         dd.addDescriptor(triggerd, triggerSd,
@@ -314,8 +321,11 @@ public class CreateTriggerConstantOperation extends DDLSingleTableConstantOperat
         ** If we have a WHEN action we create it now.
         */
         if (whenText != null) {
+            // The WHEN clause is just a search condition and not a full
+            // SQL statement. Turn in into a VALUES statement.
+            String whenValuesStmt = "VALUES " + whenText;
             whenspsd = createSPS(lcc, ddg, dd, tc, tmpTriggerId, triggerSd,
-                    whenSPSId, spsCompSchemaId, whenText, true, triggerTable);
+                    whenSPSId, spsCompSchemaId, whenValuesStmt, true, triggerTable);
         }
 
         /*

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
@@ -1233,7 +1233,7 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
                 // The WHEN clause is not a full SQL statement, just a search
                 // condition, so we need to turn it into a statement in order
                 // to create an SPS.
-                newText = "VALUES " + newText;
+                newText = "VALUES ( " + newText + " )";
             }
 
             sps.setText(newText);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
@@ -27,8 +27,10 @@ import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.PreparedStatement;
 import com.splicemachine.db.iapi.sql.ResultSet;
 import com.splicemachine.db.iapi.sql.StatementType;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.sql.compile.Parser;
+import com.splicemachine.db.iapi.sql.compile.Visitable;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.depend.DependencyManager;
 import com.splicemachine.db.iapi.sql.dictionary.*;
@@ -40,16 +42,16 @@ import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.util.IdUtil;
 import com.splicemachine.db.iapi.util.StringUtil;
-import com.splicemachine.db.impl.sql.compile.CollectNodesVisitor;
-import com.splicemachine.db.impl.sql.compile.ColumnDefinitionNode;
-import com.splicemachine.db.impl.sql.compile.ColumnReference;
-import com.splicemachine.db.impl.sql.compile.StatementNode;
+import com.splicemachine.db.impl.sql.compile.*;
 import com.splicemachine.db.impl.sql.execute.ColumnInfo;
 import com.splicemachine.pipeline.ErrorState;
 import org.apache.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.SortedSet;
+
+import static com.splicemachine.db.impl.sql.compile.CreateTriggerNode.bindWhenClause;
 
 /**
  * @author Scott Fines
@@ -57,6 +59,35 @@ import java.util.List;
  */
 public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
     private static final Logger LOG = Logger.getLogger(ModifyColumnConstantOperation.class);
+
+    /**
+     * <p>
+     * A list that describes how the original SQL text of the trigger action
+     * statement was modified when transition tables and transition variables
+     * were replaced by VTI calls. Each element in the list contains four
+     * integers describing positions where modifications have happened. The
+     * first two integers are begin and end positions of a transition table
+     * or transition variable in {@link #originalActionText the original SQL
+     * text}. The last two integers are begin and end positions of the
+     * corresponding replacement in {@link #actionText the transformed SQL
+     * text}.
+     * </p>
+     *
+     * <p>
+     * Begin positions are inclusive and end positions are exclusive.
+     * </p>
+     */
+    private final ArrayList<int[]>
+            actionTransformations = new ArrayList<int[]>();
+
+    /**
+     * Structure that has the same shape as {@code actionTransformations},
+     * except that it describes the transformations in the WHEN clause.
+     */
+    private final ArrayList<int[]>
+            whenClauseTransformations = new ArrayList<int[]>();
+
+    private int[] referencedColsInTriggerAction;
 
     /**
      * Make the AlterAction for an ALTER TABLE statement.
@@ -851,7 +882,23 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
                         // depends on the column being dropped, it will be
                         // caught here.
                         TriggerDescriptor trdToBeDropped = dd.getTriggerDescriptor(depsTriggerDesc.getUUID());
-                        columnDroppedAndTriggerDependencies(trdToBeDropped,tableDescriptor, cascade, columnName,activation);
+                        UUID whenClauseId = trdToBeDropped.getWhenClauseId();
+                        boolean gotDropped = false;
+                        if (whenClauseId != null) {
+                            gotDropped = columnDroppedAndTriggerDependencies(
+                                    trdToBeDropped, tableDescriptor, whenClauseId,
+                                    true, cascade, columnName, activation);
+                        }
+                        // If no dependencies were found in the WHEN clause,
+                        // we have to check if the triggered SQL statement
+                        // depends on the column being dropped. But if there
+                        // were dependencies and the trigger has already been
+                        // dropped, there is no point in looking for more
+                        // dependencies.
+                        if (!gotDropped)
+                            columnDroppedAndTriggerDependencies(trdToBeDropped, tableDescriptor,
+                                                                trdToBeDropped.getActionId(),
+                                                                false, cascade, columnName, activation);
                     }
                 }
             }
@@ -1106,11 +1153,12 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
         }
     }
 
-    private void columnDroppedAndTriggerDependencies(TriggerDescriptor trd,
-                                                     TableDescriptor td,
-                                                     boolean cascade,
-                                                     String columnName,
-                                                     Activation activation)
+    private boolean
+    columnDroppedAndTriggerDependencies(TriggerDescriptor trd,
+                                        TableDescriptor td,
+                                        UUID spsUUID, boolean isWhenClause,
+			                boolean cascade, String columnName,
+                                        Activation activation)
             throws StandardException {
         /*
          * For the trigger, get the trigger action sql provided by the user
@@ -1127,80 +1175,89 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
 
         // Here we get the trigger action sql and use the parser to build
         // the parse tree for it.
-        SchemaDescriptor compSchema;
-        compSchema = dd.getSchemaDescriptor(trd.getSchemaDescriptor().getUUID(), null);
+        SchemaDescriptor compSchema = dd.getSchemaDescriptor(
+                dd.getSPSDescriptor(spsUUID).getCompSchemaId(),
+                null);
         CompilerContext newCC = lcc.pushCompilerContext(compSchema);
-        Parser pa = newCC.getParser();
-        StatementNode stmtnode = (StatementNode)pa.parseStatement(trd.getTriggerDefinition());
+        Parser	pa = newCC.getParser();
+        String originalSQL = isWhenClause ? trd.getWhenClauseText()
+                                          : trd.getTriggerDefinition();
+
+        Visitable node = isWhenClause ? pa.parseSearchCondition(originalSQL)
+                                      : pa.parseStatement(originalSQL);
         lcc.popCompilerContext(newCC);
         // Do not delete following. We use this in finally clause to
         // determine if the CompilerContext needs to be popped.
         newCC = null;
 
         try {
-            // We are interested in ColumnReference classes in the parse tree
-            CollectNodesVisitor visitor = new CollectNodesVisitor(ColumnReference.class);
-            stmtnode.accept(visitor);
+            // Regenerate the internal representation for the trigger action
+            // sql using the ColumnReference classes in the parse tree. It
+            // will catch dropped column getting used in trigger action sql
+            // through the REFERENCING clause(this can happen only for the
+            // the triggers created prior to 10.7. Trigger created with
+            // 10.7 and higher keep track of trigger action column used
+            // through the REFERENCING clause in system table and hence
+            // use of dropped column will be detected earlier in this
+            // method for such triggers).
+            //
+            // We might catch errors like following during this step.
+            // Say that following pre-10.7 trigger exists in the system and
+            // user is dropping column c11. During the regeneration of the
+            // internal trigger action sql format, we will catch that
+            // column oldt.c11 does not exist anymore
+            // CREATE TRIGGER DERBY4998_SOFT_UPGRADE_RESTRICT_tr1
+            //    AFTER UPDATE OF c12
+            //    ON DERBY4998_SOFT_UPGRADE_RESTRICT REFERENCING OLD AS oldt
+            //    FOR EACH ROW
+            //    SELECT oldt.c11 from DERBY4998_SOFT_UPGRADE_RESTRICT
 
-            /*
-             * Regenerate the internal representation for the trigger action
-             * sql using the ColumnReference classes in the parse tree. It
-             * will catch dropped column getting used in trigger action sql
-             * through the REFERENCING clause(this can happen only for the
-             * the triggers created prior to 10.7. Trigger created with
-             * 10.7 and higher keep track of trigger action column used
-             * through the REFERENCING clause in system table and hence
-             * use of dropped column will be detected earlier in this
-             * method for such triggers).
-             *
-             * We might catch errors like following during this step.
-             * Say that following pre-10.7 trigger exists in the system and
-             * user is dropping column c11. During the regeneration of the
-             * internal trigger action sql format, we will catch that
-             * column oldt.c11 does not exist anymore
-             * CREATE TRIGGER DERBY4998_SOFT_UPGRADE_RESTRICT_tr1
-             *    AFTER UPDATE OF c12
-             *    ON DERBY4998_SOFT_UPGRADE_RESTRICT REFERENCING OLD AS oldt
-             *    FOR EACH ROW
-             *    SELECT oldt.c11 from DERBY4998_SOFT_UPGRADE_RESTRICT
-             */
-            SPSDescriptor triggerActionSPSD = trd.getActionSPS(lcc);
-            int[] referencedColsInTriggerAction = new int[td.getNumberOfColumns()];
-            java.util.Arrays.fill(referencedColsInTriggerAction, -1);
-            triggerActionSPSD.setText(dd.getTriggerActionString(stmtnode,
-                    trd.getOldReferencingName(),
-                    trd.getNewReferencingName(),
-                    trd.getTriggerDefinition(),
-                    trd.getReferencedCols(),
-                    referencedColsInTriggerAction,
-                    0,
-                    trd.getTableDescriptor(),
-                    trd.getTriggerEventDML(),
-                    true
-            ));
+            SPSDescriptor sps = isWhenClause ? trd.getWhenClauseSPS(lcc)
+                                             : trd.getActionSPS(lcc);
+			int[] referencedColsInTriggerAction = new int[td.getNumberOfColumns()];
+			java.util.Arrays.fill(referencedColsInTriggerAction, -1);
+            String newText = dd.getTriggerActionString(node,
+				trd.getOldReferencingName(),
+				trd.getNewReferencingName(),
+                originalSQL,
+				trd.getReferencedCols(),
+				referencedColsInTriggerAction,
+				0,
+				trd.getTableDescriptor(),
+				trd.getTriggerEventDML(),
+                true,
+                null,
+                null);
 
-            /*
-             * Now that we have the internal format of the trigger action sql,
-             * bind that sql to make sure that we are not using colunm being
-             * dropped in the trigger action sql directly (ie not through
-             * REFERENCING clause.
-             * eg
-             * create table atdc_12 (a integer, b integer);
-             * create trigger atdc_12_trigger_1 after update of a
-             *     on atdc_12 for each row select a,b from atdc_12
-             * Drop one of the columns used in the trigger action
-             *   alter table atdc_12 drop column b
-             * Following rebinding of the trigger action sql will catch the use
-             * of column b in trigger atdc_12_trigger_1
-             */
-            compSchema = dd.getSchemaDescriptor(trd.getSchemaDescriptor().getUUID(), null);
+            if (isWhenClause) {
+                // The WHEN clause is not a full SQL statement, just a search
+                // condition, so we need to turn it into a statement in order
+                // to create an SPS.
+                newText = "VALUES " + newText;
+            }
+
+            sps.setText(newText);
+
+            // Now that we have the internal format of the trigger action sql,
+            // bind that sql to make sure that we are not using colunm being
+            // dropped in the trigger action sql directly (ie not through
+            // REFERENCING clause.
+            // eg
+            // create table atdc_12 (a integer, b integer);
+            // create trigger atdc_12_trigger_1 after update of a
+            //     on atdc_12 for each row select a,b from atdc_12
+            // Drop one of the columns used in the trigger action
+            //   alter table atdc_12 drop column b
+            // Following rebinding of the trigger action sql will catch the use
+            // of column b in trigger atdc_12_trigger_1
             newCC = lcc.pushCompilerContext(compSchema);
             newCC.setReliability(CompilerContext.INTERNAL_SQL_LEGAL);
             pa = newCC.getParser();
-            stmtnode = (StatementNode)pa.parseStatement(triggerActionSPSD.getText());
+            StatementNode stmtnode = (StatementNode) pa.parseStatement(newText);
             // need a current dependent for bind
-            newCC.setCurrentDependent(triggerActionSPSD.getPreparedStatement());
+            newCC.setCurrentDependent(sps.getPreparedStatement());
             stmtnode.bindStatement();
+
         } catch (StandardException se) {
             /*
              *Need to catch for few different kinds of sql states depending
@@ -1248,7 +1305,7 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
                             StandardException.newWarning(
                                     SQLState.LANG_TRIGGER_DROPPED,
                                     trd.getName(), td.getName()));
-                    return;
+                    return true;
                 }
                 else
                 {	// we'd better give an error if don't drop it,
@@ -1276,6 +1333,7 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
          * columns in the table. We will save that in the system table.
         */
         dd.addDescriptor(trd, sd, DataDictionary.SYSTRIGGERS_CATALOG_NUM, false, tc, false);
+        return false;
     }
 
     /**

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SetOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SetOperation.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.impl.sql.execute.operations;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.services.loader.GeneratedMethod;
+import com.splicemachine.db.iapi.sql.Activation;
+import com.splicemachine.db.iapi.sql.execute.ExecRow;
+import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.derby.iapi.sql.execute.SpliceOperationContext;
+import com.splicemachine.derby.impl.SpliceMethod;
+import com.splicemachine.derby.stream.iapi.DataSet;
+import com.splicemachine.derby.stream.iapi.DataSetProcessor;
+import com.splicemachine.derby.stream.iapi.OperationContext;
+import org.spark_project.guava.base.Strings;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+
+/**
+ * Created by msirek on Nov. 23, 2019.
+ */
+public class SetOperation extends NoRowsOperation {
+
+    private static int CURRENT_CLASS_VERSION = 1;
+    private int classVersion = CURRENT_CLASS_VERSION;
+
+    private String getColumnDVDsMethodNames;
+    private String [] getColumnDVDsMethodName;
+    private String getNewDVDsMethodName;
+
+    protected static final String NAME = SetOperation.class.getSimpleName().replaceAll("Operation", "");
+
+    public SetOperation() {
+
+    }
+
+    private void setupGetColumnDVDsMethodNames() {
+        this.getColumnDVDsMethodName = getColumnDVDsMethodNames.split("\\.");
+    }
+
+    /**
+     * Make the Operation for a SET statement.
+     *
+     *  @param getColumnDVDsMethodNames	The names of the methods used to access the columns in the NEW row, separated by periods.
+     */
+    public SetOperation(Activation activation,
+                        String getColumnDVDsMethodNames,
+                        GeneratedMethod getNewDVDsMethod) throws StandardException {
+        super(activation);
+        this.getColumnDVDsMethodNames = getColumnDVDsMethodNames;
+        this.getNewDVDsMethodName = getNewDVDsMethod.getMethodName();
+        setupGetColumnDVDsMethodNames();
+
+        init();
+    }
+
+    public	String	toString() {
+        return "SET: ";
+    }
+
+    @Override
+    public boolean isReferencingTable(long tableNumber) {
+        return false;
+    }
+
+    @Override
+    public int[] getRootAccessedCols(long tableNumber) throws StandardException {
+        return new int[0];
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String prettyPrint(int indentLevel) {
+                    String indent = "\n"+ Strings.repeat("\t",indentLevel);
+
+                    return "Signal:" + indent
+                            + "getColumnDVDsMethodNames:" + getColumnDVDsMethodNames + indent
+                            + "getNewDVDsMethodName:" + getNewDVDsMethodName + indent;
+    }
+
+    @Override
+    public void init(SpliceOperationContext context) throws StandardException, IOException {
+        super.init(context);
+    }
+
+    /**
+      @see java.io.Externalizable#readExternal
+      @exception IOException thrown on error
+      @exception ClassNotFoundException	thrown on error
+     */
+    public void readExternal( ObjectInput in ) throws IOException, ClassNotFoundException {
+            // Read in the serialized class version, but don't use it (for now).
+            in.readInt();
+            super.readExternal(in);
+            getColumnDVDsMethodNames = readNullableString(in);
+            getNewDVDsMethodName = readNullableString(in);
+            setupGetColumnDVDsMethodNames();
+    }
+
+    /**
+
+      @exception IOException thrown on error
+     */
+    public void writeExternal( ObjectOutput out ) throws IOException {
+            out.writeInt(classVersion);
+            super.writeExternal(out);
+            writeNullableString(getColumnDVDsMethodNames, out);
+            writeNullableString(getNewDVDsMethodName, out);
+
+    }
+
+    @Override
+    public DataSet<ExecRow> getDataSet(DataSetProcessor dsp) throws StandardException {
+        if (!isOpen)
+            throw new IllegalStateException("Operation is not open");
+
+        SpliceMethod<DataValueDescriptor[]> getNewDVDsMethod = new SpliceMethod<>(getNewDVDsMethodName, activation);
+        DataValueDescriptor [] columnDVDs = new DataValueDescriptor[getColumnDVDsMethodName.length];
+        DataValueDescriptor [] replacementValues = getNewDVDsMethod.invoke();
+        if (columnDVDs.length != replacementValues.length)
+            throw new RuntimeException();
+
+        OperationContext<SetOperation> operationContext =
+            dsp.createOperationContext(this);
+
+        for (int i = 0; i < columnDVDs.length; i++) {
+            SpliceMethod<DataValueDescriptor> getColumnDVDsMethod =
+                new SpliceMethod<DataValueDescriptor>(getColumnDVDsMethodName[i], activation);
+            columnDVDs[i] = getColumnDVDsMethod.invoke();
+            DataValueDescriptor itemToUpdate = ((DataValueDescriptor)columnDVDs[i].getObject());
+            itemToUpdate.setValue(replacementValues[i]);
+        }
+
+        operationContext.pushScope();
+        try {
+            return dsp.getEmpty();
+        } finally {
+            operationContext.popScope();
+        }
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SignalOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SignalOperation.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2012 - 2019 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.impl.sql.execute.operations;
+
+import com.splicemachine.db.iapi.error.ExceptionSeverity;
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.services.loader.GeneratedMethod;
+import com.splicemachine.db.iapi.sql.Activation;
+import com.splicemachine.db.iapi.sql.execute.ExecRow;
+import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.derby.iapi.sql.execute.SpliceOperationContext;
+import com.splicemachine.derby.impl.SpliceMethod;
+import com.splicemachine.derby.stream.iapi.DataSet;
+import com.splicemachine.derby.stream.iapi.DataSetProcessor;
+import com.splicemachine.derby.stream.iapi.OperationContext;
+import org.spark_project.guava.base.Strings;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import static com.splicemachine.db.iapi.error.StandardException.newException;
+
+/**
+ * Created by msirek on Nov. 18, 2019.
+ */
+public class SignalOperation extends NoRowsOperation {
+    private static int CURRENT_CLASS_VERSION = 1;
+    private int classVersion = CURRENT_CLASS_VERSION;
+    private String sqlState;
+    private String errorText;
+    private String errorTextGeneratorMethodName;
+    public SpliceMethod<DataValueDescriptor>  errorTextMethod;
+    protected static final String NAME = SignalOperation.class.getSimpleName().replaceAll("Operation", "");
+
+    public SignalOperation() {
+
+    }
+
+    /**
+     * Make the ConstantAction for a SIGNAL statement.
+     *
+     *  @param sqlState	The error code to return.
+     */
+    public SignalOperation(Activation activation,
+                           String sqlState,
+                           GeneratedMethod errorTextGenerator) throws StandardException {
+        super(activation);
+        this.sqlState = sqlState;
+        this.errorText = "";
+        this.errorTextGeneratorMethodName =
+              (errorTextGenerator == null) ? null :
+                 errorTextGenerator.getMethodName();
+        init();
+    }
+
+    public String toString() {
+        return "SIGNAL: " + sqlState;
+    }
+
+    @Override
+    public boolean isReferencingTable(long tableNumber) {
+        return false;
+    }
+
+    @Override
+    public int[] getRootAccessedCols(long tableNumber) throws StandardException {
+        return new int[0];
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String prettyPrint(int indentLevel) {
+                    String indent = "\n"+ Strings.repeat("\t",indentLevel);
+
+                    return "Signal:" + indent
+                            + "sqlState:" + sqlState + indent
+                            + "errorTextGeneratorMethodName:" + errorTextGeneratorMethodName + indent;
+    }
+
+    @Override
+    public void init(SpliceOperationContext context) throws StandardException, IOException {
+        super.init(context);
+
+        if (errorTextGeneratorMethodName != null)
+            errorTextMethod = new SpliceMethod<>(errorTextGeneratorMethodName, activation);
+    }
+
+    private void throwSignal() throws StandardException {
+        StandardException e = newException(sqlState, null, "");
+        e.setTextMessage("Application raised error or warning with diagnostic text: \"" + errorText + "\"");
+        e.setIsSignal(true);
+        e.setSeverity(ExceptionSeverity.STATEMENT_SEVERITY);
+        throw e;
+    }
+
+    /**
+      @see java.io.Externalizable#readExternal
+      @exception IOException thrown on error
+      @exception ClassNotFoundException	thrown on error
+     */
+    public void readExternal( ObjectInput in ) throws IOException, ClassNotFoundException {
+            // Read in the serialized class version, but don't use it (for now).
+            in.readInt();
+            super.readExternal(in);
+            sqlState = readNullableString(in);
+            errorText = readNullableString(in);
+            errorTextGeneratorMethodName = readNullableString(in);
+    }
+
+    /**
+
+      @exception IOException thrown on error
+     */
+    public void writeExternal( ObjectOutput out ) throws IOException {
+            out.writeInt(classVersion);
+            super.writeExternal(out);
+            writeNullableString(sqlState, out);
+            writeNullableString(errorText, out);
+            writeNullableString(errorTextGeneratorMethodName, out);
+    }
+
+    @Override
+    public DataSet<ExecRow> getDataSet(DataSetProcessor dsp) throws StandardException {
+        if (!isOpen)
+            throw new IllegalStateException("Operation is not open");
+
+        OperationContext<SignalOperation> operationContext =
+            dsp.createOperationContext(this);
+
+        DataValueDescriptor errorTextDVD =
+            errorTextMethod != null ? errorTextMethod.invoke() : null;
+        if (errorTextDVD != null)
+            errorText = errorTextDVD.getString();
+        throwSignal();
+
+        // We shouldn't reach here, but just in case...
+        operationContext.pushScope();
+        try {
+            return dsp.getEmpty();
+        } finally {
+            operationContext.popScope();
+        }
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceAccessManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceAccessManager.java
@@ -215,7 +215,7 @@ public class SpliceAccessManager implements AccessFactory, CacheableFactory, Mod
      *
      * @exception  StandardException  Standard exception policy.
      **/
-	/* package */ void conglomCacheRemoveEntry(long conglomid)
+    public void conglomCacheRemoveEntry(long conglomid)
             throws StandardException {
         database.getDataDictionary().getDataDictionaryCache().conglomerateCacheRemove(conglomid);
         database.getDataDictionary().getDataDictionaryCache().conglomerateDescriptorCacheRemove(conglomid);

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceSchemaWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceSchemaWatcher.java
@@ -135,6 +135,17 @@ public class SpliceSchemaWatcher extends TestWatcher {
         }
     }
 
+    public void cleanSchemaObjects() throws RuntimeException {
+        try (Connection connection = SpliceNetConnection.getConnection()) {
+            SchemaDAO schemaDAO = new SchemaDAO(connection);
+            schemaDAO.cleanSchemaObjects(schemaName, null, null);
+
+            connection.commit();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override
     public String toString() {
         return schemaName;

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
@@ -407,6 +407,21 @@ public class SpliceUnitTest {
         }
     }
 
+    protected void testFail(String sqlText,
+                            List<String> expectedErrors,
+                            Statement s) throws Exception {
+        try {
+            s.execute(sqlText);
+            String failMsg = format("Query not expected to succeed.\n%s", sqlText);
+            fail(failMsg);
+        }
+        catch (Exception e) {
+            boolean found = expectedErrors.contains(e.getMessage());
+            if (!found)
+                fail(format("\n + Unexpected error message: %s + \n", e.getMessage()));
+        }
+    }
+
     protected void testFail(String expectedErrorCode,
                             String sqlText,
                             Statement s) throws AssertionError {

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
@@ -126,7 +126,7 @@ public class SpliceWatcher extends TestWatcher {
         return currentConnection;
     }
 
-    public PreparedStatement prepareStatement(String sql) throws Exception {
+    public PreparedStatement prepareStatement(String sql) throws SQLException {
         PreparedStatement ps = getOrCreateConnection().prepareStatement(sql);
         statements.add(ps);
         return ps;
@@ -198,7 +198,7 @@ public class SpliceWatcher extends TestWatcher {
         currentConnection = null;
     }
 
-    public ResultSet executeQuery(String sql) throws Exception {
+    public ResultSet executeQuery(String sql) throws SQLException {
         Statement s = getStatement();
         ResultSet rs = s.executeQuery(sql);
         resultSets.add(rs);
@@ -267,7 +267,7 @@ public class SpliceWatcher extends TestWatcher {
         return s.executeUpdate(sql);
     }
 
-    public Statement getStatement() throws Exception {
+    public Statement getStatement() throws SQLException {
         Statement s = getOrCreateConnection().createStatement();
         statements.add(s);
         return s;

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Exists_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Exists_IT.java
@@ -827,7 +827,7 @@ public class Subquery_Flattening_Exists_IT {
         6 rows selected
          */
         SpliceUnitTest.rowContainsQuery(new int[]{3, 4, 5}, "explain " + sqlText, methodWatcher,
-                new String[]{"ProjectRestrict", "preds=[is not null(subq=1)]"},
+                new String[]{"ProjectRestrict", "preds=[is not null(subq=0)]"},
                 new String[]{"Subquery", "correlated=false,expression=true,invariant=true"},
                 new String[] {"Values"});
 

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_NotExists_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_NotExists_IT.java
@@ -996,7 +996,7 @@ public class Subquery_Flattening_NotExists_IT {
 
          */
         SpliceUnitTest.rowContainsQuery(new int[]{3, 4, 5}, "explain " + sqlText, methodWatcher,
-                new String[]{"ProjectRestrict", "preds=[is null(subq=1)]"},
+                new String[]{"ProjectRestrict", "preds=[is null(subq=0)]"},
                 new String[]{"Subquery", "correlated=false,expression=true,invariant=true"},
                 new String[] {"Values"});
 

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Create_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Create_IT.java
@@ -165,7 +165,7 @@ public class Trigger_Create_IT {
     public void create_illegal_statementTriggersCannotHaveReferencingClause() throws Exception {
         verifyTriggerCreateFails(
                 tb.on("T").named("t1").before().delete().referencing("NEW AS N").statement().then("select * from sys.systables"),
-                "STATEMENT triggers may only reference table transition variables/tables.");
+                "DELETE triggers may only reference OLD transition variables/tables.");
     }
 
     @Test
@@ -202,9 +202,9 @@ public class Trigger_Create_IT {
 
         // DELETE row triggers cannot reference a NEW row
         verifyTriggerCreateFails(tb.on("T").named("t1").before().delete().referencing("NEW as NEW_ROW").row().then("select NEW_ROW.a from sys.systables"),
-                "DELETE triggers may only reference old transition variables/tables.");
+                "DELETE triggers may only reference OLD transition variables/tables.");
         verifyTriggerCreateFails(tb.on("T").named("t1").after().delete().referencing("NEW as NEW_ROW").row().then("select NEW_ROW.a from sys.systables"),
-                "DELETE triggers may only reference old transition variables/tables.");
+                "DELETE triggers may only reference OLD transition variables/tables.");
     }
 
     @Test

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_When_Clause_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_When_Clause_IT.java
@@ -1,0 +1,1415 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2019 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.triggers;
+
+import com.splicemachine.derby.test.framework.*;
+import com.splicemachine.test.SerialTest;
+import com.splicemachine.test_dao.TriggerBuilder;
+import com.splicemachine.util.StatementUtils;
+import org.junit.*;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.spark_project.guava.collect.Lists;
+
+import java.sql.*;
+import java.util.*;
+
+import static com.splicemachine.db.shared.common.reference.MessageId.SPLICE_GENERIC_EXCEPTION;
+import static org.junit.Assert.*;
+
+/**
+ * Test WHEN clause in triggers.
+ */
+@Category(value = {SerialTest.class})
+@RunWith(Parameterized.class)
+public class Trigger_When_Clause_IT extends SpliceUnitTest {
+
+
+    private static final String SCHEMA = Trigger_When_Clause_IT.class.getSimpleName();
+    public static final String CLASS_NAME = Trigger_When_Clause_IT.class.getSimpleName().toUpperCase();
+    protected static final String USER1 = "U1";
+    protected static final String PASSWORD1 = "U1";
+    protected static final String USER2 = "U2";
+    protected static final String PASSWORD2 = "U2";
+
+    @ClassRule
+    public static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(SCHEMA);
+
+    @ClassRule
+    public static SpliceWatcher classWatcher = new SpliceWatcher(SCHEMA);
+
+    @ClassRule
+    public static SpliceUserWatcher spliceUserWatcher1 = new SpliceUserWatcher(USER1, PASSWORD1);
+
+    @ClassRule
+    public static SpliceUserWatcher spliceUserWatcher2 = new SpliceUserWatcher(USER2, PASSWORD2);
+
+    private TestConnection conn;
+    private TestConnection c1;
+    private TestConnection c2;
+
+    private static final String SYNTAX_ERROR = "42X01";
+    private static final String NOT_BOOLEAN = "42X19";
+    private static final String HAS_PARAMETER = "42Y27";
+    private static final String HAS_DEPENDENTS = "X0Y25";
+    private static final String TRUNCATION = "22001";
+    private static final String NOT_AUTHORIZED = "42504";
+    private static final String NO_TABLE_PERMISSION = "42500";
+    private static final String JAVA_EXCEPTION = "XJ001";
+    private static final String NOT_SINGLE_COLUMN = "42X39";
+    private static final String NON_SCALAR_QUERY = "21000";
+    private static final String TRIGGER_RECURSION = "54038";
+    private static final String PROC_USED_AS_FUNC = "42Y03";
+
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        Collection<Object[]> params = Lists.newArrayListWithCapacity(2);
+        params.add(new Object[]{"jdbc:splice://localhost:1527/splicedb;user=splice;password=admin"});
+        params.add(new Object[]{"jdbc:splice://localhost:1527/splicedb;user=splice;password=admin;useSpark=true"});
+        return params;
+    }
+
+    private String connectionString;
+
+    public Trigger_When_Clause_IT(String connectionString ) {
+        this.connectionString = connectionString;
+    }
+
+    protected void createInt_Proc() throws Exception {
+        Connection c = conn;
+        //Connection c = classWatcher.createConnection();
+        try(Statement s = c.createStatement()) {
+            s.execute("create function f(x varchar(50)) returns boolean "
+            + "language java parameter style java external name "
+            + "'org.splicetest.sqlj.SqlJTestProcs.tableIsEmpty' reads sql data");
+
+            s.executeUpdate("create procedure int_proc(i int) language java "
+            + "parameter style java external name "
+            + "'org.splicetest.sqlj.SqlJTestProcs.intProcedure' no sql");
+            // If running tests in IntelliJ, use one of the commented-out versions of STORED_PROCS_JAR_FILE.
+            String STORED_PROCS_JAR_FILE = System.getProperty("user.dir") + "/target/sql-it/sql-it.jar";
+            //String STORED_PROCS_JAR_FILE = System.getProperty("user.dir") + "/../platform_it/target/sql-it/sql-it.jar";
+            //String STORED_PROCS_JAR_FILE = System.getProperty("user.dir") + "/../mem_sql/target/sql-it/sql-it.jar";
+            String JAR_FILE_SQL_NAME = CLASS_NAME + "." + "SQLJ_IT_PROCS_JAR";
+            s.execute(String.format("CALL SQLJ.INSTALL_JAR('%s', '%s', 0)", STORED_PROCS_JAR_FILE, JAR_FILE_SQL_NAME));
+            s.execute(String.format("CALL SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY('derby.database.classpath', '%s')", JAR_FILE_SQL_NAME));
+            c.commit();
+        }
+        //c.close();
+    }
+
+    /* Each test starts with same table state */
+    @Before
+    public void initTable() throws Exception {
+        spliceSchemaWatcher.cleanSchemaObjects();
+        conn = new TestConnection(DriverManager.getConnection(connectionString, new Properties()));
+        // grant schema privileges
+        conn.execute(format("grant ALL PRIVILEGES on schema %s to %s", SCHEMA, USER1));
+        conn.execute(format("grant access on schema %s to %s", SCHEMA, USER2));
+
+        // grant execution privileges
+        conn.execute(format("grant execute on procedure syscs_util.syscs_get_schema_info to %s", USER1));
+        conn.execute(format("grant execute on procedure syscs_util.syscs_get_schema_info to %s", USER2));
+        conn.execute(format("grant execute on procedure SYSCS_UTIL.INVALIDATE_GLOBAL_DICTIONARY_CACHE to %s", USER1));
+        conn.execute(format("grant execute on procedure SYSCS_UTIL.INVALIDATE_GLOBAL_DICTIONARY_CACHE to %s", USER2));
+        conn.execute(format("grant execute on procedure SYSCS_UTIL.INVALIDATE_DICTIONARY_CACHE to %s", USER1));
+        conn.execute(format("grant execute on procedure SYSCS_UTIL.INVALIDATE_DICTIONARY_CACHE to %s", USER2));
+
+        conn.setAutoCommit(false);
+        conn.setSchema(SCHEMA.toUpperCase());
+
+        c1 = classWatcher.createConnection("U1", "U1");
+        c2 = classWatcher.createConnection("U2", "U2");
+        c1.setAutoCommit(false);
+        c1.setSchema(SCHEMA.toUpperCase());
+        c2.setAutoCommit(false);
+        c2.setSchema(SCHEMA.toUpperCase());
+    }
+
+    @After
+    public void rollback() throws Exception{
+        conn.rollback();
+        //conn.reset();
+        c1.rollback();
+        //c1.reset();
+        c2.rollback();
+        //c2.reset();
+    }
+
+    @Test
+    public void testBasicSyntax() throws Exception {
+        try(Statement s = conn.createStatement()) {
+            s.executeUpdate("create table t1(x int)");
+            s.executeUpdate("create table t2(y varchar(20))");
+
+            // Create after triggers that should always be executed. Create row
+            // trigger, statement trigger and implicit statement trigger.
+            s.executeUpdate("create trigger tr01 after insert on t1 for each row "
+            + "when (true) insert into t2 values 'Executed tr01'");
+            s.executeUpdate("create trigger tr02 after insert on t1 for each statement "
+            + "when (true) insert into t2 values 'Executed tr02'");
+            s.executeUpdate("create trigger tr03 after insert on t1 "
+            + "when (true) insert into t2 values 'Executed tr03'");
+
+            // Create corresponding triggers that should never fire (their WHEN
+            // clause is false).
+            s.executeUpdate("create trigger tr04 after insert on t1 for each row "
+            + "when (false) insert into t2 values 'Executed tr04'");
+            s.executeUpdate("create trigger tr05 after insert on t1 for each statement "
+            + "when (false) insert into t2 values 'Executed tr05'");
+            s.executeUpdate("create trigger tr06 after insert on t1 "
+            + "when (false) insert into t2 values 'Executed tr06'");
+
+            // Create triggers with EXISTS subqueries in the WHEN clause. The
+            // first returns TRUE and the second returns FALSE.
+            s.executeUpdate("create trigger tr07 after insert on t1 "
+            + "when (exists (select * from sysibm.sysdummy1)) "
+            + "insert into t2 values 'Executed tr07'");
+            s.executeUpdate("create trigger tr08 after insert on t1 "
+            + "when (exists "
+            + "(select * from sysibm.sysdummy1 where ibmreqd <> 'Y')) "
+            + "insert into t2 values 'Executed tr08'");
+
+            // WHEN clause returns NULL, trigger should not be fired.
+            s.executeUpdate("create trigger tr09 after insert on t1 "
+            + "when (cast(null as boolean))"
+            + "insert into t2 values 'Executed tr09'");
+
+            // WHEN clause contains reference to a transition variable.
+            s.executeUpdate("create trigger tr10 after insert on t1 "
+            + "referencing new as new for each row "
+            + "when (new.x <> 2) insert into t2 values 'Executed tr10'");
+
+            // WHEN clause contains reference to a transition table.
+            // Needs DB-8883
+//            s.executeUpdate("create trigger tr11 after insert on t1 "
+//            + "referencing new table as new "
+//            + "when (exists (select * from new where x > 5)) "
+//            + "insert into t2 values 'Executed tr11'");
+        }
+        // Scalar subqueries are allowed in the WHEN clause, but they need an
+        // extra set of parantheses.
+        //
+        // The first set of parantheses is required by the WHEN clause syntax
+        // itself: WHEN ( <search condition> )
+        //
+        // The second set of parantheses is required by <search condition>.
+        // Follow this path through the SQL standard's syntax rules:
+        //    <search condition> -> <boolean value expression>
+        //      -> <boolean term> -> <boolean factor> -> <boolean test>
+        //      -> <boolean primary> -> <boolean predicand>
+        //      -> <nonparenthesized value expression primary>
+        //      -> <scalar subquery> -> <subquery> -> <left paren>
+        String sqlText = "create trigger tr12 after insert on t1 "
+                + "when (values true) insert into t2 values 'Executed tr12'";
+        List<String> expectedErrors =
+           Arrays.asList("Syntax error: Encountered \"values\" at line 1, column 46.");
+        testUpdateFail(sqlText, expectedErrors, classWatcher);
+
+        sqlText = "create trigger tr13 after insert on t1 "
+                + "when (select true from sysibm.sysdummy1) "
+                + "insert into t2 values 'Executed tr13'";
+        expectedErrors =
+           Arrays.asList("Syntax error: Encountered \"select\" at line 1, column 46.");
+        testUpdateFail(sqlText, expectedErrors, classWatcher);
+        try(Statement s = conn.createStatement()) {
+            s.execute("create trigger tr12 after insert on t1 "
+            + "when ((values true)) insert into t2 values 'Executed tr12'");
+            s.execute("create trigger tr13 after insert on t1 "
+            + "when ((select true from sysibm.sysdummy1)) "
+            + "insert into t2 values 'Executed tr13'");
+
+            // Now fire the triggers and verify the results.
+            assertUpdateCount(s, 3, "insert into t1 values 1, 2, 3");
+
+            String query = "select y, count(*) from t2 group by y order by y";
+            String expected = "Y       | 2 |\n" +
+            "-------------------\n" +
+            "Executed tr01 | 3 |\n" +
+            "Executed tr02 | 1 |\n" +
+            "Executed tr03 | 1 |\n" +
+            "Executed tr07 | 1 |\n" +
+            "Executed tr10 | 2 |\n" +
+            "Executed tr12 | 1 |\n" +
+            "Executed tr13 | 1 |";
+            testQuery(query, expected, s);
+
+            // Empty t2 before firing the triggers again.
+            s.execute("delete from t2");
+
+            // Insert more rows with different values and see that a slightly
+            // different set of triggers get fired.
+            assertUpdateCount(s, 2, "insert into t1 values 2, 6");
+
+            query = "select y, count(*) from t2 group by y order by y";
+            expected = "Y       | 2 |\n" +
+            "-------------------\n" +
+            "Executed tr01 | 2 |\n" +
+            "Executed tr02 | 1 |\n" +
+            "Executed tr03 | 1 |\n" +
+            "Executed tr07 | 1 |\n" +
+            "Executed tr10 | 1 |\n" +
+            "Executed tr12 | 1 |\n" +
+            "Executed tr13 | 1 |";
+            testQuery(query, expected, s);
+        }
+    }
+
+
+    /**
+     * A row trigger whose WHEN clause contains a subquery, used to cause a
+     * NullPointerException in some situations.
+     */
+    @Test
+    public void testSubqueryInWhenClauseNPE() throws SQLException {
+        try(Statement s = conn.createStatement()) {
+            s.executeUpdate("create table t1(x int)");
+            s.executeUpdate("create table t2(x int)");
+            s.executeUpdate("create trigger tr1 after insert on t1 for each row "
+            + "when ((values true)) insert into t2 values 1");
+
+            // This statement used to result in a NullPointerException.
+            s.executeUpdate("insert into t1 values 1,2,3");
+        }
+    }
+
+    /**
+     * Test generated columns referenced from WHEN clauses. In particular,
+     * test that references to generated columns are disallowed in the NEW
+     * transition variable of BEFORE triggers. See DERBY-3948.
+     *
+     * @see GeneratedColumnsTest#test_024_beforeTriggers()
+     */
+    @Ignore // DERBY-3948
+    @Test
+    public void testGeneratedColumns() throws Exception {
+        createInt_Proc();
+        try(Statement s = conn.createStatement()) {
+            s.executeUpdate("create table t1(x int, y int, "
+            + "z int generated always as (x+y))");
+            s.executeUpdate("create table t2(x int)");
+
+            // BEFORE INSERT trigger without generated column in WHEN clause, OK.
+            s.executeUpdate("create trigger btr1 no cascade before insert on t1 "
+            + "referencing new as new for each row when (new.x < new.y) "
+            + "call INT_PROC(1)");
+
+            // BEFORE INSERT trigger with generated column in WHEN clause, fail.
+            testFail("42XAA",
+            "create trigger btr2 no cascade before insert on t1 "
+            + "referencing new as new for each row when (new.x < new.z) "
+            + "select * from sysibm.sysdummy1", s);
+
+            // BEFORE UPDATE trigger without generated column in WHEN clause, OK.
+            s.executeUpdate("create trigger btr3 no cascade before update on t1 "
+            + "referencing new as new old as old for each row "
+            + "when (new.x < old.x) call int_proc(3)");
+
+            // BEFORE UPDATE trigger with generated column in WHEN clause. OK,
+            // since the generated column is in the OLD transition variable.
+            s.executeUpdate("create trigger btr4 no cascade before update on t1 "
+            + "referencing old as old for each row when (old.x < old.z) "
+            + "call int_proc(4)");
+
+            // BEFORE UPDATE trigger with generated column in NEW transition
+            // variable, fail.
+            testFail("42XAA",
+            "create trigger btr5 no cascade before update on t1 "
+            + "referencing new as new for each row when (new.x < new.z) "
+            + "select * from sysibm.sysdummy1", s);
+
+            // BEFORE DELETE trigger without generated column in WHEN clause, OK.
+            s.executeUpdate("create trigger btr6 no cascade before delete on t1 "
+            + "referencing old as old for each row when (old.x < 3) "
+            + "call int_proc(6)");
+
+            // BEFORE DELETE trigger with generated column in WHEN clause. OK,
+            // since the generated column is in the OLD transition variable.
+            s.executeUpdate("create trigger btr7 no cascade before delete on t1 "
+            + "referencing old as old for each row when (old.x < old.z) "
+            + "call int_proc(7)");
+
+            // References to generated columns in AFTER triggers should always
+            // be allowed.
+            s.executeUpdate("create trigger atr1 after insert on t1 "
+            + "referencing new as new for each row "
+            + "when (new.x < new.z) insert into t2 values 1");
+            s.executeUpdate("create trigger atr2 after update on t1 "
+            + "referencing new as new old as old for each row "
+            + "when (old.z < new.z) insert into t2 values 2");
+            s.executeUpdate("create trigger atr3 after delete on t1 "
+            + "referencing old as old for each row "
+            + "when (old.x < old.z) insert into t2 values 3");
+
+            // Finally, fire the triggers.
+            s.execute("insert into t1(x, y) values (1, 2), (4, 3)");
+            s.execute("update t1 set x = y");
+            s.execute("delete from t1");
+
+            // Verify that the before triggers were executed as expected.
+            // No way to access this.
+            //assertEquals(Arrays.asList(1, 3, 4, 4, 6, 7, 7), org.splicetest.sqlj.SqlJTestProcs.procedureCalls);
+
+            // Verify that the after triggers were executed as expected.
+            String query = "select * from t2 order by x";
+            String expected = "Y      |\n" +
+            "-------------------\n" +
+            "1 |\n" +
+            "2 |\n" +
+            "3 |\n" +
+            "3 |\n";
+            testQuery(query, expected, s);
+        }
+    }
+
+    /**
+     * Test various illegal WHEN clauses.
+     */
+    @Test
+    public void testIllegalWhenClauses() throws Exception {
+        createInt_Proc();
+        try(Statement s = conn.createStatement()) {
+            s.executeUpdate("create table t1(x int)");
+            s.executeUpdate("create table t2(x int)");
+
+            // The WHEN clause expression must be BOOLEAN.
+            testFail(NOT_BOOLEAN,
+            "create trigger tr after insert on t1 "
+            + "when (1) insert into t2 values 1", s);
+            testFail(NOT_BOOLEAN,
+            "create trigger tr after update on t1 "
+            + "when ('abc') insert into t2 values 1", s);
+            testFail(NOT_BOOLEAN,
+            "create trigger tr after delete on t1 "
+            + "when ((values 1)) insert into t2 values 1", s);
+            testFail(NOT_BOOLEAN,
+            "create trigger tr no cascade before insert on t1 "
+            + "when ((select ibmreqd from sysibm.sysdummy1)) "
+            + "call int_proc(1)", s);
+            testFail(NOT_BOOLEAN,
+            "create trigger tr no cascade before insert on t1 "
+            + "when ((select ibmreqd from sysibm.sysdummy1)) "
+            + "call int_proc(1)", s);
+            testFail(NOT_BOOLEAN,
+            "create trigger tr no cascade before update on t1 "
+            + "referencing old as old for each row "
+            + "when (old.x) call int_proc(1)", s);
+
+            // Dynamic parameters (?) are not allowed in the WHEN clause.
+            testFail(HAS_PARAMETER,
+            "create trigger tr no cascade before delete on t1 "
+            + "when (?) call int_proc(1)", s);
+            testFail(HAS_PARAMETER,
+            "create trigger tr after insert on t1 "
+            + "when (cast(? as boolean)) call int_proc(1)", s);
+            testFail(HAS_PARAMETER,
+            "create trigger tr after delete on t1 "
+            + "when ((select true from sysibm.sysdummy where ibmreqd = ?)) "
+            + "call int_proc(1)", s);
+
+            // Subqueries in the WHEN clause must have a single column
+            testFail(NOT_SINGLE_COLUMN,
+            "create trigger tr no cascade before insert on t1 "
+            + "when ((values (true, false))) call int_proc(1)", s);
+            testFail(NOT_SINGLE_COLUMN,
+            "create trigger tr after update of x on t1 "
+            + "when ((select tablename, schemaid from sys.systables)) "
+            + "call int_proc(1)", s);
+        }
+    }
+
+    /**
+     * Test that dropping objects referenced from the WHEN clause will
+     * detect that the trigger depends on the object.
+     */
+    @Test
+    public void testDependencies() throws Exception {
+        try(Statement s = conn.createStatement()) {
+            s.executeUpdate("create table t1(x int, y int, z int)");
+            s.executeUpdate("create table t2(x int, y int, z int)");
+
+            Savepoint sp = conn.setSavepoint();
+
+            // Dropping columns referenced via the NEW transition variable in
+            // a WHEN clause should fail.
+            s.executeUpdate("create trigger tr after insert on t1 "
+            + "referencing new as new for each row "
+            + "when (new.x < new.y) values 1");
+            assertStatementError(HAS_DEPENDENTS, s,
+            "alter table t1 drop column x restrict");
+            assertStatementError(HAS_DEPENDENTS, s,
+            "alter table t1 drop column y restrict");
+            // DB-8897 needed for this statement to succeed.
+//            s.executeUpdate("alter table t1 drop column z restrict");
+            //conn.rollback(sp);
+
+            // Due to DB-8897 rollback doesn't work, so we
+            // need to do manual cleanup.
+            conn.commit();
+            s.executeUpdate("drop table t1");
+            s.executeUpdate("drop table t2");
+            s.executeUpdate("create table t1(x int, y int, z int)");
+            s.executeUpdate("create table t2(x int, y int, z int)");
+
+            // Dropping columns referenced via the OLD transition variable in
+            // a WHEN clause should fail.
+            s.executeUpdate("create trigger tr no cascade before delete on t1 "
+            + "referencing old as old for each row "
+            + "when (old.x < old.y) values 1");
+            assertStatementError(HAS_DEPENDENTS, s,
+            "alter table t1 drop column x restrict");
+            assertStatementError(HAS_DEPENDENTS, s,
+            "alter table t1 drop column y restrict");
+            // DB-8897 needed for this statement to succeed.
+//            s.executeUpdate("alter table t1 drop column z restrict");
+//            conn.rollback(sp);
+            // Due to DB-8897 rollback doesn't work, so we
+            // need to do manual cleanup.
+            conn.commit();
+            s.executeUpdate("drop table t1");
+            s.executeUpdate("drop table t2");
+            s.executeUpdate("create table t1(x int, y int, z int)");
+            s.executeUpdate("create table t2(x int, y int, z int)");
+
+            // Dropping columns referenced via either the OLD or the NEW
+            // transition variable referenced in the WHEN clause should fail.
+            s.executeUpdate("create trigger tr no cascade before update on t1 "
+            + "referencing old as old new as new for each row "
+            + "when (old.x < new.y) values 1");
+            assertStatementError(HAS_DEPENDENTS, s,
+            "alter table t1 drop column x restrict");
+            assertStatementError(HAS_DEPENDENTS, s,
+            "alter table t1 drop column y restrict");
+            // DB-8897 needed for this statement to succeed.
+//            s.executeUpdate("alter table t1 drop column z restrict");
+//            conn.rollback(sp);
+            // Due to DB-8897 rollback doesn't work, so we
+            // need to do manual cleanup.
+            conn.commit();
+            s.executeUpdate("drop table t1");
+            s.executeUpdate("drop table t2");
+            s.executeUpdate("create table t1(x int, y int, z int)");
+            s.executeUpdate("create table t2(x int, y int, z int)");
+
+            // Dropping columns referenced either in the WHEN clause or in the
+            // triggered SQL statement should fail.
+            s.executeUpdate("create trigger tr no cascade before insert on t1 "
+            + "referencing new as new for each row "
+            + "when (new.x < 5) values new.y");
+            assertStatementError(HAS_DEPENDENTS, s,
+            "alter table t1 drop column x restrict");
+            assertStatementError(HAS_DEPENDENTS, s,
+            "alter table t1 drop column y restrict");
+             // DB-8897 needed for this statement to succeed.
+//            s.executeUpdate("alter table t1 drop column z restrict");
+//            conn.rollback(sp);
+            // DB-8897 needed for this statement to succeed.
+//            s.executeUpdate("alter table t1 drop column z restrict");
+//            conn.rollback(sp);
+            // Due to DB-8897 rollback doesn't work, so we
+            // need to do manual cleanup.
+            conn.commit();
+            s.executeUpdate("drop table t1");
+            s.executeUpdate("drop table t2");
+            s.executeUpdate("create table t1(x int, y int, z int)");
+            s.executeUpdate("create table t2(x int, y int, z int)");
+
+            // Dropping any column in a statement trigger with a NEW transition
+            // table fails, even if the column is not referenced in the WHEN clause
+            // or in the triggered SQL text.
+            // Need DB-8883 for the following commented tests:
+//            s.executeUpdate("create trigger tr after update of x on t1 "
+//            + "referencing new table as new "
+//            + "when (exists (select 1 from new where x < y)) values 1");
+//            assertStatementError(HAS_DEPENDENTS, s,
+//            "alter table t1 drop column x restrict");
+//            assertStatementError(HAS_DEPENDENTS, s,
+//            "alter table t1 drop column y restrict");
+//            // Z is not referenced, but the transition table depends on all columns.
+//            assertStatementError(HAS_DEPENDENTS, s,
+//            "alter table t1 drop column z restrict");
+//            conn.rollback(sp);
+
+            // Dropping any column in a statement trigger with an OLD transition
+            // table fails, even if the column is not referenced in the WHEN clause
+            // or in the triggered SQL text.
+//            s.executeUpdate("create trigger tr after delete on t1 "
+//            + "referencing old table as old "
+//            + "when (exists (select 1 from old where x < y)) values 1");
+//            assertStatementError(HAS_DEPENDENTS, s,
+//            "alter table t1 drop column x restrict");
+//            assertStatementError(HAS_DEPENDENTS, s,
+//            "alter table t1 drop column y restrict");
+//            // Z is not referenced, but the transition table depends on all columns.
+//            assertStatementError(HAS_DEPENDENTS, s,
+//            "alter table t1 drop column z restrict");
+//            conn.rollback(sp);
+
+            // References to columns in other ways than via transition variables
+            // or transition tables should also be detected.
+//            s.executeUpdate("create trigger tr after delete on t1 "
+//            + "referencing old table as old "
+//            + "when (exists (select 1 from t1 where x < y)) values 1");
+//            assertStatementError(HAS_DEPENDENTS, s,
+//            "alter table t1 drop column x restrict");
+//            assertStatementError(HAS_DEPENDENTS, s,
+//            "alter table t1 drop column y restrict");
+//            s.executeUpdate("alter table t1 drop column z restrict");
+//            conn.rollback(sp);
+
+            // References to columns in another table than the trigger table
+            // should prevent them from being dropped.
+            s.executeUpdate("create trigger tr after insert on t1 "
+            + "when (exists (select * from t2 where x < y)) "
+            + "values 1");
+            assertStatementError(HAS_DEPENDENTS, s,
+            "alter table t2 drop column x restrict");
+            assertStatementError(HAS_DEPENDENTS, s,
+            "alter table t2 drop column y restrict");
+             // DB-8897 needed for this statement to succeed.
+//            s.executeUpdate("alter table t2 drop column z restrict");
+
+            // Dropping a table referenced in a WHEN clause should fail and leave
+            // the trigger intact. Before DERBY-2041, DROP TABLE would succeed
+            // and leave the trigger in an invalid state so that subsequent
+            // INSERT statements would fail when trying to fire the trigger.
+            //Need DERBY-2041 for the following:
+            //assertStatementError(HAS_DEPENDENTS, s, "drop table t2");
+            String query = format("select triggername from sys.systriggers t, sys.sysschemas s"
+            + " where s.schemaid = t.schemaid and s.schemaname = '%s' ", SCHEMA.toUpperCase());
+            String expected = "TRIGGERNAME |\n" +
+            "--------------\n" +
+            "     TR      |";
+            testQuery(query, expected, s);
+
+            s.executeUpdate("insert into t1 values (1, 2, 3)");
+            // Uncomment after DB-8897 ships:
+            //conn.rollback(sp);
+
+            // Due to DB-8897 rollback doesn't work, so we
+            // need to do manual cleanup.
+            conn.commit();
+            s.executeUpdate("drop table t1");
+            s.executeUpdate("drop table t2");
+            s.executeUpdate("create table t1(x int, y int, z int)");
+            s.executeUpdate("create table t2(x int, y int, z int)");
+
+            // Test references to columns in both the WHEN clause and the
+            // triggered SQL statement.
+            s.executeUpdate("create trigger tr after update on t1 "
+            + "when (exists (select * from t2 where x < 5)) "
+            + "select y from t2");
+            assertStatementError(HAS_DEPENDENTS, s,
+            "alter table t2 drop column x restrict");
+            assertStatementError(HAS_DEPENDENTS, s,
+            "alter table t2 drop column y restrict");
+            // DB-8897 needed for this statement to succeed.
+            //s.executeUpdate("alter table t2 drop column z restrict");
+
+            // DROP TABLE should fail because of the dependencies (didn't before
+            // DERBY-2041).
+            //Need DERBY-2041 for the following:
+//            assertStatementError(HAS_DEPENDENTS, s, "drop table t2");
+            query = format("select triggername from sys.systriggers t, sys.sysschemas s"
+             + " where s.schemaid = t.schemaid and s.schemaname = '%s' ", SCHEMA.toUpperCase());
+            expected = "TRIGGERNAME |\n" +
+            "--------------\n" +
+            "     TR      |";
+            testQuery(query, expected, s);
+        }
+    }
+
+    /**
+     * Verify that DERBY-4874, which was fixed before support for the WHEN
+     * clause was implemented, does not affect the WHEN clause.
+     * The first stab at the WHEN clause implementation did suffer from it.
+     */
+    @Test
+    public void testDerby4874() throws SQLException {
+        try(Statement s = conn.createStatement()) {
+            s.executeUpdate("create table t(x varchar(3))");
+            s.executeUpdate("create trigger tr after update of x on t "
+            + "referencing new as new for each row "
+            + "when (new.x < 'abc') values 1");
+            s.executeUpdate("insert into t values 'aaa'");
+
+            // Updating X to something longer than 3 characters should fail,
+            // since it's a VARCHAR(3).
+            assertStatementError(TRUNCATION, s, "update t set x = 'aaaa'");
+
+            // Change the type of X to VARCHAR(4) and try again. This time it
+            // should succeed, but it used to fail because the trigger hadn't
+            // been recompiled and still thought the max length was 3.
+            s.executeUpdate("alter table t alter x set data type varchar(4)");
+            assertUpdateCount(s, 1, "update t set x = 'aaaa'");
+
+            // Updating it to a longer value should still fail.
+            assertStatementError(TRUNCATION, s, "update t set x = 'aaaaa'");
+        }
+    }
+
+    /**
+     * Test for Derby-6783.
+     */
+
+    @Test
+    public void testDerby6783() throws Exception {
+        try(Statement s = conn.createStatement()) {
+
+            s.execute("CREATE TABLE tabDerby6783(id INTEGER, result VARCHAR(10), status CHAR(1))");
+
+            s.execute("CREATE TRIGGER trigger6783 AFTER UPDATE OF status ON tabDerby6783 "
+            + "REFERENCING NEW AS newrow FOR EACH ROW WHEN (newrow.status='d') "
+            + "UPDATE tabDerby6783 SET result='completed' WHERE id=newrow.id");
+            s.execute("insert into tabDerby6783 values (1, null, 'a')");
+            // Fire the trigger.
+            s.execute("UPDATE tabDerby6783 SET status='d'");
+
+            String query = "SELECT result FROM tabDerby6783";
+            String expected = "RESULT   |\n" +
+            "-----------\n" +
+            "completed |";
+            testQuery(query, expected, s);
+
+        }
+    }
+
+    /**
+     * Derby6783_1_1 test, this test has two trigger fields and
+     * more than 3 column references in the update statement.
+     */
+    @Test
+    public void testDerby6783_1_1() throws Exception
+    {
+        try(Statement s = conn.createStatement()) {
+
+            s.execute("CREATE TABLE tabDerby6783_1_1(ID INTEGER, GRADE1 char(1), GRADE2 char(1),"
+            + " MARKS1 integer, MARKS2 integer, TOTAL_MARKS integer)");
+
+            s.execute("CREATE TRIGGER trigger6783_1 AFTER UPDATE OF GRADE1, GRADE2 ON tabDerby6783_1_1"
+            + " REFERENCING NEW AS newrow OLD AS oldrow"
+            + " FOR EACH ROW WHEN ((oldrow.GRADE1 <> newrow.GRADE1 OR oldrow.GRADE2 <> newrow.GRADE2))"
+            + " UPDATE tabDerby6783_1_1 SET TOTAL_MARKS = oldrow.MARKS1 + oldrow.MARKS2 where id=newrow.id");
+
+            s.execute("INSERT INTO tabDerby6783_1_1 VALUES (1, 'a', 'b', 30, 50, 0)");
+            // Fire the trigger.
+            s.execute("UPDATE tabDerby6783_1_1 SET GRADE1='b'");
+
+
+            String query = "SELECT TOTAL_MARKS FROM tabDerby6783_1_1";
+            String expected = "TOTAL_MARKS |\n" +
+            "--------------\n" +
+            "     80      |";
+            testQuery(query, expected, s);
+
+        }
+    }
+
+    /**
+     * Derby6783_1_2 test, is a less complex version of Derby6783_1_1
+     * It has only one column reference in trigger part and in update part.
+     */
+    @Test
+    public void testDerby6783_1_2() throws Exception
+    {
+        try(Statement s = conn.createStatement()) {
+
+            s.execute("CREATE TABLE tabDerby6783_1_2(ID INTEGER, GRADE1 char(1), GRADE2 char(1),"
+            + " MARKS1 integer, MARKS2 integer, FINAL_GRADE char(1))");
+
+            s.execute("CREATE TRIGGER trigger6783_1 AFTER UPDATE OF MARKS1 ON tabDerby6783_1_2 "
+            + " REFERENCING NEW AS newrow OLD AS oldrow"
+            + " FOR EACH ROW WHEN (oldrow.MARKS1 <> newrow.MARKS1)"
+            + " UPDATE tabDerby6783_1_2 SET FINAL_GRADE = oldrow.GRADE1 where id=newrow.id");
+
+            s.execute("INSERT INTO tabDerby6783_1_2 VALUES (1, 'a', 'b', 30, 50, 'c')");
+
+            s.execute("UPDATE tabDerby6783_1_2 SET MARKS1=20");
+
+            String query = "SELECT FINAL_GRADE FROM tabDerby6783_1_2";
+            String expected = "FINAL_GRADE |\n" +
+            "--------------\n" +
+            "      a      |";
+            testQuery(query, expected, s);
+
+        }
+    }
+
+    /**
+     * Derby6783_2 test, this test has a single trigger column reference
+     * and two column reference in update statement. Also the when clause
+     * has a different column reference than the trigger reference
+    */
+    @Test
+    public void testDerby6783_2() throws Exception
+    {
+        try(Statement s = conn.createStatement()) {
+            s.execute("CREATE TABLE tabDerby6783_2(ACC_NUMBER INT, BALANCE FLOAT, RATE REAL,"
+            + " INTEREST REAL)");
+
+            s.execute("CREATE TRIGGER trigger_2 AFTER UPDATE OF BALANCE ON tabDerby6783_2 "
+            + " REFERENCING NEW AS newrow OLD AS oldrow"
+            + " FOR EACH ROW WHEN (oldrow.RATE < 10.0)"
+            + " UPDATE tabDerby6783_2 SET INTEREST = oldrow.balance + newrow.BALANCE * RATE");
+
+            s.execute("INSERT INTO tabDerby6783_2 VALUES (123, 12383.4534, 8.98, 2340)");
+
+            s.execute("UPDATE tabDerby6783_2 SET BALANCE=22383.4543");
+
+            s.execute("select INTEREST from tabDerby6783_2");
+
+            String query = "SELECT INTEREST FROM tabDerby6783_2";
+            String expected = "INTEREST  |\n" +
+            "-----------\n" +
+            "213386.88 |";
+            testQuery(query, expected, s);
+
+        }
+    }
+
+    /**
+     * Derby6783_3 test, this test referes to different tables in
+     * when clause and update clause.
+    */
+    @Test
+    public void testDerby6783_3() throws Exception
+    {
+        try(Statement s = conn.createStatement()) {
+            s.execute("CREATE TABLE tabDerby6783_3_1(FIELD1 VARCHAR(10),"
+            + " FIELD2 DOUBLE)");
+
+            s.execute("INSERT INTO tabDerby6783_3_1 VALUES ('helloworld', 5454567)");
+
+            s.execute("CREATE TABLE tabDerby6783_3_2(FIELD3 NUMERIC (7,1))");
+
+            s.execute("INSERT INTO tabDerby6783_3_2 VALUES (3.143)");
+
+            s.execute("CREATE TRIGGER TRIGGER_3 AFTER UPDATE OF FIELD1 ON tabDerby6783_3_1"
+            + " REFERENCING NEW AS newrow OLD AS oldrow"
+            + " FOR EACH ROW WHEN (newrow.FIELD2 > 3000)"
+            + " UPDATE tabDerby6783_3_2 SET FIELD3 = newrow.FIELD2 / 10");
+
+            s.execute("UPDATE tabDerby6783_3_1 set FIELD1='hello'");
+
+            String query = "SELECT FIELD3 FROM tabDerby6783_3_2";
+            String expected = "FIELD3  |\n" +
+            "----------\n" +
+            "545456.7 |";
+            testQuery(query, expected, s);
+
+        }
+    }
+
+    /**
+     * When SQL authorization is enabled, the trigger action (including the
+     * WHEN clause) should execute with definer's rights. Verify that it is
+     * so.
+     */
+    @Test
+    public void testGrantRevoke() throws Exception {
+        c1.setAutoCommit(true);
+        conn.setAutoCommit(true);
+        String spsValidQuery = format("select valid from sys.sysstatements s, sys.sysschemas sc where stmtname "
+               + "like 'TRIGGERWHEN%%' and s.schemaid = sc.schemaid and schemaname = '%s'", SCHEMA.toUpperCase());
+
+        Statement s = conn.createStatement();
+        Statement s1 = c1.createStatement();
+        s1.execute("create table t1(x varchar(20))");
+        s1.execute("create table t2(x varchar(200))");
+        s1.execute("create table t3(x int)");
+        s1.execute("create function is_true(s varchar(128)) returns boolean "
+                + "deterministic language java parameter style java "
+                + "external name 'java.lang.Boolean.parseBoolean' no sql");
+
+        //s.execute(format("grant execute on FUNCTION is_true to %s", USER1));
+
+        // Trigger that fires on T1 if inserted value is 'true'.
+        s.execute("create trigger tr1 after insert on t1 "
+                + "referencing new as new for each row "
+                + "when (is_true(new.x)) insert into t2(x) values new.x");
+
+        // Trigger that fires on T1 on insert if T3 has more than 1 row.
+        s1.execute("create trigger tr2 after insert on t1 "
+                + "when (exists (select * from t3 offset 1 row)) "
+                + "insert into t2(x) values '***'");
+
+        // Allow U2 to insert into T1, but nothing else on U1's schema.
+        s.execute("grant insert on table t1 to u2");
+
+        c2.setAutoCommit(true);
+        Statement s2 = c2.createStatement();
+
+        // User U2 is not authorized to invoke the function IS_TRUE, but
+        // is allowed to insert into T1.
+        assertStatementError(NOT_AUTHORIZED, s2, format("values %s.is_true('abc')", SCHEMA));
+        assertUpdateCount(s2, 4,
+                "insert into t1(x) values 'abc', 'true', 'TrUe', 'false'");
+
+        // Verify that the trigger fired. Since the trigger runs with
+        // definer's rights, it should be allowed to invoke IS_TRUE in the
+        // WHEN clause even though U2 isn't allowed to invoke it directly.
+        String query = "select * from t2 order by x";
+        String expected = "X  |\n" +
+        "------\n" +
+        "TrUe |\n" +
+        "true |";
+        testQuery(query, expected, s1);
+
+        s1.execute("delete from t2");
+
+        // Now test that TR1 will also fire, even though U2 isn't granted
+        // SELECT privileges on the table read by the WHEN clause.
+        s1.execute("insert into t3 values 1, 2");
+        assertUpdateCount(s2, 2, "insert into t1(x) values 'x', 'y'");
+
+        query = "select * from t2 order by x";
+        expected = "X  |\n" +
+        "-----\n" +
+        "*** |";
+        testQuery(query, expected, s1);
+
+        s1.execute("delete from t2");
+
+        // SPS is valid after triggers are fired.
+        expected = "VALID |\n" +
+        "--------\n" +
+        " true  |\n" +
+        " true  |";
+        testQuery(spsValidQuery, expected, s);
+
+        // Now invalidate the triggers and make sure they still work after
+        // recompilation.
+        s1.execute("alter table t1 alter column x set data type varchar(200)");
+
+
+        // SPS is not valid after alter
+        expected = "VALID |\n" +
+        "--------\n" +
+        " false |\n" +
+        " false |";
+        testQuery(spsValidQuery, expected, s);
+
+        assertUpdateCount(s2, 2, "insert into t1(x) values 'true', 'false'");
+
+        query = "select * from t2 order by x";
+        expected = "X  |\n" +
+        "------\n" +
+        " *** |\n" +
+        "true |";
+        testQuery(query, expected, s1);
+
+        // SPS is valid after trigger is fired and recompiled.
+        expected = "VALID |\n" +
+        "--------\n" +
+        " true  |\n" +
+        " true  |";
+        testQuery(spsValidQuery, expected, s);
+
+        s1.execute("delete from t2");
+
+        // Revoke U2's insert privilege on T1.
+        s.execute("revoke insert on table t1 from u2 ");
+
+        // U2 should not be allowed to insert into T1 anymore.
+        assertStatementError(NO_TABLE_PERMISSION, s2,
+                             "insert into t1(x) values 'abc'");
+
+        // U1 should still be allowed to do it (since U1 owns T1), and the
+        // triggers should still be working.
+        assertUpdateCount(s1, 2, "insert into t1(x) values 'true', 'false'");
+        query = "select * from t2 order by x";
+        expected = "X  |\n" +
+        "------\n" +
+        " *** |\n" +
+        "true |";
+        testQuery(query, expected, s1);
+
+        s1.execute("delete from t2");
+
+        // Now try to define a trigger in U2's schema that needs to invoke
+        // IS_TRUE. Should fail because U2 isn't allowed to invoke it.
+        s2.execute(format("create schema %s", USER2.toUpperCase()));
+        s2.execute(format("set schema %s", USER2.toUpperCase()));
+        s2.execute("create table t(x varchar(200))");
+        assertStatementError(NOT_AUTHORIZED, s2,
+                             format("create trigger tr after insert on t "
+                             + "referencing new as new for each row "
+                             + "when (%s.is_true(new.x)) values 1", SCHEMA));
+
+        // Try again after granting execute permission to U2.
+        s.execute("grant execute on function is_true to u2");
+        s2.execute(format("create trigger tr after insert on t "
+                + "referencing new as new for each row "
+                + "when (%s.is_true(new.x)) values 1", SCHEMA));
+
+        // Fire trigger.
+        assertUpdateCount(s2, 3, "insert into t values 'ab', 'cd', 'ef'");
+
+        // Revoking the execute permission will fail because the trigger
+        // depends on it.
+        assertStatementError(HAS_DEPENDENTS, s,
+                "revoke execute on function is_true from u2 restrict");
+
+        s2.execute("drop trigger tr");
+        s2.execute("drop table t");
+        s2.execute(format("drop schema %s restrict", USER2.toUpperCase()));
+        s1.close();
+        s2.close();
+
+        s.execute("drop function is_true");
+
+        s.close();
+
+        c2.setAutoCommit(false);
+        c1.setAutoCommit(false);
+
+        conn.setAutoCommit(false);
+        spliceSchemaWatcher.cleanSchemaObjects();
+        createInt_Proc();
+    }
+
+    /**
+     * Test that the trigger fails gracefully if the WHEN clause throws
+     * a RuntimeException.
+     */
+    @Test
+    public void testRuntimeException() throws Exception {
+        try(Statement s = conn.createStatement()) {
+            s.execute("create function f(x varchar(10)) returns int "
+            + "deterministic language java parameter style java "
+            + "external name 'java.lang.Integer.parseInt' no sql");
+            s.execute("create table t1(x varchar(10))");
+            s.execute("create table t2(x varchar(10))");
+            s.execute("create trigger tr after insert on t1 "
+            + "referencing new as new for each row "
+            + "when (f(new.x) < 100) insert into t2 values new.x");
+
+            // Insert a value that causes Integer.parseInt() to throw a
+            // NumberFormatException. The NFE will be wrapped in two SQLExceptions.
+            assertStatementError(SPLICE_GENERIC_EXCEPTION, s,
+            "insert into t1 values '1', '2', 'hello', '3', '121'");
+
+            // The statement should be rolled back, so nothing should be in
+            // either of the tables.
+            this.assertTableRowCount("T1", 0, s);
+            this.assertTableRowCount("T2", 0, s);
+
+            // Now try again with values that don't cause exceptions.
+            assertUpdateCount(s, 4, "insert into t1 values '1', '2', '3', '121'");
+
+            // Verify that the trigger fired this time.
+            String query = "select * from t2 order by x";
+            String expected = "X |\n" +
+            "----\n" +
+            " 1 |\n" +
+            " 2 |\n" +
+            " 3 |";
+            testQuery(query, expected, s);
+        }
+    }
+
+    /**
+     * Test that scalar subqueries are allowed, and that non-scalar subqueries
+     * result in exceptions when the trigger fires.
+     */
+    @Test
+    public void testScalarSubquery() throws SQLException {
+        try(Statement s = conn.createStatement()) {
+            s.execute("create table t1(x int)");
+            s.execute("create table t2(x int)");
+            s.execute("create table t3(x int)");
+
+            s.execute("insert into t3 values 0,1,2,2");
+
+            s.execute("create trigger tr1 after insert on t1 "
+            + "referencing new as new for each row "
+            + "when ((select x > 0 from t3 where x = new.x)) "
+            + "insert into t2 values 1");
+
+            // Subquery returns no rows, so the trigger should not fire.
+            s.execute("insert into t1 values 42");
+            this.assertTableRowCount("T2", 0, s);
+
+            // Subquery returns a single value, which is false, so the trigger
+            // should not fire.
+            s.execute("insert into t1 values 0");
+            this.assertTableRowCount("T2", 0, s);
+
+            // Subquery returns a single value, which is true, so the trigger
+            // should fire.
+            s.execute("insert into t1 values 1");
+            this.assertTableRowCount("T2", 1, s);
+
+            // Subquery returns multiple values, so an error should be raised.
+            assertStatementError(NON_SCALAR_QUERY, s, "insert into t1 values 2");
+            this.assertTableRowCount("T2", 1, s);
+        }
+    }
+
+    /**
+     * Test that a WHEN clause can call the CURRENT_USER function.
+     */
+    @Test
+    public void testCurrentUser() throws Exception {
+        Statement s_main = conn.createStatement();
+        Statement s = c1.createStatement();
+        s_main.execute("create table t1(x int)");
+        s_main.execute("create table t2(x varchar(10))");
+
+        // Create one trigger that should only fire when current user is U2,
+        // and one that should only fire when current user is different from
+        // U2.
+        s_main.execute("create trigger tr01 after insert on t1 "
+                + "when (current_user = 'U2') "
+                + "insert into t2 values 'TR01'");
+        s_main.execute("create trigger tr02 after insert on t1 "
+                + "when (current_user <> 'U2') "
+                + "insert into t2 values 'TR02'");
+
+        s_main.execute("grant insert on t1 to u2");
+        conn.commit();
+
+        // Used to get an assert failure or a NullPointerException here before
+        // DERBY-6348. Expect it to succeed, and expect TR02 to have fired.
+        s.execute("insert into t1 values 1");
+
+        String query = "select * from t2";
+        String expected = "X  |\n" +
+        "------\n" +
+        "TR02 |";
+        testQuery(query, expected, s);
+
+        c1.rollback();
+
+        // Now try the same insert as user U2.
+        c2.setAutoCommit(true);
+        Statement s2 = c2.createStatement();
+        s2.execute("CALL SYSCS_UTIL.INVALIDATE_GLOBAL_DICTIONARY_CACHE()");
+        s2.execute("insert into T1"
+            + " values 1");
+        s2.close();
+
+        // Since the insert was performed by user U2, expect TR01 to have fired.
+        query = "select * from t2";
+        expected = "X  |\n" +
+        "------\n" +
+        "TR01 |";
+        testQuery(query, expected, s);
+
+        // Cleanup.
+        conn.commit();
+        c2.setAutoCommit(false);
+        s.close();
+        s2.close();
+    }
+
+    /**
+     * Test that a trigger with a WHEN clause can be recursive.
+     */
+    @Test
+    public void testRecursiveTrigger() throws Exception {
+        try(Statement s = conn.createStatement()) {
+            s.execute("create table t(x int)");
+            s.execute("create trigger tr1 after insert on t "
+            + "referencing new as new for each row "
+            + "when (new.x > 0) insert into t values new.x - 1");
+
+            // Now fire the trigger. This used to cause an assert failure or a
+            // NullPointerException before DERBY-6348.
+            s.execute("insert into t values 15, 1, 2");
+
+            // The row trigger will fire three times, so that the above statement
+            // will insert the values { 15, 14, 13, ... , 0 }, { 1, 0 } and
+            // { 2, 1, 0 }.
+
+            String query = "select * from t order by x";
+            String expected = "X |\n" +
+            "----\n" +
+            " 0 |\n" +
+            " 0 |\n" +
+            " 0 |\n" +
+            " 1 |\n" +
+            " 1 |\n" +
+            " 1 |\n" +
+            "10 |\n" +
+            "11 |\n" +
+            "12 |\n" +
+            "13 |\n" +
+            "14 |\n" +
+            "15 |\n" +
+            " 2 |\n" +
+            " 2 |\n" +
+            " 3 |\n" +
+            " 4 |\n" +
+            " 5 |\n" +
+            " 6 |\n" +
+            " 7 |\n" +
+            " 8 |\n" +
+            " 9 |";
+            testQuery(query, expected, s);
+
+            // Now fire the trigger with a value so that the maximum trigger
+            // recursion depth (16) is exceeded, and verify that we get the
+            // expected error.
+            assertStatementError(TRIGGER_RECURSION, s, "insert into t values 16");
+
+            // The contents of the table should not have changed, since the
+            // above statement failed and was rolled back.
+            testQuery(query, expected, s);
+        }
+    }
+
+    /**
+     * The WHEN clause text is stored in a LONG VARCHAR column in the
+     * SYS.SYSTRIGGERS table. This test case verifies that the WHEN clause
+     * is not limited to the usual LONG VARCHAR maximum length (32700
+     * characters).
+     */
+    @Test
+    public void testVeryLongWhenClause() throws Exception {
+        Statement s = conn.createStatement();
+        s.execute("create table t1(x int)");
+        s.execute("create table t2(x int)");
+
+        // Construct a WHEN clause that is more than 32700 characters.
+        StringBuilder sb = new StringBuilder("(values /* a very");
+        for (int i = 0; i < 10000; i++) {
+            sb.append(", very");
+        }
+        sb.append(" long comment */ true)");
+
+        String when = sb.toString();
+        assertTrue(when.length() > 32700);
+
+        s.execute("create trigger very_long_trigger after insert on t1 "
+                + "when (" + when + ") insert into t2 values 1");
+
+        // Verify that the WHEN clause was stored in SYS.SYSTRIGGERS.
+        String query = "select whenclausetext from sys.systriggers "
+                         + "where triggername = 'VERY_LONG_TRIGGER'";
+
+        testQueryContains(query, "a very, very, very, very, very, very, very, very, very, very, very, very, very, very, very", s);
+
+        // Verify that the trigger fires.
+        s.execute("insert into t1 values 1");
+        this.assertTableRowCount("T1", 1, s);
+        this.assertTableRowCount("T2", 1, s);
+        s.close();
+    }
+
+    /**
+     * Test a WHEN clause that invokes a function declared with READ SQL DATA.
+     */
+    @Test
+    public void testFunctionReadsSQLData() throws Exception {
+        createInt_Proc();
+        try(Statement s = conn.createStatement()) {
+
+            s.execute("create table t1(x varchar(50))");
+            s.execute("create table t2(x varchar(50))");
+            s.execute("create table t3(x int)");
+            s.execute("create table t4(x int)");
+            s.execute("insert into t3 values 1");
+            conn.commit();
+
+            s.execute("create trigger tr after insert on t1 "
+            + "referencing new as new for each row "
+            + "when (f(new.x)) insert into t2 values new.x");
+
+            s.execute(format("insert into t1 values '%s.T3', '%s.T4', '%s.T3', '%s.T4', '%s.T3', '%s.T4'",
+                SCHEMA, SCHEMA, SCHEMA, SCHEMA, SCHEMA, SCHEMA));
+
+            String query = "select x, count(x) from t2 group by x";
+            String expected = "X             | 2 |\n" +
+            "-------------------------------\n" +
+            "Trigger_When_Clause_IT.T4 | 3 |";
+            testQuery(query, expected, s);
+
+            spliceSchemaWatcher.cleanSchemaObjects();
+        }
+    }
+
+
+    /**
+     * <p>
+     * SQL:2011, part 2, 11.49 &lt;trigger definition&gt;, syntax rule 11
+     * says that the WHEN clause shall not contain routines that possibly
+     * modifies SQL data. Derby does not currently allow functions to be
+     * declared as MODIFIES SQL DATA. It does allow procedures to be declared
+     * as MODIFIES SQL DATA, but the current grammar does not allow procedures
+     * to be invoked from a WHEN clause. So there's currently no way to
+     * invoke routines that possibly modifies SQL data from a WHEN clause.
+     * </p>
+     *
+     * <p>
+     * This test case verifies that it is not possible to declare a function
+     * as MODIFIES SQL DATA, and that it is not possible to call a procedure
+     * from a WHEN clause. If support for any of those features is added,
+     * this test case will start failing as a reminder that code must be
+     * added to prevent routines that possibly modifies SQL data from being
+     * invoked from a WHEN clause.
+     * </p>
+     */
+    @Test
+    public void testRoutineModifiesSQLData() throws SQLException {
+        try(Statement s = conn.createStatement()) {
+            // Functions cannot be declared as MODIFIES SQL DATA currently.
+            // Expect a syntax error.
+            testFail(SYNTAX_ERROR,
+                "create function f(x int) returns int language java "
+                + "parameter style java external name 'java.lang.Math.abs' "
+                + "modifies sql data", s);
+
+            // Declare a procedure as MODIFIES SQL DATA.
+            s.execute("create procedure p(i int) language java "
+            + "parameter style java external name '"
+            + getClass().getName() + ".intProcedure' no sql");
+
+            // Try to call that procedure from a WHEN clause. Expect it to fail
+            // because procedure invocations aren't allowed in a WHEN clause.
+            s.execute("create table t(x int)");
+            testFail(SYNTAX_ERROR,
+            "create trigger tr after insert on t when (call p(1)) values 1", s);
+            testFail(PROC_USED_AS_FUNC,
+            "create trigger tr after insert on t when (p(1)) values 1", s);
+        }
+    }
+
+    /**
+     * Verify that aggregates (both built-in and user-defined) can be used
+     * in a WHEN clause.
+     */
+    @Ignore("DB-8883")
+    @Test
+    public void testAggregates() throws Exception {
+        try(Statement s = conn.createStatement()) {
+            s.execute("create table t1(x int)");
+            s.execute("create table t2(y varchar(10))");
+
+            s.execute("create trigger tr1 after insert on t1 "
+            + "referencing new table as new "
+            + "when ((select max(x) from new) between 0 and 3) "
+            + "insert into t2 values 'tr1'");
+
+            s.execute("create trigger tr2 after insert on t1 "
+            + "referencing new table as new "
+            + "when ((select count(x) from new) between 0 and 3) "
+            + "insert into t2 values 'tr2'");
+
+            s.execute("create trigger tr3 after insert on t1 "
+            + "referencing new table as new "
+            + "when ((select mode_int(x) from new) between 0 and 3) "
+            + "insert into t2 values 'tr3'");
+
+            s.execute("insert into t1 values 2, 4, 4");
+
+            String query = "select * from t2 order by y";
+            String expected = "X  |\n" +
+            "------\n" +
+            "tr2 |";
+            testQuery(query, expected, s);
+
+            s.execute("delete from t2");
+
+            s.execute("insert into t1 values 2, 2, 3, 1, 0");
+            query = "select * from t2 order by y";
+            expected = "X             | 2 |\n" +
+            "-------------------------------\n" +
+            "tr1 |" +
+            "tr3 |";
+            testQuery(query, expected, s);
+
+        }
+    }
+
+    @Test
+    public void testBeginAtomic() throws Exception {
+        try(Statement s = conn.createStatement()) {
+            s.execute("create table t1 (a int, b int)");
+            s.execute("create table t2 (a int, b int, primary key(a))");
+            s.execute("insert into t1 values(1,1)");
+            s.execute("insert into t2 values(1,1)");
+
+            s.execute("CREATE TRIGGER mytrig\n" +
+            "   AFTER UPDATE OF a,b\n" +
+            "   ON t1\n" +
+            "   REFERENCING OLD AS OLD NEW AS NEW\n" +
+            "   FOR EACH ROW\n" +
+            "   WHEN (OLD.a = OLD.b)\n" +
+            "BEGIN ATOMIC\n" +
+            "insert into t2 values(1,1);\n" +
+            "END");
+
+            testFail("23505",
+                     "UPDATE t1 SET a=4", s);
+
+            String query = "select * from t1";
+            String expected = "A | B |\n" +
+            "--------\n" +
+            " 1 | 1 |";
+            testQuery(query, expected, s);
+        }
+    }
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    //
+    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    private void assertRecordCount(Statement s,String tag,long expectedCount) throws Exception {
+        long actualCount = StatementUtils.onlyLong(s, "select count(*) from RECORD where txt='" + tag + "'");
+        assertEquals("Didn't find expected number of rows:", expectedCount, actualCount);
+    }
+
+
+    private void assertQueryFails(Statement s, String query, String expectedError) {
+        try {
+            s.executeUpdate(query);
+            fail("expected to fail with message = " + expectedError);
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains(expectedError));
+        }
+    }
+
+    private void assertNonZero(long... values) {
+        for (long i : values) {
+            assertTrue(i > 0);
+        }
+    }
+
+    private void createTrigger(TriggerBuilder tb) throws Exception {
+        try(Statement s = conn.createStatement()){
+            s.executeUpdate(tb.build());
+        }
+    }
+
+}

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_When_Clause_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_When_Clause_IT.java
@@ -108,7 +108,6 @@ public class Trigger_When_Clause_IT extends SpliceUnitTest {
 
     protected void createInt_Proc() throws Exception {
         Connection c = conn;
-        //Connection c = classWatcher.createConnection();
         try(Statement s = c.createStatement()) {
             s.execute("create function f(x varchar(50)) returns boolean "
             + "language java parameter style java external name "
@@ -126,7 +125,6 @@ public class Trigger_When_Clause_IT extends SpliceUnitTest {
             s.execute(String.format("CALL SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY('derby.database.classpath', '%s')", JAR_FILE_SQL_NAME));
             c.commit();
         }
-        //c.close();
     }
 
     /* Each test starts with same table state */
@@ -1381,35 +1379,197 @@ public class Trigger_When_Clause_IT extends SpliceUnitTest {
             testQuery(query, expected, s);
         }
     }
-    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    //
-    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    private void assertRecordCount(Statement s,String tag,long expectedCount) throws Exception {
-        long actualCount = StatementUtils.onlyLong(s, "select count(*) from RECORD where txt='" + tag + "'");
-        assertEquals("Didn't find expected number of rows:", expectedCount, actualCount);
-    }
+    @Test
+    public void testSignal() throws Exception {
+        try (Statement s = conn.createStatement()) {
+            s.execute("create table t1 (a int, b char(11))");
+            s.execute("create table t2 (a int, b int)");
+            s.execute("insert into t1 values(1,1)");
+            s.execute("insert into t2 values(1,1)");
+            s.execute("INSERT INTO t1 values(2,'hello')");
+
+            Savepoint sp = conn.setSavepoint();
+
+            s.execute("CREATE TRIGGER mytrig\n" +
+            "   AFTER UPDATE OF a,b\n" +
+            "   ON t1\n" +
+            "   REFERENCING OLD AS OLD NEW AS NEW\n" +
+            "   FOR EACH ROW\n" +
+            "   WHEN (OLD.a = NEW.a)\n" +
+            "BEGIN ATOMIC\n" +
+            "SIGNAL SQLSTATE '87101' SET MESSAGE_TEXT = NEW.b CONCAT NEW.b;\n" +
+            "END");
 
 
-    private void assertQueryFails(Statement s, String query, String expectedError) {
-        try {
-            s.executeUpdate(query);
-            fail("expected to fail with message = " + expectedError);
-        } catch (Exception e) {
-            assertTrue(e.getMessage().contains(expectedError));
+            List<String> expectedErrors =
+            Arrays.asList("Application raised error or warning with diagnostic text: \"hello      hello      \"");
+
+            testFail("UPDATE t1 SET a=2", expectedErrors, s);
+
+            String query = "select * from t1";
+            String expected = "A |  B   |\n" +
+            "-----------\n" +
+            " 1 |  1   |\n" +
+            " 2 |hello |";
+            testQuery(query, expected, s);
+
+            conn.rollback(sp);
+            s.execute("CREATE TRIGGER mytrig\n" +
+            "   BEFORE UPDATE OF a,b\n" +
+            "   ON t1\n" +
+            "   REFERENCING OLD AS OLD NEW AS NEW\n" +
+            "   FOR EACH ROW\n" +
+            "   WHEN (OLD.a = NEW.a)\n" +
+            "BEGIN ATOMIC\n" +
+            "SIGNAL SQLSTATE '87101' (OLD.a);\n" +
+            "END");
+
+            expectedErrors =
+            Arrays.asList("Application raised error or warning with diagnostic text: \"2\"");
+
+            testFail("UPDATE t1 SET a=2", expectedErrors, s);
+
+            conn.rollback(sp);
+            s.execute("CREATE TRIGGER mytrig\n" +
+            "   BEFORE INSERT \n" +
+            "   ON t1\n" +
+            "   REFERENCING NEW AS NEW\n" +
+            "   FOR EACH ROW\n" +
+            "   WHEN (NEW.a > 0)\n" +
+            "BEGIN ATOMIC\n" +
+            "SIGNAL SQLSTATE '87101' ('You shall not pass!');\n" +
+            "END");
+
+            expectedErrors =
+            Arrays.asList("Application raised error or warning with diagnostic text: \"You shall not pass!\"");
+
+            testFail("insert into t1 values (1,1)", expectedErrors, s);
+
+            conn.rollback(sp);
+            s.execute("CREATE TRIGGER mytrig\n" +
+            "   AFTER UPDATE OF a,b\n" +
+            "   ON t1\n" +
+            "   REFERENCING OLD AS OLD NEW AS NEW\n" +
+            "   FOR EACH ROW\n" +
+            "   WHEN (EXISTS (SELECT 1 from t2 where t2.a = OLD.a and t2.b = OLD.b))\n" +
+            "BEGIN ATOMIC\n" +
+            "SIGNAL SQLSTATE '47584746' ;\n" +
+            "END");
+
+            expectedErrors =
+            Arrays.asList("Application raised error or warning with diagnostic text: \"\"");
+            testFail("UPDATE t1 SET a=2", expectedErrors, s);
+
+            conn.rollback(sp);
+            s.execute("CREATE TRIGGER mytrig\n" +
+            "   AFTER INSERT \n" +
+            "   ON t1\n" +
+            "   REFERENCING NEW AS NEW\n" +
+            "   FOR EACH ROW\n" +
+            "   WHEN (EXISTS (SELECT 1 from t2 where t2.a = NEW.a and t2.b = NEW.b))\n" +
+            "BEGIN ATOMIC\n" +
+            "SIGNAL SQLSTATE '4' ;\n" +
+            "END");
+
+            testFail("    4", "INSERT INTO t1 values (1,1)", s);
+
+            conn.rollback(sp);
+            s.execute("CREATE TRIGGER mytrig\n" +
+            "   AFTER INSERT \n" +
+            "   ON t1\n" +
+            "   REFERENCING NEW AS NEW\n" +
+            "   FOR EACH ROW\n" +
+            "   WHEN (EXISTS (SELECT 1 from t2 where t2.a = NEW.a and t2.b = NEW.b))\n" +
+            "BEGIN ATOMIC\n" +
+            "SIGNAL SQLSTATE '492378654823' ;\n" +
+            "END");
+
+            testFail("49237", "INSERT INTO t1 values (1,1)", s);
+
+            conn.rollback(sp);
+            s.execute("CREATE TRIGGER mytrig\n" +
+            "   AFTER INSERT \n" +
+            "   ON t1\n" +
+            "   REFERENCING NEW AS NEW\n" +
+            "   FOR EACH ROW\n" +
+            "   WHEN (EXISTS (SELECT 1 from t2 where t2.a = NEW.a and t2.b = NEW.b))\n" +
+            "BEGIN ATOMIC\n" +
+            "SIGNAL SQLSTATE 'ABC' ;\n" +
+            "END");
+
+            testFail("  ABC", "INSERT INTO t1 values (1,1)", s);
         }
     }
 
-    private void assertNonZero(long... values) {
-        for (long i : values) {
-            assertTrue(i > 0);
+    @Test
+    public void testSet() throws Exception {
+        try(Statement s = conn.createStatement()) {
+            s.execute("create table t1 (a int, b varchar(100))");
+            s.execute("create table t2 (a int, b int)");
+            s.execute("insert into t1 values(1,1)");
+            s.execute("insert into t2 values(1,1)");
+            s.execute("INSERT INTO t1 values(1,'hello')");
+
+            Savepoint sp = conn.setSavepoint();
+
+            List<String> expectedErrors =
+            Arrays.asList("'SET' statements are not allowed in 'AFTER' triggers.");
+
+            testFail("CREATE TRIGGER mytrig\n" +
+            "   AFTER UPDATE OF a,b\n" +
+            "   ON t1\n" +
+            "   REFERENCING OLD AS O NEW AS N\n" +
+            "   FOR EACH ROW\n" +
+            " WHEN (O.b = 'hello')" +
+            "BEGIN ATOMIC\n" +
+            "SET N.b = 'goodbye' ;" +
+            "END", expectedErrors, s);
+
+            expectedErrors =
+            Arrays.asList("SET triggers may only reference NEW transition variables/tables.");
+
+            testFail("CREATE TRIGGER mytrig\n" +
+            "   AFTER UPDATE OF a,b\n" +
+            "   ON t1\n" +
+            "   REFERENCING OLD AS O NEW AS N\n" +
+            "   FOR EACH ROW\n" +
+            " WHEN (O.b = 'hello')" +
+            "BEGIN ATOMIC\n" +
+            "SET O.b = 'goodbye' ;" +
+            "END", expectedErrors, s);
+
+            s.execute("CREATE TRIGGER mytrig\n" +
+            "   BEFORE UPDATE OF a,b\n" +
+            "   ON t1\n" +
+            "   REFERENCING OLD AS O NEW AS N\n" +
+            "   FOR EACH ROW\n" +
+            " WHEN (O.b LIKE 'hello%')" +
+            "BEGIN ATOMIC\n" +
+            "SET N.b = 'goodbye' ;" +
+            "END");
+
+            s.execute("UPDATE t1 SET a=2");
+
+            String query = "select * from t1";
+            String expected = "A |   B    |\n" +
+            "-------------\n" +
+            " 2 |   1    |\n" +
+            " 2 |goodbye |";
+            testQuery(query, expected, s);
+
+            expectedErrors =
+            Arrays.asList("DELETE triggers may only reference OLD transition variables/tables.");
+
+            testFail("CREATE TRIGGER mytrig\n" +
+            "   AFTER DELETE\n" +
+            "   ON t1\n" +
+            "   REFERENCING OLD AS O NEW AS N\n" +
+            "   FOR EACH ROW\n" +
+            " WHEN (O.b = 'hello')" +
+            "BEGIN ATOMIC\n" +
+            "SET N.b = 'goodbye' ;" +
+            "END", expectedErrors, s);
         }
     }
-
-    private void createTrigger(TriggerBuilder tb) throws Exception {
-        try(Statement s = conn.createStatement()){
-            s.executeUpdate(tb.build());
-        }
-    }
-
 }

--- a/sqlj-it-procs/src/main/java/org/splicetest/sqlj/SqlJTestProcs.java
+++ b/sqlj-it-procs/src/main/java/org/splicetest/sqlj/SqlJTestProcs.java
@@ -15,6 +15,8 @@
 package org.splicetest.sqlj;
 
 import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Stored procedures to test the SQLJ JAR file loading system procedures (INSTALL_JAR, REPLACE_JAR, and REMOVE_JAR).
@@ -188,5 +190,42 @@ public class SqlJTestProcs {
 	public static int MySum(int a, int b) {
 		return a+b;
 	}
+	/**
+	* List that tracks calls to {@code intProcedure()}. It is used to verify
+	* that triggers have fired.
+	*/
+	public static List<Integer> procedureCalls = new ArrayList<Integer>();
 
+	/**
+	* A procedure that takes an {@code int} argument and adds it to the
+	* {@link #procedureCalls} list. Can be used as a stored procedure to
+	* verify that a trigger has been called. Particularly useful in BEFORE
+	* triggers, as they are not allowed to modify SQL data.
+	*
+	* @param i an integer
+	*/
+	public static void intProcedure(int i) {
+	procedureCalls.add(i);
+	}
+
+
+	/**
+	* Stored function used by {@link #testFunctionReadsSQLData()}. It
+	* checks whether the given table is empty.
+	*
+	* @param table the table to check
+	* @return {@code true} if the table is empty, {@code false} otherwise
+	*/
+	public static boolean tableIsEmpty(String table) throws SQLException {
+		Connection c = DriverManager.getConnection("jdbc:splice://localhost:1527/splicedb;user=splice;password=admin");
+		Statement s = c.createStatement();
+		ResultSet rs = s.executeQuery("select * from " + table);
+		boolean empty = !rs.next();
+
+		rs.close();
+		s.close();
+		c.close();
+
+		return empty;
+	}
 }


### PR DESCRIPTION
This Jira combines both DB-8110 and DB-8112 in one pull request.

[DB-8110](https://splicemachine.atlassian.net/browse/DB-8110):
Port [DERBY-534](https://issues.apache.org/jira/browse/DERBY-534) and [DERBY-6783](https://issues.apache.org/jira/browse/DERBY-6783) to conditionally execute a trigger action when a condition, specified in the WHEN clause of the CREATE TRIGGER statement is TRUE.  

[DB-8112](https://splicemachine.atlassian.net/browse/DB-8112):
Add support for two new trigger action statements: SIGNAL SQLSTATE and SET.
SIGNAL SQLSTATE aborts the triggering SQL statement with a specified error code and diagnostic text.
SET allows columns in the new row that's being inserted or updated to be modified before writing into the database.