### PR TITLE
DB-8841 HMaster fails to initialize after Splice installation on CDH 6.3.1 (3.0)

### DIFF
--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
@@ -213,7 +213,6 @@ class SpliceTestPlatformConfig {
         config.setLong("hbase.rpc.timeout", MINUTES.toMillis(5));
         config.setInt("hbase.client.max.perserver.tasks",50);
         config.setInt("hbase.client.ipc.pool.size",10);
-        config.setInt("hbase.rowlock.wait.duration",10);
 
         config.setLong("hbase.client.scanner.timeout.period", MINUTES.toMillis(2)); // hbase.regionserver.lease.period is deprecated
         config.setLong("hbase.client.operation.timeout", MINUTES.toMillis(2));

--- a/platforms/cdh6.3.0/docs/CDH-installation.md
+++ b/platforms/cdh6.3.0/docs/CDH-installation.md
@@ -505,7 +505,6 @@ com.splicemachine.hbase.BackupEndpointObserver</code>
    <property><name>hbase.regionserver.global.memstore.size</name><value>0.25</value></property>
    <property><name>hbase.regionserver.maxlogs</name><value>48</value></property>
    <property><name>hbase.regionserver.wal.enablecompression</name><value>true</value></property>
-   <property><name>hbase.rowlock.wait.duration</name><value>0</value></property>
    <property><name>hbase.status.multicast.port</name><value>16100</value></property>
    <property><name>hbase.wal.disruptor.batch</name><value>true</value></property>
    <property><name>hbase.wal.provider</name><value>multiwal</value></property>


### PR DESCRIPTION
_hbase.rowlock.wait.duration = 0_ is no longer supported. The default value, 30 sec, appears adequate.