### PR TITLE
DB-8921 Make sporadic failure in test much less likely (2.8)

### DIFF
--- a/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceTest.scala
+++ b/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceTest.scala
@@ -406,7 +406,7 @@ class DefaultSourceTest extends FunSuite with TestContext with BeforeAndAfter wi
   }
 
   test("partitions shuffle") {
-    val rdd = generateRows(10, 5)
+    val rdd = generateRows(40, 20)
 
     var i = 0
 


### PR DESCRIPTION
the failure would happen in avg once every 5! (120) execution.
It now would happen once every 20! (2,432902008E18).