### PR TITLE
DB-8933 Support Syntax OPTIMIZE FOR n ROWS

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -2391,6 +2391,31 @@ public class SQLParser
            return buf.toString();
    }
 
+    /**
+     * Determine if we are seeing an Optimize For Rows clause or the identifier OPTIMIZE
+     *
+     * @return true if it is an Optimize For Rows clause.
+     */
+    private boolean seeingOptimizeForRowsClause()
+    {
+        int nesting = 0;
+
+        // Token number, i == 1: OPTIMIZE
+        int i = 2;
+
+        int tokKind = getToken(i).kind;
+
+        if (tokKind == FOR) {
+            tokKind = getToken(++i).kind;
+            if (tokKind == EXACT_NUMERIC) {
+                tokKind = getToken(++i).kind;
+
+                return (tokKind == ROW ||
+                        tokKind == ROWS);
+            }
+        }
+        return false;
+    }
 }
 
 PARSER_END(SQLParser)
@@ -4207,7 +4232,7 @@ preparableSelectStatement(boolean checkParams) throws StandardException :
 		[ orderCols = orderByClause(queryExpression) ]
         hasJDBClimitClause = offsetFetchFirstClause( offsetClauses )
 		[ <FOR> forUpdateState = forUpdateClause(updateColumns) ]
-		[ optimizeForRows = getOptimizeForRowsHintValue() ]
+		[ optimizeForRows = optimizeForRowsClause() ]
 		[ isolationLevel = atIsolationLevel() ]
 	{
 	    if (topNOut[0] != null) {
@@ -17198,7 +17223,6 @@ reservedKeyword() :
 |	tok = <ONLY>
 |	tok = <OPEN>
 |	tok = <OPTION>
-|   tok = <OPTIMIZE>
 |	tok = <OR>
 |	tok = <ORDER>
 |   tok = <OUT>
@@ -17452,6 +17476,11 @@ nonReservedKeyword()  :
 	|	tok = <OLD>
 	|	tok = <OLD_TABLE>
 	|	tok = <OJ>
+    |	LOOKAHEAD({
+            getToken(1).kind == OPTIMIZE &&
+            !seeingOptimizeForRowsClause()
+        })
+	    tok = <OPTIMIZE>
 	|	tok = <OVER>
 	|	tok = <PASCAL>
 	|	tok = <PASSING>
@@ -17623,20 +17652,21 @@ caseSensitiveIdentifier() :
 }
 
 /*
- * <A NAME="getOptimizeForRows">getOptimizeForRows</A>
+ * <A NAME="optimizeForRowsClause">optimizeForRowsClause</A>
  */
 int
-getOptimizeForRowsHintValue() throws StandardException:
+optimizeForRowsClause() throws StandardException :
 {
-	int optimizeForRows;
+	int optimizeForRows = 1;
 }
 {
-    <OPTIMIZE> <FOR> optimizeForRows = uint_value() (<ROW>|<ROWS>)
-    {
-
+	<OPTIMIZE> <FOR>
+     optimizeForRows = uint_value()
+	( <ROW> | <ROWS> )
+	{
         if ( optimizeForRows <= 0 )
             throw StandardException.newException(SQLState.LANG_INVALID_INTEGER_LITERAL, optimizeForRows);
         else
             return optimizeForRows;
-    }
+	}
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -3004,6 +3004,7 @@ TOKEN [IGNORE_CASE] :
 |	<PARQUET: "parquet">
 |   <AVRO: "avro">
 |	<ORC: "orc">
+|   <OPTIMIZE: "optimize">
 |	<SAVEPOINT: "savepoint">
 |	<SCALE: "scale">
 |	<SECURITY: "security">
@@ -4198,6 +4199,7 @@ preparableSelectStatement(boolean checkParams) throws StandardException :
     ValueNode[] offsetClauses = new ValueNode[ OFFSET_CLAUSE_COUNT ];
     ValueNode[] topNOut = new ValueNode[ 1 ];
     boolean     hasJDBClimitClause = false;
+    int optimizeForRows = 1;
 }
 {
     [ <WITH> withClauseList(parameterList) ]
@@ -4205,6 +4207,7 @@ preparableSelectStatement(boolean checkParams) throws StandardException :
 		[ orderCols = orderByClause(queryExpression) ]
         hasJDBClimitClause = offsetFetchFirstClause( offsetClauses )
 		[ <FOR> forUpdateState = forUpdateClause(updateColumns) ]
+		[ optimizeForRows = getOptimizeForRowsHintValue() ]
 		[ isolationLevel = atIsolationLevel() ]
 	{
 	    if (topNOut[0] != null) {
@@ -6044,6 +6047,7 @@ simpleTable(ValueNode[] topNOut) throws StandardException :
 }
 {
 	resultSetNode = querySpecification(topNOut)
+
 	{
 		return resultSetNode;
 	}
@@ -17194,6 +17198,7 @@ reservedKeyword() :
 |	tok = <ONLY>
 |	tok = <OPEN>
 |	tok = <OPTION>
+|   tok = <OPTIMIZE>
 |	tok = <OR>
 |	tok = <ORDER>
 |   tok = <OUT>
@@ -17615,4 +17620,23 @@ caseSensitiveIdentifier() :
 	{
 		return str;
 	}
+}
+
+/*
+ * <A NAME="getOptimizeForRows">getOptimizeForRows</A>
+ */
+int
+getOptimizeForRowsHintValue() throws StandardException:
+{
+	int optimizeForRows;
+}
+{
+    <OPTIMIZE> <FOR> optimizeForRows = uint_value() (<ROW>|<ROWS>)
+    {
+
+        if ( optimizeForRows <= 0 )
+            throw StandardException.newException(SQLState.LANG_INVALID_INTEGER_LITERAL, optimizeForRows);
+        else
+            return optimizeForRows;
+    }
 }


### PR DESCRIPTION
Note:
DB2 supports the syntax for ROW and ROWS both and does not care n (n > 0) is singular or plural.