### PR TITLE
DB-8974 Recompilation of "SET" trigger fails with syntax error.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -3628,6 +3628,7 @@ StatementPart(Token[] tokenHolder) throws StandardException :
         statementNode = declareTemporaryTableDeclaration() |
         statementNode = preparableSQLDataStatement() |
         statementNode = setStatement(new Token[1]) |
+        statementNode = setStatementInCreateTrigger(new Token[1], null) |
         statementNode = spsSetStatement() |
 		statementNode = truncateTableStatement() |
 		statementNode = grantStatement() |
@@ -14873,8 +14874,18 @@ setStatementInCreateTrigger(Token[] tokenHolder, HashSet<String> hs) throws Stan
         ValueNodeList	newValuesList = (ValueNodeList) nodeFactory.getNode(
                                                     C_NodeTypes.VALUE_NODE_LIST,
                                                     getContextManager());
+        if (hs == null)
+            hs = new HashSet<String>();
 }
 {
+  LOOKAHEAD ( { getToken(1).kind == SET &&
+                getToken(2).kind != CURRENT &&
+                getToken(2).kind != ISOLATION &&
+                getToken(2).kind != SCHEMA &&
+                getToken(2).kind != MESSAGE_LOCALE &&
+                getToken(2).kind != ROLE &&
+                getToken(2).kind != SESSION_PROPERTY
+              } )
   <SET> setClauseValueList(assignedColumnsList, newValuesList, hs)
   {
         return (StatementNode) nodeFactory.getNode(

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerExecutionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerExecutionContext.java
@@ -511,7 +511,7 @@ public class TriggerExecutionContext implements ExecutionStmtValidator, External
         int targetIndex = 1;
         for (; sourceIndex<=stopIndex; sourceIndex++) {
             try {
-                result.setColumn(targetIndex++, resultSet.getColumn(sourceIndex).cloneValue(false));
+                result.setColumn(targetIndex++, resultSet.getColumn(sourceIndex));
             } catch (StandardException e) {
                 throw Util.generateCsSQLException(e);
             }


### PR DESCRIPTION
Fixes a trigger execution bug when the trigger table is altered and the trigger action statement it a SET statement, e.g.  'SET new.col1 = 1'.

[DB-8974](https://splicemachine.atlassian.net/browse/DB-8974)