### PR TITLE
DB-9024 Subquery with IN or NOT IN hits AnalysisException when native spark execution is used.

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
@@ -851,8 +851,14 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     // ExecRowDefinition.
     private Dataset<Row> fixupColumnNames(JoinOperation op, JoinType joinType,
                                           Dataset<Row> leftDF, Dataset<Row> rightDF,
-                                          Dataset<Row> joinedDF) {
+                                          Dataset<Row> joinedDF,
+                                          SpliceOperation leftOp,
+                                          SpliceOperation rightOp) throws StandardException {
+        boolean isSemiOrAntiJoin =
+                joinType.strategy().equals(JoinType.LEFTANTI.strategy()) ||
+                joinType.strategy().equals(JoinType.LEFTSEMI.strategy());
         boolean needsFixup =
+                isSemiOrAntiJoin ||
                 leftDFOfJoinProjectsFewerColumnsThanDefined(op, joinType, leftDF);
         if (!needsFixup)
             return joinedDF;
@@ -887,13 +893,32 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
             expressions[i] = expression.toString();
         }
 
-         for (int i = 0; i < rightDF.schema().length(); i++) {
-            String fieldName = ValueRow.getNamedColumn(i + baseColNo);
-            expression.setLength(0);
-            expression.append(fieldName);
-            expression.append(" as ");
-            expression.append(ValueRow.getNamedColumn(i + adjColNo));
-            expressions[i + adjColNo] = expression.toString();
+        if (isSemiOrAntiJoin) {
+            ExecRow rowDef = rightOp.getExecRowDefinition();
+            for (int i = 0; i < rightDF.schema().length(); i++) {
+                String fieldName = ValueRow.getNamedColumn(i + adjColNo);
+                String sourceFieldName = ValueRow.getNamedColumn(i);
+                DataType dataType =
+                        rowDef.getColumn(i+1).getStructField(sourceFieldName).dataType();
+                String dataTypeString = dataType.typeName();
+
+                expression.setLength(0);
+                expression.append("CAST (null as ");
+                expression.append(dataTypeString);
+                expression.append(") as ");
+                expression.append(fieldName);
+                expressions[i + adjColNo] = expression.toString();
+            }
+        }
+        else {
+            for (int i = 0; i < rightDF.schema().length(); i++) {
+                String fieldName = ValueRow.getNamedColumn(i + baseColNo);
+                expression.setLength(0);
+                expression.append(fieldName);
+                expression.append(" as ");
+                expression.append(ValueRow.getNamedColumn(i + adjColNo));
+                expressions[i + adjColNo] = expression.toString();
+            }
         }
         joinedDF = joinedDF.selectExpr(expressions);
 
@@ -942,13 +967,15 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
                 NativeSparkDataSet nds =
                   new NativeSparkDataSet(rightDF.join(leftDF, expr, joinType.RIGHTOUTER.strategy()), context);
                 joinedSet = nds;
-                nds.dataset = fixupColumnNames(op, joinType, rightDF, leftDF, nds.dataset);
+                nds.dataset = fixupColumnNames(op, joinType, rightDF, leftDF, nds.dataset,
+                                               op.getRightOperation(), op.getLeftOperation());
             }
             else {
                 NativeSparkDataSet nds =
                   new NativeSparkDataSet(leftDF.join(rightDF, expr, joinType.strategy()), context);
                 joinedSet = nds;
-                nds.dataset = fixupColumnNames(op, joinType, leftDF, rightDF, nds.dataset);
+                nds.dataset = fixupColumnNames(op, joinType, leftDF, rightDF, nds.dataset,
+                                               op.getLeftOperation(), op.getRightOperation());
             }
 
             return joinedSet;
@@ -988,8 +1015,10 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
             }
             DataSet joinedSet = new NativeSparkDataSet(joinedDF, context);
             NativeSparkDataSet nds = (NativeSparkDataSet)joinedSet;
-            nds.dataset = fixupColumnNames((JoinOperation) context.getOperation(),
-                                           DataSet.JoinType.INNER, leftDF, rightDF, nds.dataset);
+            SpliceOperation op = context.getOperation();
+            nds.dataset = fixupColumnNames((JoinOperation) op,
+                                           DataSet.JoinType.INNER, leftDF, rightDF, nds.dataset,
+                                           op.getLeftOperation(), op.getRightOperation());
             return joinedSet;
 
         }  catch (Exception e) {


### PR DESCRIPTION
The Derby optimizer projects inner table columns of semijoin or antijoin sometimes.
When using native Spark execution, the inner table columns are not included in the data frame, so attempting to project out nonexistent inner table columns results in an AnalysisException.
The fix is to modify the join data frame to add nulls for the inner table columns when we have a subquery.  

See description in [DB-9024](https://splicemachine.atlassian.net/browse/DB-9024).