### PR TITLE
DB-8883 Fix IT failures on mem platform.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextManager.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextManager.java
@@ -78,31 +78,24 @@ public class ContextManager
 		private Context top_ = null;
 
 		void push(Context context) {
-		    synchronized(stack_) {
-                        stack_.add(context);
-                        top_ = context;
-                    }
+			stack_.add(context);
+			top_ = context;
 		}
 		void pop() {
-		    synchronized(stack_) {
-		        stack_.remove(stack_.size() - 1);
-
-                        top_ = stack_.isEmpty() ? null : stack_.get(stack_.size() - 1);
-                    }
-                }
+            stack_.remove(stack_.size() - 1);
+            top_ = stack_.isEmpty() ? null : stack_.get(stack_.size() - 1);
+        }
 		void remove(Context context) {
-		    synchronized(stack_) {
-                        if (context == top_) {
-                            pop();
-                            return;
-                        }
-                        int index = stack_.lastIndexOf(context);
-                        if (index >= 0)
-                            stack_.remove(index);
-                    }
+			if (context == top_) {
+				pop();
+				return;
+			}
+			int index=stack_.lastIndexOf(context);
+			if(index>=0)
+				stack_.remove(index);
 		}
-		Context top() { 
-			return top_; 
+		Context top() {
+			return top_;
 		}
 		boolean isEmpty() { return stack_.isEmpty(); }
 		List<Context> getUnmodifiableList() {
@@ -326,7 +319,7 @@ forever: for (;;) {
 				flushErrorString();
 			}
 
-			
+
 			boolean	lastHandler = false;
 
 
@@ -361,9 +354,9 @@ cleanup:	for (int index = holder.size() - 1; index >= 0; index--) {
                     }
 				}
 				catch (StandardException se) {
-	
+
 					if (error instanceof StandardException) {
-	
+
 						if (se.getSeverity() > ((StandardException) error).getSeverity()) {
 							// Ok, error handling raised a more severe error,
 							// restart with the more severe error

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionFactory.java
@@ -127,26 +127,6 @@ public interface LanguageConnectionFactory {
 								double defaultSelectivityFactor,
 								String ipAddress,
                                 String defaultSchema,
-                                Properties sessionProperties,
-                                Integer sessionNumber)
-
-		throws StandardException;
-
-	LanguageConnectionContext
-	newLanguageConnectionContext(ContextManager cm,
-								TransactionController tc,
-								LanguageFactory lf,
-								Database db,
-								String userName,
-								List<String> groupuserlist,
-								String drdaID,
-								String dbname,
-								String rdbIntTkn,
-                                CompilerContext.DataSetProcessorType type,
-								boolean skipStats,
-								double defaultSelectivityFactor,
-								String ipAddress,
-                                String defaultSchema,
                                 Properties sessionProperties)
 
 		throws StandardException;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionFactory.java
@@ -156,10 +156,7 @@ public class GenericLanguageConnectionFactory
 		double defaultSelectvityFactor,
 		String ipAddresss,
 		String defaultSchema,
-		Properties sessionProperties,
-                Integer sessionNumber) throws StandardException {
-
-                int instanceNumber = sessionNumber != null ? sessionNumber : getNextLCCInstanceNumber();
+		Properties sessionProperties) throws StandardException {
 		
 		return new GenericLanguageConnectionContext(cm,
 													tc,
@@ -168,7 +165,7 @@ public class GenericLanguageConnectionFactory
 													db,
 													userName,
 													groupuserlist,
-													instanceNumber,
+													getNextLCCInstanceNumber(),
 													drdaID,
 													dbname,
 													rdbIntTkn,
@@ -180,28 +177,6 @@ public class GenericLanguageConnectionFactory
                                                     sessionProperties
 				);
 	}
-
-	@Override
-	public LanguageConnectionContext newLanguageConnectionContext(
-		ContextManager cm,
-		TransactionController tc,
-		LanguageFactory lf,
-		Database db,
-		String userName,
-		List<String> groupuserlist,
-		String drdaID,
-		String dbname,
-        String rdbIntTkn,
-        CompilerContext.DataSetProcessorType type,
-		boolean skipStats,
-		double defaultSelectvityFactor,
-		String ipAddresss,
-		String defaultSchema,
-		Properties sessionProperties) throws StandardException {
-            return newLanguageConnectionContext(cm, tc, lf, db, userName, groupuserlist, drdaID, dbname, rdbIntTkn,
-                                                type, skipStats, defaultSelectvityFactor, ipAddresss, defaultSchema,
-		                                sessionProperties, null);
-        }
 
 	public Cacheable newCacheable(CacheManager cm) {
 		return new CachedStatement();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
@@ -165,7 +165,7 @@ public class SpliceDatabase extends BasicDatabase{
         return
             generateLanguageConnectionContext(txn, cm, user, groupuserlist, drdaID, dbname,
                                               rdbIntTkn, type, skipStats, defaultSelectivityFactor,
-                                              ipAddress, null, null);
+                                              ipAddress, null);
 
     }
 
@@ -180,14 +180,13 @@ public class SpliceDatabase extends BasicDatabase{
                                                                        boolean skipStats,
                                                                        double defaultSelectivityFactor,
                                                                        String ipAddress,
-                                                                       TransactionController reuseTC,
-                                                                       Integer sessionNumber) throws StandardException{
+                                                                       TransactionController reuseTC) throws StandardException{
         TransactionController tc = reuseTC == null ? ((SpliceAccessManager)af).marshallTransaction(cm,txn) : reuseTC;
         cm.setLocaleFinder(this);
         pushDbContext(cm);
         LanguageConnectionContext lctx=lcf.newLanguageConnectionContext(cm,tc,lf,this,user,
                 groupuserlist,drdaID,dbname,rdbIntTkn,type,skipStats, defaultSelectivityFactor, ipAddress,
-                null, null, sessionNumber);
+                null, null);
 
         pushClassFactoryContext(cm,lcf.getClassFactory());
         ExecutionFactory ef=lcf.getExecutionFactory();

--- a/splice_machine/src/main/java/com/splicemachine/derby/jdbc/SpliceTransactionResourceImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/jdbc/SpliceTransactionResourceImpl.java
@@ -109,7 +109,7 @@ public final class SpliceTransactionResourceImpl implements AutoCloseable{
             lcc=database.generateLanguageConnectionContext(txn, cm, userName,grouplist,drdaID, dbname, rdbIntTkn,
                                                            CompilerContext.DataSetProcessorType.DEFAULT_CONTROL,
                                                            false, -1, ipAddress,
-                                                            reuseTC, sessionNumber);
+                                                            reuseTC);
 
             return true;
         } catch (Throwable t) {


### PR DESCRIPTION
Reverts a couple last-minute changes to DB-8883 which cause ITs to fail in mem.
The changes were:
1. Addition of synchronization in ContextManager.
2. Sharing the same session number between all LanguageConnectionContexts used by parallel triggers (so the logs would nicely show all triggers for a given SQL fired in the same "session".  