### PR TITLE
DB-9023: dump unreplicated wals to a table

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/hbase/ReplicationUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/ReplicationUtils.java
@@ -16,12 +16,16 @@ import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.timestamp.api.TimestampSource;
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.ReplicationProtos;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.zookeeper.RecoverableZooKeeper;
 import org.apache.hadoop.hbase.zookeeper.ZKWatcher;
+import org.apache.hbase.thirdparty.com.google.protobuf.CodedOutputStream;
 import org.apache.log4j.Logger;
 import org.apache.zookeeper.KeeperException;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -217,6 +221,40 @@ public class ReplicationUtils {
         } finally {
             if (prepared)
                 transactionResource.close();
+        }
+    }
+
+    public static void disableMaster(String masterClusterKey) throws InterruptedException, KeeperException, IOException {
+
+        // Delete all peers from master cluster
+        Configuration conf = ReplicationUtils.createConfiguration(masterClusterKey);
+        ZKWatcher masterZkw = new ZKWatcher(conf, "replication monitor", null, false);
+        RecoverableZooKeeper masterRzk = masterZkw.getRecoverableZooKeeper();
+        String[] s = masterClusterKey.split(":");
+        String hbaseRootDir = s[2];
+        String peerPath = hbaseRootDir+"/replication/peers";
+        List<String> peers = masterRzk.getChildren(peerPath, false);
+        for (String peer : peers) {
+            String p = peerPath + "/" + peer;
+            List<String> children = masterRzk.getChildren(p, false);
+            String peerStatePath = p + "/" + children.get(0);
+            masterRzk.setData(peerStatePath, toByteArray(ReplicationProtos.ReplicationState.State.DISABLED), -1);
+        }
+    }
+
+    private static byte[] toByteArray(final ReplicationProtos.ReplicationState.State state) {
+        ReplicationProtos.ReplicationState msg =
+                ReplicationProtos.ReplicationState.newBuilder().setState(state).build();
+        // There is no toByteArray on this pb Message?
+        // 32 bytes is default which seems fair enough here.
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            CodedOutputStream cos = CodedOutputStream.newInstance(baos, 16);
+            msg.writeTo(cos);
+            cos.flush();
+            baos.flush();
+            return ProtobufUtil.prependPBMagic(baos.toByteArray());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/NoOpReplicationManager.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/NoOpReplicationManager.java
@@ -81,4 +81,9 @@ public class NoOpReplicationManager implements ReplicationManager {
     public void monitorReplication(String masterClusterKey, String slaveClusterKey) throws StandardException {
 
     }
+
+    @Override
+    public String dumpUnreplicatedWals() throws StandardException {
+        return null;
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -1491,6 +1491,13 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                             .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
                             .build();
                     procedures.add(getWalPosition);
+
+                    Procedure dumpUnreplicatedWals = Procedure.newBuilder().name("DUMP_UNREPLICATED_WALS")
+                            .numOutputParams(0)
+                            .numResultSets(1)
+                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                            .build();
+                    procedures.add(dumpUnreplicatedWals);
                 }  // End key == sysUUID
 
             } // End iteration through map keys (schema UUIDs)

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
@@ -18,7 +18,6 @@ import com.splicemachine.EngineDriver;
 import com.splicemachine.access.api.PartitionAdmin;
 import com.splicemachine.access.api.PartitionFactory;
 import com.splicemachine.access.api.SConfiguration;
-import com.splicemachine.concurrent.SystemClock;
 import com.splicemachine.db.catalog.IndexDescriptor;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
@@ -74,7 +73,6 @@ import java.io.StringReader;
 import java.sql.ResultSet;
 import java.sql.Types;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Created by jyuan on 8/14/17.
@@ -198,7 +196,7 @@ public class SpliceRegionAdmin {
         }
 
         // get row format for primary key or index
-        ExecRow execRow = getExecRow(td, index);
+        ExecRow execRow = getKeyExecRow(td, index);
         if (execRow == null) {
             throw StandardException.newException(SQLState.NO_PRIMARY_KEY,
                     td.getSchemaDescriptor().getSchemaName(), td.getName());
@@ -502,7 +500,7 @@ public class SpliceRegionAdmin {
         }
 
         // get row format for primary key or index
-        ExecRow execRow = getExecRow(td, index);
+        ExecRow execRow = getKeyExecRow(td, index);
         if (execRow == null) {
             throw StandardException.newException(SQLState.NO_PRIMARY_KEY,
                     td.getSchemaDescriptor().getSchemaName(), td.getName());
@@ -606,7 +604,7 @@ public class SpliceRegionAdmin {
         TxnView txnView = rawTxn.getActiveStateTxn();
 
         // Decode startKey from byte[] to ExecRow
-        ExecRow execRow = getExecRow(td, index);
+        ExecRow execRow = getKeyExecRow(td, index);
         if (execRow != null) {
             DataHash dataHash = getEncoder(td, index, execRow);
             KeyHashDecoder decoder =  dataHash.getDecoder();
@@ -666,7 +664,7 @@ public class SpliceRegionAdmin {
         return null;
     }
 
-    private static DataHash getEncoder(TableDescriptor td, ConglomerateDescriptor index, ExecRow execRow) throws Exception {
+    public static DataHash getEncoder(TableDescriptor td, ConglomerateDescriptor index, ExecRow execRow) throws Exception {
 
         String version = td.getVersion();
         DescriptorSerializer[] serializers= VersionedSerializers
@@ -725,7 +723,7 @@ public class SpliceRegionAdmin {
      * @return ExecRow for primary key or index
      * @throws Exception
      */
-    private static ExecRow getExecRow(TableDescriptor td, ConglomerateDescriptor index) throws Exception {
+    public static ExecRow getKeyExecRow(TableDescriptor td, ConglomerateDescriptor index) throws Exception {
 
         ExecRow execRow = null;
         if (index != null) {

--- a/splice_machine/src/main/java/com/splicemachine/replication/ReplicationManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/replication/ReplicationManager.java
@@ -36,4 +36,5 @@ public interface ReplicationManager {
     void monitorReplication(String masterClusterKey, String slaveClusterKey) throws StandardException;
     default String getReplicatedWalPosition(String wal) throws StandardException{ return null;}
     default List<String> getReplicatedWalPositions(short peerId) throws StandardException{return null;}
+    String dumpUnreplicatedWals() throws StandardException;
 }

--- a/splice_machine/src/main/java/com/splicemachine/replication/ReplicationSystemProcedure.java
+++ b/splice_machine/src/main/java/com/splicemachine/replication/ReplicationSystemProcedure.java
@@ -61,6 +61,17 @@ public class ReplicationSystemProcedure {
 
     private static Logger LOG = Logger.getLogger(ReplicationSystemProcedure.class);
 
+    public static void DUMP_UNREPLICATED_WALS(ResultSet[] resultSets) throws StandardException, SQLException {
+        try {
+            ReplicationManager replicationManager = EngineDriver.driver().manager().getReplicationManager();
+            String result = replicationManager.dumpUnreplicatedWals();
+            resultSets[0] = ProcedureUtils.generateResult("Success", result);
+        }
+        catch (Exception e) {
+            resultSets[0] = ProcedureUtils.generateResult("Error", e.getLocalizedMessage());
+        }
+    }
+
     public static void GET_REPLICATED_WAL_POSITION(String wal, ResultSet[] resultSets) throws StandardException, SQLException {
         ReplicationManager replicationManager = EngineDriver.driver().manager().getReplicationManager();
         String walPosition = replicationManager.getReplicatedWalPosition(wal);


### PR DESCRIPTION
Implement a standalone program to disable replication from failed master cluster to slave clusters
Implement a system procedure to dump WALs to a splice table for data resolution. Data resolution need to be done manually by administrator.

Please also review ee branch