### PR TITLE
DB-8990: fix slave timestamp

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
@@ -18,15 +18,18 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import com.splicemachine.access.configuration.HBaseConfiguration;
 import com.splicemachine.client.SpliceClient;
 import com.splicemachine.db.catalog.types.RoutineAliasInfo;
 import com.splicemachine.db.iapi.sql.conn.StatementContext;
 import com.splicemachine.db.impl.jdbc.EmbedConnection;
 import com.splicemachine.derby.hbase.AdapterPipelineEnvironment;
+import com.splicemachine.hbase.*;
 import com.splicemachine.pipeline.PipelineEnvironment;
 import com.splicemachine.si.data.hbase.coprocessor.AdapterSIEnvironment;
 import com.splicemachine.si.impl.driver.SIEnvironment;
 import com.splicemachine.utils.SpliceLogUtils;
+import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Logger;
@@ -44,9 +47,6 @@ import com.splicemachine.concurrent.SystemClock;
 import com.splicemachine.derby.hbase.HBasePipelineEnvironment;
 import com.splicemachine.derby.lifecycle.DistributedDerbyStartup;
 import com.splicemachine.derby.lifecycle.EngineLifecycleService;
-import com.splicemachine.hbase.HBaseRegionLoads;
-import com.splicemachine.hbase.RegionServerLifecycleObserver;
-import com.splicemachine.hbase.ZkUtils;
 import com.splicemachine.pipeline.ContextFactoryDriverService;
 import com.splicemachine.pipeline.PipelineDriver;
 import com.splicemachine.pipeline.contextfactory.ContextFactoryDriver;
@@ -143,7 +143,14 @@ public class SpliceSpark {
                 SConfiguration config=driver.getConfiguration();
 
                 LOG.info("Splice Client in SpliceSpark "+SpliceClient.isClient());
-                
+                String replicationPath = ReplicationUtils.getReplicationPath();
+                byte[] status = ZkUtils.getData(replicationPath);
+                if (Bytes.compareTo(status, HBaseConfiguration.REPLICATION_MASTER) == 0) {
+                    driver.lifecycleManager().setReplicationRole("MASTER");
+                }
+                else if (Bytes.compareTo(status, HBaseConfiguration.REPLICATION_SLAVE) == 0) {
+                    driver.lifecycleManager().setReplicationRole("SLAVE");
+                }
                 //boot derby components
                 new EngineLifecycleService(new DistributedDerbyStartup(){
                     @Override public void distributedStart() throws IOException{ }
@@ -170,7 +177,6 @@ public class SpliceSpark {
                         HBasePipelineEnvironment.loadEnvironment(clock,cfDriver);
                 PipelineDriver.loadDriver(pipelineEnv);
                 HBaseRegionLoads.INSTANCE.startWatching();
-
                 spliceStaticComponentsSetup = true;
             }
         } catch (RuntimeException e) {

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/GetWALPositionsTask.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/GetWALPositionsTask.java
@@ -24,17 +24,15 @@ import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.ipc.CoprocessorRpcChannel;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class GetWALPositionsTask implements Callable<Void> {
-    private ConcurrentHashMap<String, Map<String,Long>> map;
+    private ConcurrentHashMap<String, SortedMap<String,Long>> map;
     private ServerName serverName;
 
-    public GetWALPositionsTask(ConcurrentHashMap<String, Map<String,Long>> map, ServerName serverName){
+    public GetWALPositionsTask(ConcurrentHashMap<String, SortedMap<String,Long>> map, ServerName serverName){
         this.map = map;
         this.serverName = serverName;
     }
@@ -50,7 +48,7 @@ public class GetWALPositionsTask implements Callable<Void> {
 
         SpliceMessage.GetWALPositionsResponse response = service.getWALPositions(null, builder.build());
         List<SpliceMessage.GetWALPositionsResponse.Result> resultList = response.getResultList();
-        Map<String, Long> serverSnapshot = new HashMap<>();
+        SortedMap<String, Long> serverSnapshot = new TreeMap<>();
         for (SpliceMessage.GetWALPositionsResponse.Result result : resultList) {
             serverSnapshot.put(result.getWALName(), result.getPosition());
         }

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceReplicationSourceChore.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/SpliceReplicationSourceChore.java
@@ -106,7 +106,7 @@ public class SpliceReplicationSourceChore extends ScheduledChore {
             Collection<PartitionServer> servers = pa.allServers();
 
             // Get LSNs for each region server
-            ConcurrentHashMap<String, Map<String,Long>> snapshot = new ConcurrentHashMap<>();
+            ConcurrentHashMap<String, SortedMap<String,Long>> snapshot = new ConcurrentHashMap<>();
             List<Future<Void>> futures = Lists.newArrayList();
             long timestamp = SIDriver.driver().getTimestampSource().currentTimestamp();
             if (timestamp != preTimestamp) {
@@ -141,7 +141,6 @@ public class SpliceReplicationSourceChore extends ScheduledChore {
                 if (peer.isEnabled()) {
                     String clusterKey = peer.getPeerConfig().getClusterKey();
                     Connection connection = getConnection(clusterKey);
-                    removeOldWals(snapshot);
                     sendReplicationProgress(peer.getPeerId(), connection);
                 }
             }
@@ -156,7 +155,7 @@ public class SpliceReplicationSourceChore extends ScheduledChore {
     private void sendReplicationProgress(String peerId, Connection connection) throws IOException {
 
         try {
-            Map<String, Map<String, Long>> walPositions = getWalPositions(peerId);
+            Map<String, SortedMap<String, Long>> walPositions = getWalPositions(peerId);
             if (LOG.isDebugEnabled()) {
                 List<String> sortedWals = sortWals(walPositions);
                 for (String wal:sortedWals )
@@ -208,7 +207,7 @@ public class SpliceReplicationSourceChore extends ScheduledChore {
         }
     }
 
-    private Map<String, Long> getReplicationProgress(Map<String, Map<String, Long>> serverWalPositions) throws IOException {
+    private Map<String, Long> getReplicationProgress(Map<String, SortedMap<String, Long>> serverWalPositions) throws IOException {
 
         Configuration conf = HConfiguration.unwrapDelegate();
         FileSystem fs = FSUtils.getWALFileSystem(conf);
@@ -273,15 +272,15 @@ public class SpliceReplicationSourceChore extends ScheduledChore {
      * @return
      * @throws IOException
      */
-    private Map<String, Map<String, Long>> getWalPositions(String peerId) throws IOException {
+    private Map<String, SortedMap<String, Long>> getWalPositions(String peerId) throws IOException {
         try {
-            Map<String, Map<String, Long>> serverWalPositionsMap = new HashMap<>();
+            Map<String, SortedMap<String, Long>> serverWalPositionsMap = new HashMap<>();
             String rsPath = hbaseRoot + "/" + "replication/rs";
             List<String> regionServers = ZkUtils.getChildren(rsPath, false);
             for (String rs : regionServers) {
                 String peerPath = rsPath + "/" + rs + "/" + peerId;
                 List<String> walNames = ZkUtils.getChildren(peerPath, false);
-                Map<String, Long>  walPositionsMap = new HashMap<>();
+                SortedMap<String, Long>  walPositionsMap = new TreeMap<>();
                 serverWalPositionsMap.put(rs, walPositionsMap);
                 for (String walName : walNames) {
                     byte[] p = ZkUtils.getData(peerPath + "/" + walName);
@@ -302,22 +301,24 @@ public class SpliceReplicationSourceChore extends ScheduledChore {
      * Remove old Wals from each wal group
      * @param serverWalPositionsMap
      */
-    private Set<String> removeOldWals(Map<String, Map<String, Long>> serverWalPositionsMap) {
+    private Set<String> removeOldWals(Map<String, SortedMap<String, Long>> serverWalPositionsMap) {
         Map<String, Long> regionGroupMap = new HashMap<>();
-        Map<String, Long> copy = new HashMap<>();
+        SortedMap<String, Long> copy = new TreeMap<>();
         Set<String> oldWals = new HashSet<>();
-        for (Map<String, Long> walPositions : serverWalPositionsMap.values()) {
+        for (SortedMap<String, Long> walPositions : serverWalPositionsMap.values()) {
+            copy.clear();
             copy.putAll(walPositions);
 
             // If there are more than 1 wal from a region group, ignore old wal
             for (Map.Entry<String, Long> entry : copy.entrySet()) {
+                long position = entry.getValue();
                 String walName = entry.getKey();
                 int index = walName.lastIndexOf(".");
                 String walGroup = walName.substring(0, index);
                 Long logNum = new Long(walName.substring(index + 1));
                 if (regionGroupMap.containsKey(walGroup)) {
                     Long ln = regionGroupMap.get(walGroup);
-                    if (logNum > ln) {
+                    if (logNum > ln && position > 0) {
                         regionGroupMap.put(walGroup, logNum);
                         String key = walGroup + "." + ln;
                         walPositions.remove(key);
@@ -326,7 +327,7 @@ public class SpliceReplicationSourceChore extends ScheduledChore {
                     } else {
                         walPositions.remove(walName);
                         oldWals.add(walName);
-                        SpliceLogUtils.debug(LOG, "Log %s:%d has completed replication, remove it", walName, walPositions.get(walName));
+                        SpliceLogUtils.debug(LOG, "Ignore log %s:%d because it has not bee replicated", walName, walPositions.get(walName));
                     }
                 } else {
                     regionGroupMap.put(walGroup, logNum);
@@ -343,7 +344,9 @@ public class SpliceReplicationSourceChore extends ScheduledChore {
      * @param serverSnapshot
      * @throws Exception
      */
-    private void sendSnapshot(Connection conn, Long timestamp, ConcurrentHashMap<String, Map<String, Long>> serverSnapshot) throws Exception{
+    private void sendSnapshot(Connection conn,
+                              Long timestamp,
+                              ConcurrentHashMap<String, SortedMap<String, Long>> serverSnapshot) throws Exception{
 
         Table table = null;
         try {
@@ -432,7 +435,7 @@ public class SpliceReplicationSourceChore extends ScheduledChore {
         }
     }
 
-    private List<String> sortWals(Map<String, Map<String, Long>> wals) {
+    private List<String> sortWals(Map<String, SortedMap<String, Long>> wals) {
         List<String> sortedWals = Lists.newArrayList();
         for ( Map<String, Long> w : wals.values()) {
             for (Map.Entry<String, Long> walPosition : w.entrySet()) {

--- a/hbase_storage/hbase2.0.2/src/main/java/com/splicemachine/replication/HBaseReplicationPlatformUtil.java
+++ b/hbase_storage/hbase2.0.2/src/main/java/com/splicemachine/replication/HBaseReplicationPlatformUtil.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
  */
 public class HBaseReplicationPlatformUtil {
 
-    public static ReplicationPeerConfig createReplicationConfig(String clusterKey,  boolean isSerial) {
+    public static ReplicationPeerConfig createReplicationConfig(String clusterKey) {
         ReplicationPeerConfig config = ReplicationPeerConfig.newBuilder()
                 .setClusterKey(clusterKey)
                 .build();

--- a/hbase_storage/hbase2.1.4/src/main/java/com/splicemachine/replication/HBaseReplicationPlatformUtil.java
+++ b/hbase_storage/hbase2.1.4/src/main/java/com/splicemachine/replication/HBaseReplicationPlatformUtil.java
@@ -22,10 +22,10 @@ import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
  */
 public class HBaseReplicationPlatformUtil {
 
-    public static ReplicationPeerConfig createReplicationConfig(String clusterKey,  boolean isSerial) {
+    public static ReplicationPeerConfig createReplicationConfig(String clusterKey) {
         ReplicationPeerConfig config = ReplicationPeerConfig.newBuilder()
                 .setClusterKey(clusterKey)
-                .setSerial(isSerial)
+                .setSerial(true)
                 .build();
         return config;
     }

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/NoOpReplicationManager.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/NoOpReplicationManager.java
@@ -33,7 +33,7 @@ public class NoOpReplicationManager implements ReplicationManager {
     private NoOpReplicationManager(){ }
 
     @Override
-    public void addPeer(short peerId, String peerClusterKey, boolean isSerial) throws StandardException {
+    public void addPeer(short peerId, String peerClusterKey) throws StandardException {
 
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -1352,7 +1352,6 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                             .smallint("peerId")
                             .varchar("clusterKey", 32672)
                             .arg("enabled", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
-                            .arg("isSerial", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
                             .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
                             .build();
                     procedures.add(addPeer);
@@ -1491,6 +1490,15 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                             .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
                             .build();
                     procedures.add(getWalPosition);
+
+                    Procedure replicationEnabled = Procedure.newBuilder().name("REPLICATION_ENABLED")
+                            .numOutputParams(0)
+                            .catalog("schemaName")
+                            .catalog("tableName")
+                            .numResultSets(1)
+                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                            .build();
+                    procedures.add(replicationEnabled);
                 }  // End key == sysUUID
 
             } // End iteration through map keys (schema UUIDs)

--- a/splice_machine/src/main/java/com/splicemachine/replication/ReplicationManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/replication/ReplicationManager.java
@@ -24,7 +24,7 @@ import java.util.List;
  */
 public interface ReplicationManager {
 
-    void addPeer(short peerId, String peerClusterKey, boolean isSerial) throws StandardException;
+    void addPeer(short peerId, String peerClusterKey) throws StandardException;
     void removePeer(short peerId) throws StandardException;
     void enablePeer(String clusterKey, short peerId, String peerClusterKey) throws StandardException;
     void disablePeer(short peerId) throws StandardException;


### PR DESCRIPTION
Address a couple of issues:

- Make replication serial for cdh6.3.0
- Add system procedure to tell whether a table is enabled for replication
- Make sure slave cluster timestamp can only be incremented by replication. A request to a timestamp should always get the **current** timestamp, not **next** timestamp
