### PR TITLE
DB-9228 Fix MapR executor configuration (2.8)

### DIFF
--- a/assembly/mapr/src/main/resources/scripts/splice/hbase-env.sh
+++ b/assembly/mapr/src/main/resources/scripts/splice/hbase-env.sh
@@ -93,7 +93,7 @@ SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.driver.extraL
 SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.driver.extraClassPath=/opt/mapr/hbase/hbase1.1.8-splice/conf:/opt/mapr/hbase/hbase1.1.8-splice/lib/*:/opt/splice/default/lib/*"
 SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.executor.extraJavaOptions=-Dlog4j.configuration=file:/etc/spark/conf/log4j.properties"
 SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.executor.extraLibraryPath=/opt/mapr/hadoop/hadoop-2.7.0/lib/native"
-SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.executor.extraClassPath=/opt/mapr/hbase/hbase1.1.8-splice/conf:/opt/mapr/hbase/hbase1.1.8-splice/lib/*:/opt/splice/default/lib/*"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.executor.extraClassPath=/opt/mapr/hbase/hbase1.1.8-splice/conf:/opt/splice/default/lib/*:/opt/mapr/hbase/hbase1.1.8-splice/lib/*"
 SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.ui.retainedJobs=100"
 SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.ui.retainedStages=100"
 SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.worker.ui.retainedExecutors=100"

--- a/assembly/mapr/src/main/resources/scripts/splice/hbase-env.sh
+++ b/assembly/mapr/src/main/resources/scripts/splice/hbase-env.sh
@@ -90,7 +90,7 @@ SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.yarn.am.waitT
 SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.yarn.executor.memoryOverhead=2048"
 SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.driver.extraJavaOptions=-Dlog4j.configuration=file:/etc/spark/conf/log4j.properties"
 SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.driver.extraLibraryPath=/opt/mapr/hadoop/hadoop-2.7.0/lib/native"
-SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.driver.extraClassPath=/opt/mapr/hbase/hbase1.1.8-splice/conf:/opt/mapr/hbase/hbase1.1.8-splice/lib/*:/opt/splice/default/lib/*"
+SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.driver.extraClassPath=/opt/mapr/hbase/hbase1.1.8-splice/conf:/opt/splice/default/lib/*:/opt/mapr/hbase/hbase1.1.8-splice/lib/*"
 SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.executor.extraJavaOptions=-Dlog4j.configuration=file:/etc/spark/conf/log4j.properties"
 SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.executor.extraLibraryPath=/opt/mapr/hadoop/hadoop-2.7.0/lib/native"
 SPLICE_HBASE_MASTER_OPTS="$SPLICE_HBASE_MASTER_OPTS -Dsplice.spark.executor.extraClassPath=/opt/mapr/hbase/hbase1.1.8-splice/conf:/opt/splice/default/lib/*:/opt/mapr/hbase/hbase1.1.8-splice/lib/*"


### PR DESCRIPTION
One line change to switch the order of how the jars are located for MapR 6.1 executors.