### PR TITLE
DB-9265 Make memstore-only scanners PREAD instead of STREAM

### DIFF
--- a/hbase_storage/src/main/java/com/splicemachine/access/client/SkeletonClientSideRegionScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/SkeletonClientSideRegionScanner.java
@@ -232,7 +232,7 @@ public abstract class SkeletonClientSideRegionScanner implements RegionScanner{
         Scan memScan = new Scan(scan);
         memScan.setFilter(null);   // Remove SamplingFilter if the scan has it
         memScan.setAsyncPrefetch(false); // async would keep buffering rows indefinitely
-        memScan.setReadType(Scan.ReadType.STREAM);
+        memScan.setReadType(Scan.ReadType.PREAD);
         memScan.setAttribute(ClientRegionConstants.SPLICE_SCAN_MEMSTORE_ONLY,SIConstants.TRUE_BYTES);
         memScan.setAttribute(ClientRegionConstants.SPLICE_SCAN_MEMSTORE_PARTITION_BEGIN_KEY, hri.getStartKey());
         memScan.setAttribute(ClientRegionConstants.SPLICE_SCAN_MEMSTORE_PARTITION_END_KEY, hri.getEndKey());


### PR DESCRIPTION
Workaround for HBase issue where HFile scanners are opened but not
closed for Memstore-only scans, PREAD scanners don't hold any resources
so it's fine not to close them, but STREAM scanners do and leak
resources in this case.