### PR TITLE
DB-6542: create missing index rows

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -850,8 +850,9 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
     }
 
     @Override
-    public TableChecker getTableChecker(String schemaName, String tableName, DataSet table, KeyHashDecoder tableKeyDecoder, ExecRow tableKey) {
-        return new SparkTableChecker(schemaName, tableName, table, tableKeyDecoder, tableKey);
+    public TableChecker getTableChecker(String schemaName, String tableName, DataSet table,
+                                        KeyHashDecoder tableKeyDecoder, ExecRow tableKey, TxnView txn, boolean fix) {
+        return new SparkTableChecker(schemaName, tableName, table, tableKeyDecoder, tableKey, txn, fix);
     }
 
     @Override

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/CheckTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/CheckTableIT.java
@@ -26,7 +26,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.RegionInfo;
 import org.junit.*;
 
 import java.sql.Connection;
@@ -51,6 +53,10 @@ public class CheckTableIT extends SpliceUnitTest {
     private static final String BI = "BI";
     private static final String C = "C";
     private static final String D = "D";
+    private static final String E = "E";
+    private static final String EI = "EI";
+    private static final String F = "F";
+    private static final String FI = "FI";
 
     @ClassRule
     public static SpliceWatcher spliceClassWatcher = new SpliceWatcher(SCHEMA_NAME);
@@ -130,6 +136,50 @@ public class CheckTableIT extends SpliceUnitTest {
         spliceClassWatcher.execute("create index t1 on D(c, a) exclude null keys");
         spliceClassWatcher.execute("create index t2 on D(c, b) exclude default keys");
         spliceClassWatcher.execute("create index t3 on D(b, c) exclude null keys");
+
+        new TableCreator(conn)
+                .withCreate("create table CHECKTABLEIT2.E (a int, b int, c int, primary key(a,b))")
+                .withInsert("insert into CHECKTABLEIT2.E values(?,?,?)")
+                .withIndex("create index EI on CHECKTABLEIT2.E(c)")
+                .withRows(rows(
+                        row(1, 1, 1),
+                        row(2, 2, 2),
+                        row(4, 4, 4),
+                        row(5, 5, 5),
+                        row(7,7,7)))
+                .create();
+
+        spliceClassWatcher.execute("call syscs_util.syscs_split_table_or_index_at_points('CHECKTABLEIT2', 'E', null,'\\x83')");
+        spliceClassWatcher.execute("call syscs_util.syscs_split_table_or_index_at_points('CHECKTABLEIT2', 'E', 'EI','\\x83')");
+        spliceClassWatcher.execute("call syscs_util.syscs_perform_major_compaction_on_table('CHECKTABLEIT2', 'E')");
+        spliceClassWatcher.execute("call syscs_util.syscs_split_table_or_index_at_points('CHECKTABLEIT2', 'E', null,'\\x86')");
+        spliceClassWatcher.execute("call syscs_util.syscs_split_table_or_index_at_points('CHECKTABLEIT2', 'E', 'EI','\\x86')");
+        deleteFirstIndexRegion(spliceClassWatcher, conn, "CHECKTABLEIT2", E, EI);
+
+
+        new TableCreator(conn)
+                .withCreate("create table CHECKTABLEIT2.F (a int, b int, c int, primary key(a,b))")
+                .withInsert("insert into CHECKTABLEIT2.F values(?,?,?)")
+                .withIndex("create unique index CHECKTABLEIT2.FI on CHECKTABLEIT2.F(c)")
+                .withRows(rows(
+                        row(0, 0, 0)))
+                .create();
+
+        spliceClassWatcher.execute("call syscs_util.syscs_split_table_or_index_at_points('CHECKTABLEIT2', 'F', null,'\\x83')");
+        spliceClassWatcher.execute("call syscs_util.syscs_split_table_or_index_at_points('CHECKTABLEIT2', 'F', 'FI','\\x83')");
+        spliceClassWatcher.execute("call syscs_util.syscs_perform_major_compaction_on_table('CHECKTABLEIT2', 'F')");
+        spliceClassWatcher.execute("call syscs_util.syscs_split_table_or_index_at_points('CHECKTABLEIT2', 'F', null,'\\x86')");
+        spliceClassWatcher.execute("call syscs_util.syscs_split_table_or_index_at_points('CHECKTABLEIT2', 'F', 'FI','\\x86')");
+
+        ps = spliceClassWatcher.prepareStatement("insert into CHECKTABLEIT2.F select * from B");
+        ps.execute();
+        deleteFirstIndexRegion(spliceClassWatcher, conn, "CHECKTABLEIT2", F, FI);
+    }
+
+    @AfterClass
+    public static void dropTables() throws Exception {
+        spliceClassWatcher.execute("drop table CHECKTABLEIT2.E");
+        spliceClassWatcher.execute("drop table CHECKTABLEIT2.F");
     }
 
     @Test
@@ -138,6 +188,69 @@ public class CheckTableIT extends SpliceUnitTest {
         checkTable(SCHEMA_NAME, B, BI);
     }
 
+    @Test
+    public void testFixTableOnSpark() throws Exception {
+        spliceClassWatcher.execute(String.format("call syscs_util.check_table('%s', '%s', null, 1, '%s/check-%s2.out')", "CHECKTABLEIT2", F, getResourceDirectory(), F));
+        String select =
+                "SELECT \"message\" " +
+                        "from new com.splicemachine.derby.vti.SpliceFileVTI(" +
+                        "'%s',NULL,'|',NULL,'HH:mm:ss','yyyy-MM-dd','yyyy-MM-dd HH:mm:ss','true','UTF-8' ) " +
+                        "AS messages (\"message\" varchar(200)) order by 1";
+        ResultSet rs =spliceClassWatcher.executeQuery(format(select, String.format("%s/check-%s2.out", getResourceDirectory(), F)));
+        String s = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+        String expected ="message    |\n" +
+                "---------------\n" +
+                "count = 99903 |\n" +
+                "count = 99904 |\n" +
+                "     F:       |\n" +
+                "     FI:      |";
+        Assert.assertEquals(s, expected, s);
+
+        spliceClassWatcher.execute(String.format("call syscs_util.fix_table('%s', '%s', null, '%s/check-%s2.out')", "CHECKTABLEIT2", F, getResourceDirectory(), F));
+        rs = spliceClassWatcher.executeQuery(String.format("call syscs_util.check_table('%s', '%s', null, 1, '%s/check-%s2.out')", "CHECKTABLEIT2", F, getResourceDirectory(), F));
+        rs.next();
+        s = rs.getString(1);
+        Assert.assertEquals(s, s, "No inconsistencies were found.");
+    }
+
+    @Test
+    public void testFixTable() throws Exception {
+        spliceClassWatcher.execute(String.format("call syscs_util.check_table('%s', '%s', null, 2, '%s/check-%s2.out')", "CHECKTABLEIT2", E, getResourceDirectory(), E));
+        String select =
+                "SELECT \"message\" " +
+                        "from new com.splicemachine.derby.vti.SpliceFileVTI(" +
+                        "'%s',NULL,'|',NULL,'HH:mm:ss','yyyy-MM-dd','yyyy-MM-dd HH:mm:ss','true','UTF-8' ) " +
+                        "AS messages (\"message\" varchar(200)) order by 1";
+        ResultSet rs =spliceClassWatcher.executeQuery(format(select, String.format("%s/check-%s2.out", getResourceDirectory(), E)));
+        String s = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+        String expected = "message                                |\n" +
+                "-----------------------------------------------------------------------\n" +
+                "The following 2 rows from base table CHECKTABLEIT2.E are not indexed: |\n" +
+                "                              { 1, 1 }                                |\n" +
+                "                              { 2, 2 }                                |\n" +
+                "                                 EI:                                  |";
+        Assert.assertEquals(s, expected, s);
+
+        spliceClassWatcher.execute(String.format("call syscs_util.fix_table('%s', '%s', null, '%s/fix-%s.out')", "CHECKTABLEIT2", E, getResourceDirectory(), E));
+        select =
+                "SELECT \"message\" " +
+                        "from new com.splicemachine.derby.vti.SpliceFileVTI(" +
+                        "'%s',NULL,'|',NULL,'HH:mm:ss','yyyy-MM-dd','yyyy-MM-dd HH:mm:ss','true','UTF-8' ) " +
+                        "AS messages (\"message\" varchar(200)) order by 1";
+        rs =spliceClassWatcher.executeQuery(format(select, String.format("%s/fix-%s.out", getResourceDirectory(), E)));
+        s = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+        expected = "message                                |\n" +
+                "------------------------------------------------------------------------\n" +
+                "Create index for the following 2 rows from base table CHECKTABLEIT2.E: |\n" +
+                "                               { 1, 1 }                                |\n" +
+                "                               { 2, 2 }                                |\n" +
+                "                                  EI:                                  |";
+        Assert.assertEquals(s, expected, s);
+        rs = spliceClassWatcher.executeQuery(String.format("call syscs_util.check_table('%s', '%s', null, 2, '%s/check-%s2.out')", "CHECKTABLEIT2", E, getResourceDirectory(), E));
+        rs.next();
+        s = rs.getString(1);
+        Assert.assertEquals(s, s, "No inconsistencies were found.");
+    }
     @Test
     public void checkTableWithSkippedNullValues() throws Exception {
         ResultSet rs = spliceClassWatcher.executeQuery(String.format("call syscs_util.check_table('%s', '%s', null, 2, '%s/check-%s2.out')", SCHEMA_NAME, D, getResourceDirectory(), D));
@@ -355,6 +468,26 @@ public class CheckTableIT extends SpliceUnitTest {
             if (startKey.length != 0 && endKey.length != 0) {
                 String encodedRegionName = partition.getEncodedName();
                 spliceClassWatcher.execute(String.format("call syscs_util.delete_region('%s', '%s', '%s', '%s', false)",
+                        schemaName, tableName, indexName, encodedRegionName));
+                break;
+            }
+        }
+    }
+
+    public static void deleteFirstIndexRegion(SpliceWatcher spliceWatcher, Connection connection, String schemaName, String tableName, String indexName) throws Exception {
+        SConfiguration config = HConfiguration.getConfiguration();
+        HBaseTestingUtility testingUtility = new HBaseTestingUtility((Configuration) config.getConfigSource().unwrapDelegate());
+        Admin admin = testingUtility.getAdmin();
+
+        // Delete 2nd region of index
+        long   conglomerateId = TableSplit.getConglomerateId(connection, schemaName, tableName, indexName);
+        TableName iName = TableName.valueOf(config.getNamespace(),Long.toString(conglomerateId));
+        List<RegionInfo> partitions = admin.getRegions(iName);
+        for (RegionInfo partition : partitions) {
+            byte[] startKey = partition.getStartKey();
+            if (startKey.length == 0) {
+                String encodedRegionName = partition.getEncodedName();
+                spliceWatcher.execute(String.format("call syscs_util.delete_region('%s', '%s', '%s', '%s', false)",
                         schemaName, tableName, indexName, encodedRegionName));
                 break;
             }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -1337,6 +1337,17 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                             .build();
                     procedures.add(checkTable);
 
+                    Procedure fixTable = Procedure.newBuilder().name("FIX_TABLE")
+                            .catalog("schemaName")
+                            .catalog("tableName")
+                            .catalog("indexName")
+                            .varchar("outputFile", 32672)
+                            .numOutputParams(0)
+                            .numResultSets(1)
+                            .ownerClass(SpliceTableAdmin.class.getCanonicalName())
+                            .build();
+                    procedures.add(fixTable);
+
                     Procedure showCreateTable = Procedure.newBuilder().name("SHOW_CREATE_TABLE")
                             .numOutputParams(0)
                             .numResultSets(1)

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/CheckTableJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/CheckTableJob.java
@@ -119,7 +119,6 @@ public class CheckTableJob implements Callable<Void> {
         CheckTableResult checkTableResult = new CheckTableResult();
         Map<String, List<String>> errors = new TreeMap<>();
 
-        int[] baseColumnMap = getBaseColumnMap(tentativeIndexList);
         DataSet<ExecRow> tableDataSet = getTableDataSet(dsp, heapConglomId, tentativeIndexList);
         ExecRow key = getTableKeyExecRow(heapConglomId);
         KeyHashDecoder tableKeyDecoder = getKeyDecoder(key, null);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/DistributedCheckTableJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/DistributedCheckTableJob.java
@@ -39,6 +39,7 @@ public class DistributedCheckTableJob extends DistributedJob implements External
     String tableName;
     String jobGroup;
     List<DDLMessage.TentativeIndex> tentativeIndexList;
+    boolean fix;
 
     public DistributedCheckTableJob(){
     }
@@ -48,12 +49,14 @@ public class DistributedCheckTableJob extends DistributedJob implements External
                                     String schemaName,
                                     String tableName,
                                     List<DDLMessage.TentativeIndex> tentativeIndexList,
+                                    boolean fix,
                                     String jobGroup) {
         this.ah = ah;
         this.txn = txn;
         this.schemaName = schemaName;
         this.tableName = tableName;
         this.tentativeIndexList = tentativeIndexList;
+        this.fix = fix;
         this.jobGroup = jobGroup;
     }
 
@@ -78,6 +81,7 @@ public class DistributedCheckTableJob extends DistributedJob implements External
             in.readFully(message);
             tentativeIndexList.add(DDLMessage.TentativeIndex.parseFrom(message));
         }
+        fix = in.readBoolean();
         jobGroup = in.readUTF();
     }
 
@@ -93,6 +97,7 @@ public class DistributedCheckTableJob extends DistributedJob implements External
             out.writeInt(message.length);
             out.write(message);
         }
+        out.writeBoolean(fix);
         out.writeUTF(jobGroup);
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/KeyByRowIdFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/KeyByRowIdFunction.java
@@ -22,19 +22,19 @@ import scala.Tuple2;
 /**
  * Created by jyuan on 2/6/18.
  */
-public class KeyByRowIdFunction <Op extends SpliceOperation> extends SplicePairFunction<SpliceOperation,ExecRow,String,byte[]> {
+public class KeyByRowIdFunction <Op extends SpliceOperation> extends SplicePairFunction<SpliceOperation,ExecRow,String,ExecRow> {
 
     @Override
     public String genKey(ExecRow row) {
         return Bytes.toHex(row.getKey());
     }
 
-    public byte[] genValue(ExecRow row) {
-        return row.getKey();
+    public ExecRow genValue(ExecRow row) {
+        return row.getClone();
     }
 
     @Override
-    public Tuple2<String, byte[]> call(ExecRow execRow) throws Exception {
-        return new Tuple2(genKey(execRow),genValue(execRow));
+    public Tuple2<String, ExecRow> call(ExecRow execRow) throws Exception {
+        return new Tuple2(genKey(execRow), genValue(execRow));
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
@@ -33,6 +33,7 @@ import com.splicemachine.pipeline.Exceptions;
 import com.splicemachine.si.api.data.TxnOperationFactory;
 import com.splicemachine.si.api.server.Transactor;
 import com.splicemachine.si.api.txn.TxnSupplier;
+import com.splicemachine.si.api.txn.TxnView;
 import com.splicemachine.si.impl.TxnRegion;
 import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.si.impl.readresolve.NoOpReadResolver;
@@ -381,8 +382,9 @@ public class ControlDataSetProcessor implements DataSetProcessor{
     }
     
     @Override
-    public TableChecker getTableChecker(String schemaName, String tableName, DataSet table, KeyHashDecoder tableKeyDecoder, ExecRow tableKey) {
-        return new ControlTableChecker(schemaName, tableName, table, tableKeyDecoder, tableKey);
+    public TableChecker getTableChecker(String schemaName, String tableName, DataSet table,
+                                        KeyHashDecoder tableKeyDecoder, ExecRow tableKey, TxnView txn, boolean fix) {
+        return new ControlTableChecker(schemaName, tableName, table, tableKeyDecoder, tableKey, txn, fix);
     }
 
     // Operations specific to native spark explains

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlTableChecker.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlTableChecker.java
@@ -14,6 +14,17 @@
 
 package com.splicemachine.derby.stream.control;
 
+import com.splicemachine.ddl.DDLMessage;
+import com.splicemachine.derby.stream.function.IndexTransformFunction;
+import com.splicemachine.derby.stream.function.KVPairFunction;
+import com.splicemachine.derby.stream.output.DataSetWriter;
+import com.splicemachine.kvpair.KVPair;
+import com.splicemachine.pipeline.PipelineDriver;
+import com.splicemachine.pipeline.callbuffer.RecordingCallBuffer;
+import com.splicemachine.pipeline.client.WriteCoordinator;
+import com.splicemachine.pipeline.config.WriteConfiguration;
+import com.splicemachine.si.api.txn.TxnView;
+import com.splicemachine.storage.Partition;
 import org.spark_project.guava.collect.ArrayListMultimap;
 import org.spark_project.guava.collect.ListMultimap;
 import com.splicemachine.db.iapi.error.StandardException;
@@ -43,27 +54,34 @@ public class ControlTableChecker implements TableChecker {
     private long invalidIndexCount = 0;
     private long missingIndexCount = 0;
     private DataSet<ExecRow> baseTable;
-    private PairDataSet<String, byte[]> filteredTable;
+    private PairDataSet<String, ExecRow> filteredTable;
     private KeyHashDecoder tableKeyDecoder;
     private ExecRow tableKeyTemplate;
     private KeyHashDecoder indexKeyDecoder;
     private ExecRow indexKeyTemplate;
     private long maxCheckTableErrors;
-    private LeadingIndexColumnInfo leadingIndexColumnInfo;
     private ListMultimap<String, byte[]> indexData;
-    private Map<String, byte[]> tableData;
+    private Map<String, ExecRow> tableData;
+    private boolean fix;
+    private TxnView txn;
+    private long conglomerate;
+    private DDLMessage.TentativeIndex tentativeIndex;
 
     public ControlTableChecker (String schemaName,
                                 String tableName,
                                 DataSet table,
                                 KeyHashDecoder tableKeyDecoder,
-                                ExecRow tableKey) {
+                                ExecRow tableKey,
+                                TxnView txn,
+                                boolean fix) {
         this.schemaName = schemaName;
         this.tableName = tableName;
         this.baseTable = table;
         this.tableKeyDecoder = tableKeyDecoder;
         this.tableKeyTemplate = tableKey;
         this.maxCheckTableErrors = SIDriver.driver().getConfiguration().getMaxCheckTableErrors();
+        this.txn = txn;
+        this.fix = fix;
     }
 
     @Override
@@ -71,14 +89,17 @@ public class ControlTableChecker implements TableChecker {
                                    String indexName,
                                    KeyHashDecoder indexKeyDecoder,
                                    ExecRow indexKey,
-                                   LeadingIndexColumnInfo leadingIndexColumnInfo) throws Exception {
+                                   LeadingIndexColumnInfo leadingIndexColumnInfo,
+                                   long conglomerate,
+                                   DDLMessage.TentativeIndex tentativeIndex) throws Exception {
 
         this.indexName = indexName;
         this.indexKeyDecoder = indexKeyDecoder;
         this.indexKeyTemplate = indexKey;
-        this.leadingIndexColumnInfo = leadingIndexColumnInfo;
+        this.conglomerate = conglomerate;
+        this.tentativeIndex = tentativeIndex;
 
-        filteredTable = baseTable.filter(new IndexFilter<>(this.leadingIndexColumnInfo))
+        filteredTable = baseTable.filter(new IndexFilter<>(leadingIndexColumnInfo))
                 .index(new KeyByRowIdFunction());
         // Pull data into memory
         populateData(filteredTable, index);
@@ -102,12 +123,12 @@ public class ControlTableChecker implements TableChecker {
 
         tableData = new HashMap<>();
         tableCount=0;
-        Iterator<Tuple2<String, byte[]>> tableSource = ((ControlPairDataSet) table).source;
+        Iterator<Tuple2<String, ExecRow>> tableSource = ((ControlPairDataSet) table).source;
         while (tableSource.hasNext()) {
             tableCount++;
-            Tuple2<String, byte[]> t = tableSource.next();
+            Tuple2<String, ExecRow> t = tableSource.next();
             String rowId = t._1;
-            byte[] row = t._2;
+            ExecRow row = t._2;
             tableData.put(rowId, row);
         }
 
@@ -157,7 +178,7 @@ public class ControlTableChecker implements TableChecker {
 
     private List<String> checkInvalidIndexes() throws StandardException {
         invalidIndexCount = 0;
-        List<String> messages = new LinkedList<>();
+
         ArrayListMultimap<String, byte[]> result = ArrayListMultimap.create();
         for (String baseRowId : indexData.keySet()) {
             if (!tableData.containsKey(baseRowId)) {
@@ -167,15 +188,57 @@ public class ControlTableChecker implements TableChecker {
             }
         }
 
-        int i = 0;
         if (invalidIndexCount > 0) {
-            messages.add(String.format("The following %d indexes are invalid:", invalidIndexCount));
+            if (fix) {
+                return fixInvalidIndexes(result);
+            } else {
+                return reportInvalidIndexes(result);
+            }
+        }
+        return new LinkedList<>();
+    }
+
+    private List<String> reportInvalidIndexes(ArrayListMultimap<String, byte[]> result) throws StandardException {
+        List<String> messages = new LinkedList<>();
+        int i = 0;
+        messages.add(String.format("The following %d indexes are invalid:", invalidIndexCount));
+        for (String baseRowId : result.keySet()) {
+            List<byte[]> keys = result.get(baseRowId);
+            for (byte[] key : keys) {
+                if (i >= maxCheckTableErrors) {
+                    messages.add("...");
+                    return messages;
+                }
+                indexKeyDecoder.set(key, 0, key.length);
+                indexKeyDecoder.decode(indexKeyTemplate);
+                messages.add(indexKeyTemplate.getClone().toString() + "=>" + baseRowId);
+                i++;
+            }
+        }
+        return  messages;
+    }
+
+
+    private List<String> fixInvalidIndexes(ArrayListMultimap<String, byte[]> result) throws StandardException {
+        try {
+            WriteCoordinator writeCoordinator = PipelineDriver.driver().writeCoordinator();
+            WriteConfiguration writeConfiguration = writeCoordinator.defaultWriteConfiguration();
+            Partition indexPartition = SIDriver.driver().getTableFactory().getTable(Long.toString(conglomerate));
+            RecordingCallBuffer<KVPair> writeBuffer = writeCoordinator.writeBuffer(indexPartition, txn, null, writeConfiguration);
+
+            List<String> messages = new LinkedList<>();
+            int i = 0;
+            messages.add(String.format("The following %d indexes are deleted:", invalidIndexCount));
             for (String baseRowId : result.keySet()) {
                 List<byte[]> keys = result.get(baseRowId);
                 for (byte[] key : keys) {
-                    if (i >= maxCheckTableErrors) {
+                    if (i == maxCheckTableErrors) {
                         messages.add("...");
                         return messages;
+                    }
+                    writeBuffer.add(new KVPair(key, new byte[0], KVPair.Type.DELETE));
+                    if (i > maxCheckTableErrors) {
+                        continue;
                     }
                     indexKeyDecoder.set(key, 0, key.length);
                     indexKeyDecoder.decode(indexKeyTemplate);
@@ -183,41 +246,92 @@ public class ControlTableChecker implements TableChecker {
                     i++;
                 }
             }
+            writeBuffer.flushBuffer();
+            return messages;
         }
-        return  messages;
+        catch (Exception e) {
+            throw StandardException.plainWrapException(e);
+        }
     }
 
     private List<String> checkMissingIndexes() throws StandardException {
         List<String> messages = new LinkedList<>();
         missingIndexCount = 0;
-        Map<String, byte[]> result = new HashMap<>();
+        Map<String, ExecRow> result = new HashMap<>();
         for (String rowId : tableData.keySet()) {
             if (!indexData.containsKey(rowId)) {
                 missingIndexCount++;
                 result.put(rowId, tableData.get(rowId));
             }
         }
-
-        int i = 0;
         if (missingIndexCount > 0) {
-            messages.add(String.format("The following %d rows from base table %s.%s are not indexed:", result.size(), schemaName, tableName));
-            for (Map.Entry<String, byte[]> entry : result.entrySet()) {
-                if (i >= maxCheckTableErrors) {
-                    messages.add("...");
-                    break;
-                }
-                byte[] key = entry.getValue();
-                if (tableKeyTemplate.nColumns() > 0) {
-                    tableKeyDecoder.set(key, 0, key.length);
-                    tableKeyDecoder.decode(tableKeyTemplate);
-                    messages.add(tableKeyTemplate.getClone().toString());
-                }
-                else {
-                    messages.add(entry.getKey());
-                }
-                i++;
+            if (fix) {
+                return fixMissingIndexes(result);
+            } else {
+                return reportMissingIndexes(result);
             }
         }
+        return new LinkedList<>();
+    }
+
+    private List<String> fixMissingIndexes(Map<String, ExecRow> result) throws StandardException {
+        List<String> messages = new LinkedList<>();
+
+        DataSet<ExecRow> dataSet = new ControlDataSet<>(result.values().iterator());
+        PairDataSet dsToWrite = dataSet
+                .map(new IndexTransformFunction(tentativeIndex), null, false, true, "Prepare Index")
+                .index(new KVPairFunction(), false, true, "Add missing indexes");
+        DataSetWriter writer = dsToWrite.directWriteData()
+                .destConglomerate(tentativeIndex.getIndex().getConglomerate())
+                .txn(txn)
+                .build();
+        writer.write();
+
+        int i = 0;
+        messages.add(String.format("Create index for the following %d rows from base table %s.%s:", result.size(), schemaName, tableName));
+        for (Map.Entry<String, ExecRow> entry : result.entrySet()) {
+            if (i >= maxCheckTableErrors) {
+                messages.add("...");
+                break;
+            }
+            byte[] key = entry.getValue().getKey();
+            if (tableKeyTemplate.nColumns() > 0) {
+                tableKeyDecoder.set(key, 0, key.length);
+                tableKeyDecoder.decode(tableKeyTemplate);
+                messages.add(tableKeyTemplate.getClone().toString());
+            }
+            else {
+                messages.add(entry.getKey());
+            }
+            i++;
+        }
+
+        return  messages;
+    }
+
+
+    private List<String> reportMissingIndexes(Map<String, ExecRow> result) throws StandardException {
+        List<String> messages = new LinkedList<>();
+
+        int i = 0;
+        messages.add(String.format("The following %d rows from base table %s.%s are not indexed:", result.size(), schemaName, tableName));
+        for (Map.Entry<String, ExecRow> entry : result.entrySet()) {
+            if (i >= maxCheckTableErrors) {
+                messages.add("...");
+                break;
+            }
+            byte[] key = entry.getValue().getKey();
+            if (tableKeyTemplate.nColumns() > 0) {
+                tableKeyDecoder.set(key, 0, key.length);
+                tableKeyDecoder.decode(tableKeyTemplate);
+                messages.add(tableKeyTemplate.getClone().toString());
+            }
+            else {
+                messages.add(entry.getKey());
+            }
+            i++;
+        }
+
         return  messages;
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/IndexTransformFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/IndexTransformFunction.java
@@ -70,7 +70,7 @@ public class IndexTransformFunction <Op extends SpliceOperation> extends SpliceF
     private void init(ExecRow execRow) {
         transformer = new IndexTransformer(tentativeIndex);
         initialized = true;
-        indexRow = new ValueRow(execRow.nColumns());
+        indexRow = new ValueRow(projectedMapping.length);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
@@ -23,6 +23,7 @@ import com.splicemachine.db.impl.sql.compile.ExplainNode;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.stream.function.Partitioner;
 import com.splicemachine.derby.utils.marshall.KeyHashDecoder;
+import com.splicemachine.si.api.txn.TxnView;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
@@ -266,7 +267,8 @@ public interface DataSetProcessor {
 
     Boolean isCached(long conglomerateId) throws StandardException;
 
-    TableChecker getTableChecker(String schemaName, String tableName, DataSet tableDataSet, KeyHashDecoder decoder, ExecRow key);
+    TableChecker getTableChecker(String schemaName, String tableName, DataSet tableDataSet, KeyHashDecoder decoder,
+                                 ExecRow key, TxnView txn, boolean fix);
 
     // Operations related to spark explain ->
     boolean isSparkExplain();

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/TableChecker.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/TableChecker.java
@@ -15,6 +15,7 @@
 package com.splicemachine.derby.stream.iapi;
 
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
+import com.splicemachine.ddl.DDLMessage;
 import com.splicemachine.derby.impl.storage.CheckTableJob;
 import com.splicemachine.derby.utils.marshall.KeyHashDecoder;
 
@@ -27,7 +28,10 @@ public interface TableChecker {
     List<String> checkIndex(PairDataSet index,
                             String indexName,
                             KeyHashDecoder indexKeyDecoder,
-                            ExecRow indexKey, CheckTableJob.LeadingIndexColumnInfo leadingIndexColumnInfo) throws Exception;
+                            ExecRow indexKey,
+                            CheckTableJob.LeadingIndexColumnInfo leadingIndexColumnInfo,
+                            long conglomerate,
+                            DDLMessage.TentativeIndex tentativeIndex) throws Exception;
 
     void setTableDataSet(DataSet tableDataSet);
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ForwardingDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ForwardingDataSetProcessor.java
@@ -24,6 +24,7 @@ import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.stream.function.Partitioner;
 import com.splicemachine.derby.stream.iapi.*;
 import com.splicemachine.derby.utils.marshall.KeyHashDecoder;
+import com.splicemachine.si.api.txn.TxnView;
 import org.apache.spark.sql.types.StructType;
 
 import java.io.InputStream;
@@ -195,8 +196,8 @@ public abstract class ForwardingDataSetProcessor implements DataSetProcessor{
 
     @Override
     public TableChecker getTableChecker(String schemaName, String tableName, DataSet tableDataSet,
-                                        KeyHashDecoder decoder, ExecRow key) {
-        return delegate.getTableChecker(schemaName, tableName, tableDataSet, decoder, key);
+                                        KeyHashDecoder decoder, ExecRow key, TxnView txn,  boolean fix) {
+        return delegate.getTableChecker(schemaName, tableName, tableDataSet, decoder, key, txn, fix);
     }
 
     // Operations specific to native spark explains


### PR DESCRIPTION
Implement syscs_util.fix_table to make base table and index consistent.