### PR TITLE
DB-9347 Fix sentry dependency in platform_it/pom.xml (3.0)

### DIFF
--- a/platform_it/pom.xml
+++ b/platform_it/pom.xml
@@ -1149,18 +1149,10 @@
         <profile>
             <id>cdh6.3.0</id>
             <properties>
-                <extraDependency>splice_ee</extraDependency>
+                <extraDependency>splice_sentry</extraDependency>
                 <extraDependency2>splice_ee</extraDependency2>
                 <extraDependency3>splice_ee</extraDependency3>
             </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>com.splicemachine</groupId>
-                    <artifactId>splice_sentry</artifactId>
-                    <version>${project.version}</version>
-                    <classifier>${envClassifier}</classifier>
-                </dependency>
-            </dependencies>
         </profile>
         <profile>
             <id>dbaas</id>


### PR DESCRIPTION
Make dependency on _splice_sentry_ conditional (when _ee_ profile is enabled).

See corresponding PR for spliceengine-ee.