### PR TITLE
DB-9408 Harmonize peek() and next() on MemStoreFlushAwareScanner (2.8)

### DIFF
--- a/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/hbase1.2.0/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -87,26 +87,37 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
 
     @Override
     public KeyValue peek() {
-        if (didWeFlush()) {
-            if (flushAlreadyReturned) {
-                return new KeyValue(Bytes.toBytes(counter),ClientRegionConstants.FLUSH,ClientRegionConstants.FLUSH, 0l,ClientRegionConstants.FLUSH);
-            }
-            else {
-                if (LOG.isTraceEnabled())
-                    SpliceLogUtils.trace(LOG, "returning flush");
-                return ClientRegionConstants.MEMSTORE_BEGIN_FLUSH;
-            }
-        }
         if (beginRow) {
             if (LOG.isTraceEnabled())
                 SpliceLogUtils.trace(LOG, "Peek: memstore begin");
             return ClientRegionConstants.MEMSTORE_BEGIN;
         }
+        if (endRowNeedsToBeReturned) {
+            if (LOG.isTraceEnabled())
+                SpliceLogUtils.trace(LOG, "Peek: end row " + counter);
+            return new KeyValue(Bytes.toBytes(counter), ClientRegionConstants.HOLD, ClientRegionConstants.HOLD, HConstants.LATEST_TIMESTAMP, ClientRegionConstants.HOLD);
+        }
+        if (didWeFlush()) {
+            if (flushAlreadyReturned) {
+                if (LOG.isTraceEnabled())
+                    SpliceLogUtils.trace(LOG, "Peek: flushed " + counter);
+                return new KeyValue(Bytes.toBytes(counter),ClientRegionConstants.FLUSH,ClientRegionConstants.FLUSH, 0l,ClientRegionConstants.FLUSH);
+            }
+            else {
+                if (LOG.isTraceEnabled())
+                    SpliceLogUtils.trace(LOG, "Peek: begin flush");
+                return ClientRegionConstants.MEMSTORE_BEGIN_FLUSH;
+            }
+        }
         Cell peek = super.peek();
         if (peek == null || isStopRow(peek)) {
             endRowNeedsToBeReturned = true;
+            if (LOG.isTraceEnabled())
+                SpliceLogUtils.trace(LOG, "Peek: first end row");
             return new KeyValue(Bytes.toBytes(counter),ClientRegionConstants.HOLD,ClientRegionConstants.HOLD, HConstants.LATEST_TIMESTAMP,ClientRegionConstants.HOLD);
         }
+        if (LOG.isTraceEnabled())
+            SpliceLogUtils.trace(LOG, "Peek: " + peek);
         return (KeyValue)peek;
     }
 
@@ -139,6 +150,8 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
             return outResult.add(ClientRegionConstants.MEMSTORE_BEGIN);
         }
         if (endRowNeedsToBeReturned) {
+            if (LOG.isTraceEnabled())
+                SpliceLogUtils.trace(LOG, "Next: end row " + counter);
             try {
                 outResult.add(new KeyValue(Bytes.toBytes(counter), ClientRegionConstants.HOLD, ClientRegionConstants.HOLD, HConstants.LATEST_TIMESTAMP, ClientRegionConstants.HOLD));
                 return HBasePlatformUtils.scannerEndReached(scannerContext);
@@ -148,6 +161,8 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
         }
         if (didWeFlush()) {
             if (flushAlreadyReturned) {
+                if (LOG.isTraceEnabled())
+                    SpliceLogUtils.trace(LOG, "Next: flushed " + counter);
                 try {
                     outResult.add(new KeyValue(Bytes.toBytes(counter),
                             ClientRegionConstants.FLUSH, ClientRegionConstants.FLUSH, Long.MAX_VALUE, ClientRegionConstants.FLUSH));
@@ -163,9 +178,14 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
             }
             return HBasePlatformUtils.scannerEndReached(scannerContext);
         }
-        if (directInternalNext(outResult,scannerContext))
+        if (super.next(outResult,scannerContext)) {
+            if (LOG.isTraceEnabled())
+                SpliceLogUtils.trace(LOG, "Next: returning " + outResult.size());
             return true;
+        }
 
+        if (LOG.isTraceEnabled())
+            SpliceLogUtils.trace(LOG, "Next: returning first end row ");
         // We don't have more rows but can't return null here
         endRowNeedsToBeReturned = true;
         if (outResult.isEmpty()) {
@@ -195,11 +215,6 @@ public class MemStoreFlushAwareScanner extends StoreScanner {
     @Override
     public boolean next(List<Cell> outResult) throws IOException {
         return internalNext(outResult,NoLimitScannerContext.getInstance());
-    }
-
-
-    boolean directInternalNext(List<Cell> result, ScannerContext scannerContext) throws IOException {
-        return super.next(result,scannerContext);
     }
 
     @Override

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HScan.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HScan.java
@@ -24,11 +24,14 @@ import java.util.Map;
  * @author Scott Fines
  *         Date: 12/17/15
  */
-public class HScan implements DataScan{
+public class HScan implements DataScan {
+    // Sane default to prevent big scans causing memory pressure on the RegionServer
+    private final static int DEFAULT_CACHING = 1000;
     private Scan scan;
 
     public HScan(){
         this.scan = new Scan();
+        this.scan.setCaching(DEFAULT_CACHING);
     }
 
     public HScan(Scan scan){


### PR DESCRIPTION
Set default caching for HBase scans to avoid very large scans causing
memory pressure on RegionServers