### PR TITLE
DB-9156 3.0 startTime, badRecords, returnedRows added to reset()

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
@@ -68,7 +68,6 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
     protected boolean isTopResultSet=false;
     protected ExecRow currentRow;
     protected RowLocation currentRowLocation;
-    protected boolean executed=false;
     protected OperationContext operationContext;
     protected volatile boolean isOpen=true;
     protected int resultSetNumber;
@@ -403,6 +402,9 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
         isKilled = false;
         isTimedout = false;
         modifiedRowCount = new long[] {0};
+        badRecords = 0;
+        returnedRows = false;
+        startTime = System.nanoTime();
         for (SpliceOperation op : getSubOperations()) {
             op.reset();
         }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
@@ -159,7 +159,7 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
             activation.addWarning(StandardException.newWarning(SQLState.LANG_MODIFIED_ROW_COUNT_TOO_LARGE, modifiedRowCount));
             return new long[]{ -1 };
         }
-        return this.modifiedRowCount;
+        return Arrays.copyOf(this.modifiedRowCount, this.modifiedRowCount.length);
     }
 
     @Override


### PR DESCRIPTION
also executed field has been removed as nowhere used to clean up