### PR TITLE
DB-9448 Fix resurfacing rows issue in Spark

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/compactions/SpliceCompactionRequest.java
+++ b/hbase_sql/src/main/java/com/splicemachine/compactions/SpliceCompactionRequest.java
@@ -114,4 +114,14 @@ public class SpliceCompactionRequest extends CompactionRequestImpl {
             afterExecute();
         }
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
 }

--- a/hbase_sql/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactionPolicy.java
+++ b/hbase_sql/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactionPolicy.java
@@ -48,7 +48,9 @@ public class SpliceDefaultCompactionPolicy extends ExploringCompactionPolicy {
         HRegion region = store.getHRegion();
         String storeName = store.getColumnFamilyName();
         scr.setIsMajor(cr.isMajor(), cr.isAllFiles());
-        scr.setOffPeak(cr.isOffPeak());
+        // Ignoring cr.isOffPeak() and hardcoding true because SpliceCompactionRequest.setOffPeak is hijacked to run
+        // SpliceCompactionRequest.afterExecute if isOffPeak(false) is called.
+        scr.setOffPeak(true);
         scr.setPriority(cr.getPriority());
         scr.setDescription(region.getRegionInfo().getEncodedName(), storeName);
         return scr;

--- a/hbase_sql/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
@@ -151,50 +151,46 @@ public class SpliceDefaultCompactor extends DefaultCompactor {
         CompactionResult result = null;
         SpliceCompactionRequest scr = (SpliceCompactionRequest) request;
 
-        try {
-            Future<CompactionResult> futureResult = EngineDriver.driver().getOlapClient().submit(jobRequest, getCompactionQueue());
-            while (result == null) {
-                try {
-                    result = futureResult.get(config.getOlapClientTickTime(), TimeUnit.MILLISECONDS);
-                } catch (InterruptedException e) {
-                    //we were interrupted processing, so we're shutting down. Nothing to be done, just die gracefully
-                    Thread.currentThread().interrupt();
-                    throw new IOException(e);
-                } catch (ExecutionException e) {
-                    if (e.getCause() instanceof RejectedExecutionException) {
-                        LOG.warn("Spark compaction execution rejected, falling back to RegionServer execution", e.getCause());
-                        return super.compact(request, throughputController, user);
-                    }
-                    throw Exceptions.rawIOException(e.getCause());
-                } catch (TimeoutException e) {
-                    // check region write status
-                    if (!store.areWritesEnabled()) {
-                        futureResult.cancel(true);
-                        progress.cancel();
-                        // TODO should we cleanup files written by Spark?
-                        throw new IOException("Region has been closed, compaction aborted");
-                    }
+        Future<CompactionResult> futureResult = EngineDriver.driver().getOlapClient().submit(jobRequest, getCompactionQueue());
+        while (result == null) {
+            try {
+                result = futureResult.get(config.getOlapClientTickTime(), TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                //we were interrupted processing, so we're shutting down. Nothing to be done, just die gracefully
+                Thread.currentThread().interrupt();
+                throw new IOException(e);
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof RejectedExecutionException) {
+                    LOG.warn("Spark compaction execution rejected, falling back to RegionServer execution", e.getCause());
+                    return super.compact(request, throughputController, user);
+                }
+                throw Exceptions.rawIOException(e.getCause());
+            } catch (TimeoutException e) {
+                // check region write status
+                if (!store.areWritesEnabled()) {
+                    futureResult.cancel(true);
+                    progress.cancel();
+                    // TODO should we cleanup files written by Spark?
+                    throw new IOException("Region has been closed, compaction aborted");
                 }
             }
-
-            List<String> sPaths = result.getPaths();
-
-            if (LOG.isTraceEnabled())
-                SpliceLogUtils.trace(LOG, "Paths Returned: %s", sPaths);
-
-            this.progress.complete();
-
-            scr.preStorefilesRename();
-
-            List<Path> paths = new ArrayList<>();
-            for (String spath : sPaths) {
-                paths.add(new Path(spath));
-            }
-
-            return paths;
-        } finally {
-            scr.afterExecute();
         }
+
+        List<String> sPaths = result.getPaths();
+
+        if (LOG.isTraceEnabled())
+            SpliceLogUtils.trace(LOG, "Paths Returned: %s", sPaths);
+
+        this.progress.complete();
+
+        scr.preStorefilesRename();
+
+        List<Path> paths = new ArrayList<>();
+        for (String spath : sPaths) {
+            paths.add(new Path(spath));
+        }
+
+        return paths;
     }
 
     private SparkCompactionFunction getCompactionFunction(boolean isMajor, InetSocketAddress[] favoredNodes) {

--- a/hbase_sql/src/main/java/com/splicemachine/hbase/RegionSizeEndpoint.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/RegionSizeEndpoint.java
@@ -29,6 +29,7 @@ import org.spark_project.guava.collect.Lists;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessor;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -85,8 +86,7 @@ public class RegionSizeEndpoint extends SpliceMessage.SpliceDerbyCoprocessorServ
             for (byte[] split : splits)
                 writeResponse.addCutPoint(com.google.protobuf.ByteString.copyFrom(split));
         } catch (java.io.IOException e) {
-            // FIXME: 4/12/19
-            //org.apache.hadoop.hbase.protobuf.ResponseConverter.setControllerException(controller, e);
+            org.apache.hadoop.hbase.shaded.protobuf.ResponseConverter.setControllerException(controller, e);
         }
         callback.run(writeResponse.build());
     }
@@ -100,8 +100,7 @@ public class RegionSizeEndpoint extends SpliceMessage.SpliceDerbyCoprocessorServ
             writeResponse.setEncodedName(region.getRegionInfo().getRegionNameAsString());
             writeResponse.setSizeInBytes(region.getMemStoreHeapSize()+getStoreFileSize());
         } catch (Exception e) {
-            // FIXME: 4/12/19
-            //org.apache.hadoop.hbase.protobuf.ResponseConverter.setControllerException(controller, new IOException(e));
+            org.apache.hadoop.hbase.shaded.protobuf.ResponseConverter.setControllerException(controller, new IOException(e));
         }
         callback.run(writeResponse.build());
     }
@@ -128,5 +127,32 @@ public class RegionSizeEndpoint extends SpliceMessage.SpliceDerbyCoprocessorServ
         } finally {
             HRegionUtil.unlockStore(store);
         }
+    }
+
+    @Override
+    public void getCompactedHFiles(RpcController controller,
+                                   SpliceMessage.GetCompactedHFilesRequest request,
+                                   RpcCallback<SpliceMessage.GetCompactedHFilesResponse> callback) {
+        if (LOG.isDebugEnabled()) {
+            SpliceLogUtils.debug(LOG, "getCompactedHFiles");
+        }
+        SpliceMessage.GetCompactedHFilesResponse.Builder writeResponse = SpliceMessage.GetCompactedHFilesResponse.newBuilder();
+
+        HStore store = region.getStore(SIConstants.DEFAULT_FAMILY_BYTES);
+        try {
+            HRegionUtil.lockStore(store);
+            Collection<? extends StoreFile> compactedFiles = store.getCompactedFiles();
+            if (LOG.isDebugEnabled()) {
+                String regionName = region.getRegionInfo().getRegionNameAsString();
+                SpliceLogUtils.debug(LOG, "region store files " + regionName + ": " + store.getStorefiles());
+                SpliceLogUtils.debug(LOG, "compacted files " + regionName + ": " + compactedFiles);
+            }
+            for (StoreFile file: compactedFiles) {
+                writeResponse.addFilePath(file.getPath().toString());
+            }
+        } finally {
+            HRegionUtil.unlockStore(store);
+        }
+        callback.run(writeResponse.build());
     }
 }

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/MemstoreAware.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/MemstoreAware.java
@@ -20,11 +20,11 @@ package com.splicemachine.access.client;
  *
  */
 public class MemstoreAware {
-    public boolean splitMerge = false;
-    public int totalFlushCount;
-    public int currentCompactionCount;
-    public int currentScannerCount;
-    public boolean flush = false;
+    public final boolean splitMerge;
+    public final int totalFlushCount;
+    public final int currentCompactionCount;
+    public final int currentScannerCount;
+    public final boolean flush;
 
     public MemstoreAware() {
         this.splitMerge = false;
@@ -42,37 +42,35 @@ public class MemstoreAware {
         this.flush = isFlushing;
     }
     
-    
+    public static MemstoreAware changeSplitMerge(MemstoreAware clone, boolean splitMerge) {
+        return new MemstoreAware(splitMerge, clone.totalFlushCount, clone.currentCompactionCount,
+                clone.currentScannerCount,clone.flush);
+    }
 
-        public static MemstoreAware changeSplitMerge(MemstoreAware clone, boolean splitMerge) {
-            return new MemstoreAware(splitMerge, clone.totalFlushCount, clone.currentCompactionCount,
-                    clone.currentScannerCount,clone.flush);
-        }
+    public static MemstoreAware changeFlush(MemstoreAware clone, boolean flush) {
+        return new MemstoreAware(clone.splitMerge, clone.totalFlushCount+1, clone.currentCompactionCount,
+                clone.currentScannerCount,flush);
+    }
 
-        public static MemstoreAware changeFlush(MemstoreAware clone, boolean flush) {
-            return new MemstoreAware(clone.splitMerge, clone.totalFlushCount+1, clone.currentCompactionCount,
-                    clone.currentScannerCount,flush);
-        }
-       
-        public static MemstoreAware incrementCompactionCount(MemstoreAware clone) {
-            return new MemstoreAware(clone.splitMerge, clone.totalFlushCount, clone.currentCompactionCount+1,
-                    clone.currentScannerCount,clone.flush);
-        }
+    public static MemstoreAware incrementCompactionCount(MemstoreAware clone) {
+        return new MemstoreAware(clone.splitMerge, clone.totalFlushCount, clone.currentCompactionCount+1,
+                clone.currentScannerCount,clone.flush);
+    }
 
-        public static MemstoreAware decrementCompactionCount(MemstoreAware clone) {
-            return new MemstoreAware(clone.splitMerge, clone.totalFlushCount, clone.currentCompactionCount-1,
-                    clone.currentScannerCount,clone.flush);
-        }
+    public static MemstoreAware decrementCompactionCount(MemstoreAware clone) {
+        return new MemstoreAware(clone.splitMerge, clone.totalFlushCount, clone.currentCompactionCount-1,
+                clone.currentScannerCount,clone.flush);
+    }
 
-        public static MemstoreAware incrementScannerCount(MemstoreAware clone) {
-            return new MemstoreAware(clone.splitMerge, clone.totalFlushCount, clone.currentCompactionCount,
-                    clone.currentScannerCount+1,clone.flush);
-        }
+    public static MemstoreAware incrementScannerCount(MemstoreAware clone) {
+        return new MemstoreAware(clone.splitMerge, clone.totalFlushCount, clone.currentCompactionCount,
+                clone.currentScannerCount+1,clone.flush);
+    }
 
-        public static MemstoreAware decrementScannerCount(MemstoreAware clone) {
-            return new MemstoreAware(clone.splitMerge, clone.totalFlushCount, clone.currentCompactionCount,
-                    clone.currentScannerCount-1,clone.flush);
-        }
+    public static MemstoreAware decrementScannerCount(MemstoreAware clone) {
+        return new MemstoreAware(clone.splitMerge, clone.totalFlushCount, clone.currentCompactionCount,
+                clone.currentScannerCount-1,clone.flush);
+    }
 
     @Override
     public String toString() {

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/SkeletonClientSideRegionScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/SkeletonClientSideRegionScanner.java
@@ -15,12 +15,17 @@
 package com.splicemachine.access.client;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
 
+import com.google.common.collect.Sets;
+import com.splicemachine.coprocessor.SpliceMessage;
 import com.splicemachine.mrio.MRConstants;
 import com.splicemachine.si.constants.SIConstants;
+import com.splicemachine.si.impl.driver.SIDriver;
+import com.splicemachine.storage.Partition;
+import com.splicemachine.storage.SkeletonHBaseClientPartition;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -29,6 +34,8 @@ import org.apache.hadoop.hbase.client.IsolationLevel;
 import org.apache.hadoop.hbase.client.*;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.ipc.CoprocessorRpcUtils;
+import org.apache.hadoop.hbase.ipc.ServerRpcController;
 import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.FSUtils;
@@ -37,6 +44,7 @@ import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.log4j.Logger;
 import com.splicemachine.utils.SpliceLogUtils;
+import org.spark_project.guava.base.Throwables;
 
 /**
  * 
@@ -45,49 +53,49 @@ import com.splicemachine.utils.SpliceLogUtils;
 public abstract class SkeletonClientSideRegionScanner implements RegionScanner{
     private boolean isClosed = false;
     private static final Logger LOG = Logger.getLogger(SkeletonClientSideRegionScanner.class);
-	private HRegion region;
-	private RegionScanner scanner;
-	private Configuration conf;
-	private FileSystem fs;
-	private Path rootDir;
-	private HTableDescriptor htd;
-	private HRegionInfo hri;
-	private Scan scan;
+    private HRegion region;
+    private RegionScanner scanner;
+    private Configuration conf;
+    private FileSystem fs;
+    private Path rootDir;
+    private HTableDescriptor htd;
+    private HRegionInfo hri;
+    private Scan scan;
     private String hostAndPort;
-	private Cell topCell;
-	private List<KeyValueScanner>	memScannerList = new ArrayList<>(1);
-	private boolean flushed;
-	private long numberOfRows = 0;
+    private Cell topCell;
+    private List<KeyValueScanner>    memScannerList = new ArrayList<>(1);
+    private boolean flushed;
+    private long numberOfRows = 0;
     private FileSystem customFilesystem;
 
-	
-	public SkeletonClientSideRegionScanner(Configuration conf,
+
+    public SkeletonClientSideRegionScanner(Configuration conf,
                                            FileSystem fs,
                                            Path rootDir,
                                            HTableDescriptor htd,
                                            HRegionInfo hri,
                                            Scan scan, String hostAndPort) throws IOException {
-		if (LOG.isDebugEnabled())
-			SpliceLogUtils.debug(LOG, "init for regionInfo=%s, scan=%s", hri,scan);
-		scan.setIsolationLevel(IsolationLevel.READ_UNCOMMITTED);
-		this.conf = conf;
-		this.fs = fs;
-		this.rootDir = rootDir;
-		this.htd = htd;
-		this.hri = new SpliceHRegionInfo(hri);
-		this.scan = scan;
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "init for regionInfo=%s, scan=%s", hri,scan);
+        scan.setIsolationLevel(IsolationLevel.READ_UNCOMMITTED);
+        this.conf = conf;
+        this.fs = fs;
+        this.rootDir = rootDir;
+        this.htd = htd;
+        this.hri = new SpliceHRegionInfo(hri);
+        this.scan = scan;
         this.hostAndPort = hostAndPort;
-	}
+    }
 
     @Override
-	public void close() throws IOException {
+    public void close() throws IOException {
         if (isClosed)
             return;
-		if (LOG.isDebugEnabled())
-			SpliceLogUtils.debug(LOG, "close");
-		if (scanner != null)
-			scanner.close();
-		memScannerList.get(0).close();
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "close");
+        if (scanner != null)
+            scanner.close();
+        memScannerList.get(0).close();
         region.close();
         if (customFilesystem != null)
             customFilesystem.close();
@@ -95,19 +103,19 @@ public abstract class SkeletonClientSideRegionScanner implements RegionScanner{
     }
 
 
-	public HRegionInfo getRegionInfo() {
-		return (HRegionInfo) scanner.getRegionInfo();
-	}
+    public HRegionInfo getRegionInfo() {
+        return (HRegionInfo) scanner.getRegionInfo();
+    }
 
     @Override
-	public boolean reseek(byte[] row) throws IOException {
-		return scanner.reseek(row);
-	}
+    public boolean reseek(byte[] row) throws IOException {
+        return scanner.reseek(row);
+    }
 
     @Override
-	public long getMvccReadPoint() {
-		return scanner.getMvccReadPoint();
-	}
+    public long getMvccReadPoint() {
+        return scanner.getMvccReadPoint();
+    }
 
     public boolean next(List<Cell> result,int limit) throws IOException{
         return nextRaw(result,limit);
@@ -133,20 +141,20 @@ public abstract class SkeletonClientSideRegionScanner implements RegionScanner{
     }
 
     @Override
-	public boolean nextRaw(List<Cell> result) throws IOException {
-    	boolean res = nextMerged(result);
+    public boolean nextRaw(List<Cell> result) throws IOException {
+        boolean res = nextMerged(result);
         boolean returnValue = updateTopCell(res,result);
         if (returnValue)
             numberOfRows++;
-		return returnValue;
-	}
+        return returnValue;
+    }
 
 
-	/**
-	 * refresh underlying RegionScanner we call this when new store file gets
-	 * created by MemStore flushes or current scanner fails due to compaction
-	 */
-	public void updateScanner() throws IOException {
+    /**
+     * refresh underlying RegionScanner we call this when new store file gets
+     * created by MemStore flushes or current scanner fails due to compaction
+     */
+    public void updateScanner() throws IOException {
             if (LOG.isDebugEnabled()) {
                 SpliceLogUtils.debug(LOG,
                         "updateScanner with hregionInfo=%s, tableName=%s, rootDir=%s, scan=%s",
@@ -170,7 +178,7 @@ public abstract class SkeletonClientSideRegionScanner implements RegionScanner{
                     scanner.close();
             }
             scanner = regionScanner;
-	}
+    }
 
     public HRegion getRegion(){
         return region;
@@ -222,10 +230,46 @@ public abstract class SkeletonClientSideRegionScanner implements RegionScanner{
         return res;
     }
 
+    @SuppressWarnings("unchecked")
+    private Set<String> getCompactedFilesPathsFromHBaseRegionServer() {
+        try {
+            String regionName = hri.getRegionNameAsString();
+            try (Partition partition = SIDriver.driver().getTableFactory().getTable(htd.getTableName())) {
+                Map<byte[], List<String>> results = ((SkeletonHBaseClientPartition) partition).coprocessorExec(
+                        SpliceMessage.SpliceDerbyCoprocessorService.class,
+                        hri.getStartKey(),
+                        hri.getStartKey(),
+                        instance -> {
+                            ServerRpcController controller = new ServerRpcController();
+                            SpliceMessage.GetCompactedHFilesRequest message = SpliceMessage.GetCompactedHFilesRequest
+                                    .newBuilder()
+                                    .setRegionEncodedName(regionName)
+                                    .build();
+
+                            CoprocessorRpcUtils.BlockingRpcCallback<SpliceMessage.GetCompactedHFilesResponse> rpcCallback = new CoprocessorRpcUtils.BlockingRpcCallback<>();
+                            instance.getCompactedHFiles(controller, message, rpcCallback);
+                            if (controller.failed()) {
+                                Throwable t = Throwables.getRootCause(controller.getFailedOn());
+                                if (t instanceof IOException) throw (IOException) t;
+                                else throw new IOException(t);
+                            }
+                            SpliceMessage.GetCompactedHFilesResponse response = rpcCallback.get();
+                            return response.getFilePathList();
+                        });
+                assert results.size() == 1;
+                return Sets.newHashSet(results.get(hri.getRegionName()));
+            }
+        } catch (Throwable e) {
+            SpliceLogUtils.error(LOG, "Unable to set Compacted Files from HBase region server", e);
+            throw new RuntimeException(e);
+        }
+    }
+
     private HRegion openHRegion() throws IOException {
         Path tableDir = FSUtils.getTableDir(rootDir, hri.getTable());
-        SpliceHRegion spliceHRegion = new SpliceHRegion(tableDir, null, fs, conf, hri, htd, null);
-        return spliceHRegion;
+        Set<String> compactedFilesPaths = getCompactedFilesPathsFromHBaseRegionServer();
+        return new SpliceHRegion(
+                tableDir, null, fs, conf, hri, htd, null, compactedFilesPaths);
     }
 
     private KeyValueScanner getMemStoreScanner() throws IOException {

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/SkeletonClientSideRegionScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/SkeletonClientSideRegionScanner.java
@@ -256,7 +256,7 @@ public abstract class SkeletonClientSideRegionScanner implements RegionScanner{
                             SpliceMessage.GetCompactedHFilesResponse response = rpcCallback.get();
                             return response.getFilePathList();
                         });
-                assert results.size() == 1;
+                //assert results.size() == 1: results;
                 return Sets.newHashSet(results.get(hri.getRegionName()));
             }
         } catch (Throwable e) {

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/SpliceHRegion.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/SpliceHRegion.java
@@ -14,30 +14,38 @@
 
 package com.splicemachine.access.client;
 
+import com.splicemachine.si.constants.SIConstants;
+import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.CellComparator;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.TableDescriptor;
-import org.apache.hadoop.hbase.regionserver.HRegion;
-import org.apache.hadoop.hbase.regionserver.RegionServerServices;
+import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.hadoop.hbase.wal.WAL;
+import org.apache.log4j.Logger;
+import org.spark_project.guava.collect.ImmutableList;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Created by jyuan on 5/13/19.
  */
 public class SpliceHRegion extends HRegion {
-
+    private static final Logger LOG = Logger.getLogger(SpliceHRegion.class);
 
     public SpliceHRegion(final Path tableDir, final WAL wal, final FileSystem fs,
                          final Configuration confParam, final RegionInfo regionInfo,
-                         final TableDescriptor htd, final RegionServerServices rsServices) throws IOException{
+                         final TableDescriptor htd, final RegionServerServices rsServices,
+                         Set<String> compactedFilesPaths) throws IOException{
 
         super(tableDir, wal, fs, confParam, regionInfo, htd, rsServices);
         openHRegion(null);
+        setCompactedFiles(compactedFilesPaths);
     }
 
     @Override
@@ -45,4 +53,29 @@ public class SpliceHRegion extends HRegion {
         return SpliceCellComparator.INSTANCE;
     }
 
+    private void setCompactedFiles(Set<String> compactedFilesPaths) {
+        try {
+            List<HStoreFile> compactedFiles = new ArrayList<>();
+            HStore store = this.getStore(SIConstants.DEFAULT_FAMILY_BYTES);
+
+            if (LOG.isDebugEnabled()) {
+                SpliceLogUtils.debug(LOG, "regionName " + this.getRegionInfo().getRegionNameAsString());
+                SpliceLogUtils.debug(LOG, "compactedFilePaths to add: " + compactedFilesPaths);
+                SpliceLogUtils.debug(LOG, "region store files: " + store.getStorefiles());
+            }
+            for (HStoreFile storeFile: store.getStorefiles()) {
+                if (compactedFilesPaths.contains(storeFile.getPath().toString())) {
+                    compactedFiles.add(storeFile);
+                }
+            }
+            if (LOG.isDebugEnabled()) {
+                SpliceLogUtils.debug(LOG, "filtered compacted files: " + compactedFiles);
+            }
+            HRegionUtil.replaceStoreFiles(store, compactedFiles, ImmutableList.of());
+
+        } catch (Throwable e) {
+            SpliceLogUtils.error(LOG, "Unable to set Compacted Files from HBase region server", e);
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/hbase_storage/src/main/java/com/splicemachine/storage/AdapterPartition.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/AdapterPartition.java
@@ -376,6 +376,14 @@ public class AdapterPartition extends SkeletonHBaseClientPartition{
         return delegate.coprocessorExec(serviceClass,call);
     }
 
+    public <T extends Service,V> Map<byte[],V> coprocessorExec(
+            Class<T> serviceClass,
+            byte[] startKey,
+            byte[] endKey,
+            final Batch.Call<T,V> callable) throws Throwable {
+        return delegate.coprocessorExec(serviceClass, startKey, endKey, callable);
+    }
+
     public Table unwrapDelegate(){
         return delegate.unwrapDelegate();
     }

--- a/hbase_storage/src/main/java/com/splicemachine/storage/ClientPartition.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/ClientPartition.java
@@ -295,6 +295,14 @@ public class ClientPartition extends SkeletonHBaseClientPartition{
         return table.coprocessorService(serviceClass,getStartKey(),getEndKey(),call);
     }
 
+    public <T extends Service,V> Map<byte[],V> coprocessorExec(
+            Class<T> serviceClass,
+            byte[] startKey,
+            byte[] endKey,
+            Batch.Call<T,V> call) throws Throwable{
+        return table.coprocessorService(serviceClass, startKey, endKey, call);
+    }
+
     public Table unwrapDelegate(){
         return table;
     }

--- a/hbase_storage/src/main/java/com/splicemachine/storage/SkeletonHBaseClientPartition.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/SkeletonHBaseClientPartition.java
@@ -239,4 +239,10 @@ public abstract class SkeletonHBaseClientPartition implements Partition{
     public abstract Table unwrapDelegate();
 
     public abstract  <T extends Service,V> Map<byte[],V> coprocessorExec(Class<T> serviceClass, Batch.Call<T,V> call) throws Throwable;
+
+    public abstract <T extends Service,V> Map<byte[],V> coprocessorExec(
+            Class<T> serviceClass,
+            byte[] startKey,
+            byte[] endKey,
+            final Batch.Call<T,V> callable) throws Throwable;
 }

--- a/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionUtil.java
+++ b/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionUtil.java
@@ -288,4 +288,9 @@ public class HRegionUtil {
     public static RegionScanner getScanner(HRegion region, Scan scan, List<KeyValueScanner> keyValueScanners) throws IOException {
         return region.getScanner(scan, keyValueScanners);
     }
+
+    public static void replaceStoreFiles(HStore store, Collection<HStoreFile> compactedFiles, Collection<HStoreFile> result)
+            throws IOException {
+        store.replaceStoreFiles(compactedFiles, result);
+    }
 }

--- a/platform_it/src/main/resources/info-log4j.properties
+++ b/platform_it/src/main/resources/info-log4j.properties
@@ -127,6 +127,12 @@ log4j.logger.com.splicemachine.db.impl.jdbc.authentication=INFO
 
 log4j.logger.org.apache.hadoop.hbase.regionserver.HRegionServer=INFO
 
+# Useful to print observe Region creation on Spark side
+log4j.logger.org.apache.hadoop.hbase.regionserver.CompactSplit=DEBUG
+log4j.logger.com.splicemachine.hbase.RegionSizeEndpoint=DEBUG
+log4j.logger.com.splicemachine.compactions.SpliceDefaultCompactor=TRACE
+log4j.logger.com.splicemachine.derby.stream.compaction=TRACE
+
 log4j.logger.com.splicemachine.storage=INFO
 log4j.logger.com.splicemachine.access.client=INFO
 log4j.logger.com.splicemachine.mrio.api.core=DEBUG

--- a/splice_protocol/src/main/protobuf/Splice.proto
+++ b/splice_protocol/src/main/protobuf/Splice.proto
@@ -5,17 +5,17 @@ option java_generate_equals_and_hash = true;
 option optimize_for = SPEED;
 
 message SpliceSchedulerRequest {
-	optional bytes taskStart = 1;
-	optional bytes taskEnd = 2;
-	optional string className = 3;
-	optional bytes classBytes = 4;
+    optional bytes taskStart = 1;
+    optional bytes taskEnd = 2;
+    optional string className = 3;
+    optional bytes classBytes = 4;
     optional bool allowSplits = 5;
 }
 
 message TaskFutureResponse {
-	required string taskNode = 1;
-	required bytes taskId = 2;
-	optional double estimatedCost = 3;
+    required string taskNode = 1;
+    required bytes taskId = 2;
+    optional double estimatedCost = 3;
     required bytes startRow = 4;
 }
 
@@ -24,16 +24,16 @@ message SchedulerResponse{
 }
 
 message ConstraintContext {
-	optional string tableName = 1;
-	optional string constraintName = 2;
+    optional string tableName = 1;
+    optional string constraintName = 2;
 }
 
 message AllocateFilterMessage {
-	optional bytes addressMatch = 1;
+    optional bytes addressMatch = 1;
 }
 
 message SuccessFilterMessage {
-	repeated bytes failedTasks = 1;
+    repeated bytes failedTasks = 1;
 }
 
 message SkippingScanFilterMessage {
@@ -82,16 +82,16 @@ message BulkWriteResponse {
      * build a Response regardless of whether or not an error is thrown, which
      * causes the original BulkWrite error to be lost in the Protobuf messaging error.
      */
-	optional bytes bytes = 1;
+    optional bytes bytes = 1;
 }
 
 message BulkWriteRequest {
-	required bytes bytes = 1;
+    required bytes bytes = 1;
 }
 
 message DropIndexRequest {
-	optional uint64 indexConglomId = 1;
-	optional uint64 baseConglomId = 2;
+    optional uint64 indexConglomId = 1;
+    optional uint64 baseConglomId = 2;
     required int64 txnId = 3;
 }
 
@@ -100,8 +100,8 @@ message DropIndexResponse {
 }
 
 service SpliceIndexService {
-	rpc bulkWrite(BulkWriteRequest)
-	  returns (BulkWriteResponse);
+    rpc bulkWrite(BulkWriteRequest)
+      returns (BulkWriteResponse);
 }
 
 service MultiRowService {
@@ -123,20 +123,22 @@ message KV {
 }
 
 service SpliceIndexManagementService {
-	rpc dropIndex(DropIndexRequest) 
-	  returns (DropIndexResponse);	
+    rpc dropIndex(DropIndexRequest)
+      returns (DropIndexResponse);
 }
 
 service SpliceSchedulerService {
-	rpc submit(SpliceSchedulerRequest)
-	  returns (SchedulerResponse);
+    rpc submit(SpliceSchedulerRequest)
+      returns (SchedulerResponse);
 }
 
 service SpliceDerbyCoprocessorService {
-	rpc computeSplits(SpliceSplitServiceRequest)
-		returns (SpliceSplitServiceResponse);
-	rpc computeRegionSize(SpliceRegionSizeRequest)
-		returns (SpliceRegionSizeResponse);
+    rpc computeSplits(SpliceSplitServiceRequest)
+        returns (SpliceSplitServiceResponse);
+    rpc computeRegionSize(SpliceRegionSizeRequest)
+        returns (SpliceRegionSizeResponse);
+    rpc getCompactedHFiles(GetCompactedHFilesRequest)
+        returns (GetCompactedHFilesResponse);
 }
 
 message SpliceSplitServiceRequest {
@@ -238,6 +240,14 @@ message SpliceOldestActiveTransactionResponse {
 
 message TestResponse {
     optional uint64 count = 1;
+}
+
+message GetCompactedHFilesRequest {
+    required string regionEncodedName = 1;
+}
+
+message GetCompactedHFilesResponse {
+    repeated string filePath = 1;
 }
 
 service SpliceRSRpcServices {


### PR DESCRIPTION
Migration to hbase2.0 created two issues:
1. We did not use memStoreAware's lock properly anymore
2. We did not know about compacted files when creating a HRegion from
Spark's side

This commit addresses these two issues in the following way:

1.
SpliceCompactionRequest.setOffPeak is now hijacked to properly
release the lock on memStoreAware once a compaction has completed.
Short of modifying HBase's code to be able to use a custom
CompactionLifeCycleTracker (only DUMMY is used outside of their tests),
this seems to be the only reliable solution.

2.
Spark side now RPC calls the relevant region to get a list of compacted
files so that regions created on Spark side can properly exclude
compacted store files that pertains to a specific region.
