### PR TITLE
DB-9109 fix jenkins problem with testCollectStats

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -53,6 +53,26 @@ public class ExternalTableIT extends SpliceUnitTest {
     public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
             .around(spliceSchemaWatcher);
 
+    static File tempDir;
+
+    @BeforeClass
+    public static void createTempDirectory() throws Exception
+    {
+        tempDir = createOrWipeTestDirectory( SCHEMA_NAME );
+    }
+
+    @AfterClass
+    public static void deleteTempDirectory() throws Exception
+    {
+        deleteTempDirectory(tempDir);
+    }
+
+    /// this will return the temp directory, that is created on demand once for each test
+    public String getExternalResourceDirectory() throws Exception
+    {
+        return tempDir.toString() + "/";
+    }
+
     @Test
     public void testNativeSparkExtractFunction() throws Exception {
         try {
@@ -493,7 +513,7 @@ public class ExternalTableIT extends SpliceUnitTest {
 
     @Test
     public void testLocationCannotBeAFileAvro() throws  Exception{
-        File temp = createTempOutputFile("temp-file-avro", ".tmp");
+        File temp = File.createTempFile("temp-file-avro", ".tmp", tempDir);
         try {
             methodWatcher.executeUpdate(String.format("create external table table_to_existing_file_avro_temp (col1 varchar(24), col2 varchar(24), col3 varchar(24))" +
                     " STORED AS AVRO LOCATION '%s'", temp.getAbsolutePath()));
@@ -505,7 +525,7 @@ public class ExternalTableIT extends SpliceUnitTest {
 
     @Test
     public void testLocationCannotBeAFile() throws  Exception{
-        File temp = createTempOutputFile("temp-file", ".tmp");
+        File temp = File.createTempFile("temp-file", ".tmp", tempDir);
 
         try {
             methodWatcher.executeUpdate(String.format("create external table table_to_existing_file (col1 varchar(24), col2 varchar(24), col3 varchar(24))" +
@@ -2669,7 +2689,7 @@ public class ExternalTableIT extends SpliceUnitTest {
 
     @Test
     public void testReadWriteAvroFromHive() throws Exception {
-        String path = getTempCopyOfResourceDirectory( "t_avro" );
+        String path = getTempCopyOfResourceDirectory(tempDir, "t_avro" );
         methodWatcher.execute(String.format("create external table t_avro (col1 varchar(30), col2 int)" +
                 " STORED AS AVRO LOCATION '%s'", path ));
 

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
@@ -22,6 +22,7 @@ import org.junit.*;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
+import java.io.File;
 import java.sql.ResultSet;
 
 import static org.junit.Assert.assertEquals;
@@ -43,6 +44,26 @@ public class ExternalTablePartitionIT extends SpliceUnitTest {
     @ClassRule
     public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
             .around(spliceSchemaWatcher);
+
+    static File tempDir;
+
+    @BeforeClass
+    public static void createTempDirectory() throws Exception
+    {
+        tempDir = createOrWipeTestDirectory( SCHEMA_NAME );
+    }
+
+    @AfterClass
+    public static void deleteTempDirectory() throws Exception
+    {
+        deleteTempDirectory(tempDir);
+    }
+
+    /// this will return the temp directory, that is created on demand once for each test
+    public String getExternalResourceDirectory() throws Exception
+    {
+        return tempDir.toString() + "/";
+    }
 
     @Test
     public void testParquetPartitionFirst() throws Exception {
@@ -1301,7 +1322,7 @@ public class ExternalTablePartitionIT extends SpliceUnitTest {
 
     @Test
     public void testInsertionToHiveParquetData() throws Exception {
-        String tmp = getTempCopyOfResourceDirectory( "pt_parquet" );
+        String tmp = getTempCopyOfResourceDirectory(tempDir, "pt_parquet" );
         methodWatcher.executeUpdate(
                 String.format("create external table pt_parquet(\"name\" varchar(10), \"age\" int, \"state\" char(2)) partitioned by (\"state\") stored as parquet location '%s'",
                         tmp));
@@ -1318,7 +1339,7 @@ public class ExternalTablePartitionIT extends SpliceUnitTest {
 
     @Test
     public void testInsertionToHiveAvroData() throws Exception {
-        String tmp = getTempCopyOfResourceDirectory( "pt_avro" );
+        String tmp = getTempCopyOfResourceDirectory(tempDir, "pt_avro" );
         methodWatcher.executeUpdate( String.format(
                 "create external table pt_avro(col1 varchar(10), col2 int, col3 char(2)) " +
                         "partitioned by (col3) stored as avro location '%s'", tmp) );

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/catalog/ViewsInSysIbmIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/catalog/ViewsInSysIbmIT.java
@@ -26,6 +26,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
+import java.io.File;
 import java.sql.Connection;
 import java.sql.ResultSet;
 
@@ -37,6 +38,26 @@ public class ViewsInSysIbmIT extends SpliceUnitTest {
     public static final String CLASS_NAME = ViewsInSysIbmIT.class.getSimpleName().toUpperCase();
     protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);
     protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
+
+    static File tempDir;
+
+    @BeforeClass
+    public static void createTempDirectory() throws Exception
+    {
+        tempDir = createOrWipeTestDirectory( CLASS_NAME );
+    }
+
+    @AfterClass
+    public static void deleteTempDirectory() throws Exception
+    {
+        deleteTempDirectory(tempDir);
+    }
+
+    /// this will return the temp directory, that is created on demand once for each test
+    public String getExternalResourceDirectory() throws Exception
+    {
+        return tempDir.toString() + "/";
+    }
 
     @ClassRule
     public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
@@ -17,7 +17,7 @@ package com.splicemachine.derby.test.framework;
 import com.splicemachine.homeless.TestUtils;
 import com.splicemachine.utils.Pair;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.runner.Description;
 import org.spark_project.guava.base.Joiner;
@@ -43,10 +43,7 @@ public class SpliceUnitTest {
     private static Pattern scannedRowsP = Pattern.compile("scannedRows=[0-9]+\\.?[0-9]*");
 
     /// set the following boolean to true to prevent deletion of temporary files (e.g. for debugging)
-    public boolean debug_no_delete = false;
-    /// the temporary directory (created on demand)
-    /// will reside under e.g. GITROOT/platform_it/target/external when running cdh6.3.0
-    private Path tempDir = null;
+    static private final boolean debug_no_delete = false;
 
 	public String getSchemaName() {
 		Class<?> enclosingClass = getClass().getEnclosingClass();
@@ -934,44 +931,33 @@ public class SpliceUnitTest {
         }
     }
 
-    /// this will be called after each test, deleting possible temp directories.
-    @After
-    public void deleteTempDirectory() throws Exception
+    public static File createOrWipeTestDirectory( String subpath ) throws java.io.IOException
+    {
+        File path = new File(getHBaseDirectory(), "/target/external/" + subpath);
+        path.mkdirs();
+        FileUtils.deleteDirectory(path); // clean directory
+        path.mkdir();
+        return path;
+    }
+
+    public static void deleteTempDirectory(File tempDir) throws Exception
     {
         if( tempDir == null )
             return;
         else if( debug_no_delete )
             System.out.println( "Not deleting test temporary directory " + tempDir );
         else {
-            FileUtils.deleteDirectory(tempDir.toFile());
+            FileUtils.deleteDirectory(tempDir);
         }
-    }
-
-    /// this will return the temp directory, that is created on demand once for each test
-    public String getExternalResourceDirectory() throws Exception
-    {
-        if( tempDir == null) {
-            File basepath = new File(getHBaseDirectory(), "/target/external/");
-            basepath.mkdirs();
-            tempDir = Files.createTempDirectory( basepath.toPath(), "SpliceUnitTest_temp_");
-        }
-        // add '/' to avoid leaking directories if someone misses the '/'
-        return tempDir.toString() + "/";
-    }
-
-    /// creates a temporary file in the temporary directory, so will be deleted after test
-    public File createTempOutputFile( String prefix, String suffix ) throws Exception
-    {
-        return File.createTempFile(prefix, suffix, new File(getExternalResourceDirectory()) );
     }
 
     /// copy subfolder of resource directory (i.e. GITROOT/splice_machine/src/test/test-data/)
     /// to temporary directory @sa getTempOutputDirectory
     /// @return destination directory as string
-    public String getTempCopyOfResourceDirectory( String subfolder ) throws Exception
+    public String getTempCopyOfResourceDirectory( File tmpDir, String subfolder ) throws Exception
     {
-        File src = new File(SpliceUnitTest.getResourceDirectory() + subfolder);
-        File dest = new File( getExternalResourceDirectory() + subfolder );
+        File src = new File( SpliceUnitTest.getResourceDirectory(), subfolder);
+        File dest = new File( tmpDir, subfolder );
         FileUtils.copyDirectory( src, dest );
         return dest.toString();
     }

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/ShowCreateTableIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/ShowCreateTableIT.java
@@ -37,6 +37,7 @@ import com.splicemachine.test_tools.TableCreator;
 import org.junit.*;
 import org.junit.experimental.categories.Category;
 
+import java.io.File;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.regex.Matcher;
@@ -99,6 +100,26 @@ public class ShowCreateTableIT extends SpliceUnitTest
     public static void cleanup()
     {
         classWatcher.closeAll();
+    }
+
+    static File tempDir;
+
+    @BeforeClass
+    public static void createTempDirectory() throws Exception
+    {
+        tempDir = createOrWipeTestDirectory( SCHEMA );
+    }
+
+    @AfterClass
+    public static void deleteTempDirectory() throws Exception
+    {
+        deleteTempDirectory(tempDir);
+    }
+
+    /// this will return the temp directory, that is created on demand once for each test
+    public String getExternalResourceDirectory() throws Exception
+    {
+        return tempDir.toString() + "/";
     }
 
     @Test


### PR DESCRIPTION
in the previous version the temporary directory gets deleted after every test,
however the table gets only deleted after the whole class shuts down,
so e.g. analyze schema fails as it can't access those tables anymore

what will happen now:
- before instantiating a test class like, e.g. ExternalTableIT would go to /platform_it/target/external + /SCHEMA_NAME,
e.g. /platform_it/target/external/EXTERNALTABLEIT, wipe that directory (with @BeforeClass)
- we then run all tests, create external tables in that subdirectory (e.g. .../external/EXTNERALTABLEIT/avro_simple_file_test etc.)
- at the end of the whole class @AfterClass, delete the temporary directory (target/external/EXTERNALTABLEIT), but not all of target/external

with this
- allows parallel runs of ExternalTableIT while running ExternalTablePartitionIT
- temporary files are delete when running normally
- even if VM crashes or similar, the directory will be cleaned the next time, reducing trash on developers system