### PR TITLE
DB-9434 ORDER BY can use the aliases defined in SELECT AS

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnReference.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnReference.java
@@ -468,7 +468,13 @@ public class ColumnReference extends ValueNode {
         matchingRC = fromList.bindColumnReference(this);
             /* Error if no match found in fromList */
         if (matchingRC == null) {
-            throw StandardException.newException(SQLState.LANG_COLUMN_NOT_FOUND, getSQLColumnName());
+            // not found in normal table, check if it is an alias?
+            ValueNode node = fromList.getAlias(this);
+            if (node == null) {
+                throw StandardException.newException(SQLState.LANG_COLUMN_NOT_FOUND, getSQLColumnName());
+            }
+            // if found, REPLACE this alias-referencing node with the expression the alias is pointing to
+            return node;
         }
 
         return this;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromList.java
@@ -77,6 +77,10 @@ public class FromList extends QueryTreeNodeVector<QueryTreeNode> implements Opti
      */
     private WindowList windows;
 
+    /// list of aliases that can be used later by the ORDER BY statement in ResultColumnList
+    private List<ResultColumn> aliases = new ArrayList<>();
+    /// @sa useAliases
+    private boolean aliasesUsable = false;
 
     /**
      * Initializer for a FromList
@@ -1383,5 +1387,43 @@ public class FromList extends QueryTreeNodeVector<QueryTreeNode> implements Opti
             for (FromTable fromTable: ssqList)
                 addElement(fromTable);
         }
+    }
+
+    /// add something that might be used later by ORDER BY for aliases resolving
+    public void addAlias(ResultColumn vn) {
+        if( vn != null && vn.getName() != null )
+            aliases.add(vn);
+    }
+
+    /// check if the columnReference is referencing an alias.
+    /// this should only happen when ColumnReferences that are in ValueNodes of ORDER BY part of ResultColumnList
+    /// callee should then replace the reference to the aliases by the expression that this alias points too
+    public ValueNode getAlias(ColumnReference columnReference) throws StandardException {
+        if( !aliasesUsable ) return null;
+        ResultColumn rc = aliases.stream().filter(c -> c.getName().equals(columnReference.columnName))
+                                 .findFirst().orElse(null);
+        if( rc != null ) {
+            // we might have to replace this with rc.getExpression().getClone() (and fix all getClone())
+            return rc.getExpression();
+        }
+        else
+            return null;
+    }
+
+    /**
+     * we have to call useAliases to make aliases accessible,
+     * otherwise SELECT would also have access to aliases left-to-right
+     */
+    public void useAliases() {
+        aliasesUsable = true;
+    }
+    /// clear aliases so that they're not usable from HAVING or GROUP BY
+    // this is intentional currently, as it's not clear if the current approach in FromList.getAlias
+    // is valid in WHERE, HAVING and GROUP BY statements. maybe we would need to do a copy of the expression,
+    // not only a reference
+    public void clearAliases()
+    {
+        aliases.clear();
+        aliasesUsable = false;
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/OrderByIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/OrderByIT.java
@@ -55,6 +55,11 @@ public class OrderByIT extends SpliceUnitTest {
                         row(1,2,1,1,1)))
                 .create();
 
+        new TableCreator(conn)
+                .withCreate("create table t2 (a1 int)")
+                .withInsert("insert into t2 values (?)")
+                .withRows( rows( row(1), row(2), row(3), row(4), row(5) ))
+                .create();
         conn.commit();
     }
 
@@ -377,4 +382,48 @@ public class OrderByIT extends SpliceUnitTest {
         rs.close();
     }
 
+    @Test
+    public void testAliasInOrderComplex() throws Exception {
+        String sqlText = "select sum(a1) as ALIAS from t2 order by -ALIAS";
+        String expected = "ALIAS |\n" +
+                         "--------\n" +
+                         "  15   |" ;
+        SqlExpectToString( methodWatcher, sqlText, expected, false );
+
+        sqlText = "select sqrt(a1*a1)*2 as ALIAS from t2 order by -2*ALIAS+a1";
+        expected = "ALIAS |\n" +
+                  "--------\n" +
+                  " 10.0  |\n" +
+                  "  8.0  |\n" +
+                  "  6.0  |\n" +
+                  "  4.0  |\n" +
+                  "  2.0  |";
+        SqlExpectToString( methodWatcher, sqlText, expected, false );
+    }
+
+    @Test
+    public void testAliasInOrderSimple() throws Exception {
+        // use these TWO order by to make sure ResultColumnList correctly calculates getFirstOrderByIndex.
+        String sqlText = "select a1 as ALIAS from t2 order by -ALIAS, -2*ALIAS";
+        String expected = "ALIAS |\n--------\n   5   |\n   4   |\n   3   |\n   2   |\n   1   |";
+        SqlExpectToString( methodWatcher, sqlText, expected, false );
+    }
+
+    // make sure we disable access to alias for WHERE, HAVING and GROUP BY
+    @Test
+    public void testUsingAliasOnlyInOrderBy() throws Exception {
+        String sqlTexts[] =
+                {       "select a1+1 as ALIAS from t2 WHERE ALIAS > 0 ORDER BY -ALIAS",
+                        "select a1+1 as ALIAS from t2 GROUP BY ALIAS ORDER BY -ALIAS",
+                        "select a1, sum(b1+1) as ALIAS from t1 GROUP BY a1 HAVING ALIAS > 0 ORDER BY -ALIAS"
+                        };
+        for( String sqlText : sqlTexts ) {
+            SqlExpectException( methodWatcher, sqlText, "42X04" );
+        }
+    }
+    // avoid that we refer an alias on the more left hand side inside the same select
+    @Test
+    public void testAliasNoLeftToRightReferal() throws Exception {
+        SqlExpectException( methodWatcher, "select a1*2 as ALIAS1, ALIAS1+1 as ALIAS2 from t2 order by -ALIAS2", "42X04" );
+    }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
@@ -963,4 +963,29 @@ public class SpliceUnitTest {
         }
         return count;
     }
+
+    /// execute sql query 'sqlText' and expect an exception of certain state being thrown
+    public static void SqlExpectException( SpliceWatcher methodWatcher, String sqlText, String expectedState )
+    {
+        try {
+            ResultSet rs = methodWatcher.executeQuery(sqlText);
+            rs.close();
+            Assert.fail("Exception not thrown for " + sqlText);
+
+        } catch (SQLException e) {
+            System.out.println( e );
+            Assert.assertEquals("Wrong Exception for " + sqlText, expectedState, e.getSQLState());
+        }
+    }
+
+    /// execute sql query 'sqlText' and expect a certain formatted result
+    public static void SqlExpectToString( SpliceWatcher methodWatcher, String sqlText, String expected, boolean sort ) throws Exception
+    {
+        try( ResultSet rs = methodWatcher.executeQuery(sqlText) ) {
+            String val = sort
+                    ? TestUtils.FormattedResult.ResultFactory.toString(rs)
+                    : TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            Assert.assertEquals(expected, val);
+        }
+    }
 }


### PR DESCRIPTION
e.g. as in
  select C as C2+1 from A order by -C2;