### PR TITLE
DB-9465 external tables shouldn't write when only reading

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -465,19 +465,42 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             if (!mergeSchema) {
                 fs = FileSystem.get(URI.create(location), conf);
                 String fileName = getFile(fs, location);
-                if (fileName != null) {
-                    temp = new Path(location, TEMP_DIR_PREFIX + "_" + UUID.randomUUID().toString().replaceAll("-",""));
-                    fs.mkdirs(temp);
-                    SpliceLogUtils.info(LOG, "created temporary directory %s", temp);
+                boolean canWrite = true;
+                if( (fileName == null || (fs.getFileStatus(new Path(location)).getPermission().toShort() & 0222) == 0 )) {
+                    canWrite = false;
+                }
+                else {
+                    temp = new Path(location, TEMP_DIR_PREFIX + "_" + UUID.randomUUID().toString().replaceAll("-", ""));
 
+                    try {
+                        fs.mkdirs(temp);
+                    } catch (IOException e) {
+                        canWrite = false;
+                        temp = null;
+                    }
+                }
+
+                if( canWrite )
+                {
+                    SpliceLogUtils.info(LOG, "created temporary directory %s", temp);
                     // Copy a data file to temp directory
                     int index = fileName.indexOf(location);
                     if (index != -1) {
                         String s = fileName.substring(index + location.length() + 1);
                         Path destDir = new Path(temp, s);
-                        FileUtil.copy(fs, new Path(fileName), fs, destDir, false, conf);
-                        location = temp.toString();
+                        try {
+                            FileUtil.copy(fs, new Path(fileName), fs, destDir, false, conf);
+                            location = temp.toString();
+                        } catch (IOException e) {
+                            canWrite = false;
+                        }
                     }
+                }
+
+                if( !canWrite )
+                {
+                    SpliceLogUtils.info(LOG, "couldn't create temporary directory %s, " +
+                            "will read schema from whole directory", temp);
                 }
             }
             try {

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -470,20 +470,28 @@ public class ExternalTableIT extends SpliceUnitTest {
 
     @Test
     public void createParquetTableMergeSchema() throws  Exception{
-        String tablePath = getResourceDirectory()+"parquet_sample_one";
+        String tablePath = getTempCopyOfResourceDirectory(tempDir, "parquet_sample_one" );
+        try {
+            // check also that merging doesn't require writeable directory
+            new File(tablePath).setWritable(false);
 
-        methodWatcher.executeUpdate(String.format("create external table parquet_table_to_existing_file (\"partition1\" varchar(24), \"column1\" varchar(24), \"column2\" varchar(24))" +
-                " PARTITIONED BY (\"partition1\") STORED AS PARQUET  LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate(String.format("create external table parquet_table_to_existing_file (\"partition1\" varchar(24), \"column1\" varchar(24), \"column2\" varchar(24))" +
+                    " PARTITIONED BY (\"partition1\") STORED AS PARQUET  LOCATION '%s'", tablePath));
 
-        ResultSet rs = methodWatcher.executeQuery("select * from parquet_table_to_existing_file order by 1");
-        String actual = TestUtils.FormattedResult.ResultFactory.toString(rs);
-        String expected =
-                "partition1 | column1 | column2 |\n" +
-                        "--------------------------------\n" +
-                        "    AAA    |   AAA   |   AAA   |\n" +
-                        "    BBB    |   BBB   |   BBB   |\n" +
-                        "    CCC    |   CCC   |   CCC   |";
-        Assert.assertEquals(actual, expected, actual);
+            ResultSet rs = methodWatcher.executeQuery("select * from parquet_table_to_existing_file order by 1");
+            String actual = TestUtils.FormattedResult.ResultFactory.toString(rs);
+            String expected =
+                    "partition1 | column1 | column2 |\n" +
+                            "--------------------------------\n" +
+                            "    AAA    |   AAA   |   AAA   |\n" +
+                            "    BBB    |   BBB   |   BBB   |\n" +
+                            "    CCC    |   CCC   |   CCC   |";
+            Assert.assertEquals(actual, expected, actual);
+        }
+        finally {
+            // otherwise cleanup scripts can't delete this directory
+            new File(tablePath).setWritable(true);
+        }
     }
 
     @Test


### PR DESCRIPTION
SparkDataSetProcessor.getExternalFileSchema was copying one file out of the location so that the schema infer is only looking at one file (performance optimization). In the case that we can't access that file, we fall back to the normal behavior.