### PR TITLE
DB-9540 Make RegionLoads use bytes instead of MBs (3.0)

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/hbase/HBaseRegionLoads.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/HBaseRegionLoads.java
@@ -210,19 +210,11 @@ public class HBaseRegionLoads implements PartitionLoadWatcher{
                         }
                     });
             Collection<Pair<String, Long>> collection = ret.values();
-            long factor = 1024 * 1024;
             Map<String, PartitionLoad> retMap = new HashMap<>();
             for(Pair<String, Long> info : collection){
-                long sizeMB = info.getSecond() / factor;
-                ClusterStatusProtos.RegionLoad.Builder rl = ClusterStatusProtos.RegionLoad.newBuilder();
-                rl.setMemstoreSizeMB((int)(sizeMB / 2));
-                rl.setStorefileSizeMB((int) (sizeMB / 2));
-                rl.setRegionSpecifier(HBaseProtos.RegionSpecifier.newBuilder()
-                    .setType(HBaseProtos.RegionSpecifier.RegionSpecifierType.ENCODED_REGION_NAME).setValue(
-                                        ZeroCopyLiteralByteString.copyFromUtf8(info.getFirst())).build());
-                ClusterStatusProtos.RegionLoad load = rl.build();
-                HPartitionLoad value=new HPartitionLoad(info.getFirst(),load.getStorefileSizeMB(),
-                        load.getMemstoreSizeMB(), (int)load.getStorefileIndexSizeKB()/1024);
+                long size = info.getSecond();
+                HPartitionLoad value=new HPartitionLoad(info.getFirst(),size/2,
+                        size/2);
                 retMap.put(info.getFirst(),value);
             }
 
@@ -278,10 +270,10 @@ public class HBaseRegionLoads implements PartitionLoadWatcher{
         return loads.get(tableName);
     }
     /**
-     * Region Size in MB
+     * Region Size in bytes
      */
-    public static int memstoreAndStorefileSize(PartitionLoad load){
-        return load.getStorefileSizeMB() + load.getMemStoreSizeMB();
+    public static long memstoreAndStorefileSize(PartitionLoad load){
+        return load.getStorefileSize() + load.getMemStoreSize();
     }
 
     public static long memstoreAndStoreFileSize(String tableName) {

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/AbstractSMInputFormat.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/core/AbstractSMInputFormat.java
@@ -115,10 +115,8 @@ public abstract class AbstractSMInputFormat<K,V> extends InputFormat<K, V> imple
                     boolean refreshPartitionLoad = splits.size() < PARTITION_LOAD_REFRESH_THRESHOLD;
                     Collection<PartitionLoad> tableLoad = loadWatcher.tableLoad(tableName, refreshPartitionLoad);
                     for (PartitionLoad partitionLoad : tableLoad) {
-                        tableSize += (partitionLoad.getStorefileSizeMB() + partitionLoad.getMemStoreSizeMB());
+                        tableSize += (partitionLoad.getStorefileSize() + partitionLoad.getMemStoreSize());
                     }
-                    // Convert MB to bytes.
-                    tableSize *= 1048576;
                     if (tableSize < 0)
                         tableSize = 0;
                 }

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/SpliceRegionAdminIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/SpliceRegionAdminIT.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.*;
 import org.spark_project.guava.collect.Lists;
 
+import java.io.File;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -72,15 +73,16 @@ public class SpliceRegionAdminIT {
 
     @BeforeClass
     public static void init() throws Exception {
+        String badDir = SpliceUnitTest.createBadLogDirectory(SCHEMA_NAME).getCanonicalPath();
         TestUtils.executeSqlFile(spliceClassWatcher, "tcph/TPCHIT.sql", SCHEMA_NAME);
         spliceClassWatcher.execute(String.format("call SYSCS_UTIL.SYSCS_SPLIT_TABLE_OR_INDEX('%s','%s',null,'L_ORDERKEY,L_LINENUMBER'," +
-                        "'%s','|',null,null,null,null,-1,'/BAD',true,null)",SCHEMA_NAME,LINEITEM,
-                getResource("lineitemKey.csv")));
+                        "'%s','|',null,null,null,null,-1,'%s',true,null)",SCHEMA_NAME,LINEITEM,
+                getResource("lineitemKey.csv"), badDir));
 
         spliceClassWatcher.execute(String.format("call SYSCS_UTIL.SYSCS_SPLIT_TABLE_OR_INDEX('%s','%s','O_CUST_IDX'," +
                         "'O_CUSTKEY,O_ORDERKEY'," +
-                        "'%s','|',null,null,null,null,-1,'/BAD',true,null)",SCHEMA_NAME,ORDERS,
-                getResource("custIndex.csv")));
+                        "'%s','|',null,null,null,null,-1,'%s',true,null)",SCHEMA_NAME,ORDERS,
+                getResource("custIndex.csv"), badDir));
         spliceClassWatcher.execute(String.format("CALL SYSCS_UTIL.BULK_IMPORT_HFILE('%s','%s',null,'%s','|','\"',null,null,null,0,null,true,null, '%s', true)", SCHEMA_NAME, LINEITEM, getResource("lineitem.tbl"), getResource("data")));
 
         spliceTableSplitKeys.add(0, "{ NULL, NULL }");

--- a/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/RegionSplitsIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/RegionSplitsIT.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.JobID;
 import org.apache.hadoop.mapreduce.task.JobContextImpl;
+import org.apache.log4j.Logger;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,6 +40,7 @@ import static org.junit.Assert.assertTrue;
  *         Date: 4/30/19
  */
 public class RegionSplitsIT extends SpliceUnitTest {
+    private static final Logger LOG = Logger.getLogger(RegionSplitsIT.class);
     private static final String SCHEMA_NAME = RegionSplitsIT.class.getSimpleName().toUpperCase();
     private static final SpliceWatcher spliceClassWatcher = new SpliceWatcher(SCHEMA_NAME);
     private static final String TABLE1_NAME = "TAB1";
@@ -107,7 +109,7 @@ public class RegionSplitsIT extends SpliceUnitTest {
         SMInputFormat smInputFormat = new SMInputFormat();
         final Configuration conf=new Configuration(HConfiguration.unwrapDelegate());
         conf.setClass(JobContext.OUTPUT_FORMAT_CLASS_ATTR, FakeOutputFormat.class,FakeOutputFormat.class);
-        conf.setInt(MRConstants.SPLICE_SPLITS_PER_TABLE, 4);
+        conf.setInt(MRConstants.SPLICE_SPLITS_PER_TABLE, 8);
         // Get splits for the SYSCOLUMNS table.
         String tableName = format("%s.%s", SCHEMA_NAME, TABLE1_NAME);
         conf.set(MRConstants.SPLICE_INPUT_TABLE_NAME, tableName);
@@ -125,13 +127,9 @@ public class RegionSplitsIT extends SpliceUnitTest {
         JobContext ctx = new JobContextImpl(conf,new JobID("test",1));
         List<InputSplit> splits = smInputFormat.getSplits(ctx);
 
-        // The current formula for splits ignores the first and last partitions, so
-        // Requesting 4 splits from 4 partitions gives 4/(4-2) splits per partition.
-        // 2 splits/partition * 4 partitions = 8 splits.
-        // Each region split request is just an approximation.  We may have up to one
-        // extra split per region, or in this case, 12 splits.
-        assertTrue(format("Expected between 8 and 12 splits, got %d.", splits.size()),
-                splits.size() >= 8 && splits.size() <= 12);
+        LOG.info("Got "+splits.size() + " splits");
+        assertTrue(format("Expected between 6 and 10 splits, got %d.", splits.size()),
+                splits.size() >= 6 && splits.size() <= 10);
 
     }
 

--- a/hbase_storage/src/main/java/com/splicemachine/storage/ClientPartition.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/ClientPartition.java
@@ -200,9 +200,8 @@ public class ClientPartition extends SkeletonHBaseClientPartition{
                 info.add(location.getRegion());
             }
         }
-        int totalStoreFileSizeMB = 0;
-        int totalMemstoreSieMB = 0;
-        int storeFileIndexSizeMB = 0;
+        long totalStoreFileSize = 0;
+        long totalMemstoreSize = 0;
         try (Admin admin = connection.getAdmin()) {
             ClusterMetrics metrics = admin.getClusterMetrics();
             for (Map.Entry<ServerName, List<RegionInfo>> entry : serverToRegionMap.entrySet()) {
@@ -212,14 +211,13 @@ public class ClientPartition extends SkeletonHBaseClientPartition{
                 for (RegionInfo regionInfo : entry.getValue()) {
                     RegionMetrics regionMetrics = regionsMetrics.get(regionInfo.getRegionName());
                     if (regionMetrics != null) {
-                        totalStoreFileSizeMB += (int) regionMetrics.getStoreFileSize().get(Size.Unit.MEGABYTE);
-                        totalMemstoreSieMB += (int) regionMetrics.getMemStoreSize().get(Size.Unit.MEGABYTE);
-                        storeFileIndexSizeMB += (int) regionMetrics.getStoreFileIndexSize().get(Size.Unit.MEGABYTE);
+                        totalStoreFileSize += regionMetrics.getStoreFileSize().get(Size.Unit.BYTE);
+                        totalMemstoreSize += regionMetrics.getMemStoreSize().get(Size.Unit.BYTE);
                     }
                 }
             }
         }
-        return new HPartitionLoad(getName(), totalStoreFileSizeMB, totalMemstoreSieMB, storeFileIndexSizeMB);
+        return new HPartitionLoad(getName(), totalStoreFileSize, totalMemstoreSize);
     }
 
     /**

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HPartitionLoad.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HPartitionLoad.java
@@ -19,15 +19,13 @@ package com.splicemachine.storage;
  *         Date: 1/7/16
  */
 public class HPartitionLoad implements PartitionLoad{
-    private final int storefileSizeMB;
-    private final int memStoreSizeMB;
-    private final int storefileIndexSizeMB;
+    private final long storefileSize;
+    private final long memStoreSize;
     private final String name;
 
-    public HPartitionLoad(String name,int storefileSizeMB,int memStoreSizeMB,int storefileIndexSizeMB){
-        this.storefileSizeMB=storefileSizeMB;
-        this.memStoreSizeMB=memStoreSizeMB;
-        this.storefileIndexSizeMB=storefileIndexSizeMB;
+    public HPartitionLoad(String name,long storefileSize, long memStoreSize){
+        this.storefileSize=storefileSize;
+        this.memStoreSize=memStoreSize;
         this.name = name;
     }
 
@@ -37,17 +35,17 @@ public class HPartitionLoad implements PartitionLoad{
     }
 
     @Override
-    public int getStorefileSizeMB(){
-        return storefileSizeMB;
+    public long getStorefileSize(){
+        return storefileSize;
     }
 
     @Override
-    public int getMemStoreSizeMB(){
-        return memStoreSizeMB;
+    public long getMemStoreSize(){
+        return memStoreSize;
     }
 
     @Override
-    public int getStorefileIndexSizeMB(){
-        return storefileIndexSizeMB;
+    public long getStorefileIndexSize(){
+        return 0;
     }
 }

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HServerLoad.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HServerLoad.java
@@ -16,7 +16,9 @@ package com.splicemachine.storage;
 
 import com.splicemachine.primitives.Bytes;
 import org.apache.hadoop.hbase.RegionLoad;
+import org.apache.hadoop.hbase.RegionMetrics;
 import org.apache.hadoop.hbase.ServerLoad;
+import org.apache.hadoop.hbase.Size;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -50,17 +52,17 @@ public class HServerLoad implements PartitionServerLoad{
 
     @Override
     public long totalRequests(){
-        return load.getTotalNumberOfRequests();
+        return load.getRequestCount();
     }
 
     @Override
     public Set<PartitionLoad> getPartitionLoads(){
-        Map<byte[], RegionLoad> regionsLoad=load.getRegionsLoad();
+        Map<byte[], RegionMetrics> regionsLoad=load.getRegionMetrics();
         Set<PartitionLoad> loads = new HashSet<>(regionsLoad.size(),0.9f);
-        for(Map.Entry<byte[],RegionLoad> regionLoad:regionsLoad.entrySet()){
+        for(Map.Entry<byte[], RegionMetrics> regionLoad:regionsLoad.entrySet()){
             String name = Bytes.toString(regionLoad.getKey());
-            RegionLoad rl = regionLoad.getValue();
-            PartitionLoad pl = new HPartitionLoad(name,rl.getStorefileSizeMB()*1024,rl.getMemStoreSizeMB()*1024);
+            RegionMetrics rm = regionLoad.getValue();
+            PartitionLoad pl = new HPartitionLoad(name, (long) rm.getStoreFileSize().get(Size.Unit.BYTE), (long) rm.getMemStoreSize().get(Size.Unit.BYTE));
             loads.add(pl);
         }
         return loads;

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HServerLoad.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HServerLoad.java
@@ -60,7 +60,7 @@ public class HServerLoad implements PartitionServerLoad{
         for(Map.Entry<byte[],RegionLoad> regionLoad:regionsLoad.entrySet()){
             String name = Bytes.toString(regionLoad.getKey());
             RegionLoad rl = regionLoad.getValue();
-            PartitionLoad pl = new HPartitionLoad(name,rl.getStorefileSizeMB(),rl.getMemStoreSizeMB(),rl.getStorefileIndexSizeMB());
+            PartitionLoad pl = new HPartitionLoad(name,rl.getStorefileSizeMB()*1024,rl.getMemStoreSizeMB()*1024);
             loads.add(pl);
         }
         return loads;

--- a/mem_storage/src/main/java/com/splicemachine/storage/MPartitionLoad.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MPartitionLoad.java
@@ -26,17 +26,17 @@ public class MPartitionLoad implements PartitionLoad{
     }
 
     @Override
-    public int getStorefileSizeMB(){
+    public long getStorefileSize(){
         return 0;
     }
 
     @Override
-    public int getMemStoreSizeMB(){
+    public long getMemStoreSize(){
         return 1;
     }
 
     @Override
-    public int getStorefileIndexSizeMB(){
+    public long getStorefileIndexSize(){
         return 0;
     }
 

--- a/splice_access_api/src/main/java/com/splicemachine/storage/PartitionLoad.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/PartitionLoad.java
@@ -19,11 +19,11 @@ package com.splicemachine.storage;
  *         Date: 1/6/16
  */
 public interface PartitionLoad{
-    int getStorefileSizeMB();
+    long getStorefileSize();
 
-    int getMemStoreSizeMB();
+    long getMemStoreSize();
 
-    int getStorefileIndexSizeMB();
+    long getStorefileIndexSize();
 
     String getPartitionName();
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/IndexConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/IndexConstantOperation.java
@@ -182,6 +182,8 @@ public abstract class IndexConstantOperation extends DDLSingleTableConstantOpera
 	}
 
 
+	private static int MB = 1024*1024;
+
     public ScanSetBuilder<ExecRow> getIndexScanBuilder(TableDescriptor td,
                                                        TxnView indexTransaction,
                                                        long demarcationPoint,
@@ -231,7 +233,7 @@ public abstract class IndexConstantOperation extends DDLSingleTableConstantOpera
         String table = Long.toString(tentativeIndex.getTable().getConglomerate());
         Collection<PartitionLoad> partitionLoadCollection = EngineDriver.driver().partitionLoadWatcher().tableLoad(table,false);
         for (PartitionLoad load: partitionLoadCollection) {
-            if (load.getMemStoreSizeMB() > 0 || load.getStorefileSizeMB() > 0)
+            if (load.getMemStoreSize() > 1*MB || load.getStorefileSize() > 1*MB)
                 distributed = true;
         }
         DataSetProcessor dsp;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/stats/RegionLoadStatistics.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/stats/RegionLoadStatistics.java
@@ -61,7 +61,7 @@ public class RegionLoadStatistics{
             if(regionLoad==null){
                 heapSize =partitionMaxFileSize;
             }else {
-                heapSize = ((long)(regionLoad.getStorefileSizeMB()+regionLoad.getMemStoreSizeMB()))*1024*1024;
+                heapSize = regionLoad.getStorefileSize()+regionLoad.getMemStoreSize();
                 rowSizeRatio = ((double)heapSize)/partitionMaxFileSize;
             }
             long fbRegionRowCount = config.getFallbackRegionRowCount();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/CheckTableJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/CheckTableJob.java
@@ -88,6 +88,7 @@ public class CheckTableJob implements Callable<Void> {
         this.request = request;
     }
 
+    private static int MB = 1024*1024;
     @Override
     public Void call() throws Exception {
         if(!jobStatus.markRunning()){
@@ -100,7 +101,7 @@ public class CheckTableJob implements Callable<Void> {
         Collection<PartitionLoad> partitionLoadCollection = EngineDriver.driver().partitionLoadWatcher().tableLoad(table, true);
         boolean distributed = false;
         for (PartitionLoad load: partitionLoadCollection) {
-            if (load.getMemStoreSizeMB() > 0 || load.getStorefileSizeMB() > 0)
+            if (load.getMemStoreSize() > 1*MB || load.getStorefileSize() > 1*MB)
                 distributed = true;
         }
         DataSetProcessor dsp = null;

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
@@ -616,12 +616,12 @@ public class SpliceAdmin extends BaseAdminProcedures{
                 int idx=0;
                 dvds[idx++].setValue(ps.getHostname());
                 Set<PartitionLoad> partitionLoads=psLoad.getPartitionLoads();
-                long storeFileCount = 0L;
+                long storeFileSize = 0L;
                 for(PartitionLoad pLoad:partitionLoads){
-                    storeFileCount+=pLoad.getStorefileSizeMB();
+                    storeFileSize+=pLoad.getStorefileSize();
                 }
                 dvds[idx++].setValue(partitionLoads.size());
-                dvds[idx++].setValue(storeFileCount);
+                dvds[idx++].setValue(storeFileSize);
                 dvds[idx++].setValue(psLoad.totalWriteRequests());
                 dvds[idx++].setValue(psLoad.totalReadRequests());
                 dvds[idx++].setValue(psLoad.totalRequests());
@@ -638,7 +638,7 @@ public class SpliceAdmin extends BaseAdminProcedures{
         int idx=0;
         columnInfo[idx++]=new GenericColumnDescriptor("host",DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR));
         columnInfo[idx++]=new GenericColumnDescriptor("regionCount",DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BIGINT));
-        columnInfo[idx++]=new GenericColumnDescriptor("storeFileCount",DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BIGINT));
+        columnInfo[idx++]=new GenericColumnDescriptor("storeFileSize",DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BIGINT));
         columnInfo[idx++]=new GenericColumnDescriptor("writeRequestCount",DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BIGINT));
         columnInfo[idx++]=new GenericColumnDescriptor("readRequestCount",DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BIGINT));
         columnInfo[idx++]=new GenericColumnDescriptor("totalRequestCount",DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BIGINT));
@@ -840,12 +840,13 @@ public class SpliceAdmin extends BaseAdminProcedures{
                         int storefileSizeMB=0;
                         int memStoreSizeMB=0;
                         int storefileIndexSizeMB=0;
+                        int factor = 1024*1024;
                         if(regionName!=null && !regionName.isEmpty()){
                             PartitionLoad regionLoad=ri.getLoad();//regionLoadMap.get(regionName);
                             if(regionLoad!=null){
-                                storefileSizeMB=regionLoad.getStorefileSizeMB();
-                                memStoreSizeMB=regionLoad.getMemStoreSizeMB();
-                                storefileIndexSizeMB=regionLoad.getStorefileIndexSizeMB();
+                                storefileSizeMB= (int) (regionLoad.getStorefileSize()/factor);
+                                memStoreSizeMB= (int) (regionLoad.getMemStoreSize()/factor);
+                                storefileIndexSizeMB= (int) (regionLoad.getStorefileIndexSize()/factor);
                             }
                         }
                         DataValueDescriptor[] cols=template.getRowArray();


### PR DESCRIPTION
Fix RegionSplitsIT and don't require /BAD directory to exist for
SpliceRegionAdminIT