### PR TITLE
DB-9590 SnapshotIT leaves an active transaction, breaks vacuuming during ITs

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/hbase/SnapshotIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/SnapshotIT.java
@@ -92,12 +92,15 @@ public class SnapshotIT extends SpliceUnitTest
     @AfterClass
     public static void cleanup() throws Exception
     {
-        TestConnection conn = classWatcher.getOrCreateConnection();
-        conn.execute("call syscs_util.delete_snapshot('EXIST')");
-        PreparedStatement ps = conn.prepareStatement("select count(*) from sys.syssnapshots");
-        ResultSet rs = ps.executeQuery();
-        rs.next();
-        Assert.assertEquals(0, rs.getInt(1));
+        try (TestConnection conn = classWatcher.getOrCreateConnection()) {
+            conn.execute("call syscs_util.delete_snapshot('EXIST')");
+            try (PreparedStatement ps = conn.prepareStatement("select count(*) from sys.syssnapshots")) {
+                try (ResultSet rs = ps.executeQuery()) {
+                    rs.next();
+                    Assert.assertEquals(0, rs.getInt(1));
+                }
+            }
+        }
     }
 
     @Test

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/Vacuum.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/Vacuum.java
@@ -77,7 +77,7 @@ public class Vacuum{
                 }
             }
         }
-        LOG.info("Found " + activeConglomerates.size() + " active conglomerates.");
+        LOG.info("Found " + activeConglomerates.size() + " active conglomerates, oldest transaction: " + oldestActiveTransaction);
 
         //get all dropped conglomerates
         Map<Long, Long> droppedConglomerates = new HashMap<>();

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SimpleDateArithmeticIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SimpleDateArithmeticIT.java
@@ -50,7 +50,7 @@ public class SimpleDateArithmeticIT {
     private static final String QUALIFIED_TABLE_NAME = schemaWatcher.schemaName + ".date_add_test";
     private static final String QUALIFIED_TABLE_NAME2 = schemaWatcher.schemaName + ".old_date_test";
     private static final String QUALIFIED_TIME_TABLE_NAME = schemaWatcher.schemaName + ".time_test";
-    private static final String QUALIFIED_TABLE_NAME3 = schemaWatcher.schemaName + "null_value_test";
+    private static final String QUALIFIED_TABLE_NAME3 = schemaWatcher.schemaName + ".null_value_test";
 
     private static String BADDIR;
 


### PR DESCRIPTION
Explicitly close connection in an @AfterClass method.