### PR TITLE
DB-9597 NSDS v2 Build Jar

### DIFF
--- a/splice_spark/pom.xml
+++ b/splice_spark/pom.xml
@@ -312,7 +312,7 @@
     </build>
     <profiles>
         <profile>
-            <id>dbaas</id>
+            <id>nsdsjar</id>
             <build>
                 <plugins>
                     <plugin>

--- a/splice_spark2/pom.xml
+++ b/splice_spark2/pom.xml
@@ -269,12 +269,7 @@
     </build>
     <profiles>
         <profile>
-            <id>dbaas</id>
-            <activation>
-                <property>
-                    <name>nsds2jar</name>
-                </property>
-            </activation>
+            <id>nsds2jar</id>
             <build>
                 <plugins>
                     <plugin>

--- a/splice_spark2/pom.xml
+++ b/splice_spark2/pom.xml
@@ -270,6 +270,11 @@
     <profiles>
         <profile>
             <id>dbaas</id>
+            <activation>
+                <property>
+                    <name>nsds2jar</name>
+                </property>
+            </activation>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
Requires -Dnsds2jar to be added to the mvn command so that the jar will be built.

Example: mvn -P core,cdh6.3.0,ee -DskipTests -Dnsds2jar clean install

The jar will be at splice_spark2/target/splice_spark2-3.1.0.1959-SNAPSHOT-shaded.jar

The jar size in my env was about 120 MB.