### PR TITLE
DB-9605 OlapServerMaster fails to start during ITs 

### DIFF
--- a/platform_it/src/test/bin/start-splice-its
+++ b/platform_it/src/test/bin/start-splice-its
@@ -58,13 +58,7 @@ while getopts ":chp:b:" flag ; do
 done
 
 # Check if server running. Shut down if so.
-Y=( $(ps -ef | awk '/spliceYarn|CoarseGrainedScheduler|ExecutorLauncher/ && !/awk/ {print $2}') )
-S=( $(ps -ef | awk '/SpliceTestPlatform|SpliceSinglePlatform|SpliceTestClusterParticipant/ && !/awk/ {print $2}') )
-Z=( $(ps -ef | awk '/ZooKeeperServerMain/ && !/awk/ {print $2}') )
-if [[ -n ${Y[0]} || -n ${S[0]} || -n ${Z[0]} ]]; then
-    echo "Splice server is running. Shutting down."
-    "${SCRIPT_DIR}"/stop-splice-its
-fi
+"${SCRIPT_DIR}"/stop-splice-its
 
 # Start zookeeper in background.
 echo "Starting ZooKeeperServerMain, log file is ${ZOOLOG}"


### PR DESCRIPTION
The reason is a leftover OlapServerMaster process that is not recognized by the start-splice-its script. If there are no other Splice related processes, the stop-splice-its script is not invoked and the already running OlapServerMaster process is not killed. The new OlapServerMaster process tries to bind to the same debugging port and fails.