### PR TITLE
DB-9609 SpliceTestYarnPlatform fails to start during ITs 

### DIFF
--- a/platform_it/src/test/bin/stop-splice-its
+++ b/platform_it/src/test/bin/stop-splice-its
@@ -7,7 +7,7 @@
 
 # Check if server running. If not, no need to proceed.
 splice_pids=( $(ps -ef | awk '/SpliceTestPlatform|SpliceSinglePlatform|SpliceTestClusterParticipant|OlapServerMaster/ && !/awk/ {print $2}') )
-yarn_pids=( $(ps -ef | awk '/spliceYarn|CoarseGrainedScheduler|ExecutorLauncher/ && !/awk/ {print $2}') )
+yarn_pids=( $(ps -ef | awk '/spliceYarn|SpliceTestYarnPlatform|CoarseGrainedScheduler|ExecutorLauncher/ && !/awk/ {print $2}') )
 zoo_pids=( $(ps -ef | awk '/ZooKeeperServerMain/ && !/awk/ {print $2}') )
 kafka_pids=( $(ps -ef | awk '/TestKafkaCluster/ && !/awk/ {print $2}') )
 


### PR DESCRIPTION
Integration tests appear to get stuck for hours on the first test (BackupManagerLoaderIT).
The reason is SpliceTestYarnPlatform failed to start. The error in platform_it/target/yarn_it.log indicates that the failure occurred when binding to spark.shuffle.service.port, 8061.
The port is owned by the previous SpliceTestYarnPlatform process, which was missed by the stop-splice-its script.
Incidentally, the start-splice-cluster script has been fixed in that regard.