### PR TITLE
DB-9613 DefaultSourceIT Insertion with Sampling Fix

### DIFF
--- a/platform_it/pom.xml
+++ b/platform_it/pom.xml
@@ -420,6 +420,11 @@
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <additionalClasspathElements>
+                        <additionalClasspathElement>${project.basedir}/target/hbase-site.xml</additionalClasspathElement>
+                    </additionalClasspathElements>
+                </configuration>
                 <executions>
                     <!-- = = = = = = = = = = = = = = = = = = = = = = = = = = = Integration tests: SERIAL -->
                     <execution>

--- a/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceIT.scala
+++ b/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceIT.scala
@@ -118,6 +118,10 @@ class DefaultSourceIT extends FunSuite with TestContext with BeforeAndAfter with
   }
 
   test("insertion with sampling") {
+    val userDir: String = System.getProperty("user.dir")
+    val hbaseDir = new File(userDir).getParent + "/platform_it/target/hbase"
+    System.setProperty("hbase.rootdir", hbaseDir)
+
     val conn = JdbcUtils.createConnectionFactory(internalJDBCOptions)()
     conn.createStatement().execute("create table TestContext.T(id INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1), c1 double, c2 double, c3 double, primary key(id))")
     conn.createStatement().execute("insert into TestContext.T(c1,c2,c3) values (100, 100, 100), (200, 200, 200), (300, 300, 300), (400, 400, 400)");
@@ -127,15 +131,13 @@ class DefaultSourceIT extends FunSuite with TestContext with BeforeAndAfter with
     conn.createStatement().execute("create table TestContext.T2(id int, c1 double, c2 double, c3 double, primary key(id))")
     val options = Map(
       JDBCOptions.JDBC_TABLE_NAME -> (schema+"."+"T"),
-      JDBCOptions.JDBC_URL -> defaultJDBCURL,
-      SpliceJDBCOptions.JDBC_INTERNAL_QUERIES -> "true"
+      JDBCOptions.JDBC_URL -> defaultJDBCURL
     )
     val df = sqlContext.read.options(options).splicemachine
 
     val options2 = Map(
       JDBCOptions.JDBC_TABLE_NAME -> (schema+"."+"T2"),
-      JDBCOptions.JDBC_URL -> defaultJDBCURL,
-      SpliceJDBCOptions.JDBC_INTERNAL_QUERIES -> "true"
+      JDBCOptions.JDBC_URL -> defaultJDBCURL
     )
     splicemachineContext.splitAndInsert(df, schema+"."+"T2", 0.001)
     val newDF = sqlContext.read.options(options2).splicemachine

--- a/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceIT.scala
+++ b/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceIT.scala
@@ -19,7 +19,6 @@ import java.nio.file.{Files, Path}
 import java.sql.{Time, Timestamp}
 import java.util.Date
 
-import com.splicemachine.access.HConfiguration
 import org.apache.commons.io.FileUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcUtils}

--- a/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceIT.scala
+++ b/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceIT.scala
@@ -121,23 +121,25 @@ class DefaultSourceIT extends FunSuite with TestContext with BeforeAndAfter with
     val conn = JdbcUtils.createConnectionFactory(internalJDBCOptions)()
     conn.createStatement().execute("create table TestContext.T(id INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1), c1 double, c2 double, c3 double, primary key(id))")
     conn.createStatement().execute("insert into TestContext.T(c1,c2,c3) values (100, 100, 100), (200, 200, 200), (300, 300, 300), (400, 400, 400)");
-    for (i <- 0 to 15) {
+    for (i <- 0 to 20) {
       conn.createStatement().execute("insert into TestContext.T(c1,c2,c3) select c1,c2,c3 from TestContext.t")
     }
     conn.createStatement().execute("create table TestContext.T2(id int, c1 double, c2 double, c3 double, primary key(id))")
     val options = Map(
       JDBCOptions.JDBC_TABLE_NAME -> (schema+"."+"T"),
-      JDBCOptions.JDBC_URL -> defaultJDBCURL
+      JDBCOptions.JDBC_URL -> defaultJDBCURL,
+      SpliceJDBCOptions.JDBC_INTERNAL_QUERIES -> "true"
     )
     val df = sqlContext.read.options(options).splicemachine
 
     val options2 = Map(
       JDBCOptions.JDBC_TABLE_NAME -> (schema+"."+"T2"),
-      JDBCOptions.JDBC_URL -> defaultJDBCURL
+      JDBCOptions.JDBC_URL -> defaultJDBCURL,
+      SpliceJDBCOptions.JDBC_INTERNAL_QUERIES -> "true"
     )
     splicemachineContext.splitAndInsert(df, schema+"."+"T2", 0.001)
     val newDF = sqlContext.read.options(options2).splicemachine
-    assert(newDF.count == 262144)
+    assert(newDF.count == 8388608)
   }
 
   test("insertion using RDD") {

--- a/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceIT.scala
+++ b/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceIT.scala
@@ -19,7 +19,7 @@ import java.nio.file.{Files, Path}
 import java.sql.{Time, Timestamp}
 import java.util.Date
 
-import com.splicemachine.derby.vti.SpliceDatasetVTI
+import com.splicemachine.access.HConfiguration
 import org.apache.commons.io.FileUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcUtils}
@@ -121,7 +121,10 @@ class DefaultSourceIT extends FunSuite with TestContext with BeforeAndAfter with
     val userDir: String = System.getProperty("user.dir")
     val hbaseDir = new File(userDir).getParent + "/platform_it/target/hbase"
     System.setProperty("hbase.rootdir", hbaseDir)
-
+    
+    val conf = HConfiguration.unwrapDelegate()
+    conf.set("hbase.rpc.timeout", "1200000")
+    
     val conn = JdbcUtils.createConnectionFactory(internalJDBCOptions)()
     conn.createStatement().execute("create table TestContext.T(id INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1), c1 double, c2 double, c3 double, primary key(id))")
     conn.createStatement().execute("insert into TestContext.T(c1,c2,c3) values (100, 100, 100), (200, 200, 200), (300, 300, 300), (400, 400, 400)");

--- a/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceIT.scala
+++ b/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceIT.scala
@@ -117,13 +117,11 @@ class DefaultSourceIT extends FunSuite with TestContext with BeforeAndAfter with
     assert(newDF.count == 20)
   }
 
-  test("insertion with sampling") {  // DB-9395
-    val userDir: String = System.getProperty("user.dir")
-    val dataDir = userDir+"/src/test/data/lineitem.csv";
+  test("insertion with sampling") {
     val conn = JdbcUtils.createConnectionFactory(internalJDBCOptions)()
     conn.createStatement().execute("create table TestContext.T(id INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1), c1 double, c2 double, c3 double, primary key(id))")
     conn.createStatement().execute("insert into TestContext.T(c1,c2,c3) values (100, 100, 100), (200, 200, 200), (300, 300, 300), (400, 400, 400)");
-    for (i <- 0 to 20) {
+    for (i <- 0 to 15) {
       conn.createStatement().execute("insert into TestContext.T(c1,c2,c3) select c1,c2,c3 from TestContext.t")
     }
     conn.createStatement().execute("create table TestContext.T2(id int, c1 double, c2 double, c3 double, primary key(id))")
@@ -139,7 +137,7 @@ class DefaultSourceIT extends FunSuite with TestContext with BeforeAndAfter with
     )
     splicemachineContext.splitAndInsert(df, schema+"."+"T2", 0.001)
     val newDF = sqlContext.read.options(options2).splicemachine
-    assert(newDF.count == 8388608)
+    assert(newDF.count == 262144)
   }
 
   test("insertion using RDD") {


### PR DESCRIPTION
Setting hbase.rpc.timeout to avoid rpc timeouts in Jenkins.

The reason for setting hbase.rootdir as a system property: the sqlContext.read calls returning the dataframes are implemented as calls to SplicemachineContext.df() in SpliceRelation.buildScan().  The df function uses an EmbeddedConnection to query the data from the db.  Somewhere in the call stack, SplitRegionScanner.createAndRegisterClientSideRegionScanner() is called and it looks for hbase.rootdir in config files or in system properties.  It wasn’t getting the correct value for hbase.rootdir.  So the code was probably reading rows from the memstore, but didn’t have the right path to HBase to be able to read the additional rows stored in HFiles, and so it wasn't returning all of the rows.  The solution for DefaultSourceIT was to set the value in system properties at the beginning of the test.  In normal environments, hbase-site.xml in the driver/executor extraClassPath would provide hbase.rootdir.  (Thanks to Jun for troubleshooting the cause of not all rows being retrieved.)