### PR TITLE
DB-9593 reset the variable optimized for JoinNode in-between the two-…(2.8)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLStatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLStatementNode.java
@@ -183,6 +183,8 @@ public abstract class DMLStatementNode extends StatementNode {
             for (Object obj : cnv.getList()) {
                 FromTable ft = (FromTable) obj;
                 ft.resetAccessPaths();
+                if (ft instanceof JoinNode)
+                    ((JoinNode)ft).resetOptimized();
             }
             resultSet = resultSet.optimize(getDataDictionary(), null, 1.0d, true);
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
@@ -320,7 +320,6 @@ public class JoinNode extends TableOperatorNode{
              * Also need to figure out the pushing of the joinClause.
              */
             subqueryList.optimize(optimizer.getDataDictionary(), costEstimate.rowCount(), optimizer.isForSpark());
-            subqueryList.modifyAccessPaths();
         }
 
         optimized=true;
@@ -371,6 +370,10 @@ public class JoinNode extends TableOperatorNode{
 
     @Override
     public Optimizable modifyAccessPath(JBitSet outerTables) throws StandardException{
+        // modify access path for On clause subqueries
+        if (subqueryList != null)
+            subqueryList.modifyAccessPaths();
+
         super.modifyAccessPath(outerTables);
 
         /* By the time we're done here, both the left and right
@@ -2235,5 +2238,9 @@ public class JoinNode extends TableOperatorNode{
             }
         }
         return rightHashKeysToBaseTableMap;
+    }
+
+    public void resetOptimized() {
+        optimized = false;
     }
 }


### PR DESCRIPTION
…pass costing for control and spark.