### PR TITLE
DB-9645 OlapServerIT.testKillOlapServer fails with OlapServerNotReadyException

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/lifecycle/HEngineSqlEnv.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/lifecycle/HEngineSqlEnv.java
@@ -134,9 +134,8 @@ public class HEngineSqlEnv extends EngineSqlEnvironment{
     private OlapClient initializeOlapClient(SConfiguration config,Clock clock) {
         int timeoutMillis = config.getOlapClientWaitTime();
         final int retries = config.getOlapClientRetries();
-        int maxRetries = config.getMaxRetries();
         HBaseConnectionFactory hbcf = HBaseConnectionFactory.getInstance(config);
-        final OlapServerProvider osp = new OlapServerProviderImpl(config, maxRetries, clock, hbcf);
+        final OlapServerProvider osp = new OlapServerProviderImpl(config, clock, hbcf);
 
         Stream.Builder<String> queuesBuilder = Stream.builder();
         queuesBuilder.accept(SIConstants.OLAP_DEFAULT_QUEUE_NAME);

--- a/hbase_sql/src/main/java/com/splicemachine/derby/lifecycle/OlapServerProviderImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/lifecycle/OlapServerProviderImpl.java
@@ -23,13 +23,11 @@ public class OlapServerProviderImpl implements OlapServerProvider {
     private static final Logger LOG = Logger.getLogger(OlapServerProviderImpl.class);
 
     private final SConfiguration config;
-    private final int maxRetries;
     private final Clock clock;
     private final HBaseConnectionFactory hbcf;
 
-    public OlapServerProviderImpl(SConfiguration config, int maxRetries, Clock clock, HBaseConnectionFactory hbcf) {
+    public OlapServerProviderImpl(SConfiguration config, Clock clock, HBaseConnectionFactory hbcf) {
         this.config = config;
-        this.maxRetries = maxRetries;
         this.clock = clock;
         this.hbcf = hbcf;
     }
@@ -42,7 +40,7 @@ public class OlapServerProviderImpl implements OlapServerProvider {
                 int tries = 0;
                 OlapServerNotReadyException osnr = null;
                 String root = HConfiguration.getConfiguration().getSpliceRootPath() + HBaseConfiguration.OLAP_SERVER_PATH + HBaseConfiguration.OLAP_SERVER_QUEUE_PATH;
-                while (tries < maxRetries) {
+                while (tries < config.getOlapServerMaxRetries()) {
                     tries++;
                     try {
                         List<String> servers = ZkUtils.getChildren(root, false);

--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
@@ -215,6 +215,7 @@ class SpliceTestPlatformConfig {
         config.setLong("hbase.rpc.timeout", MINUTES.toMillis(5));
         config.setInt("hbase.client.max.perserver.tasks",50);
         config.setInt("hbase.client.ipc.pool.size",10);
+        config.setInt("hbase.client.retries.number", 35);
         config.setInt("hbase.rowlock.wait.duration",10);
 
         config.setLong("hbase.client.scanner.timeout.period", MINUTES.toMillis(2)); // hbase.regionserver.lease.period is deprecated

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/SConfiguration.java
@@ -240,6 +240,8 @@ public interface SConfiguration {
 
     boolean getOlapServerExternal();
 
+    int getOlapServerMaxRetries();
+
     long getOlapServerKeepAliveTimeout();
 
     int getOlapServerThreads();

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/ConfigurationBuilder.java
@@ -145,6 +145,7 @@ public class ConfigurationBuilder {
     public int olapServerBindPort;
     public String olapServerStagingDir;
     public boolean olapServerExternal;
+    public int olapServerMaxRetries;
     public int olapServerThreads;
     public int olapServerTickLimit;
     public int olapServerSubmitAttempts;

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/OlapConfigurations.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/OlapConfigurations.java
@@ -83,6 +83,9 @@ public class OlapConfigurations implements ConfigurationDefault {
     public static final String OLAP_SERVER_EXTERNAL = "splice.olap_server.external";
     private static final boolean DEFAULT_OLAP_SERVER_EXTERNAL = true;
 
+    public static final String OLAP_SERVER_MAX_RETRIES = "splice.olap_server.maxRetries";
+    public static final int DEFAULT_OLAP_SERVER_MAX_RETRIES = 30;
+
     public static final String OLAP_SERVER_SUBMIT_ATTEMPTS = "splice.olap_server.submitAttempts";
     private static final int DEFAULT_OLAP_SERVER_SUBMIT_ATTEMPTS = 50;
 
@@ -187,6 +190,7 @@ public class OlapConfigurations implements ConfigurationDefault {
         builder.olapServerBindPort  = configurationSource.getInt(OLAP_SERVER_BIND_PORT, DEFAULT_OLAP_SERVER_BIND_PORT);
         builder.olapServerStagingDir = configurationSource.getString(OLAP_SERVER_STAGING_DIR, DEFAULT_OLAP_SERVER_STAGING_DIR);
         builder.olapServerExternal  = configurationSource.getBoolean(OLAP_SERVER_EXTERNAL, DEFAULT_OLAP_SERVER_EXTERNAL);
+        builder.olapServerMaxRetries = configurationSource.getInt(OLAP_SERVER_MAX_RETRIES, DEFAULT_OLAP_SERVER_MAX_RETRIES);
         builder.olapClientWaitTime  = configurationSource.getInt(OLAP_CLIENT_WAIT_TIME, DEFAULT_OLAP_CLIENT_WAIT_TIME);
         builder.olapClientTickTime  = configurationSource.getInt(OLAP_CLIENT_TICK_TIME, DEFAULT_OLAP_CLIENT_TICK_TIME);
         builder.olapServerThreads = configurationSource.getInt(OLAP_SERVER_THREADS, DEFAULT_OLAP_SERVER_THREADS);

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
@@ -155,6 +155,7 @@ public final class SConfigurationImpl implements SConfiguration {
     private final int olapServerBindPort;
     private final String olapServerStagingDir;
     private final boolean olapServerExternal;
+    private final int olapServerMaxRetries;
     private final int olapServerThreads;
     private final int olapServerTickLimit;
     private final int olapClientRetries;
@@ -646,6 +647,12 @@ public final class SConfigurationImpl implements SConfiguration {
     public boolean getOlapServerExternal() {
         return olapServerExternal;
     }
+
+    @Override
+    public int getOlapServerMaxRetries() {
+        return olapServerMaxRetries;
+    }
+
     @Override
     public int getOlapServerSubmitAttempts() {
         return olapServerSubmitAttempts;
@@ -1056,6 +1063,7 @@ public final class SConfigurationImpl implements SConfiguration {
         olapServerBindPort = builder.olapServerBindPort;
         olapServerStagingDir = builder.olapServerStagingDir;
         olapServerExternal = builder.olapServerExternal;
+        olapServerMaxRetries = builder.olapServerMaxRetries;
         olapServerThreads = builder.olapServerThreads;
         olapServerTickLimit = builder.olapServerTickLimit;
         olapServerSubmitAttempts = builder.olapServerSubmitAttempts;


### PR DESCRIPTION
New config: "splice.olap_server.maxRetries" = 30
Set "hbase.client.retries.number" to 35 for ITs (as in 2.8).