### PR TITLE
DB-9449 Fix spark scan issue that missed a row during flush (3.0)

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SparkFlushMissingRowsIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SparkFlushMissingRowsIT.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.impl.sql.execute.operations;
+
+import com.splicemachine.access.HConfiguration;
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.homeless.TestUtils;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.log4j.Logger;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class SparkFlushMissingRowsIT extends SpliceUnitTest {
+    private static Logger LOG = Logger.getLogger(SparkFlushMissingRowsIT.class);
+
+    public static final String CLASS_NAME = StressSparkIT.class.getSimpleName().toUpperCase();
+
+    private static SpliceWatcher classWatcher = new SpliceWatcher(CLASS_NAME);
+
+    private static final SpliceSchemaWatcher schema = new SpliceSchemaWatcher(CLASS_NAME);
+
+    @ClassRule
+    public static TestRule chain = RuleChain.outerRule(classWatcher)
+            .around(schema);
+
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher(CLASS_NAME);
+
+    @Test
+    public void testMissingRows() throws Exception {
+        Connection conn = methodWatcher.createConnection();
+        conn.setAutoCommit(false);
+        HBaseTestingUtility testingUtility = new HBaseTestingUtility(HConfiguration.unwrapDelegate());
+        Admin admin = testingUtility.getAdmin();
+
+        conn.createStatement().executeUpdate("CREATE TABLE A (A1 int, a2 int)");
+        conn.createStatement().executeUpdate("INSERT INTO A VALUES (1,1),(1,1),(1,1),(1,1),(1,1),(1,1),(1,1),(1,1),(1,1),(1,1),(1,1),(1,1),(1,1),(1,1),(1,1),(1,1),(1,1),(1,1),(1,1),(1,1)");
+        for (int i = 0; i < 10; i++) {
+            conn.createStatement().executeUpdate("insert into a select * from a --splice-properties useSpark=false\n");
+        }
+
+        String conglomerateNumber = TestUtils.lookupConglomerateNumber(CLASS_NAME, "A", methodWatcher);
+        final TableName tableName = TableName.valueOf("splice", conglomerateNumber);
+        admin.flush(tableName);
+
+        conn.createStatement().executeUpdate("UPDATE A SET A1 = 2");
+
+        PreparedStatement ps = conn.prepareStatement("SELECT a2 FROM A --splice-properties useSpark=true, splits=1\n");
+        try (ResultSet rs = ps.executeQuery()) {
+            rs.next();
+            int numberOfRows = 1;
+            admin.flush(tableName);
+            while (rs.next()) {
+                numberOfRows++;
+                assertNotNull("Failure at row: " + numberOfRows, rs.getObject(1));
+                assertEquals(1, rs.getInt(1));
+            }
+        }
+    }
+}
+

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/CountingRegionScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/CountingRegionScanner.java
@@ -18,10 +18,7 @@ package com.splicemachine.access.client;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.client.Scan;
-import org.apache.hadoop.hbase.regionserver.HRegion;
-import org.apache.hadoop.hbase.regionserver.RegionScanner;
-import org.apache.hadoop.hbase.regionserver.ScannerContext;
-import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
@@ -76,7 +73,11 @@ public class CountingRegionScanner implements RegionScanner {
     @Override
     public boolean nextRaw(List<Cell> result) throws IOException {
         rows++;
-        return delegate.nextRaw(result);
+        boolean returnCode = delegate.nextRaw(result);
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Next: (" +result.size() + ") " + result);
+        }
+        return returnCode;
     }
 
     @Override

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -14,13 +14,9 @@
 
 package com.splicemachine.access.client;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.NavigableSet;
-import java.util.concurrent.atomic.AtomicReference;
+import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HConstants;
-import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.Scan;
@@ -28,7 +24,11 @@ import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.regionserver.*;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.log4j.Logger;
-import com.splicemachine.utils.SpliceLogUtils;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.concurrent.atomic.AtomicReference;
 
 
 /**
@@ -176,8 +176,11 @@ public class MemStoreFlushAwareScanner extends StoreScanner implements RegionSca
             return HBasePlatformUtils.scannerEndReached(scannerContext);
         }
         if (super.next(outResult,scannerContext)) {
-            if (LOG.isTraceEnabled())
-                SpliceLogUtils.trace(LOG, "Next: returning " + outResult.size());
+            if (LOG.isTraceEnabled()) {
+                SpliceLogUtils.trace(LOG, "Next: returning " + outResult.size() +
+                        ". mayHaveMoreCellsInARow=" + HRegionUtil.mayHaveMoreCellsInARow(scannerContext));
+                SpliceLogUtils.trace(LOG, "Next: actual output: %s" + outResult);
+            }
             return true;
         }
 

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/MemstoreKeyValueScanner.java
@@ -15,10 +15,9 @@
 package com.splicemachine.access.client;
 
 import com.splicemachine.utils.SpliceLogUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.Cell;
-import org.apache.hadoop.hbase.DoNotRetryIOException;
-import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.*;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
@@ -26,16 +25,21 @@ import org.apache.hadoop.hbase.regionserver.InternalScanner;
 import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
 import org.apache.hadoop.hbase.regionserver.ScannerContext;
 import org.apache.hadoop.hbase.regionserver.HStore;
+import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import static com.splicemachine.access.client.ClientRegionConstants.FLUSH;
 
 public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner{
     protected static final Logger LOG=Logger.getLogger(MemstoreKeyValueScanner.class);
     protected ResultScanner resultScanner;
     protected Result currentResult;
+    protected Result previousResult;
     protected KeyValue peakKeyValue;
     protected Cell[] cells;
     int cellScannerIndex=0;
@@ -59,16 +63,33 @@ public class MemstoreKeyValueScanner implements KeyValueScanner, InternalScanner
 
     public boolean nextResult() throws IOException{
         cellScannerIndex=0;
-        currentResult=this.resultScanner.next();
-        if(currentResult!=null){
-            cells=currentResult.rawCells();
-            peakKeyValue=(KeyValue)current();
-            rows++;
-            return true;
-        }else{
+        previousResult = currentResult;
+        currentResult = this.resultScanner.next();
+        if(currentResult == null) {
             // This shouldn't happen, throw exception and re-init the scanner
             throw new DoNotRetryIOException("Memstore scanner shouldn't end prematurely");
         }
+        if (currentResult.rawCells() != null && CellUtil.matchingFamily(currentResult.rawCells()[0], FLUSH) ) {
+            if (LOG.isTraceEnabled())
+                LOG.trace("CURRENT CELL: " + currentResult.rawCells()[0]);
+            assert currentResult.rawCells().length == 1;
+            if (previousResult != null && previousResult.rawCells() != null) {
+                assert previousResult.rawCells().length > 0;
+                KeyValue previousCell = (KeyValue) previousResult.rawCells()[previousResult.rawCells().length - 1];
+                if (LOG.isTraceEnabled())
+                    LOG.trace("PREVIOUS CELL: " + previousCell);
+                if (CellUtil.matchingRows(currentResult.rawCells()[0], HConstants.EMPTY_START_ROW)) {
+                    byte[] rowId = Bytes.add(CellUtil.cloneRow(previousCell), new byte[]{0});
+                    currentResult = Result.create(new KeyValue[]{new KeyValue(rowId, FLUSH, FLUSH, previousCell.getTimestamp(), new byte[0])});
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("NEW CELL: " + currentResult.rawCells()[0]);
+                }
+            }
+        }
+        cells=currentResult.rawCells();
+        peakKeyValue = (KeyValue) current();
+        rows++;
+        return true;
     }
 
 

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/SkeletonClientSideRegionScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/SkeletonClientSideRegionScanner.java
@@ -155,29 +155,29 @@ public abstract class SkeletonClientSideRegionScanner implements RegionScanner{
      * created by MemStore flushes or current scanner fails due to compaction
      */
     public void updateScanner() throws IOException {
-            if (LOG.isDebugEnabled()) {
-                SpliceLogUtils.debug(LOG,
-                        "updateScanner with hregionInfo=%s, tableName=%s, rootDir=%s, scan=%s",
-                        hri, htd.getNameAsString(), rootDir, scan);
-            }
-            if (flushed) {
+        if (LOG.isDebugEnabled()) {
+            SpliceLogUtils.debug(LOG,
+                    "updateScanner with hregionInfo=%s, tableName=%s, rootDir=%s, scan=%s",
+                    hri, htd.getNameAsString(), rootDir, scan);
+        }
+        if (flushed) {
+            if (LOG.isDebugEnabled())
+                SpliceLogUtils.debug(LOG, "Flush occurred");
+            if (this.topCell != null) {
                 if (LOG.isDebugEnabled())
-                    SpliceLogUtils.debug(LOG, "Flush occurred");
-                if (this.topCell != null) {
-                    if (LOG.isDebugEnabled())
-                        SpliceLogUtils.debug(LOG, "setting start row to %s", topCell);
-                    //noinspection deprecation
-                    scan.setStartRow(Bytes.add(CellUtil.cloneRow(topCell), new byte[]{0}));
-                }
+                    SpliceLogUtils.debug(LOG, "setting start row to %s", topCell);
+                //noinspection deprecation
+                scan.setStartRow(Bytes.add(CellUtil.cloneRow(topCell), new byte[]{0}));
             }
-            memScannerList.add(getMemStoreScanner());
-            this.region = openHRegion();
-            RegionScanner regionScanner = new CountingRegionScanner(HRegionUtil.getScanner(region, scan, memScannerList), region, scan);
-            if (flushed) {
-                if (scanner != null)
-                    scanner.close();
-            }
-            scanner = regionScanner;
+        }
+        memScannerList.add(getMemStoreScanner());
+        this.region = openHRegion();
+        RegionScanner regionScanner = new CountingRegionScanner(HRegionUtil.getScanner(region, scan, memScannerList), region, scan);
+        if (flushed) {
+            if (scanner != null)
+                scanner.close();
+        }
+        scanner = regionScanner;
     }
 
     public HRegion getRegion(){

--- a/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionUtil.java
+++ b/hbase_storage/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionUtil.java
@@ -293,4 +293,8 @@ public class HRegionUtil {
             throws IOException {
         store.replaceStoreFiles(compactedFiles, result);
     }
+
+    public static boolean mayHaveMoreCellsInARow(ScannerContext context) {
+        return context.mayHaveMoreCellsInRow();
+    }
 }

--- a/platform_it/src/main/resources/info-log4j.properties
+++ b/platform_it/src/main/resources/info-log4j.properties
@@ -133,6 +133,13 @@ log4j.logger.com.splicemachine.hbase.RegionSizeEndpoint=DEBUG
 log4j.logger.com.splicemachine.compactions.SpliceDefaultCompactor=TRACE
 log4j.logger.com.splicemachine.derby.stream.compaction=TRACE
 
+# DB-9449
+#log4j.logger.com.splicemachine.access.client.MemStoreFlushAwareScanner=TRACE
+#log4j.logger.com.splicemachine.access.client.SkeletonClientSideRegionScanner=DEBUG
+#log4j.logger.com.splicemachine.access.client.SpliceHRegion=DEBUG
+#log4j.logger.com.splicemachine.access.client.CountingRegionScanner=TRACE
+
+
 log4j.logger.com.splicemachine.storage=INFO
 log4j.logger.com.splicemachine.access.client=INFO
 log4j.logger.com.splicemachine.mrio.api.core=DEBUG


### PR DESCRIPTION
If a flush happened during a Spark scan, the flush token that is
returned by MemStoreFlushAwareScanner would be marked with timestamp 0
and would therefore be read before any other cell.
However, when the scanner fetches a row, it first reads from the mem
store, then from hfiles. The flush token would prevent us from reading
from hfiles for that row and we would resume the scan at the next row.

We addressed the issue by making sure that the flush token will be
sorted exactly after the last row that was being scanned, so that we can
properly merge data from MemStore and HFiles before addressing the flush
and resetting scanners