### PR TITLE
DB-9572 add useOLAP=X as query and session config/hint (2.8)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/SessionProperties.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/SessionProperties.java
@@ -42,6 +42,7 @@ import java.sql.SQLException;
 public interface SessionProperties {
     enum PROPERTYNAME{
         USESPARK(0),
+        USEOLAP(0), // alias for USESPARK
         DEFAULTSELECTIVITYFACTOR(1),
         SKIPSTATS(2),
         RECURSIVEQUERYITERATIONLIMIT(3),
@@ -79,7 +80,7 @@ public interface SessionProperties {
             property = SessionProperties.PROPERTYNAME.valueOf(propertyNameString);
         } catch (IllegalArgumentException e) {
             throw StandardException.newException(SQLState.LANG_INVALID_SESSION_PROPERTY,propertyNameString,
-                    "useSpark, defaultSelectivityFactor, skipStats, olapQueue, recursiveQueryIterationLimit");
+                    "useSpark, useOLAP, defaultSelectivityFactor, skipStats, olapQueue, recursiveQueryIterationLimit");
         }
 
         String valString = pair.getSecond();
@@ -88,6 +89,7 @@ public interface SessionProperties {
 
         switch (property) {
             case USESPARK:
+            case USEOLAP:
             case SKIPSTATS:
             case DISABLE_TC_PUSHED_DOWN_INTO_VIEWS:
                 try {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/TransactionResourceImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/TransactionResourceImpl.java
@@ -136,6 +136,7 @@ public final class TransactionResourceImpl
     private DataSetProcessorType useSpark;
     private boolean skipStats;
     private double defaultSelectivityFactor;
+
 	private String ipAddress;
 	private String defaultSchema;
 	// set these up after constructor, called by EmbedConnection
@@ -171,17 +172,7 @@ public final class TransactionResourceImpl
 		rdbIntTkn = info.getProperty(Attribute.RDBINTTKN_ATTR, null);
 		ipAddress = info.getProperty(Property.IP_ADDRESS, null);
 		defaultSchema = info.getProperty(Property.CONNECTION_SCHEMA, null);
-        String useSparkString = info.getProperty(Property.CONNECTION_USE_SPARK,null);
-        if (useSparkString != null) {
-            try {
-                useSpark = Boolean.parseBoolean(StringUtil.SQLToUpperCase(useSparkString))?
-                        DataSetProcessorType.SESSION_HINTED_SPARK:
-                        DataSetProcessorType.SESSION_HINTED_CONTROL;
-            } catch (Exception sparkE) {
-                throw new SQLException(StandardException.newException(SQLState.LANG_INVALID_FORCED_SPARK,useSparkString));
-            }
-        } else
-            useSpark = DataSetProcessorType.DEFAULT_CONTROL;
+		useSpark = getDataSetProcessorType(info);
 
         String skipStatsString = info.getProperty(Property.CONNECTION_SKIP_STATS, null);
         if (skipStatsString != null) {
@@ -217,6 +208,27 @@ public final class TransactionResourceImpl
 		// call is made.
 		cm = csf.newContextManager();
 	}
+	
+	/// we allow useOLAP and useSpark for backward-compatibility
+    private DataSetProcessorType getDataSetProcessorType(Properties info) throws SQLException
+    {
+        for( String propertyStr : new String[]{ Property.CONNECTION_USE_OLAP, Property.CONNECTION_USE_SPARK } )
+        {
+            String val = info.getProperty(propertyStr, null);
+            if (val != null) {
+                try {
+                    // return the first config found, useOLAP before useSpark
+                    return Boolean.parseBoolean(StringUtil.SQLToUpperCase(val)) ?
+                            DataSetProcessorType.SESSION_HINTED_SPARK :
+                            DataSetProcessorType.SESSION_HINTED_CONTROL;
+                } catch (Exception sparkE) {
+                    throw new SQLException(StandardException.newException(SQLState.LANG_INVALID_FORCED_SPARK,
+                            propertyStr, val));
+                }
+            }
+        }
+        return DataSetProcessorType.DEFAULT_CONTROL; // no config found, return default.
+    }
 
 	/**
 	 * Called only in EmbedConnection construtor.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -662,14 +662,14 @@ public class FromBaseTable extends FromTable {
                     dataSetProcessorType = dataSetProcessorType.combine(DataSetProcessorType.FORCED_SPARK);
                 }
             }
-            else if (key.equals("useSpark")) {
+            else if (key.equals("useSpark") || key.equals("useOLAP")) {
                 try {
                     dataSetProcessorType = dataSetProcessorType.combine(
                             Boolean.parseBoolean(StringUtil.SQLToUpperCase(value))?
                                     DataSetProcessorType.QUERY_HINTED_SPARK:
                                     DataSetProcessorType.QUERY_HINTED_CONTROL);
                 } catch (Exception sparkE) {
-                    throw StandardException.newException(SQLState.LANG_INVALID_FORCED_SPARK,value);
+                    throw StandardException.newException(SQLState.LANG_INVALID_FORCED_SPARK, key, value);
                 }
             }
             else if (key.equals("pin")) {
@@ -678,7 +678,7 @@ public class FromBaseTable extends FromTable {
                     dataSetProcessorType = dataSetProcessorType.combine(DataSetProcessorType.FORCED_SPARK);
                     tableProperties.setProperty("index","null");
                 } catch (Exception pinE) {
-                    throw StandardException.newException(SQLState.LANG_INVALID_FORCED_SPARK,value); // TODO Fix Error message - JL
+                    throw StandardException.newException(SQLState.LANG_INVALID_FORCED_SPARK, key, value); // TODO Fix Error message - JL
                 }
             }
             else if (key.equals("skipStats")) {
@@ -720,7 +720,8 @@ public class FromBaseTable extends FromTable {
             }else {
                 // No other "legal" values at this time
                 throw StandardException.newException(SQLState.LANG_INVALID_FROM_TABLE_PROPERTY,key,
-                        "index, constraint, joinStrategy, useSpark, pin, skipStats, splits, useDefaultRowcount, defaultSelectivityFactor");
+                        "index, constraint, joinStrategy, useSpark, useOLAP, pin, skipStats, splits, " +
+                                "useDefaultRowcount, defaultSelectivityFactor");
             }
 
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
@@ -403,6 +403,7 @@ public abstract class FromTable extends ResultSetNode implements Optimizable{
                     }
                     break;
                 case "useSpark":
+                case "useOLAP":
                     dataSetProcessorType = dataSetProcessorType.combine(
                             Boolean.parseBoolean(StringUtil.SQLToUpperCase(value))?
                                     DataSetProcessorType.QUERY_HINTED_SPARK:

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1467,6 +1467,7 @@ public interface Property {
      * True force Spark execution for this session; false forces Control execution for this connection
      */
     String CONNECTION_USE_SPARK = "useSpark";
+    String CONNECTION_USE_OLAP = "useOLAP";
 
     /**
      * True ignores statistics for this connection

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -2595,7 +2595,8 @@ Guide.
 
             <msg>
                 <name>42Y47</name>
-                <text>Invalid Properties list in FROM list.  The hint useSpark needs (true/false) and does not support '{0}'.</text>
+                <text>Invalid Properties list in FROM list.  The hint {0} needs (true/false) and does not support '{1}'.</text>
+                <arg>hintName</arg>
                 <arg>value</arg>
             </msg>
 
@@ -3205,11 +3206,13 @@ Guide.
             <msg>
                 <name>42ZD0</name>
 		<text>Surpassed limit of buffered rows in control mode, please resubmit as Spark query</text>
+                <!-- todo(Spark->OLAP) -->
             </msg>
 
             <msg>
                 <name>42ZD1</name>
                 <text>Using both useSpark=true and useSpark=false at the same level ('{0}') is illegal</text>
+                <!-- todo(Spark->OLAP) -->
                 <arg>level</arg>
             </msg>
 

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SessionPropertyIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SessionPropertyIT.java
@@ -136,9 +136,9 @@ public class SessionPropertyIT extends SpliceUnitTest {
 
         String sqlText = "values current session_property";
         ResultSet rs = conn.query(sqlText);
-        String expected = "1       |\n" +
-                "----------------\n" +
-                "USESPARK=true; |";
+        String expected = "1              |\n" +
+                "------------------------------\n" +
+                "USESPARK=true; USEOLAP=true; |";
         assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         rs.close();
 
@@ -149,9 +149,9 @@ public class SessionPropertyIT extends SpliceUnitTest {
         conn.execute("set session_property useSpark=false");
         sqlText = "values current session_property";
         rs = conn.query(sqlText);
-        expected = "1        |\n" +
-                "-----------------\n" +
-                "USESPARK=false; |";
+        expected = "1               |\n" +
+                "--------------------------------\n" +
+                "USESPARK=false; USEOLAP=false; |";
         assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         rs.close();
 


### PR DESCRIPTION
Note that useOLAP is added. useSpark=X still works.