### PR TITLE
DB-9714 Support time travel SELECT statements with tx id

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
@@ -970,6 +970,7 @@ public interface ResultSetFactory {
 		@param optimizerEstimatedRowCount	Estimated total # of rows by
 											optimizer
 		@param optimizerEstimatedCost		Estimated total cost by optimizer
+		@param pastTxId                     The ID of a past transaction for time-travel queries
 
 		@return the table scan operation as a result set.
 		@exception StandardException thrown when unable to create the
@@ -1012,7 +1013,8 @@ public interface ResultSetFactory {
 								String location,
 								int partitionByRefItem,
 								GeneratedMethod defaultRowFunc,
-								int defaultValueMapItem
+								int defaultValueMapItem,
+								long pastTxId
 								)
 			throws StandardException;
 
@@ -1072,7 +1074,8 @@ public interface ResultSetFactory {
 								String location,
 								int partitionByRefItem,
 								GeneratedMethod defaultRowFunc,
-								int defaultValueMapItem
+								int defaultValueMapItem,
+								long pastTxId
 								)
 			throws StandardException;
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -221,10 +221,11 @@ public class SQLParser
     private static final int    USING_CLAUSE = 1;
 
     // Defines for optional table clauses
-    private static final int    OPTIONAL_TABLE_CLAUSES_SIZE = 3;
+    private static final int    OPTIONAL_TABLE_CLAUSES_SIZE = 4;
     private static final int    OPTIONAL_TABLE_CLAUSES_TABLE_PROPERTIES = 0;
     private static final int    OPTIONAL_TABLE_CLAUSES_DERIVED_RCL = 1;
     private static final int    OPTIONAL_TABLE_CLAUSES_CORRELATION_NAME = 2;
+    private static final int    OPTIONAL_TABLE_CLAUSES_TXN_ID = 3;
 
     // Define for UTF8 max
     private static final int    MAX_UTF8_LENGTH = 65535;
@@ -10752,13 +10753,13 @@ existsExpression() throws StandardException :
 ResultSetNode
 tableExpression(ResultColumnList selectList) throws StandardException :
 {
-    SelectNode    selectNode;
-    FromList    fromList;
-    ValueNode    whereClause = null;
-    GroupByList    groupByList = null;
+    SelectNode   selectNode;
+    FromList     fromList;
+    ValueNode    whereClause  = null;
+    GroupByList  groupByList  = null;
     ValueNode    havingClause = null;
     Token        whereToken;
-    WindowList  windows = null;
+    WindowList   windows      = null;
 }
 {
     fromList = fromClause()
@@ -10914,21 +10915,25 @@ tableReferenceTypes(boolean nestedInParens) throws StandardException :
 Object[]
 optionalTableClauses() throws StandardException :
 {
-    Object[]             otc = null;
-    Properties            tableProperties = null;
-    ResultColumnList    derivedRCL = null;
-    String                correlationName = null;
+    Object[]         otc = null;
+    Properties       tableProperties = null;
+    ResultColumnList derivedRCL = null;
+    String           correlationName = null;
+    Long             txnId = null;
 }
 {
     otc = optionalTableProperties()
     {
         otc[OPTIONAL_TABLE_CLAUSES_DERIVED_RCL] = derivedRCL;
         otc[OPTIONAL_TABLE_CLAUSES_CORRELATION_NAME] = correlationName;
+        otc[OPTIONAL_TABLE_CLAUSES_TXN_ID] = txnId;
         return otc;
     }
 |
+    LOOKAHEAD( { getToken(1).kind != AS || getToken(2).kind != OF })
     [ [ <AS> ]
         correlationName = identifier(Limits.MAX_IDENTIFIER_LENGTH, true)
+        [txnId = asOfClause()]
         [ <LEFT_PAREN> derivedRCL = derivedColumnList() <RIGHT_PAREN> ]
         [tableProperties = propertyList(true) <CHECK_PROPERTIES>] ]
     {
@@ -10936,6 +10941,19 @@ optionalTableClauses() throws StandardException :
         otc[OPTIONAL_TABLE_CLAUSES_TABLE_PROPERTIES] = tableProperties;
         otc[OPTIONAL_TABLE_CLAUSES_DERIVED_RCL] = derivedRCL;
         otc[OPTIONAL_TABLE_CLAUSES_CORRELATION_NAME] = correlationName;
+        otc[OPTIONAL_TABLE_CLAUSES_TXN_ID] = txnId;
+        return otc;
+    }
+|
+    [txnId = asOfClause()]
+    [ <LEFT_PAREN> derivedRCL = derivedColumnList() <RIGHT_PAREN> ]
+    [tableProperties = propertyList(true) <CHECK_PROPERTIES>]
+    {
+        otc = new Object[OPTIONAL_TABLE_CLAUSES_SIZE];
+        otc[OPTIONAL_TABLE_CLAUSES_TABLE_PROPERTIES] = tableProperties;
+        otc[OPTIONAL_TABLE_CLAUSES_DERIVED_RCL] = derivedRCL;
+        otc[OPTIONAL_TABLE_CLAUSES_CORRELATION_NAME] = correlationName;
+        otc[OPTIONAL_TABLE_CLAUSES_TXN_ID] = txnId;
         return otc;
     }
 }
@@ -11023,9 +11041,10 @@ FromTable tableFactor() throws StandardException :
         fromTable = (FromTable) nodeFactory.getNode(
                                             C_NodeTypes.FROM_BASE_TABLE,
                                             tableName,
-                                                (String) optionalTableClauses[OPTIONAL_TABLE_CLAUSES_CORRELATION_NAME],
-                                                (ResultColumnList) optionalTableClauses[OPTIONAL_TABLE_CLAUSES_DERIVED_RCL],
-                                                (Properties) optionalTableClauses[OPTIONAL_TABLE_CLAUSES_TABLE_PROPERTIES],
+                                            (String) optionalTableClauses[OPTIONAL_TABLE_CLAUSES_CORRELATION_NAME],
+                                            (ResultColumnList) optionalTableClauses[OPTIONAL_TABLE_CLAUSES_DERIVED_RCL],
+                                            (Properties) optionalTableClauses[OPTIONAL_TABLE_CLAUSES_TABLE_PROPERTIES],
+                                            (Long) optionalTableClauses[OPTIONAL_TABLE_CLAUSES_TXN_ID],
                                             getContextManager());
         return fromTable;
     }
@@ -12273,6 +12292,18 @@ windowDefinition(WindowList wl) throws StandardException :
                 getContextManager()));
 
         return wl;
+    }
+}
+
+Long
+asOfClause() throws StandardException :
+{
+    Long txId = null;
+}
+{
+    LOOKAHEAD({(getToken(1).kind == AS && getToken(2).kind == OF)}) <AS> <OF> txId = exactNumber()
+    {
+        return txId;
     }
 }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
@@ -433,7 +433,8 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                                                 String location,
                                                 int partitionByRefItem,
                                                 GeneratedMethod defaultRowFunc,
-                                                int defaultValueMapItem)
+                                                int defaultValueMapItem,
+                                                long pastTx )
             throws StandardException {
         SpliceLogUtils.trace(LOG, "getTableScanResultSet");
         try{
@@ -476,7 +477,8 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                     location,
                     partitionByRefItem,
                     defaultRowFunc,
-                    defaultValueMapItem);
+                    defaultValueMapItem,
+                    pastTx );
             op.setExplainPlan(explainPlan);
             return op;
         }catch(Exception e){
@@ -872,7 +874,8 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             String location,
             int partitionByRefItem,
             GeneratedMethod defaultRowFunc,
-            int defaultValueMapItem)
+            int defaultValueMapItem,
+            long pastTxId )
 
             throws StandardException {
         try{
@@ -919,7 +922,8 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                     location,
                     partitionByRefItem,
                     defaultRowFunc,
-                    defaultValueMapItem
+                    defaultValueMapItem,
+                    pastTxId
                     );
             op.setExplainPlan(explainPlan);
             return op;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperation.java
@@ -124,7 +124,8 @@ public class MultiProbeTableScanOperation extends TableScanOperation  {
                                         String location,
                                         int partitionByRefItem,
                                         GeneratedMethod defaultRowFunc,
-                                        int defaultValueMapItem
+                                        int defaultValueMapItem,
+                                        long pastTxId
                                         )
             throws StandardException
     {
@@ -165,7 +166,8 @@ public class MultiProbeTableScanOperation extends TableScanOperation  {
                 location,
                 partitionByRefItem,
                 defaultRowFunc,
-                defaultValueMapItem);
+                defaultValueMapItem,
+                pastTxId);
 
         this.inlistPosition = inlistPosition;
 
@@ -220,7 +222,7 @@ public class MultiProbeTableScanOperation extends TableScanOperation  {
             throw new IllegalStateException("Operation is not open");
 
         try {
-            TxnView txn = getCurrentTransaction();
+            TxnView txn = getTransaction();
             DataValueDescriptor[] probeValues = ((MultiProbeDerbyScanInformation)scanInformation).getProbeValues();
             List<DataScan> scans = scanInformation.getScans(getCurrentTransaction(), null, activation, getKeyDecodingMap());
             DataSet<ExecRow> dataSet = dsp.getEmpty();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
@@ -16,15 +16,21 @@ package com.splicemachine.derby.impl.sql.execute.operations;
 
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.context.ContextManager;
+import com.splicemachine.db.iapi.services.context.ContextService;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.services.loader.GeneratedMethod;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.store.access.StaticCompiledOpenConglomInfo;
+import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.db.iapi.store.access.conglomerate.TransactionManager;
+import com.splicemachine.db.iapi.store.raw.Transaction;
 import com.splicemachine.db.impl.sql.compile.ActivationClassBuilder;
 import com.splicemachine.db.impl.sql.compile.FromTable;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperationContext;
+import com.splicemachine.derby.impl.store.access.BaseSpliceTransaction;
 import com.splicemachine.derby.stream.function.SetCurrentLocatedRowAndRowKeyFunction;
 import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
@@ -56,6 +62,7 @@ public class TableScanOperation extends ScanOperation{
     protected int[] baseColumnMap;
     protected static final String NAME=TableScanOperation.class.getSimpleName().replaceAll("Operation","");
     protected byte[] tableNameBytes;
+    protected long pastTx;
 
     /**
      *
@@ -119,6 +126,7 @@ public class TableScanOperation extends ScanOperation{
      * @param storedAs
      * @param defaultRowFunc
      * @param defaultValueMapItem
+     * @param pastTx the id of a committed transaction for time-travel queries, -1 for not set.
      *
      * @throws StandardException
      */
@@ -159,7 +167,8 @@ public class TableScanOperation extends ScanOperation{
                               String location,
                               int partitionByRefItem,
                               GeneratedMethod defaultRowFunc,
-                              int defaultValueMapItem) throws StandardException{
+                              int defaultValueMapItem,
+                              long pastTx) throws StandardException{
         super(conglomId,activation,resultSetNumber,startKeyGetter,startSearchOperator,stopKeyGetter,stopSearchOperator,
                 sameStartStopPosition,rowIdKey,qualifiersField,resultRowAllocator,lockMode,tableLocked,isolationLevel,
                 colRefItem,indexColItem,oneRowScan,optimizerEstimatedRowCount,optimizerEstimatedCost,tableVersion,
@@ -174,6 +183,7 @@ public class TableScanOperation extends ScanOperation{
         this.tableNameBytes=Bytes.toBytes(this.tableName);
         this.indexColItem=indexColItem;
         this.indexName=indexName;
+        this.pastTx = pastTx;
         init();
         if(LOG.isTraceEnabled())
             SpliceLogUtils.trace(LOG,"isTopResultSet=%s,optimizerEstimatedCost=%f,optimizerEstimatedRowCount=%f",isTopResultSet,optimizerEstimatedCost,optimizerEstimatedRowCount);
@@ -195,6 +205,7 @@ public class TableScanOperation extends ScanOperation{
         tableDisplayName=in.readUTF();
         tableNameBytes=Bytes.toBytes(tableName);
         indexColItem=in.readInt();
+        pastTx=in.readLong();
         if(in.readBoolean())
             indexName=in.readUTF();
     }
@@ -212,6 +223,7 @@ public class TableScanOperation extends ScanOperation{
         out.writeUTF(tableName);
         out.writeUTF(tableDisplayName);
         out.writeInt(indexColItem);
+        out.writeLong(pastTx);
         out.writeBoolean(indexName!=null);
         if(indexName!=null)
             out.writeUTF(indexName);
@@ -337,15 +349,37 @@ public class TableScanOperation extends ScanOperation{
     }
 
     /**
-     *
-     * Retrieve the Table Scan Builder for creating the actual data set from a scan.
-     *
-     * @param dsp
-     * @return
+     * @param pastTx The ID of the past transaction.
+     * @return a view of a past transaction.
+     * @throws StandardException
+     */
+    private TxnView getPastTransaction(long pastTx) throws StandardException {
+        TransactionController transactionExecute=activation.getLanguageConnectionContext().getTransactionExecute();
+        ContextManager cm = ContextService.getFactory().newContextManager();
+        TransactionController pastTC = transactionExecute.getAccessManager().getReadOnlyTransaction(cm, pastTx);
+        Transaction rawStoreXact=((TransactionManager)pastTC).getRawStoreXact();
+        return ((BaseSpliceTransaction)rawStoreXact).getActiveStateTxn();
+    }
+
+    /**
+     * @return either current transaction or a committed transaction in the past.
+     * @throws StandardException
+     */
+    protected TxnView getTransaction() throws StandardException {
+        return (pastTx >= 0) ? getPastTransaction(pastTx) : super.getCurrentTransaction();
+    }
+
+    @Override
+    public TxnView getCurrentTransaction() throws StandardException{
+        return getTransaction();
+    }
+
+    /**
+     * @return the Table Scan Builder for creating the actual data set from a scan.
      * @throws StandardException
      */
     public DataSet<ExecRow> getTableScannerBuilder(DataSetProcessor dsp) throws StandardException{
-        TxnView txn=getCurrentTransaction();
+        TxnView txn = getTransaction();
         operationContext = dsp.createOperationContext(this);
         return dsp.<TableScanOperation,ExecRow>newScanSet(this,tableName)
                 .tableDisplayName(tableDisplayName)

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SelectTimeTravelIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SelectTimeTravelIT.java
@@ -1,0 +1,253 @@
+package com.splicemachine.derby.impl.sql.execute.operations;
+
+import com.splicemachine.derby.test.framework.*;
+import org.junit.*;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+
+import java.sql.*;
+
+public class SelectTimeTravelIT {
+
+    private static final String SCHEMA = SelectTimeTravelIT.class.getSimpleName().toUpperCase();
+
+    @ClassRule
+    public static SpliceWatcher watcher = new SpliceWatcher(SCHEMA);
+
+    @ClassRule
+    public static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(SCHEMA);
+
+    private long GetTxId() throws SQLException {
+        long result = -1;
+        ResultSet rs =  watcher.executeQuery("CALL SYSCS_UTIL.SYSCS_GET_CURRENT_TRANSACTION()");
+        Assert.assertTrue(rs.next());
+        result = rs.getLong(1);
+        Assert.assertFalse(rs.next());
+        return result;
+    }
+
+    static int counter = 0;
+    private static String GenerateTableName() {
+        return "T" + counter++;
+    }
+
+    @Test
+    public void testTimeTravelWorks() throws Exception {
+        String tbl = GenerateTableName();
+        watcher.executeUpdate("CREATE TABLE " + tbl + "(a INT)");
+
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 1");
+
+        long txId = GetTxId();
+
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 2");
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 3");
+
+        // check that data exists
+        ResultSet rs =  watcher.executeQuery("SELECT * FROM " + tbl + " ORDER BY a ASC");
+        Assert.assertTrue(rs.next()); Assert.assertEquals(1, rs.getInt(1));
+        Assert.assertTrue(rs.next()); Assert.assertEquals(2, rs.getInt(1));
+        Assert.assertTrue(rs.next()); Assert.assertEquals(3, rs.getInt(1));
+        Assert.assertFalse(rs.next());
+
+        // travel back in time
+        rs =  watcher.executeQuery("SELECT * FROM " + tbl + " AS OF " + txId + " ORDER BY a ASC");
+        Assert.assertTrue(rs.next()); Assert.assertEquals(1, rs.getInt(1));
+        Assert.assertFalse(rs.next());
+    }
+
+    @Test
+    public void testTimeTravelMultipleTablesWorks() throws Exception {
+        String tbl = GenerateTableName();
+
+        watcher.executeUpdate("CREATE TABLE " + tbl + "(a INT)");
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 1");
+        long txId1 = GetTxId();
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 2");
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 3");
+        // check which transaction we are at the moment after adding both numbers
+        long txId2 = GetTxId();
+
+        // add noise
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 200");
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 300");
+
+        // check that data exists
+        ResultSet rs =  watcher.executeQuery("SELECT * FROM " + tbl + " ORDER BY a ASC");
+        Assert.assertTrue(rs.next()); Assert.assertEquals(1, rs.getInt(1));
+        Assert.assertTrue(rs.next()); Assert.assertEquals(2, rs.getInt(1));
+        Assert.assertTrue(rs.next()); Assert.assertEquals(3, rs.getInt(1));
+        Assert.assertTrue(rs.next()); Assert.assertEquals(200, rs.getInt(1));
+        Assert.assertTrue(rs.next()); Assert.assertEquals(300, rs.getInt(1));
+        Assert.assertFalse(rs.next());
+
+        // 4. travel back in time
+        rs =  watcher.executeQuery("SELECT * FROM " + tbl + " L AS OF " + txId1 + ", "
+                + tbl + " R AS OF " + txId2 + " ORDER BY R.a ASC");
+        Assert.assertTrue(rs.next()); Assert.assertEquals(1, rs.getInt(1)); Assert.assertEquals(1, rs.getInt(2));
+        Assert.assertTrue(rs.next()); Assert.assertEquals(1, rs.getInt(1)); Assert.assertEquals(2, rs.getInt(2));
+        Assert.assertTrue(rs.next()); Assert.assertEquals(1, rs.getInt(1)); Assert.assertEquals(3, rs.getInt(2));
+        Assert.assertFalse(rs.next());
+    }
+
+    @Test
+    public void testCreateTableFromTimeTravelSelectWorks() throws Exception {
+        String tbl = GenerateTableName();
+
+        watcher.executeUpdate("CREATE TABLE " + tbl + "(a INT)");
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 1");
+        long txId = GetTxId();
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 2");
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 3");
+
+        String newTbl = GenerateTableName();
+        watcher.executeUpdate("CREATE TABLE " + newTbl + " AS SELECT * FROM " + tbl + " AS OF " + txId);
+
+        ResultSet rs = watcher.executeQuery("SELECT * FROM " + newTbl);
+        Assert.assertTrue(rs.next()); Assert.assertEquals(1, rs.getInt(1));
+        Assert.assertFalse(rs.next());
+    }
+
+    @Test
+    public void testInsertIntoFromTimeTravelSelectWorks() throws Exception {
+        String tbl = GenerateTableName();
+
+        watcher.executeUpdate("CREATE TABLE " + tbl + "(a INT)");
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 1");
+        long txId = GetTxId();
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 2");
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 3");
+
+        watcher.executeUpdate("INSERT INTO " + tbl + " SELECT * FROM " + tbl + " AS OF " + txId);
+
+        ResultSet rs = watcher.executeQuery("SELECT * FROM " + tbl + " ORDER BY a ASC");
+        Assert.assertTrue(rs.next()); Assert.assertEquals(1, rs.getInt(1));
+        Assert.assertTrue(rs.next()); Assert.assertEquals(1, rs.getInt(1)); // added by time-travel
+        Assert.assertTrue(rs.next()); Assert.assertEquals(2, rs.getInt(1));
+        Assert.assertTrue(rs.next()); Assert.assertEquals(3, rs.getInt(1));
+        Assert.assertFalse(rs.next());
+    }
+
+    // this test should sync up with documentation
+    @Test
+    public void testTimeTravelAfterTruncateDoesNotWork() throws Exception {
+        String tbl = GenerateTableName();
+
+        watcher.executeUpdate("CREATE TABLE " + tbl + "(a INT)");
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 1");
+        long txId = GetTxId();
+        watcher.executeUpdate("TRUNCATE TABLE " + tbl);
+
+        ResultSet rs = watcher.executeQuery("SELECT * FROM " + tbl + " AS OF " + txId);
+        Assert.assertFalse(rs.next()); // we don't get old rows back after truncate.
+    }
+
+    @Test
+    public void testTimeTravelWithJoinsWorks() throws  Exception {
+        String tblA = GenerateTableName();
+        String tblB = GenerateTableName();
+
+        watcher.executeUpdate("CREATE TABLE " + tblA + "(id INT, i INT)");
+        watcher.executeUpdate("CREATE TABLE " + tblB + "(id INT, c CHAR(1))");
+
+        watcher.executeUpdate("INSERT INTO " + tblA + " VALUES (0, 0)");
+        watcher.executeUpdate("INSERT INTO " + tblA + " VALUES (2, 2)");
+        long txIdA = GetTxId();
+
+        watcher.executeUpdate("INSERT INTO " + tblB + " VALUES (0, 'a')");
+        watcher.executeUpdate("INSERT INTO " + tblB + " VALUES (1, 'b')");
+        long txIdB = GetTxId();
+
+        // add noise
+        watcher.executeUpdate("INSERT INTO " + tblA + " VALUES (0, 42)");
+        watcher.executeUpdate("INSERT INTO " + tblA + " VALUES (0, 43)");
+        watcher.executeUpdate("INSERT INTO " + tblA + " VALUES (1, 44)");
+        watcher.executeUpdate("INSERT INTO " + tblB + " VALUES (0, 'x')");
+        watcher.executeUpdate("INSERT INTO " + tblB + " VALUES (1, 'y')");
+        watcher.executeUpdate("INSERT INTO " + tblB + " VALUES (2, 'z')");
+
+        ResultSet rs = watcher.executeQuery("SELECT i,c FROM " + tblA + " AS OF " + txIdA + " INNER JOIN " + tblB +
+                " AS OF " + txIdB +" ON " + tblA + ".id = " + tblB + ".id");
+        Assert.assertTrue(rs.next()); Assert.assertEquals(0, rs.getInt(1));Assert.assertEquals("a", rs.getString(2));
+        Assert.assertFalse(rs.next());
+
+        rs = watcher.executeQuery("SELECT i,c FROM " + tblA + " AS OF " + txIdA + " FULL JOIN " + tblB +
+                " AS OF " + txIdB +" ON " + tblA + ".id = " + tblB + ".id ORDER BY i ASC");
+        Assert.assertTrue(rs.next()); Assert.assertEquals(0, rs.getInt(1));Assert.assertEquals("a", rs.getString(2));
+        Assert.assertTrue(rs.next()); Assert.assertEquals(2, rs.getInt(1));rs.getString(2); Assert.assertTrue(rs.wasNull());
+        Assert.assertTrue(rs.next()); rs.getInt(1); Assert.assertTrue(rs.wasNull());Assert.assertEquals("b", rs.getString(2));
+        Assert.assertFalse(rs.next());
+
+        rs = watcher.executeQuery("SELECT i,c FROM " + tblA + " AS OF " + txIdA + " LEFT OUTER JOIN " + tblB +
+                " AS OF " + txIdB +" ON " + tblA + ".id = " + tblB + ".id ORDER BY i ASC");
+        Assert.assertTrue(rs.next()); Assert.assertEquals(0, rs.getInt(1));Assert.assertEquals("a", rs.getString(2));
+        Assert.assertTrue(rs.next()); Assert.assertEquals(2, rs.getInt(1));rs.getString(2); Assert.assertTrue(rs.wasNull());
+        Assert.assertFalse(rs.next());
+
+        rs = watcher.executeQuery("SELECT i,c FROM " + tblA + " AS OF " + txIdA + " RIGHT OUTER JOIN " + tblB +
+                " AS OF " + txIdB +" ON " + tblA + ".id = " + tblB + ".id ORDER BY i ASC");
+        Assert.assertTrue(rs.next()); Assert.assertEquals(0, rs.getInt(1));Assert.assertEquals("a", rs.getString(2));
+        Assert.assertTrue(rs.next()); rs.getInt(1); Assert.assertTrue(rs.wasNull());Assert.assertEquals("b", rs.getString(2));
+        Assert.assertFalse(rs.next());
+
+        rs = watcher.executeQuery("SELECT i,c FROM " + tblA + " AS OF " + txIdA + " CROSS JOIN " + tblB +
+                " AS OF " + txIdB + " ORDER BY i,c ASC");
+        Assert.assertTrue(rs.next()); Assert.assertEquals(0, rs.getInt(1));Assert.assertEquals("a", rs.getString(2));
+        Assert.assertTrue(rs.next()); Assert.assertEquals(0, rs.getInt(1));Assert.assertEquals("b", rs.getString(2));
+        Assert.assertTrue(rs.next()); Assert.assertEquals(2, rs.getInt(1));Assert.assertEquals("a", rs.getString(2));
+        Assert.assertTrue(rs.next()); Assert.assertEquals(2, rs.getInt(1));Assert.assertEquals("b", rs.getString(2));
+        Assert.assertFalse(rs.next());
+
+        rs = watcher.executeQuery("SELECT i,c FROM " + tblA + " AS OF " + txIdA + " NATURAL JOIN " + tblB +
+                " AS OF " + txIdB + " ORDER BY i,c ASC");
+        Assert.assertTrue(rs.next()); Assert.assertEquals(0, rs.getInt(1));Assert.assertEquals("a", rs.getString(2));
+        Assert.assertFalse(rs.next());
+    }
+
+    @Test
+    public void testTimeTravelWithUpdatedWorks() throws Exception {
+        String tbl = GenerateTableName();
+
+        watcher.executeUpdate("CREATE TABLE " + tbl + "(a INT)");
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 1");
+        long txId = GetTxId();
+        watcher.executeUpdate("UPDATE " + tbl + " SET a=42");
+
+        ResultSet rs = watcher.executeQuery("SELECT * FROM " + tbl + " AS OF " + txId);
+        Assert.assertTrue(rs.next()); Assert.assertEquals(1, rs.getInt(1));
+        Assert.assertFalse(rs.next());
+    }
+
+    @Test
+    public void testTimeTravelWithDeleteWorks() throws Exception {
+        String tbl = GenerateTableName();
+
+        watcher.executeUpdate("CREATE TABLE " + tbl + "(a INT)");
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 1");
+        long txId = GetTxId();
+        watcher.executeUpdate("DELETE FROM " + tbl);
+
+        ResultSet rs = watcher.executeQuery("SELECT * FROM " + tbl + " AS OF " + txId);
+        Assert.assertTrue(rs.next()); Assert.assertEquals(1, rs.getInt(1));
+        Assert.assertFalse(rs.next());
+    }
+
+    @Test
+    public void testTimeTravelWithSparkOptionWorks() throws Exception {
+        String tbl = GenerateTableName();
+        watcher.executeUpdate("CREATE TABLE " + tbl + "(a INT)");
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 1");
+
+        long txId = GetTxId();
+
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 2");
+        watcher.executeUpdate("INSERT INTO " + tbl + " VALUES 3");
+
+        // travel back in time
+        String query = "SELECT * FROM " + tbl + " AS OF " + txId + " --splice-properties useSpark=true\n ORDER BY a ASC";
+        ResultSet rs =  watcher.executeQuery(query);
+        Assert.assertTrue(rs.next()); Assert.assertEquals(1, rs.getInt(1));
+        Assert.assertFalse(rs.next());
+    }
+}


### PR DESCRIPTION
- add parser extensions to support AS OF clause.
- only the tx id is supported.
- propagate the transaction id down the execution tree to
  TableScanOperation.
- adapt code generation to pass the tx id to TableScanOperation
  at runtime.
- add tests