### PR TITLE
DB-9329 Client makes many unnecessary CLOBRELEASELOCATOR() calls

### DIFF
--- a/db-client/src/main/java/com/splicemachine/db/client/am/ResultSet.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ResultSet.java
@@ -444,10 +444,7 @@ public abstract class ResultSet implements java.sql.ResultSet,
             return;
         }
         closeOpenStreams();
-        // See if there are open locators on the current row, if valid.
-        if (isValidCursorPosition_ && !isOnInsertRow_) {
-            lobState.checkCurrentRow(cursor_);
-        }
+
         // NOTE: The preClose_ method must also check for locators if
         //       prefetching of data is enabled for result sets containing LOBs.
         preClose_();
@@ -459,6 +456,11 @@ public abstract class ResultSet implements java.sql.ResultSet,
             }
         } finally {
             markClosed(true);
+        }
+
+        // See if there are open locators on the current row, if valid.
+        if (isValidCursorPosition_ && !isOnInsertRow_) {
+            lobState.checkCurrentRow(cursor_);
         }
 
         if (statement_.openOnClient_ && statement_.isCatalogQuery_) {


### PR DESCRIPTION
Move explicit release of CLOB locators in _ResultSet.closeX()_ after a call to _flowCloseAndAutoCommitIfNotAutoCommitted()_, which invokes _completeLocalCommit() -> LOBStateTracker.discardState()_ making a call to _checkCurrentRow()_ a no-op. Retain the call in case _discardState()_ is bypassed. 