### PR TITLE
DB-9756 reduce filesystem metadata calls for external tables (2.8)

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -337,11 +337,8 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             Dataset<Row> table = null;
 
             try {
-                if (!ExternalTableUtils.isExisting(location))
-                    throw StandardException.newException(SQLState.EXTERNAL_TABLES_LOCATION_NOT_EXIST, location);
-
-                if (ExternalTableUtils.isEmptyDirectory(location)) // Handle Empty Directory
-                    return getEmpty(RDDName.EMPTY_DATA_SET.displayName(), context);
+                DataSet<V> empty_ds = checkExistingOrEmpty( location, context );
+                if( empty_ds != null ) return empty_ds;
 
                 ExternalTableUtils.preSortColumns(tableSchema.fields(), partitionColumnMap);
 
@@ -379,11 +376,8 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         try {
             Dataset<Row> table = null;
             try {
-                if (!ExternalTableUtils.isExisting(location))
-                    throw StandardException.newException(SQLState.EXTERNAL_TABLES_LOCATION_NOT_EXIST, location);
-
-                if (ExternalTableUtils.isEmptyDirectory(location)) // Handle Empty Directory
-                    return getEmpty();
+                DataSet<V> empty_ds = checkExistingOrEmpty( location, context );
+                if( empty_ds != null ) return empty_ds;
 
                 StructType copy = new StructType(Arrays.copyOf(tableSchema.fields(), tableSchema.fields().length));
 
@@ -681,6 +675,15 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                     SQLState.PIN_READ_FAILURE, e, e.getMessage());
         }
     }
+    private <V> DataSet<V> checkExistingOrEmpty( String location, OperationContext context ) throws StandardException {
+        FileInfo fileinfo = ExternalTableUtils.getFileInfoOrNull(location);
+        if( fileinfo == null )
+            throw StandardException.newException(SQLState.EXTERNAL_TABLES_LOCATION_NOT_EXIST, location);
+        if ( fileinfo.isEmptyDirectory() ) // Handle Empty Directory
+            return getEmpty(RDDName.EMPTY_DATA_SET.displayName(), context);
+        else
+            return null;
+    }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
@@ -691,11 +694,8 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         assert baseColumnMap != null:"baseColumnMap Null";
         assert partitionColumnMap != null:"partitionColumnMap Null";
         try {
-            if (!ExternalTableUtils.isExisting(location))
-                throw StandardException.newException(SQLState.EXTERNAL_TABLES_LOCATION_NOT_EXIST, location);
-
-            if (ExternalTableUtils.isEmptyDirectory(location)) // Handle Empty Directory
-                return getEmpty(RDDName.EMPTY_DATA_SET.displayName(), context);
+            DataSet<V> empty_ds = checkExistingOrEmpty( location, context );
+            if( empty_ds != null ) return empty_ds;
 
             SpliceORCPredicate predicate = new SpliceORCPredicate(qualifiers,baseColumnMap,execRow.createStructType(baseColumnMap));
             Configuration configuration = new Configuration(HConfiguration.unwrapDelegate());

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -675,9 +675,9 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                     SQLState.PIN_READ_FAILURE, e, e.getMessage());
         }
     }
-    private <V> DataSet<V> checkExistingOrEmpty( String location, OperationContext context ) throws StandardException {
-        FileInfo fileinfo = ExternalTableUtils.getFileInfoOrNull(location);
-        if( fileinfo == null )
+    private <V> DataSet<V> checkExistingOrEmpty( String location, OperationContext context ) throws StandardException, IOException {
+        FileInfo fileinfo = ImportUtils.getImportFileInfo(location);
+        if( !fileinfo.exists() )
             throw StandardException.newException(SQLState.EXTERNAL_TABLES_LOCATION_NOT_EXIST, location);
         if ( fileinfo.isEmptyDirectory() ) // Handle Empty Directory
             return getEmpty(RDDName.EMPTY_DATA_SET.displayName(), context);

--- a/hbase_sql/src/main/java/com/splicemachine/fs/s3/PrestoS3FileSystem.java
+++ b/hbase_sql/src/main/java/com/splicemachine/fs/s3/PrestoS3FileSystem.java
@@ -261,7 +261,6 @@ public class PrestoS3FileSystem
         }
 
         ObjectMetadata metadata = getS3ObjectMetadata(path);
-
         if (metadata == null) {
             // check if this path is a directory
             Iterator<LocatedFileStatus> iterator = listPrefix(path);

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
@@ -186,8 +186,7 @@ public class HNIOFileSystem extends DistributedFileSystem{
                 if (fileStatus.isFile()) {
                     // f is a file
                     long length = fileStatus.getLen();
-                    contentSummary = new ContentSummary.Builder().length(length).
-                            fileCount(1).directoryCount(0).spaceConsumed(length).build();
+                    contentSummary = new ContentSummary(length, 1, 0);
                 }
                 else {
                     // f is a directory
@@ -204,9 +203,7 @@ public class HNIOFileSystem extends DistributedFileSystem{
                             fileCount++;
                         }
                     }
-                    contentSummary = new ContentSummary.Builder().length(length).
-                            fileCount(fileCount).directoryCount(dirCount).
-                            spaceConsumed(length).build();
+                    contentSummary = new ContentSummary(length, fileCount, dirCount);
                 }
             } catch (IOException ioe) {
                 LOG.error("Unexpected error getting content summary. We ignore it for now, but you should probably check it out:", ioe);

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
@@ -148,24 +148,6 @@ public class HNIOFileSystem extends DistributedFileSystem{
         }
     }
 
-    @Override
-    public void concat(Path target, Path... sources)  throws IOException {
-        org.apache.hadoop.fs.Path[] srcPaths = new org.apache.hadoop.fs.Path[sources.length];
-        for (int i=0; i<sources.length; i++) {
-            srcPaths[i] = new org.apache.hadoop.fs.Path(sources[i].getParent().toString(), sources[i].getFileName().toString());
-        }
-        org.apache.hadoop.fs.Path targetPath = new org.apache.hadoop.fs.Path(target.getParent().toString(), target.getFileName().toString());
-
-
-        if (isDistributedFS) {
-            fs.concat(targetPath, srcPaths);
-        } else {
-            for (org.apache.hadoop.fs.Path src : srcPaths) {
-                fs.copyFromLocalFile(true, false, src, targetPath);
-            }
-        }
-    }
-
     /* *************************************************************************************/
     /*private helper methods*/
     private org.apache.hadoop.fs.Path toHPath(Path path){

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
@@ -21,9 +21,7 @@ import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.fs.permission.FsAction;
-import org.apache.hadoop.hdfs.protocol.AclException;
 import org.apache.log4j.Logger;
 
 import java.io.FileNotFoundException;
@@ -92,22 +90,9 @@ public class HNIOFileSystem extends DistributedFileSystem{
         return fs.exists(p);
     }
 
-    @Override
-    public FileInfo getInfo(String filePath) throws IOException{
-        org.apache.hadoop.fs.Path f=new org.apache.hadoop.fs.Path(filePath);
-        ContentSummary contentSummary;
-        try{
-            contentSummary=fs.getContentSummary(f);
-        }catch(IOException ioe){
-            LOG.error("Unexpected error getting content summary. We ignore it for now, but you should probably check it out:",ioe);
-            contentSummary = new ContentSummary(0L,0L,0L);
+    public FileInfo getInfo(String filePath) throws IOException {
 
-        }
-        return new HFileInfo(f,contentSummary);
-    }
-
-    public FileSystem getFileSystem(URI uri){
-        throw new UnsupportedOperationException("IMPLEMENT");
+        return new HFileInfo( new org.apache.hadoop.fs.Path(filePath) );
     }
 
     public Path getPath(URI uri){
@@ -187,58 +172,62 @@ public class HNIOFileSystem extends DistributedFileSystem{
         return new org.apache.hadoop.fs.Path(path.toUri());
     }
 
-
     private class HFileInfo implements FileInfo{
-        private final boolean isDir;
-        private final AclStatus aclStatus;
-        private final boolean isReadable;
-        private final boolean isWritable;
         private org.apache.hadoop.fs.Path path;
-        private ContentSummary contentSummary;
+        FileStatus fileStatus;
+        private ContentSummary contentSummary = null; // calculate on demand
 
-        public HFileInfo(org.apache.hadoop.fs.Path path,ContentSummary contentSummary) throws IOException{
+        public HFileInfo(org.apache.hadoop.fs.Path path) throws IOException{
             this.path=path;
-            this.contentSummary=contentSummary;
-            this.isDir = fs.isDirectory(path);
-            AclStatus aclS;
-            try{
-                aclS=fs.getAclStatus(path);
-            } catch (UnsupportedOperationException | AclException e) { // Runtime Exception for RawFS
-                aclS = new AclStatus.Builder().owner("unknown").group("unknown").build();
-            } catch(Exception e){
-                e = exceptionFactory.processRemoteException(e); //strip any multi-retry errors out
-                //noinspection ConstantConditions
-                if(e instanceof UnsupportedOperationException|| e instanceof AclException){
-                    /*
-                     * Some Filesystems don't support aclStatus. In that case,
-                     * we replace it with our own ACL status object
-                     */
-                    aclS=new AclStatus.Builder().owner("unknown").group("unknown").build();
-                }else{
-                    /*
-                     * the remaining errors are of the category of FileNotFound,UnresolvedPath,
-                     * etc. These are environmental, so we should throw up here.
-                     */
-                    throw new IOException(e);
+            try {
+                this.fileStatus = fs.getFileStatus(path);
+            } catch( FileNotFoundException e )
+            {
+                this.fileStatus = null;
+            }
+        }
+
+        // these two methods are to avoid having to re-calculate the list of files in the directory
+        // for isEmptyDirectory
+        // todo(martinrupp): replace with recursive listdir
+        private FileStatus rootFileStatusArr[];
+        private FileStatus[] listRoot() throws IOException {
+            if (rootFileStatusArr != null || !exists() || !fileStatus.isDirectory()) return rootFileStatusArr;
+            rootFileStatusArr = fs.listStatus(path);
+            return rootFileStatusArr;
+        }
+        // note this is expensive for deeply nested directories. avoid calling fileCount, spaceConsumed and size
+        // partly copied FileSystem.getContentSummary , however with cached fileStatus and using (cached) listRoot for listing root.
+        private ContentSummary getContentSummary() {
+            if( contentSummary != null ) return contentSummary;
+            try {
+                if (fileStatus.isFile()) {
+                    // f is a file
+                    long length = fileStatus.getLen();
+                    contentSummary = new ContentSummary.Builder().length(length).
+                            fileCount(1).directoryCount(0).spaceConsumed(length).build();
                 }
+                else {
+                    // f is a directory
+                    long[] summary = {0, 0, 1};
+                    for (FileStatus s : listRoot()) {
+                        long length = s.getLen();
+                        ContentSummary c = s.isDirectory() ? fs.getContentSummary(s.getPath()) :
+                                new ContentSummary.Builder().length(length).
+                                        fileCount(1).directoryCount(0).spaceConsumed(length).build();
+                        summary[0] += c.getLength();
+                        summary[1] += c.getFileCount();
+                        summary[2] += c.getDirectoryCount();
+                    }
+                    contentSummary = new ContentSummary.Builder().length(summary[0]).
+                            fileCount(summary[1]).directoryCount(summary[2]).
+                            spaceConsumed(summary[0]).build();
+                }
+            } catch (IOException ioe) {
+                LOG.error("Unexpected error getting content summary. We ignore it for now, but you should probably check it out:", ioe);
+                contentSummary = new ContentSummary(0L, 0L, 0L);
             }
-            this.aclStatus = aclS;
-            boolean readable;
-            try{
-                fs.access(path,FsAction.READ);
-                readable= true;
-            }catch(IOException ioe){
-               readable = false;
-            }
-            boolean writable;
-            try{
-                fs.access(path,FsAction.WRITE);
-                writable = true;
-            }catch(IOException ioe){
-                writable = false;
-            }
-            this.isReadable = readable;
-            this.isWritable = writable;
+            return contentSummary;
         }
 
         @Override
@@ -253,64 +242,87 @@ public class HNIOFileSystem extends DistributedFileSystem{
 
         @Override
         public boolean isDirectory(){
-            return isDir;
+            return fileStatus != null && fileStatus.isDirectory();
         }
 
         @Override
         public long fileCount(){
-            return contentSummary.getFileCount();
+            if( !exists() ) return 0;
+            return getContentSummary().getFileCount();
+        }
+
+        @Override
+        public boolean isEmptyDirectory() {
+            if( !exists() ) return false;
+            if( !isDirectory() ) return false;
+            try {
+                for (FileStatus s : listRoot() ) {
+                    if (s.getPath().getName().equals("_SUCCESS") || s.getPath().getName().equals("_SUCCESS.crc") ) continue;
+                    return false;
+                }
+                return true;
+            } catch( Exception e ) {
+                // this shouldn't happen, as we already check if it exists.
+                return false;
+            }
         }
 
         @Override
         public long spaceConsumed(){
-            return contentSummary.getSpaceConsumed();
+            if( !exists() ) return 0;
+            return getContentSummary().getSpaceConsumed();
         }
 
         @Override
         public long size(){
-            return contentSummary.getLength();
+            if( !exists() ) return 0;
+            return getContentSummary().getLength();
         }
 
         @Override
         public boolean isReadable(){
-            return isReadable;
+            if( !exists() ) return false;
+            return fileStatus.getPermission().getUserAction().implies(FsAction.READ);
         }
 
         @Override
         public String getUser(){
-            return aclStatus.getOwner();
+            if( !exists() ) return "";
+            return fileStatus.getOwner();
         }
 
         @Override
         public String getGroup(){
-            return aclStatus.getGroup();
+            if( !exists() ) return "";
+            return fileStatus.getGroup();
         }
 
         @Override
         public boolean isWritable(){
-            return isWritable;
+            if( !exists() ) return false;
+            return fileStatus.getPermission().getUserAction().implies(FsAction.WRITE);
         }
 
         @Override
-        public String toSummary() { // FileUtils.byteCountToDisplaySize
+        public String toSummary() {
+            if( !exists() ) return "file not found " + fullPath();
             StringBuilder sb = new StringBuilder();
             sb.append(this.isDirectory() ? "Directory = " : "File = ").append(fullPath());
-            sb.append("\nFile Count = ").append(contentSummary.getFileCount());
-            sb.append("\nSize = ").append(FileUtils.byteCountToDisplaySize(this.size()));
-            // Not important to display here, but keep it around in case.
-            // For import we only care about the actual file size, not space consumed.
-            // if (this.spaceConsumed() != this.size())
-            //     sb.append("\nSpace Consumed = ").append(FileUtils.byteCountToDisplaySize(this.spaceConsumed()));
+            if( !isDirectory() ) {
+                // this is slow for directories (needs recursive scan), so just do for files
+                sb.append("\nSize = ").append(FileUtils.byteCountToDisplaySize(this.size()));
+                // Not important to display here, but keep it around in case.
+                // For import we only care about the actual file size, not space consumed.
+                // if (this.spaceConsumed() != this.size())
+                //     sb.append("\nSpace Consumed = ").append(FileUtils.byteCountToDisplaySize(this.spaceConsumed()));
+            }
+
             return sb.toString();
         }
 
         @Override
         public boolean exists(){
-            try{
-                return fs.exists(path);
-            }catch(IOException e){
-                throw new RuntimeException(e);
-            }
+            return fileStatus != null;
         }
     }
 }

--- a/mem_storage/src/main/java/com/splicemachine/storage/MemFileSystem.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MemFileSystem.java
@@ -139,14 +139,6 @@ public class MemFileSystem extends DistributedFileSystem{
         localDelegate.copy(source,target,options);
     }
 
-    @Override
-    public void concat(Path target, Path... sources) throws IOException {
-        for (Path source : sources) {
-            localDelegate.copy(source, target);
-            localDelegate.delete(source);
-        }
-    }
-
     private static class PathInfo implements FileInfo{
         private final Path p;
 

--- a/mem_storage/src/main/java/com/splicemachine/storage/MemFileSystem.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MemFileSystem.java
@@ -17,6 +17,7 @@ package com.splicemachine.storage;
 import com.splicemachine.access.api.DistributedFileSystem;
 import com.splicemachine.access.api.FileInfo;
 import com.splicemachine.utils.SpliceLogUtils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.util.regex.Pattern;
  * @author Scott Fines
  *         Date: 1/18/16
  */
+@SuppressFBWarnings(value={ "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"}, justification = ".")
 public class MemFileSystem extends DistributedFileSystem{
     private final FileSystemProvider localDelegate;
     private static Logger LOG=Logger.getLogger(MemFileSystem.class);
@@ -168,6 +170,23 @@ public class MemFileSystem extends DistributedFileSystem{
         @Override
         public boolean isDirectory(){
             return Files.isDirectory(p);
+        }
+
+        @Override
+        public boolean isEmptyDirectory()
+        {
+            if(!isDirectory()) return false;
+            try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(p)) {
+                for (Path p : directoryStream) {
+                    if ( p == null || p.getFileName() == null ) continue;
+                    String name = p.getFileName().toString();
+                    if( name.equals("_SUCCESS") || name.equals("_SUCCESS.crc") ) continue;
+                    return false;
+                }
+                return true;
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
         }
 
         @Override

--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
@@ -108,7 +108,7 @@ class SpliceTestPlatformConfig {
             SpliceHFileCleaner.class,
             TimeToLiveHFileCleaner.class);
 
-    public static void ConfigureS3(Configuration config)
+    public static void configureS3(Configuration config)
     {
         // AWS Credentials for test
         splice.aws.com.amazonaws.auth.AWSCredentialsProvider credentialproviders[] = {
@@ -311,7 +311,7 @@ class SpliceTestPlatformConfig {
         config.set("hbase.cluster.distributed", "true");  // don't start zookeeper for us
         config.set("hbase.master.distributed.log.splitting", "false"); // TODO: explain why we are setting this
 
-        ConfigureS3( config );
+        configureS3( config );
 
         config.set("hive.exec.orc.split.strategy","BI");
         config.setInt("io.file.buffer.size",65536);

--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
@@ -18,6 +18,15 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.splicemachine.access.HConfiguration;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static com.google.common.collect.Lists.transform;
+import java.util.List;
 import com.splicemachine.access.configuration.OlapConfigurations;
 import com.splicemachine.access.configuration.SQLConfiguration;
 import com.splicemachine.compactions.SpliceDefaultCompactionPolicy;
@@ -99,6 +108,33 @@ class SpliceTestPlatformConfig {
             SpliceHFileCleaner.class,
             TimeToLiveHFileCleaner.class);
 
+    public static void ConfigureS3(Configuration config)
+    {
+        // AWS Credentials for test
+        splice.aws.com.amazonaws.auth.AWSCredentialsProvider credentialproviders[] = {
+                new splice.aws.com.amazonaws.auth.EnvironmentVariableCredentialsProvider(), // first try env AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+                new splice.aws.com.amazonaws.auth.profile.ProfileCredentialsProvider()              // second try from $HOME/.aws/credentials (aws cli store)
+        };
+        for( splice.aws.com.amazonaws.auth.AWSCredentialsProvider provider : credentialproviders )
+        {
+            try {
+                // can throw SdkClientException if env is not set or can't parse .aws/credentials
+                // or IllegalArgumentException if .aws/credentials is not there
+                splice.aws.com.amazonaws.auth.AWSCredentials cred = provider.getCredentials();
+                config.set("presto.s3.access-key", cred.getAWSAccessKeyId());
+                config.set("presto.s3.secret-key", cred.getAWSSecretKey());
+                config.set("fs.s3a.access.key", cred.getAWSAccessKeyId());
+                config.set("fs.s3a.secret.key", cred.getAWSSecretKey());
+                config.set("fs.s3a.awsAccessKeyId", cred.getAWSAccessKeyId());
+                config.set("fs.s3a.awsSecretAccessKey", cred.getAWSSecretKey());
+                break;
+            } catch( Exception e )
+            {
+                continue;
+            }
+        }
+        config.set("fs.s3a.impl", com.splicemachine.fs.s3.PrestoS3FileSystem.class.getCanonicalName() );
+    }
     /*
      * Create an HBase config object suitable for use in our test platform.
      */
@@ -275,13 +311,8 @@ class SpliceTestPlatformConfig {
         config.set("hbase.cluster.distributed", "true");  // don't start zookeeper for us
         config.set("hbase.master.distributed.log.splitting", "false"); // TODO: explain why we are setting this
 
-        //
-        // AWS Credentials for test...
-        //
+        ConfigureS3( config );
 
-        //config.set("presto.s3.access-key","");
-        //config.set("presto.s3.secret-key","");
-        config.set("fs.s3a.impl",com.splicemachine.fs.s3.PrestoS3FileSystem.class.getCanonicalName());
         config.set("hive.exec.orc.split.strategy","BI");
         config.setInt("io.file.buffer.size",65536);
 

--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestYarnPlatform.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestYarnPlatform.java
@@ -37,6 +37,10 @@ import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fifo.FifoScheduler;
 import org.apache.log4j.Logger;
+import splice.aws.com.amazonaws.auth.AWSCredentials;
+import splice.aws.com.amazonaws.auth.AWSCredentialsProvider;
+import splice.aws.com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import splice.aws.com.amazonaws.auth.profile.ProfileCredentialsProvider;
 
 /**
  * Starts Yarn server
@@ -99,6 +103,35 @@ public class SpliceTestYarnPlatform {
             yarnCluster.stop();
         }
     }
+    // todo: this is the same as SpliceTestPlatform.ConfigureS3( config ),
+    // but I didn't manage to get dependencies right
+    private static void ConfigureS3(Configuration config)
+    {
+        // AWS Credentials for test
+        AWSCredentialsProvider credentialproviders[] = {
+                new EnvironmentVariableCredentialsProvider(), // first try env AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+                new ProfileCredentialsProvider()              // second try from $HOME/.aws/credentials (aws cli store)
+        };
+        for( AWSCredentialsProvider provider : credentialproviders )
+        {
+            try {
+                // can throw SdkClientException if env is not set or can't parse .aws/credentials
+                // or IllegalArgumentException if .aws/credentials is not there
+                AWSCredentials cred = provider.getCredentials();
+                config.set("presto.s3.access-key", cred.getAWSAccessKeyId());
+                config.set("presto.s3.secret-key", cred.getAWSSecretKey());
+                config.set("fs.s3a.access.key", cred.getAWSAccessKeyId());
+                config.set("fs.s3a.secret.key", cred.getAWSSecretKey());
+                config.set("fs.s3a.awsAccessKeyId", cred.getAWSAccessKeyId());
+                config.set("fs.s3a.awsSecretAccessKey", cred.getAWSSecretKey());
+                break;
+            } catch( Exception e )
+            {
+                continue;
+            }
+        }
+        config.set("fs.s3a.impl",com.splicemachine.fs.s3.PrestoS3FileSystem.class.getCanonicalName());
+    }
 
     public void start(int nodeCount) throws Exception {
         if (yarnCluster == null) {
@@ -130,7 +163,9 @@ public class SpliceTestYarnPlatform {
             // save the server config to classpath so yarn clients can read it
             Configuration yarnClusterConfig = yarnCluster.getConfig();
             yarnClusterConfig.set("yarn.application.classpath", new File(yarnSiteConfigURL.getPath()).getParent());
-            yarnClusterConfig.set("fs.s3a.impl",com.splicemachine.fs.s3.PrestoS3FileSystem.class.getCanonicalName());
+
+            ConfigureS3( yarnClusterConfig );
+
             //write the document to a buffer (not directly to the file, as that
             //can cause the file being written to get read -which will then fail.
             ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();

--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestYarnPlatform.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestYarnPlatform.java
@@ -105,7 +105,7 @@ public class SpliceTestYarnPlatform {
     }
     // todo: this is the same as SpliceTestPlatform.ConfigureS3( config ),
     // but I didn't manage to get dependencies right
-    private static void ConfigureS3(Configuration config)
+    private static void configureS3(Configuration config)
     {
         // AWS Credentials for test
         AWSCredentialsProvider credentialproviders[] = {
@@ -164,7 +164,7 @@ public class SpliceTestYarnPlatform {
             Configuration yarnClusterConfig = yarnCluster.getConfig();
             yarnClusterConfig.set("yarn.application.classpath", new File(yarnSiteConfigURL.getPath()).getParent());
 
-            ConfigureS3( yarnClusterConfig );
+            configureS3( yarnClusterConfig );
 
             //write the document to a buffer (not directly to the file, as that
             //can cause the file being written to get read -which will then fail.

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/DistributedFileSystem.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/DistributedFileSystem.java
@@ -56,14 +56,4 @@ public abstract class DistributedFileSystem {
     public abstract boolean createDirectory(String fullPath,boolean errorIfExists) throws IOException;
 
     public abstract void touchFile(String dir, String fileName) throws IOException;
-
-    /**
-     * Append sources to target, deleting sources after the copy.
-     * @param target path to which to write. Expecting exists and is writable.
-     * @param sources paths from which to read.  Expecting exists and are readable.
-     *                These will be deleted.
-     */
-    public void concat(Path target, Path... sources)  throws IOException {
-        throw new UnsupportedOperationException("IMPLEMENT concat");
-    }
 }

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/FileInfo.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/FileInfo.java
@@ -26,10 +26,17 @@ public interface FileInfo{
 
     boolean isDirectory();
 
+    /// returns true if isDirectory() and (directory is empty or only contains one file _SUCCESS)
+    boolean isEmptyDirectory();
+
     /**
      * @return the number of files in the directory, or 1 if this is a file.
+     * Note: this is SLOW on big directory trees when using remote filesystems like S3,
+     * since requiring a full recursive listdir
+     * If just need to check for empty directory, use {@link #isEmptyDirectory()}
      */
     long fileCount();
+
 
     /**
      * Returns the overall space consumed for the file.
@@ -38,9 +45,14 @@ public interface FileInfo{
      * current size * replication factor. For a local system,
      * it would return the same value as {@link #size()},
      * the actual current size of the file.
+     * Note: this is SLOW on big directory trees when using remote filesystems like S3,
+     * since requiring a full recursive listdir
      */
     long spaceConsumed();
 
+    /* Note: this is SLOW on big directory trees when using remote filesystems like S3,
+     * since requiring a full recursive listdir
+     */
     long size();
 
     boolean isReadable();

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/FileInfo.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/FileInfo.java
@@ -26,7 +26,7 @@ public interface FileInfo{
 
     boolean isDirectory();
 
-    /// returns true if isDirectory() and (directory is empty or only contains one file _SUCCESS)
+    /** returns true if isDirectory() and (directory is empty or only contains one file _SUCCESS) */
     boolean isEmptyDirectory();
 
     /**
@@ -50,7 +50,8 @@ public interface FileInfo{
      */
     long spaceConsumed();
 
-    /* Note: this is SLOW on big directory trees when using remote filesystems like S3,
+    /**
+     *  Note: this is SLOW on big directory trees when using remote filesystems like S3,
      * since requiring a full recursive listdir
      */
     long size();

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ExternalTableUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ExternalTableUtils.java
@@ -37,6 +37,7 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -270,16 +271,6 @@ public class ExternalTableUtils {
         FileInfo fileInfo = ImportUtils.getFileSystem(location).getInfo(location);
         return fileInfo.exists();
 
-    }
-    public static FileInfo getFileInfoOrNull(String location)
-    {
-        try {
-            return ImportUtils.getFileSystem(location).getInfo(location);
-        }
-        catch( StandardException | IOException e )
-        {
-            return null;
-        }
     }
 
     public static String truncateFileNameFromFullPath(String file)

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ExternalTableUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ExternalTableUtils.java
@@ -15,6 +15,7 @@
 
 package com.splicemachine.derby.stream.utils;
 
+import com.splicemachine.access.api.DistributedFileSystem;
 import com.splicemachine.access.api.FileInfo;
 import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.error.StandardException;
@@ -261,15 +262,24 @@ public class ExternalTableUtils {
     }
 
     public static boolean isEmptyDirectory(String location) throws Exception {
-        String[] files = ImportUtils.getFileSystem(location).getExistingFiles(location, "*");
-        return ((files.length == 0) || (files.length == 1 && "_SUCCESS".equals(truncateFileNameFromFullPath(files[0]))));
-
+        DistributedFileSystem dfs = ImportUtils.getFileSystem(location);
+        return dfs.getInfo(location).isEmptyDirectory();
     }
 
     public static boolean isExisting(String location) throws Exception {
         FileInfo fileInfo = ImportUtils.getFileSystem(location).getInfo(location);
-        return  fileInfo.exists();
+        return fileInfo.exists();
 
+    }
+    public static FileInfo getFileInfoOrNull(String location)
+    {
+        try {
+            return ImportUtils.getFileSystem(location).getInfo(location);
+        }
+        catch( StandardException | IOException e )
+        {
+            return null;
+        }
     }
 
     public static String truncateFileNameFromFullPath(String file)

--- a/splice_si_api/src/test/java/com/splicemachine/si/impl/TestingFileSystem.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/impl/TestingFileSystem.java
@@ -21,20 +21,10 @@ import com.splicemachine.access.api.FileInfo;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URI;
-import java.nio.channels.AsynchronousFileChannel;
-import java.nio.channels.FileChannel;
-import java.nio.channels.SeekableByteChannel;
 import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ExecutorService;
 import java.util.regex.Pattern;
 
 /**
@@ -177,6 +167,21 @@ public class TestingFileSystem extends DistributedFileSystem{
         @Override
         public boolean isDirectory(){
             return Files.isDirectory(p);
+        }
+
+        @Override
+        public boolean isEmptyDirectory()
+        {
+            if(!isDirectory()) return false;
+            try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(p)) {
+                for (Path p : directoryStream) {
+                    if (p.getFileName().equals("_SUCCESS") || p.getFileName().equals("_SUCCESS.crc") ) continue;
+                    return false;
+                }
+                return true;
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
         }
 
         @Override

--- a/standalone/pom.xml
+++ b/standalone/pom.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2012 - 2020 Splice Machine, Inc.
+  ~
+  ~ This file is part of Splice Machine.
+  ~ Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+  ~ GNU Affero General Public License as published by the Free Software Foundation, either
+  ~ version 3, or (at your option) any later version.
+  ~ Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  ~ See the GNU Affero General Public License for more details.
+  ~ You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+  ~ If not, see <http://www.gnu.org/licenses/>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>standalone</artifactId>
+    <description>Support profiles for Integration Tests</description>
+    <parent>
+        <artifactId>spliceengine-parent</artifactId>
+        <groupId>com.splicemachine</groupId>
+        <version>3.1.0.1962-SNAPSHOT</version>
+    </parent>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-yarn-server-tests</artifactId>
+            <version>${hadoop.version}</version>
+            <classifier>tests</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-yarn-client</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.splicemachine</groupId>
+            <artifactId>splice_aws</artifactId>
+            <version>${project.version}</version>
+            <classifier>shade</classifier>
+        </dependency>
+    </dependencies>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.5.0.Final</version>
+            </extension>
+        </extensions>
+        <plugins>
+           <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-jar-plugin</artifactId>
+               <executions>
+                   <execution>
+                       <goals>
+                           <goal>test-jar</goal>
+                       </goals>
+                   </execution>
+               </executions>
+           </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.9.1</version>
+                <executions>
+                    <execution>
+                        <id>add-platform-test-resource</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>spark${spark.version}/src/test/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+    </build>
+    <profiles>
+        <profile>
+            <id>spliceYarn</id>
+            <activation>
+                <property>
+                    <name>spliceYarn</name>
+                </property>
+            </activation>
+            <properties>
+                <nodeCount>1</nodeCount>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-network-yarn_${scala.binary.version}</artifactId>
+                    <version>${spark.version}</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.4.0</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <!-- exec:java required so that these 2 dependency properties are available (they aren't with exec:exec -->
+                            <classpathScope>test</classpathScope>
+                            <!--<includeProjectDependencies>false</includeProjectDependencies>-->
+                            <!--<includePluginDependencies>true</includePluginDependencies>-->
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath />
+                                <argument>-Djava.io.tmpdir=${project.build.directory}/../../platform_it/target/tmp</argument>
+                                <argument>com.splicemachine.test.SpliceTestYarnPlatform</argument>
+                                <argument>${project.build.directory}/../../platform_it/target/classes</argument>
+                                <argument>${secure}</argument>
+                                <argument>${nodeCount}</argument>
+                                <argument>-Dlog4j.configurationFile=${log4j.config.uri}</argument>
+                            </arguments>
+                            <workingDirectory>${project.build.directory}/../../platform_it/</workingDirectory>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/start-splice-cluster
+++ b/start-splice-cluster
@@ -152,9 +152,9 @@ if [[ "${BUILD}" == "1" ]]; then
   echo "Building first..."
   pushd "${BASE_DIR}" > /dev/null
   if [[ "${CLEAN}" == "1" ]]; then
-    (${MVN} clean install -Pcore,${PROFILE} -DskipTests )
+    (${MVN} clean install -Pcore,${PROFILE} -DskipTests ) || exit
   else
-    (${MVN} install -Pcore,${PROFILE} -DskipTests )
+    (${MVN} install -Pcore,${PROFILE} -DskipTests ) || exit
   fi
   popd > /dev/null
   echo "Running Splice $PROFILE master and ${MEMBERS} regionservers with CHAOS = $CHAOS in:"


### PR DESCRIPTION
- some cleanup in SparkDataSetProcessor.write{X}
- HNIOFileSystem.getInfo will return a FileInfo which is calculating expensive (recursive) size() and fileCount() only on demand.
- added FileInfo.isEmptyDirectory to avoid scanning the whole directory tree for this
- modified SpliceTestPlatformConfig and SpliceTestYarnPlatform so that standalone spliceengine can use s3 access keys from ~/.aws/credentials or environment (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY).
- start-splice-cluster: don't start splice cluster if build failed.