### PR TITLE
DB-9610 fix start-splice-cluster on linux, add docker build&start scripts (3.0)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM maven:3.6.3-jdk-8
+
+# nc is used in start-splice-cluster to check if connection is opened -> service is ready
+RUN apt-get update && apt-get install -y netcat
+
+COPY entrypoint.sh /usr/local/bin/se-entrypoint.sh
+RUN chmod +x /usr/local/bin/se-entrypoint.sh
+ENTRYPOINT [ "/usr/local/bin/se-entrypoint.sh" ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo starting inside container command:
+echo $*
+$*

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./start-splice-cluster $* && ./sqlshell.sh

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,0 +1,46 @@
+# used base image for docker is maven:3.6.3-jdk-8 + netcat installed.
+
+docker build --tag se-spliceengine-build docker
+
+# - to be able to sqlshell.sh into the container, we are exposing the containers' port 1527
+# as port 2527 for the host, so you can connect from host e.g. with
+#   ./sqlshell.sh -h localhost -p 2527
+# 
+# - to re-use the $HOME/.m2/settings.xml and the already downloaded
+# maven dependencies, we map the path $HOME/.m2 of host to
+#  /root/.m2 inside of the container (since $HOME=/root, this mimicks $HOME/.m2 in the container)
+# 
+# - to have access to the source, we map $(pwd) to /usr/src/
+# - we cd into /usr/src in the container.
+# 
+# With these preparation steps, you can then just instantiate mvn,
+# short scripts are:
+# 
+# build:
+# ./docker_run.sh mvn clean install -Pcdh6.3.0 -DskipTests
+# 
+# start splice cluster + sqlshell:
+# ./docker_start-splice_cluster.sh -b
+# 
+# To get a normal bash inside the container:
+# ./docker_run.sh /bin/bash
+# ./start-splice-cluster -pcdh6.3.0 -b
+# 
+#
+# TODO: when running on linux, the container will create files with user "root"
+# this can be prevented with e.g. https://vsupalov.com/docker-shared-permissions/
+
+# ATTENTION: Because of the path mapping of $HOME/.m2 and $(pwd), this means the docker
+# container will MODIFY these directories on the host.
+
+HOST_PORT=2527
+
+echo "starting $*"
+
+docker run -it \
+  -p ${HOST_PORT}:1527         `# 1527 inside docker -> ${HOST_PORT}`                   \
+  -v "$HOME/.m2":/root/.m2     `# reusing maven root from the host (avoid re-download)` \
+  -v "$(pwd)":/usr/src/        `# map the gitroot of spliceengine to /usr/src`          \
+  -w /usr/src/                 `# set /usr/src as current working directoy`             \
+  se-spliceengine-build \
+  $*

--- a/docker_start-splice_cluster.sh
+++ b/docker_start-splice_cluster.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+bash docker_run.sh /bin/bash docker/start.sh $*

--- a/start-splice-cluster
+++ b/start-splice-cluster
@@ -170,6 +170,9 @@ if [[ ${HBASE_PROFILE} == ${IN_MEM_PROFILE} ]]; then
   MEM_LOG="${RUN_DIR}/spliceMem.log"
   echo "Starting MEM. Log file is ${MEM_LOG}"
   (MAVEN_OPTS="${MAVEN_OPTS} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=4000" ${MVN} -Pmem exec:java > ${MEM_LOG} 2>&1) &    ## IN MEMORY
+  echo -n "wait until ready . "
+  until nc -z localhost 1527 2> /dev/null; do echo -n ". " ; sleep 2; done
+  echo "MEM Started!"
   exit 0;
 fi
 
@@ -188,7 +191,7 @@ COUNT=65
 ZOO_UP=""
 until [ ${COUNT} -eq 0 ] || [ "${ZOO_UP}" == "imok" ]; do
     sleep 1
-    ZOO_UP="$(echo 'ruok' | nc localhost 2181)"
+    ZOO_UP="$(echo 'ruok' | nc localhost 2181 2> /dev/null)"
     let COUNT-=1
 done
 
@@ -233,7 +236,7 @@ else
 fi
 
 echo -n "  Waiting. "
-while ! echo exit | nc localhost 1527; do echo -n ". " ; sleep 2; done
+until nc -z localhost 1527 2> /dev/null; do echo -n ". " ; sleep 2; done
 echo
 
 if [[ ${MEMBERS} -gt 0 ]]; then
@@ -243,7 +246,7 @@ if [[ ${MEMBERS} -gt 0 ]]; then
     ## (region server, splice on 1528, 1529, ...)
     (${MVN} exec:exec -Denv=${HBASE_PROFILE} -P${PROFILE},spliceClusterMember ${SYSTEM_PROPS} -DmemberNumber=${MEMBER} -Dxml.plan.debug.path=${DEBUG_PATH} > ${REGION_SVR_LOG} 2>&1) &
     echo -n "  Waiting. "
-    while ! echo exit | nc localhost $(( 1527 + ${MEMBER} )); do echo -n ". " ; sleep 2; done
+    until nc -z localhost $(( 1527 + ${MEMBER} )) 2> /dev/null; do echo -n ". " ; sleep 2; done
     echo
   done
 fi


### PR DESCRIPTION
used base image for docker is maven:3.6.3-jdk-8 .

both docker_run.sh and docker_start-splice-cluster.sh do:

- to be able to sqlshell.sh into the container, we are exposing the containers' port 1527
as port 2527 for the host, so you can connect from host e.g. with
  ./sqlshell.sh -h localhost -p 2527

- to re-use the $HOME/.m2/settings.xml and the already downloaded
maven dependencies, we map the path $HOME/.m2 of host to
 /root/.m2 inside of the container (since $HOME=/root, this mimicks $HOME/.m2 in the container)

- to have access to the source, we map $(pwd) to /usr/src/
- we cd into /usr/src in the container.

With these preparation steps, you can then just instantiate mvn,
short scripts are:

build:
./docker_run.sh mvn install -Pcdh6.3.0 -DskipTests

start splice cluster + sqlshell:
./docker_start-splice_cluster.sh -b

To get a normal bash inside the container:
./docker_run.sh /bin/bash

ATTENTION: Because of the path mapping of $HOME/.m2 and $(pwd), this means the docker
container will MODIFY these directories on the host.