### PR TITLE
DB-9783 use recursive listdir (2.8)

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/fs/s3/PrestoS3FileSystem.java
+++ b/hbase_sql/src/main/java/com/splicemachine/fs/s3/PrestoS3FileSystem.java
@@ -217,10 +217,15 @@ public class PrestoS3FileSystem
     @Override
     public RemoteIterator<LocatedFileStatus> listLocatedStatus(Path path)
     {
+        return listFiles(path, false);
+    }
+
+    @Override
+    public RemoteIterator<LocatedFileStatus> listFiles(Path path, boolean recursive) {
         STATS.newListLocatedStatusCall();
         return new RemoteIterator<LocatedFileStatus>()
         {
-            private final Iterator<LocatedFileStatus> iterator = listPrefix(path);
+            private final Iterator<LocatedFileStatus> iterator = listPrefix(path, recursive, -1);
 
             @Override
             public boolean hasNext()
@@ -263,7 +268,7 @@ public class PrestoS3FileSystem
         ObjectMetadata metadata = getS3ObjectMetadata(path);
         if (metadata == null) {
             // check if this path is a directory
-            Iterator<LocatedFileStatus> iterator = listPrefix(path);
+            Iterator<LocatedFileStatus> iterator = listPrefix(path, false, 3);
             if (iterator.hasNext()) {
                 return new FileStatus(0, true, 1, 0, 0, qualifiedPath(path));
             }
@@ -414,7 +419,7 @@ public class PrestoS3FileSystem
         return true;
     }
 
-    private Iterator<LocatedFileStatus> listPrefix(Path path)
+    private Iterator<LocatedFileStatus> listPrefix(Path path, boolean recursive, int maxKeys)
     {
         String key = keyFromPath(path);
         if (!key.isEmpty()) {
@@ -423,8 +428,11 @@ public class PrestoS3FileSystem
 
         ListObjectsRequest request = new ListObjectsRequest()
                 .withBucketName(uri.getHost())
-                .withPrefix(key)
-                .withDelimiter(PATH_SEPARATOR);
+                .withPrefix(key);
+        if( !recursive )
+            request = request.withDelimiter(PATH_SEPARATOR);
+        if( maxKeys > 0)
+            request = request.withMaxKeys(maxKeys);
 
         STATS.newListObjectsCall();
         Iterator<ObjectListing> listings = new AbstractSequentialIterator<ObjectListing>(s3.listObjects(request))

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
@@ -21,6 +21,8 @@ import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.log4j.Logger;
 
@@ -30,6 +32,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.file.*;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.Iterables.toArray;
 
 /**
  * @author Scott Fines
@@ -156,8 +162,9 @@ public class HNIOFileSystem extends DistributedFileSystem{
 
     private class HFileInfo implements FileInfo{
         private org.apache.hadoop.fs.Path path;
-        FileStatus fileStatus;
-        private ContentSummary contentSummary = null; // calculate on demand
+        private FileStatus fileStatus;
+        private ContentSummary contentSummary;               // calculated on demand
+        private List<LocatedFileStatus> rootFileStatusList;  // calculated on demand
 
         public HFileInfo(org.apache.hadoop.fs.Path path) throws IOException{
             this.path=path;
@@ -170,42 +177,36 @@ public class HNIOFileSystem extends DistributedFileSystem{
         }
 
         // these two methods are to avoid having to re-calculate the list of files in the directory
-        // for isEmptyDirectory
-        // todo(martinrupp): replace with recursive listdir
-        private FileStatus rootFileStatusArr[];
-        private FileStatus[] listRoot() throws IOException {
-            if (rootFileStatusArr != null || !exists() || !fileStatus.isDirectory()) return rootFileStatusArr;
-            rootFileStatusArr = fs.listStatus(path);
-            return rootFileStatusArr;
+        // for isEmptyDirectory, size() and fileCount()
+        private List<LocatedFileStatus> listRoot() throws IOException {
+            if (rootFileStatusList != null) return rootFileStatusList;
+            rootFileStatusList = new ArrayList<>();
+            RemoteIterator<LocatedFileStatus> iterator = fs.listFiles(path, true); // recursive!
+            while (iterator.hasNext()) {
+                rootFileStatusList.add(iterator.next());
+            }
+            return rootFileStatusList;
         }
-        // note this is expensive for deeply nested directories. avoid calling fileCount, spaceConsumed and size
-        // partly copied FileSystem.getContentSummary , however with cached fileStatus and using (cached) listRoot for listing root.
+
         private ContentSummary getContentSummary() {
             if( contentSummary != null ) return contentSummary;
-            try {
+            try
+            {
+                long directories = 0, fileCount = 0, length = 0;
                 if (fileStatus.isFile()) {
                     // f is a file
-                    long length = fileStatus.getLen();
-                    contentSummary = new ContentSummary(length, 1, 0);
+                    length      = fileStatus.getLen();
+                    fileCount   = 1;
+                    directories = 0;
                 }
                 else {
-                    // f is a directory
-                    long length = 0, fileCount = 0, dirCount = 1;
-                    for (FileStatus s : listRoot()) {
-                        if( s.isDirectory() ) {
-                            ContentSummary c = fs.getContentSummary(s.getPath());
-                            length += c.getLength();
-                            fileCount += c.getFileCount();
-                            dirCount += c.getDirectoryCount();
-                        }
-                        else {
-                            length += s.getLen();
-                            fileCount++;
-                        }
-                    }
-                    contentSummary = new ContentSummary(length, fileCount, dirCount);
+                    length      = listRoot().stream().map( s -> s.getLen() ).reduce(Long::sum).orElse((long) 0);
+                    fileCount   = listRoot().stream().count();
+                    directories = listRoot().stream().map( s -> s.getPath().getParent() ).distinct().count();
                 }
-            } catch (IOException ioe) {
+                contentSummary = new ContentSummary(length, fileCount, directories);
+            }
+            catch (IOException ioe) {
                 LOG.error("Unexpected error getting content summary. We ignore it for now, but you should probably check it out:", ioe);
                 contentSummary = new ContentSummary(0L, 0L, 0L);
             }
@@ -233,6 +234,9 @@ public class HNIOFileSystem extends DistributedFileSystem{
             return getContentSummary().getFileCount();
         }
 
+        // Note: we need to be sure that the underlying filesystem can support recursive listdir efficiently.
+        // this is done for S3 and HDFS has this anyhow. If this is not the case, it would be better to not use
+        // (cached, but recursive) listRoot() here, but to just list the root (without recursive).
         @Override
         public boolean isEmptyDirectory() {
             if( !exists() ) return false;


### PR DESCRIPTION
- HNIOFileSystem's FileInfo, will use FileSystem.listFiles(path, recursive) to calculate (recursive) size() and fileCount() (FileInfo.size/fileCount is used in StoreCostController)
- PrestoS3FileSystem will now implement FileSystem.listFiles(Path path, boolean recursive) directly.

(On Cloud Storage systems like s3/adl/gcp etc. metadata requests are limited not by bandwidth, but by ping, so reducing the number of metadata requests is very important. For directories with a lot of subdirectories, this means we should do ONE request asking for "give me that directory tree" instead of listing the root, then listing each subdirectory etc. E.g. for a directory with 100 subdirectories, this can make a difference of 300ms (one request) to (1+100)*300ms = 30.3 s (1 = list root, then 100 lists in the subdirectory) )