### PR TITLE
DB-9783 use recursive listdir (3.0)

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/compactions/SpliceDefaultCompactor.java
@@ -95,7 +95,7 @@ import static org.apache.hadoop.hbase.regionserver.ScanType.COMPACT_RETAIN_DELET
  *
  */
 public class SpliceDefaultCompactor extends DefaultCompactor {
-    private static final boolean allowSpark = false;
+    private static final boolean allowSpark = true;
     private static final Logger LOG = Logger.getLogger(SpliceDefaultCompactor.class);
     private long smallestReadPoint;
     private String conglomId;

--- a/hbase_sql/src/main/java/com/splicemachine/fs/s3/PrestoS3FileSystem.java
+++ b/hbase_sql/src/main/java/com/splicemachine/fs/s3/PrestoS3FileSystem.java
@@ -217,10 +217,15 @@ public class PrestoS3FileSystem
     @Override
     public RemoteIterator<LocatedFileStatus> listLocatedStatus(Path path)
     {
+        return listFiles(path, false);
+    }
+
+    @Override
+    public RemoteIterator<LocatedFileStatus> listFiles(Path path, boolean recursive) {
         STATS.newListLocatedStatusCall();
         return new RemoteIterator<LocatedFileStatus>()
         {
-            private final Iterator<LocatedFileStatus> iterator = listPrefix(path);
+            private final Iterator<LocatedFileStatus> iterator = listPrefix(path, recursive, -1);
 
             @Override
             public boolean hasNext()
@@ -263,7 +268,7 @@ public class PrestoS3FileSystem
         ObjectMetadata metadata = getS3ObjectMetadata(path);
         if (metadata == null) {
             // check if this path is a directory
-            Iterator<LocatedFileStatus> iterator = listPrefix(path);
+            Iterator<LocatedFileStatus> iterator = listPrefix(path, false, 3);
             if (iterator.hasNext()) {
                 return new FileStatus(0, true, 1, 0, 0, qualifiedPath(path));
             }
@@ -414,7 +419,7 @@ public class PrestoS3FileSystem
         return true;
     }
 
-    private Iterator<LocatedFileStatus> listPrefix(Path path)
+    private Iterator<LocatedFileStatus> listPrefix(Path path, boolean recursive, int maxKeys)
     {
         String key = keyFromPath(path);
         if (!key.isEmpty()) {
@@ -423,8 +428,11 @@ public class PrestoS3FileSystem
 
         ListObjectsRequest request = new ListObjectsRequest()
                 .withBucketName(uri.getHost())
-                .withPrefix(key)
-                .withDelimiter(PATH_SEPARATOR);
+                .withPrefix(key);
+        if( !recursive )
+            request = request.withDelimiter(PATH_SEPARATOR);
+        if( maxKeys > 0)
+            request = request.withMaxKeys(maxKeys);
 
         STATS.newListObjectsCall();
         Iterator<ObjectListing> listings = new AbstractSequentialIterator<ObjectListing>(s3.listObjects(request))


### PR DESCRIPTION
- HNIOFileSystem's FileInfo, will use FileSystem.listFiles(path, recursive) to calculate (recursive) size() and fileCount() (FileInfo.size/fileCount is used in StoreCostController)
- PrestoS3FileSystem will now implement FileSystem.listFiles(Path path, boolean recursive) directly.

(On Cloud Storage systems like s3/adl/gcp etc. metadata requests are limited not by bandwidth, but by ping, so reducing the number of metadata requests is very important. For directories with a lot of subdirectories, this means we should do ONE request asking for "give me that directory tree" instead of listing the root, then listing each subdirectory etc. E.g. for a directory with 100 subdirectories, this can make a difference of 300ms (one request) to (1+100)*300ms = 30.3 s (1 = list root, then 100 lists in the subdirectory) )