### PR TITLE
DB-9782 improve ExternalTableIT to handle more column types / unify tests

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableTypeHelper.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableTypeHelper.java
@@ -1,0 +1,247 @@
+package com.splicemachine.derby.impl.sql.execute.operations;
+
+import org.junit.Assert;
+
+import java.sql.Clob;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Locale;
+
+/// a helper class to define column types, and then create external tables and insert data into them
+/// to make writing tests for all column types easier.
+
+public class CreateTableTypeHelper {
+    /// @param types: an array of Types that should be used
+    /// @param ivalues: an array of values to use. 0 is NULL value, all other values will
+    /// generate corresponding entries that are somewhat associated with the integer val
+    /// e.g. mostly if the int values increase, the corresponding e.g. date value also increases.
+    public CreateTableTypeHelper(int[] types, int[] ivalues)
+    {
+        for( int i = 0; i < types.length; i++ )
+        {
+            String comma = i > 0 ? ", " : "";
+            int t = types[i];
+            schema = schema + comma + getTypesName(t);
+            suggestedTypes = suggestedTypes + comma + getTypesNameInfered(t);
+        }
+
+        for( int i = 0; i < ivalues.length; i++ ) {
+            insertValues = insertValues + (i > 0 ? ", " : "") + "(";
+            StringBuilder sb = new StringBuilder();
+            for (int j = 0; j < types.length; j++) {
+                sb.append( j > 0 ? ", " : "");
+                sb.append( getTypeValue(types[j], ivalues[i]) );
+            }
+            values2.add( sb.toString() );
+            insertValues = insertValues + sb.toString() + ")";
+        }
+        values2.sort(String::compareTo);
+    }
+
+    public String getInsertValues() {
+        return insertValues;
+    }
+
+    /// @return schema as to be used in `create external table <NAME> ( <SCHEMA> ) ...`
+    public String getSchema()
+    {
+        return schema;
+    }
+
+    /// @return schema that will be returned when suggesting a schema to the user.
+    public String getSuggestedTypes() {
+        return suggestedTypes;
+    }
+
+
+    /// @return types that are supported by Parquet
+    static public int[] getParquetTypes() {
+        return new int[]{
+                Types.VARCHAR, Types.CHAR,
+                Types.DATE, Types.TIMESTAMP,
+                // Types.TIME, // supported, but will be written as TIMESTAMP
+                Types.TINYINT, Types.SMALLINT, Types.INTEGER, Types.BIGINT,
+                Types.DOUBLE, Types.REAL, Types.DECIMAL, Types.BOOLEAN
+        };
+    }
+
+    /// @return types that are supported by ORC
+    static public int[] getORCTypes() {
+        return new int[]{
+                Types.VARCHAR, Types.CHAR,
+                Types.DATE, Types.TIMESTAMP,
+                // Types.TIME, // supported, but will be written as TIMESTAMP
+                Types.TINYINT, Types.SMALLINT, Types.INTEGER, Types.BIGINT,
+                Types.DOUBLE, Types.REAL, Types.DECIMAL, Types.BOOLEAN
+        };
+    }
+
+    /// @return types that are supported by Avro
+    static public int[] getAvroTypes() {
+        return new int[]{
+                Types.VARCHAR, Types.CHAR,
+                // Types.DATE, Types.TIME // not supported
+                Types.TIMESTAMP,
+                //Types.TINYINT, Types.SMALLINT, // not supported
+                Types.INTEGER, Types.BIGINT,
+                Types.DOUBLE, Types.REAL,
+                // Types.DECIMAL, // not supported
+                Types.BOOLEAN
+        };
+    }
+
+    /// @return supported types by fileFormat PARQUET, ORC or AVRO
+    static public int[] getTypes(String fileFormat) {
+        if(fileFormat.equalsIgnoreCase("PARQUET"))
+            return getParquetTypes();
+        else if(fileFormat.equalsIgnoreCase("ORC"))
+            return getORCTypes();
+        else if(fileFormat.equalsIgnoreCase("AVRO"))
+            return getAvroTypes();
+        throw new RuntimeException("unsupported fileformat " + fileFormat);
+    }
+
+    /// compare that result in ResultSet rs is the same as from the generated insert values.
+    public void checkResultSetSelectAll(ResultSet rs) throws SQLException {
+        ArrayList<String> results = new ArrayList<>();
+        int nCols = rs.getMetaData().getColumnCount();
+        int rows = 0;
+        while (rs.next()) {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 1; i <= nCols; i++) {
+                Object value = rs.getObject(i);
+                if (value != null && value instanceof Clob) {
+                    throw new RuntimeException("Clob not supported");
+                } else {
+                    if( i > 1 ) sb.append(", ");
+                    if( value != null && value.toString() != null ) {
+                        sb.append("'");
+                        sb.append(value.toString());
+                        sb.append("'");
+                    }
+                    else {
+                        sb.append("NULL");
+                    }
+                }
+            }
+            results.add(sb.toString());
+        }
+        results.sort(String::compareTo);
+        Assert.assertEquals( values2.size(), results.size() );
+        for( int i = 0; i < results.size(); i++ ) {
+            Assert.assertEquals( values2.get(i), results.get(i) );
+        }
+    }
+
+    private String getTypesName(int type) {
+        switch (type) {
+            case Types.CHAR:
+                return "COL_CHAR CHAR(10)";
+            case Types.VARCHAR:
+                return "COL_VARCHAR VARCHAR(10)";
+            case Types.DATE:
+                return "COL_DATE DATE";
+            case Types.TIME:
+                return "COL_TIME TIME";
+            case Types.TIMESTAMP:
+                return "COL_TIMESTAMP TIMESTAMP";
+            case Types.TINYINT:
+                return "COL_TINYINT TINYINT";
+            case Types.SMALLINT:
+                return "COL_SMALLINT SMALLINT";
+            case Types.INTEGER:
+                return "COL_INTEGER INT";
+            case Types.BIGINT:
+                return "COL_BIGINT BIGINT";
+            //case Types.NUMERIC: Decimal and Numeric should be the same
+            case Types.DECIMAL:
+                return "COL_DECIMAL DECIMAL(7,2)";
+            case Types.DOUBLE:
+                return "COL_DOUBLE DOUBLE";
+            case Types.REAL:
+                return "COL_REAL REAL";
+            case Types.BOOLEAN:
+                return "COL_BOOLEAN BOOLEAN";
+            default:
+                throw new RuntimeException("unsupported type " + type);
+        }
+    }
+
+    private String getTypesNameInfered(int type) {
+        switch (type) {
+            case Types.CHAR:
+                return "COL_CHAR CHAR/VARCHAR(x)";
+            case Types.VARCHAR:
+                return "COL_VARCHAR CHAR/VARCHAR(x)";
+            default:
+                return getTypesName(type);
+        }
+    }
+    private String getTime( int val ){
+        if( val < 0 ) val = -val;
+        int seconds = val;
+        int minutes = seconds / 60;
+        int hours = minutes / 60;
+        seconds %= 60;
+        minutes %= 60;
+        hours %= 60;
+        return String.format("%d:%02d:%02d", hours, minutes, seconds);
+    }
+    private String getDate( int val ){
+        int days = val;
+        int months = days / 28;
+        int years = months / 12;
+        days = days%28 + 1;
+        months = months%12 + 1;
+        years += 2000;
+        return String.format("%d-%02d-%02d", years, months, days);
+    }
+
+    private String getTypeValue(int type, int val) {
+        // DB-9829: BOOLEAN can't use NULL together with non-null
+        // ERROR 42X61: Types 'CHAR' and 'BOOLEAN' are not UNION compatible.
+        // Note this is not a problem with external tables
+        if( type != Types.BOOLEAN
+                && val == 0 ) { return "NULL"; }
+        switch (type) {
+            case Types.CHAR:
+                return "'" + padSpaces("AAAA " + Integer.toString(val), 10) + "'";
+            case Types.VARCHAR:
+                return "'AAAA " + Integer.toString(val) + "'";
+            case Types.TIME:
+                return "'" + getTime(val) + "'";
+            case Types.DATE:
+                return "'" + getDate(val) + "'";
+            case Types.TIMESTAMP:
+                return "'" + getDate(val) + " 09:45:01.123'";
+            case Types.TINYINT:
+            case Types.SMALLINT:
+            case Types.INTEGER:
+            case Types.BIGINT:
+                return "'" + Integer.toString(val) + "'";
+            case Types.DOUBLE:
+            case Types.REAL:
+                return "'" + Double.toString(val * 0.001 + 1.5) + "'";
+            case Types.DECIMAL:
+                return "'" + Double.toString((val % 10000) * 0.01 + 1.5) + "'";
+            case Types.BOOLEAN:
+                return val % 2 == 0 ? "'true'" : "'false'";
+            default:
+                throw new RuntimeException("unsupported type " + type);
+        }
+    }
+
+    private String padSpaces(String s, int i) {
+        while( s.length() < i ) s = s + " ";
+        return s;
+    }
+
+    DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ENGLISH);
+    private ArrayList<String> values2= new ArrayList<>();
+    private String schema = "";
+    private String suggestedTypes = "";
+    private String insertValues = "";
+}

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableTypeHelper.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableTypeHelper.java
@@ -8,7 +8,12 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
 
 /// a helper class to define column types, and then create external tables and insert data into them
 /// to make writing tests for all column types easier.
@@ -20,25 +25,15 @@ public class CreateTableTypeHelper {
     /// e.g. mostly if the int values increase, the corresponding e.g. date value also increases.
     public CreateTableTypeHelper(int[] types, int[] ivalues)
     {
-        for( int i = 0; i < types.length; i++ )
-        {
-            String comma = i > 0 ? ", " : "";
-            int t = types[i];
-            schema = schema + comma + getTypesName(t);
-            suggestedTypes = suggestedTypes + comma + getTypesNameInfered(t);
-        }
+        schema = Arrays.stream(types).mapToObj(this::getTypesName).collect(Collectors.joining(", "));
+        suggestedTypes = Arrays.stream(types).mapToObj(this::getTypesNameInfered).collect(Collectors.joining(", "));
 
-        for( int i = 0; i < ivalues.length; i++ ) {
-            insertValues = insertValues + (i > 0 ? ", " : "") + "(";
-            StringBuilder sb = new StringBuilder();
-            for (int j = 0; j < types.length; j++) {
-                sb.append( j > 0 ? ", " : "");
-                sb.append( getTypeValue(types[j], ivalues[i]) );
-            }
-            values2.add( sb.toString() );
-            insertValues = insertValues + sb.toString() + ")";
-        }
-        values2.sort(String::compareTo);
+        IntFunction<String> iValueStringFunc = ivalue -> Arrays.stream(types)
+                .mapToObj(type -> getTypeValue(type, ivalue))
+                .collect(Collectors.joining(", "));
+
+        values2 = Arrays.stream(ivalues).mapToObj(iValueStringFunc).sorted().collect(Collectors.toList());
+        insertValues = Arrays.stream(ivalues).mapToObj(iValueStringFunc).map(s -> "(" + s + ")").collect(Collectors.joining(", "));
     }
 
     public String getInsertValues() {
@@ -108,7 +103,6 @@ public class CreateTableTypeHelper {
     public void checkResultSetSelectAll(ResultSet rs) throws SQLException {
         ArrayList<String> results = new ArrayList<>();
         int nCols = rs.getMetaData().getColumnCount();
-        int rows = 0;
         while (rs.next()) {
             StringBuilder sb = new StringBuilder();
             for (int i = 1; i <= nCols; i++) {
@@ -208,9 +202,9 @@ public class CreateTableTypeHelper {
                 && val == 0 ) { return "NULL"; }
         switch (type) {
             case Types.CHAR:
-                return "'" + padSpaces("AAAA " + Integer.toString(val), 10) + "'";
+                return "'" + padSpaces("AAAA " + val, 10) + "'";
             case Types.VARCHAR:
-                return "'AAAA " + Integer.toString(val) + "'";
+                return "'AAAA " + val + "'";
             case Types.TIME:
                 return "'" + getTime(val) + "'";
             case Types.DATE:
@@ -221,12 +215,12 @@ public class CreateTableTypeHelper {
             case Types.SMALLINT:
             case Types.INTEGER:
             case Types.BIGINT:
-                return "'" + Integer.toString(val) + "'";
+                return "'" + val + "'";
             case Types.DOUBLE:
             case Types.REAL:
-                return "'" + Double.toString(val * 0.001 + 1.5) + "'";
+                return "'" + (val * 0.001 + 1.5) + "'";
             case Types.DECIMAL:
-                return "'" + Double.toString((val % 10000) * 0.01 + 1.5) + "'";
+                return "'" + ((val % 10000) * 0.01 + 1.5) + "'";
             case Types.BOOLEAN:
                 return val % 2 == 0 ? "'true'" : "'false'";
             default:
@@ -235,13 +229,15 @@ public class CreateTableTypeHelper {
     }
 
     private String padSpaces(String s, int i) {
-        while( s.length() < i ) s = s + " ";
+        StringBuilder sBuilder = new StringBuilder(s);
+        while( sBuilder.length() < i ) sBuilder.append(" ");
+        s = sBuilder.toString();
         return s;
     }
 
     DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ENGLISH);
-    private ArrayList<String> values2= new ArrayList<>();
-    private String schema = "";
-    private String suggestedTypes = "";
-    private String insertValues = "";
+    private final List<String> values2;
+    private final String schema;
+    private final String suggestedTypes;
+    private final String insertValues;
 }

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableTypeHelper.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableTypeHelper.java
@@ -15,14 +15,18 @@ import java.util.function.Consumer;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 
-/// a helper class to define column types, and then create external tables and insert data into them
-/// to make writing tests for all column types easier.
-
+/**
+ * a helper class to define column types, and then create external tables and insert data into them
+ * to make writing tests for all column types easier.
+ */
 public class CreateTableTypeHelper {
-    /// @param types: an array of Types that should be used
-    /// @param ivalues: an array of values to use. 0 is NULL value, all other values will
-    /// generate corresponding entries that are somewhat associated with the integer val
-    /// e.g. mostly if the int values increase, the corresponding e.g. date value also increases.
+    /**
+     *
+     * @param types     an array of Types that should be used
+     * @param ivalues   an array of values to use. 0 is NULL value, all other values will
+     * generate corresponding entries that are somewhat associated with the integer val
+     * e.g. mostly if the int values increase, the corresponding e.g. date value also increases.
+     */
     public CreateTableTypeHelper(int[] types, int[] ivalues)
     {
         schema = Arrays.stream(types).mapToObj(this::getTypesName).collect(Collectors.joining(", "));
@@ -40,19 +44,28 @@ public class CreateTableTypeHelper {
         return insertValues;
     }
 
-    /// @return schema as to be used in `create external table <NAME> ( <SCHEMA> ) ...`
+
+
+    /**
+     * @return schema as to be used in `create external table <NAME> ( <SCHEMA> ) ...`
+     */
     public String getSchema()
     {
         return schema;
     }
 
-    /// @return schema that will be returned when suggesting a schema to the user.
+    /**
+     *
+     * @return schema that will be returned when suggesting a schema to the user.
+     */
     public String getSuggestedTypes() {
         return suggestedTypes;
     }
 
 
-    /// @return types that are supported by Parquet
+    /**
+     * @return types that are supported by Parquet
+     */
     static public int[] getParquetTypes() {
         return new int[]{
                 Types.VARCHAR, Types.CHAR,
@@ -63,7 +76,9 @@ public class CreateTableTypeHelper {
         };
     }
 
-    /// @return types that are supported by ORC
+    /**
+     * @return types that are supported by ORC
+     */
     static public int[] getORCTypes() {
         return new int[]{
                 Types.VARCHAR, Types.CHAR,
@@ -74,7 +89,10 @@ public class CreateTableTypeHelper {
         };
     }
 
-    /// @return types that are supported by Avro
+    /**
+     *
+     * @return types that are supported by Avro
+     */
     static public int[] getAvroTypes() {
         return new int[]{
                 Types.VARCHAR, Types.CHAR,
@@ -88,7 +106,12 @@ public class CreateTableTypeHelper {
         };
     }
 
-    /// @return supported types by fileFormat PARQUET, ORC or AVRO
+    ///
+
+    /**
+     * @param fileFormat "PARQUET", "ORC" or "AVRO"
+     * @return supported types by fileFormat PARQUET, ORC or AVRO
+     */
     static public int[] getTypes(String fileFormat) {
         if(fileFormat.equalsIgnoreCase("PARQUET"))
             return getParquetTypes();
@@ -99,7 +122,11 @@ public class CreateTableTypeHelper {
         throw new RuntimeException("unsupported fileformat " + fileFormat);
     }
 
-    /// compare that result in ResultSet rs is the same as from the generated insert values.
+    /**
+     * compare that result in ResultSet rs is the same as from the generated insert values.
+     * @param rs ResultSet from a select *.
+     * @throws SQLException
+     */
     public void checkResultSetSelectAll(ResultSet rs) throws SQLException {
         ArrayList<String> results = new ArrayList<>();
         int nCols = rs.getMetaData().getColumnCount();

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -73,7 +73,9 @@ public class ExternalTableIT extends SpliceUnitTest {
         deleteTempDirectory(tempDir);
     }
 
-    /// this will return the temp directory, that is created on demand once for each test
+    /**
+     * @return this will return the temp directory, that is created on demand once for each test
+     */
     public String getExternalResourceDirectory() throws Exception
     {
         return tempDir.toString() + "/";

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -1350,7 +1350,6 @@ public class ExternalTableIT extends SpliceUnitTest {
     @Test
     public void testWriteToWrongPartitionedParquetExternalTable() throws Exception {
         for( String fileFormat : fileFormats) {
-            try {
                 String name = "w_partitioned_" + fileFormat;
                 String tablePath = getExternalResourceDirectory() + name;
                 methodWatcher.executeUpdate(String.format("create external table " + name + " (col1 int, col2 varchar(24))" +
@@ -1358,16 +1357,8 @@ public class ExternalTableIT extends SpliceUnitTest {
                 methodWatcher.executeUpdate(String.format("insert into " + name + " values (1,'XXXX')," +
                         "(2,'YYYY')," +
                         "(3,'ZZZZ')"));
-                methodWatcher.executeUpdate(String.format("create external table " + name + "2 (col1 int, col2 varchar(24))" +
-                        "partitioned by (col2) STORED AS PARQUET LOCATION '%s'", getExternalResourceDirectory() + "w_partitioned_parquet"));
-                methodWatcher.executeUpdate(String.format("insert into " + name + "2 values (1,'XXXX')," +
-                        "(2,'YYYY')," +
-                        "(3,'ZZZZ')"));
-                Assert.fail("Exception not thrown");
-
-            } catch (Exception e) {
-
-            }
+                assureFails(String.format("create external table " + name + "2 (col1 int, col2 varchar(24))" +
+                        "partitioned by (col2) STORED AS " + fileFormat + " LOCATION '%s'", tablePath), "EXT24", "");
         }
     }
 

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -396,59 +396,6 @@ public class ExternalTableIT extends SpliceUnitTest {
         }
     }
 
-
-    @Test
-    public void testCannotUpdateExternalTable() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_MOLITOR";
-            methodWatcher.executeUpdate(String.format("create external table update_foo (col1 int, col2 varchar(24))" +
-                    " STORED AS PARQUET LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("update update_foo set col1 = 4");
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT05",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testCannotUpdateExternalTableAvro() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_AVRO";
-            methodWatcher.executeUpdate(String.format("create external table update_foo_avro (col1 int, col2 varchar(24))" +
-                    " STORED AS AVRO LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("update update_foo_avro set col1 = 4");
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT05",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testCannotDeleteExternalTable() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_MOLITOR";
-            methodWatcher.executeUpdate(String.format("create external table delete_foo (col1 int, col2 varchar(24))" +
-                    " STORED AS PARQUET LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("delete from delete_foo where col1 = 4");
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT05",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testCannotDeleteExternalTableAvro() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_AVRO";
-            methodWatcher.executeUpdate(String.format("create external table delete_foo_avro (col1 int, col2 varchar(24))" +
-                    " STORED AS AVRO LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("delete from delete_foo_avro where col1 = 4");
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT05",e.getSQLState());
-        }
-    }
-
     @Test
     public void testFileExistingNotDeleted() throws  Exception{
         String tablePath = getResourceDirectory()+"parquet_sample_one";
@@ -544,75 +491,73 @@ public class ExternalTableIT extends SpliceUnitTest {
         Assert.assertEquals(actual, expected, actual);
     }
 
+
+    String[] fileFormats = { "PARQUET", "ORC", "AVRO" };
+
+    void assureFails(String query, String exceptionType, String test) throws Exception {
+        try {
+            methodWatcher.executeUpdate(query);
+            Assert.fail(test + ": Exception not thrown");
+        } catch (SQLException e) {
+            Assert.assertEquals(test + ": Wrong Exception", exceptionType, e.getSQLState());
+        }
+    }
+
+    // tests that we can't UPDATE or DELETE values in external tables
+    // and correct exceptions are thrown
+    @Test
+    public void testCannotDeleteOrUpdateExternalTable() throws Exception {
+        for( String fileFormat : fileFormats) {
+            String name = "delete_foo" + fileFormat;
+            String tablePath = getExternalResourceDirectory() + "/" + name;
+            methodWatcher.executeUpdate(String.format("create external table " + name + " (col1 int, col2 varchar(24))" +
+                    " STORED AS " + fileFormat + " LOCATION '%s'", tablePath));
+
+            assureFails("delete from " + name + " where col1 = 4", "EXT05", "");
+            assureFails("update " + name + " set col1 = 4", "EXT05", "");
+        }
+    }
+
+    // tests we can create an external table in a empty directory
     @Test
     public void testEmptyDirectory() throws  Exception{
-        String tablePath = getExternalResourceDirectory()+"empty_directory";
-        new File(tablePath).mkdir();
+        for( String fileFormat : fileFormats) {
+            String tablePath = getExternalResourceDirectory() + "empty_directory" + fileFormat;
+            String name = "empty_directory" + fileFormat;
+            new File(tablePath).mkdir();
 
-        methodWatcher.executeUpdate(String.format("create external table empty_directory (col1 varchar(24), col2 varchar(24), col3 varchar(24))" +
-                " STORED AS PARQUET LOCATION '%s'",tablePath));
-    }
-
-    @Test
-    public void testEmptyDirectoryAvro() throws  Exception{
-        String tablePath = getExternalResourceDirectory()+"empty_directory_avro";
-        new File(tablePath).mkdir();
-
-        methodWatcher.executeUpdate(String.format("create external table empty_directory_avro (col1 varchar(24), col2 varchar(24), col3 varchar(24))" +
-                " STORED AS AVRO LOCATION '%s'",tablePath));
-    }
-
-    @Test
-    public void testLocationCannotBeAFileAvro() throws  Exception{
-        File temp = File.createTempFile("temp-file-avro", ".tmp", tempDir);
-        try {
-            methodWatcher.executeUpdate(String.format("create external table table_to_existing_file_avro_temp (col1 varchar(24), col2 varchar(24), col3 varchar(24))" +
-                    " STORED AS AVRO LOCATION '%s'", temp.getAbsolutePath()));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException ee) {
-            Assert.assertEquals("Wrong Exception","EXT33" ,ee.getSQLState());
+            methodWatcher.executeUpdate(String.format("create external table " + name +
+                    " (col1 varchar(24), col2 varchar(24), col3 varchar(24))" +
+                    " STORED AS " + fileFormat + " LOCATION '%s'", tablePath));
         }
     }
 
     @Test
     public void testLocationCannotBeAFile() throws  Exception{
         File temp = File.createTempFile("temp-file", ".tmp", tempDir);
-
-        try {
-            methodWatcher.executeUpdate(String.format("create external table table_to_existing_file (col1 varchar(24), col2 varchar(24), col3 varchar(24))" +
-                    " STORED AS PARQUET LOCATION '%s'",temp.getAbsolutePath()));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT33",e.getSQLState());
+        for( String fileFormat : fileFormats) {
+            assureFails(String.format("create external table table_to_existing_file " +
+                            "(col1 varchar(24), col2 varchar(24), col3 varchar(24))" +
+                            " STORED AS " + fileFormat + " LOCATION '%s'", temp.getAbsolutePath()),
+                    "EXT33", "");
         }
+        temp.delete();
     }
 
     @Test
     public void refreshRequireExternalTable() throws  Exception{
-        String tablePath = getExternalResourceDirectory()+"external_table_refresh";
+        for( String fileFormat : fileFormats) {
+            String name = "XT_REFRESH_" + fileFormat;
+            String tablePath = getExternalResourceDirectory() + name;
 
-        methodWatcher.executeUpdate(String.format("create external table external_table_refresh (col1 int, col2 varchar(24))" +
-                " STORED AS PARQUET LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate(String.format("create external table " + name + " (col1 int, col2 varchar(24))" +
+                    " STORED AS " + fileFormat + " LOCATION '%s'", tablePath));
 
-        PreparedStatement ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.SYSCS_REFRESH_EXTERNAL_TABLE(?,?) ");
-        ps.setString(1, "EXTERNALTABLEIT");
-        ps.setString(2, "EXTERNAL_TABLE_REFRESH");
-        ps.execute();
-
-    }
-
-    @Test
-    public void refreshRequireExternalTableAvro() throws  Exception{
-        String tablePath = getExternalResourceDirectory()+"external_table_refresh_avro";
-
-        methodWatcher.executeUpdate(String.format("create external table external_table_refresh_avro (col1 int, col2 varchar(24))" +
-                " STORED AS AVRO LOCATION '%s'",tablePath));
-
-        PreparedStatement ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.SYSCS_REFRESH_EXTERNAL_TABLE(?,?) ");
-        ps.setString(1, "EXTERNALTABLEIT");
-        ps.setString(2, "EXTERNAL_TABLE_REFRESH_AVRO");
-        ps.execute();
-
+            PreparedStatement ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.SYSCS_REFRESH_EXTERNAL_TABLE(?,?) ");
+            ps.setString(1, "EXTERNALTABLEIT");
+            ps.setString(2, name);
+            ps.execute();
+        }
     }
 
     @Test
@@ -628,7 +573,6 @@ public class ExternalTableIT extends SpliceUnitTest {
         } catch (SQLException e) {
             Assert.assertEquals("Wrong Exception","42X05",e.getSQLState());
         }
-
     }
 
     //SPLICE-1387

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -1601,80 +1601,22 @@ public class ExternalTableIT extends SpliceUnitTest {
                 " 12  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
     }
 
-
     @Test
-    public void testCannotAlterExternalTable() throws Exception {
-        try {
+    public void testModifyExtTableFails() throws Exception {
+        for( String fileFormat : fileFormats) {
             String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_MOLITOR";
-            methodWatcher.executeUpdate(String.format("create external table alter_foo (col1 int, col2 varchar(24))" +
+            String name = "ALTER_TABLE_" + fileFormat;
+            methodWatcher.executeUpdate(String.format("create external table " + name + " (col1 int, col2 varchar(24))" +
                     " STORED AS PARQUET LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("alter table alter_foo add column col3 int");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT12",e.getSQLState());
+            assureFails("alter table " + name + " add column col3 int", "EXT12",
+                    fileFormat + ": cannotAlterExternalTable");
+            assureFails("create index add_index_foo_ix on " + name + " (col2)", "EXT13",
+                    fileFormat + ": cannotAddIndexToExternalTable");
+
+            verifyTriggerCreateFails(tb.on(name).named("trig").before().delete().row().then("select * from sys.systables"),
+                    "Cannot add triggers to external table '" + name + "'.");
         }
     }
-
-    @Test
-    public void testCannotAlterExternalTableAvro() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_AVRO";
-            methodWatcher.executeUpdate(String.format("create external table alter_foo_avro (col1 int, col2 varchar(24))" +
-                    " STORED AS AVRO LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("alter table alter_foo_avro add column col3 int");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT12",e.getSQLState());
-        }
-    }
-
-
-    @Test
-    public void testCannotAddIndexToExternalTable() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_MOLITOR";
-            methodWatcher.executeUpdate(String.format("create external table add_index_foo (col1 int, col2 varchar(24))" +
-                    " STORED AS PARQUET LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("create index add_index_foo_ix on add_index_foo (col2)");
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT13",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testCannotAddIndexToExternalTableAvro() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_AVRO";
-            methodWatcher.executeUpdate(String.format("create external table add_index_foo_avro (col1 int, col2 varchar(24))" +
-                    " STORED AS AVRO LOCATION '%s'",tablePath));
-            methodWatcher.executeUpdate("create index add_index_foo_ix on add_index_foo_avro (col2)");
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT13",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testCannotAddTriggerToExternalTable() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_MOLITOR";
-        methodWatcher.executeUpdate(String.format("create external table add_trigger_foo (col1 int, col2 varchar(24))" +
-                " STORED AS PARQUET LOCATION '%s'",tablePath));
-
-        verifyTriggerCreateFails(tb.on("add_trigger_foo").named("trig").before().delete().row().then("select * from sys.systables"),
-                "Cannot add triggers to external table 'ADD_TRIGGER_FOO'.");
-    }
-
-    @Test
-    public void testCannotAddTriggerToExternalTableAvro() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_AVRO";
-        methodWatcher.executeUpdate(String.format("create external table add_trigger_foo_avro (col1 int, col2 varchar(24))" +
-                " STORED AS AVRO LOCATION '%s'",tablePath));
-
-        verifyTriggerCreateFails(tb.on("add_trigger_foo_avro").named("trig").before().delete().row().then("select * from sys.systables"),
-                "Cannot add triggers to external table 'ADD_TRIGGER_FOO_AVRO'.");
-    }
-
-
-
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     //

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -1748,299 +1748,109 @@ public class ExternalTableIT extends SpliceUnitTest {
 
     @Test
     public void testCollectStats() throws Exception {
-        methodWatcher.executeUpdate(String.format("create external table t1_orc (col1 int, col2 char(24))" +
-                " STORED AS ORC LOCATION '%s'", getExternalResourceDirectory()+"t1_orc_test"));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into t1_orc values (1,'XXXX')," +
-                "(2,'YYYY')," +
-                "(3,'ZZZZ')"));
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
-        ResultSet rs = methodWatcher.executeQuery("select * from t1_orc");
-        Assert.assertEquals("COL1 |COL2 |\n" +
-                "------------\n" +
-                "  1  |XXXX |\n" +
-                "  2  |YYYY |\n" +
-                "  3  |ZZZZ |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        rs.close();
+        for( String fileFormat : new String[]{"ORC", "PARQUET", "AVRO", "TEXTFILE"}) {
+            String name = "TEST_COLLECT_STATS_" + fileFormat;
+            String filename = getExternalResourceDirectory() + name;
+            methodWatcher.executeUpdate(String.format("create external table " + name + " (col1 int, col2 char(24))" +
+                    " STORED AS ORC LOCATION '%s'", filename));
+            int insertCount = methodWatcher.executeUpdate(String.format("insert into " + name + " values (1,'XXXX')," +
+                    "(2,'YYYY')," +
+                    "(3,'ZZZZ')"));
+            Assert.assertEquals("insertCount is wrong",3,insertCount);
+            ResultSet rs = methodWatcher.executeQuery("select * from " + name);
+            Assert.assertEquals("COL1 |COL2 |\n" +
+                    "------------\n" +
+                    "  1  |XXXX |\n" +
+                    "  2  |YYYY |\n" +
+                    "  3  |ZZZZ |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            rs.close();
 
-        // collect table level stats
-        PreparedStatement ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.COLLECT_TABLE_STATISTICS(?,?,?) ");
-        ps.setString(1, "EXTERNALTABLEIT");
-        ps.setString(2, "T1_ORC");
-        ps.setBoolean(3, true);
-        rs = ps.executeQuery();
-        rs.next();
-        Assert.assertEquals("Error with COLLECT_TABLE_STATISTICS for external table","EXTERNALTABLEIT",  rs.getString(1));
-        rs.close();
+            // collect table level stats
+            PreparedStatement ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.COLLECT_TABLE_STATISTICS(?,?,?) ");
+            ps.setString(1, "EXTERNALTABLEIT");
+            ps.setString(2, name);
+            ps.setBoolean(3, true);
+            rs = ps.executeQuery();
+            rs.next();
+            Assert.assertEquals("Error with COLLECT_TABLE_STATISTICS for external table","EXTERNALTABLEIT",  rs.getString(1));
+            rs.close();
 
-        ResultSet rs2 = methodWatcher.executeQuery("select total_row_count from sysvw.systablestatistics where schemaname = 'EXTERNALTABLEIT' and tablename = 'T1_ORC'");
-        String expected = "TOTAL_ROW_COUNT |\n" +
-                "------------------\n" +
-                "        3        |";
-        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        rs2.close();
+            ResultSet rs2 = methodWatcher.executeQuery("select total_row_count from sysvw.systablestatistics where " +
+                    "schemaname = 'EXTERNALTABLEIT' and tablename = '" + name + "'");
+            String expected = "TOTAL_ROW_COUNT |\n" +
+                    "------------------\n" +
+                    "        3        |";
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            rs2.close();
 
-        // drop stats using table
-        spliceClassWatcher.executeUpdate("CALL  SYSCS_UTIL.DROP_TABLE_STATISTICS ('EXTERNALTABLEIT', 'T1_ORC')");
+            // drop stats using table
+            spliceClassWatcher.executeUpdate("CALL  SYSCS_UTIL.DROP_TABLE_STATISTICS ('EXTERNALTABLEIT', '" + name + "')");
 
-        // make sure it is clean
-        rs2 = methodWatcher.executeQuery("select total_row_count from sysvw.systablestatistics where schemaname = 'EXTERNALTABLEIT' and tablename = 'T1_ORC' ");
-        Assert.assertEquals("", TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        rs2.close();
+            // make sure it is clean
+            rs2 = methodWatcher.executeQuery("select total_row_count from sysvw.systablestatistics where " +
+                    "schemaname = 'EXTERNALTABLEIT' and tablename = '" + name + "' ");
+            Assert.assertEquals("", TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            rs2.close();
 
-        // Now, collect schema level stats
-        ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.COLLECT_SCHEMA_STATISTICS(?,?) ");
-        ps.setString(1, "EXTERNALTABLEIT");
-        ps.setBoolean(2, false);
-        rs = ps.executeQuery();
-        rs.next();
-        Assert.assertEquals("Error with COLLECT_SCHEMA_STATISTICS for external table","EXTERNALTABLEIT",  rs.getString(1));
-        rs.close();
+            // Now, collect schema level stats
+            ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.COLLECT_SCHEMA_STATISTICS(?,?) ");
+            ps.setString(1, "EXTERNALTABLEIT");
+            ps.setBoolean(2, false);
+            rs = ps.executeQuery();
+            rs.next();
+            Assert.assertEquals("Error with COLLECT_SCHEMA_STATISTICS for external table","EXTERNALTABLEIT",  rs.getString(1));
+            rs.close();
 
-        // check the stats again
-        rs2 = methodWatcher.executeQuery("select total_row_count from sysvw.systablestatistics where schemaname = 'EXTERNALTABLEIT' and tablename = 'T1_ORC' ");
-        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        rs2.close();
+            // check the stats again
+            rs2 = methodWatcher.executeQuery("select total_row_count from sysvw.systablestatistics where " +
+                    "schemaname = 'EXTERNALTABLEIT' and tablename = '" + name + "' ");
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            rs2.close();
 
-        // drop stats using schema
-        spliceClassWatcher.executeUpdate("CALL  SYSCS_UTIL.DROP_SCHEMA_STATISTICS ('EXTERNALTABLEIT')");
+            // drop stats using schema
+            spliceClassWatcher.executeUpdate("CALL  SYSCS_UTIL.DROP_SCHEMA_STATISTICS ('EXTERNALTABLEIT')");
 
-        // make sure it is clean
-        rs2 = methodWatcher.executeQuery("select total_row_count from sysvw.systablestatistics where schemaname = 'EXTERNALTABLEIT' ");
-        Assert.assertEquals("", TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        rs2.close();
+            // make sure it is clean
+            rs2 = methodWatcher.executeQuery("select total_row_count from sysvw.systablestatistics where schemaname = 'EXTERNALTABLEIT' ");
+            Assert.assertEquals("", TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            rs2.close();
+        }
     }
 
     @Test
-     public void testCollectStatsText() throws Exception {
-        methodWatcher.executeUpdate(String.format("create external table t1_csv (col1 int, col2 char(24))" +
-                " STORED AS TEXTFILE LOCATION '%s'", getExternalResourceDirectory()+"t1_csv_test"));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into t1_csv values (1,'XXXX')," +
-                "(2,'YYYY')," +
-                "(3,'ZZZZ')"));
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
+    public void testWriteReadArrays() throws Exception {
+        for( String fileFormat : fileFormats) {
+            String name = "TEST_ARRAY_" + fileFormat;
+            String tablePath = getExternalResourceDirectory() + name;
+            methodWatcher.executeUpdate(String.format("create external table " + name + " (col1 int array, col2 varchar(24))" +
+                    " STORED AS PARQUET LOCATION '%s'", tablePath));
+            int insertCount = methodWatcher.executeUpdate(String.format("insert into " + name + " values ([1,1,1],'XXXX')," +
+                    "([2,2,2],'YYYY')," +
+                    "([3,3,3],'ZZZZ')"));
+            Assert.assertEquals("insertCount is wrong", 3, insertCount);
 
-        ResultSet rs;
-        // collect table level stats
-        PreparedStatement ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.COLLECT_TABLE_STATISTICS(?,?,?) ");
-        ps.setString(1, "EXTERNALTABLEIT");
-        ps.setString(2, "T1_CSV");
-        ps.setBoolean(3, true);
-        rs = ps.executeQuery();
-        rs.next();
-        Assert.assertEquals("Error with COLLECT_TABLE_STATISTICS for external table","EXTERNALTABLEIT",  rs.getString(1));
-        rs.close();
+            // execute the following once without and once with analyze table
+            for( int i=0; i<2; i++) {
+                if( i == 1 )
+                    methodWatcher.executeQuery("analyze table " + name);
 
-        ResultSet rs2 = methodWatcher.executeQuery("select total_row_count from sysvw.systablestatistics where schemaname = 'EXTERNALTABLEIT' and tablename = 'T1_CSV'");
-        String expected = "TOTAL_ROW_COUNT |\n" +
-                "------------------\n" +
-                "        3        |";
-        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        rs2.close();
-    }
+                ResultSet rs = methodWatcher.executeQuery("select * from " + name);
+                Assert.assertEquals("COL1    |COL2 |\n" +
+                        "-----------------\n" +
+                        "[1, 1, 1] |XXXX |\n" +
+                        "[2, 2, 2] |YYYY |\n" +
+                        "[3, 3, 3] |ZZZZ |", TestUtils.FormattedResult.ResultFactory.toString(rs));
+                ResultSet rs2 = methodWatcher.executeQuery("select distinct col1 from " + name);
+                Assert.assertEquals("COL1    |\n" +
+                        "-----------\n" +
+                        "[1, 1, 1] |\n" +
+                        "[2, 2, 2] |\n" +
+                        "[3, 3, 3] |", TestUtils.FormattedResult.ResultFactory.toString(rs2));
 
-    @Test
-    public void testCollectStatsParquet() throws Exception {
-        methodWatcher.executeUpdate(String.format("create external table t1_parq (col1 int, col2 char(24))" +
-                " STORED AS PARQUET LOCATION '%s'", getExternalResourceDirectory()+"t1_parq_test"));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into t1_parq values (1,'XXXX')," +
-                "(2,'YYYY')," +
-                "(3,'ZZZZ')"));
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
-
-        ResultSet rs;
-        // collect table level stats
-        PreparedStatement ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.COLLECT_TABLE_STATISTICS(?,?,?) ");
-        ps.setString(1, "EXTERNALTABLEIT");
-        ps.setString(2, "T1_PARQ");
-        ps.setBoolean(3, true);
-        rs = ps.executeQuery();
-        rs.next();
-        Assert.assertEquals("Error with COLLECT_TABLE_STATISTICS for external table","EXTERNALTABLEIT",  rs.getString(1));
-        rs.close();
-
-        ResultSet rs2 = methodWatcher.executeQuery("select total_row_count from sysvw.systablestatistics where schemaname = 'EXTERNALTABLEIT' and tablename = 'T1_PARQ'");
-        String expected = "TOTAL_ROW_COUNT |\n" +
-                "------------------\n" +
-                "        3        |";
-        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        rs2.close();
-    }
-
-    @Test
-    public void testCollectStatsAvro() throws Exception {
-        methodWatcher.executeUpdate(String.format("create external table t1_avro (col1 int, col2 char(24))" +
-                " STORED AS AVRO LOCATION '%s'", getExternalResourceDirectory()+"t1_avro_test"));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into t1_avro values (1,'XXXX')," +
-                "(2,'YYYY')," +
-                "(3,'ZZZZ')"));
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
-
-        ResultSet rs;
-        // collect table level stats
-        PreparedStatement ps = spliceClassWatcher.prepareCall("CALL  SYSCS_UTIL.COLLECT_TABLE_STATISTICS(?,?,?) ");
-        ps.setString(1, "EXTERNALTABLEIT");
-        ps.setString(2, "T1_AVRO");
-        ps.setBoolean(3, true);
-        rs = ps.executeQuery();
-        rs.next();
-        Assert.assertEquals("Error with COLLECT_TABLE_STATISTICS for external table","EXTERNALTABLEIT",  rs.getString(1));
-        rs.close();
-
-        ResultSet rs2 = methodWatcher.executeQuery("select total_row_count from sysvw.systablestatistics where schemaname = 'EXTERNALTABLEIT' and tablename = 'T1_AVRO'");
-        String expected = "TOTAL_ROW_COUNT |\n" +
-                "------------------\n" +
-                "        3        |";
-        Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        rs2.close();
-
-        ResultSet rs3 = methodWatcher.executeQuery("select * from t1_avro");
-        Assert.assertEquals("COL1 |COL2 |\n" +
-                "------------\n" +
-                "  1  |XXXX |\n" +
-                "  2  |YYYY |\n" +
-                "  3  |ZZZZ |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        rs3.close();
-    }
-
-    @Test
-    public void testWriteReadArraysParquet() throws Exception {
-
-        String tablePath = getExternalResourceDirectory()+"parquet_array";
-        methodWatcher.executeUpdate(String.format("create external table parquet_array (col1 int array, col2 varchar(24))" +
-                " STORED AS PARQUET LOCATION '%s'",tablePath));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into parquet_array values ([1,1,1],'XXXX')," +
-                "([2,2,2],'YYYY')," +
-                "([3,3,3],'ZZZZ')"));
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
-        ResultSet rs = methodWatcher.executeQuery("select * from parquet_array");
-        Assert.assertEquals("COL1    |COL2 |\n" +
-                "-----------------\n" +
-                "[1, 1, 1] |XXXX |\n" +
-                "[2, 2, 2] |YYYY |\n" +
-                "[3, 3, 3] |ZZZZ |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select distinct col1 from parquet_array");
-        Assert.assertEquals("COL1    |\n" +
-                "-----------\n" +
-                "[1, 1, 1] |\n" +
-                "[2, 2, 2] |\n" +
-                "[3, 3, 3] |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-
-        //Make sure empty file is created
-        Assert.assertTrue(String.format("Table %s hasn't been created",tablePath), new File(tablePath).exists());
-    }
-
-    @Test
-    public void testWriteReadArraysAvro() throws Exception {
-
-        String tablePath = getExternalResourceDirectory()+"avro_array";
-        methodWatcher.executeUpdate(String.format("create external table avro_array (col1 int array, col2 varchar(24))" +
-                " STORED AS AVRO LOCATION '%s'",tablePath));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into avro_array values ([1,1,1],'XXXX')," +
-                "([2,2,2],'YYYY')," +
-                "([3,3,3],'ZZZZ')"));
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
-        ResultSet rs = methodWatcher.executeQuery("select * from avro_array");
-        Assert.assertEquals("COL1    |COL2 |\n" +
-                "-----------------\n" +
-                "[1, 1, 1] |XXXX |\n" +
-                "[2, 2, 2] |YYYY |\n" +
-                "[3, 3, 3] |ZZZZ |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select distinct col1 from avro_array");
-        Assert.assertEquals("COL1    |\n" +
-                "-----------\n" +
-                "[1, 1, 1] |\n" +
-                "[2, 2, 2] |\n" +
-                "[3, 3, 3] |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-
-        //Make sure empty file is created
-        Assert.assertTrue(String.format("Table %s hasn't been created",tablePath), new File(tablePath).exists());
-    }
-
-    @Test
-    public void testWriteReadArraysWithStatsParquet() throws Exception {
-
-        String tablePath = getExternalResourceDirectory()+"parquet_array_stats";
-        methodWatcher.executeUpdate(String.format("create external table parquet_array_stats (col1 int array, col2 varchar(24))" +
-                " STORED AS PARQUET LOCATION '%s'",tablePath));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into parquet_array_stats values ([1,1,1],'XXXX')," +
-                "([2,2,2],'YYYY')," +
-                "([3,3,3],'ZZZZ')"));
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
-        methodWatcher.executeQuery("analyze table parquet_array_stats");
-
-        ResultSet rs = methodWatcher.executeQuery("select * from parquet_array_stats");
-        Assert.assertEquals("COL1    |COL2 |\n" +
-                "-----------------\n" +
-                "[1, 1, 1] |XXXX |\n" +
-                "[2, 2, 2] |YYYY |\n" +
-                "[3, 3, 3] |ZZZZ |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select distinct col1 from parquet_array_stats");
-        Assert.assertEquals("COL1    |\n" +
-                "-----------\n" +
-                "[1, 1, 1] |\n" +
-                "[2, 2, 2] |\n" +
-                "[3, 3, 3] |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-
-        //Make sure empty file is created
-        Assert.assertTrue(String.format("Table %s hasn't been created",tablePath), new File(tablePath).exists());
-    }
-
-    @Test
-    public void testWriteReadArraysWithStatsAvro() throws Exception {
-
-        String tablePath = getExternalResourceDirectory()+"avro_array_stats";
-        methodWatcher.executeUpdate(String.format("create external table avro_array_stats (col1 int array, col2 varchar(24))" +
-                " STORED AS AVRO LOCATION '%s'",tablePath));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into avro_array_stats values ([1,1,1],'XXXX')," +
-                "([2,2,2],'YYYY')," +
-                "([3,3,3],'ZZZZ')"));
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
-        methodWatcher.executeQuery("analyze table avro_array_stats");
-
-        ResultSet rs = methodWatcher.executeQuery("select * from avro_array_stats");
-        Assert.assertEquals("COL1    |COL2 |\n" +
-                "-----------------\n" +
-                "[1, 1, 1] |XXXX |\n" +
-                "[2, 2, 2] |YYYY |\n" +
-                "[3, 3, 3] |ZZZZ |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select distinct col1 from avro_array_stats");
-        Assert.assertEquals("COL1    |\n" +
-                "-----------\n" +
-                "[1, 1, 1] |\n" +
-                "[2, 2, 2] |\n" +
-                "[3, 3, 3] |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-
-        //Make sure empty file is created
-        Assert.assertTrue(String.format("Table %s hasn't been created",tablePath), new File(tablePath).exists());
-    }
-
-
-    @Test
-    public void testWriteReadArraysORC() throws Exception {
-
-        String tablePath = getExternalResourceDirectory()+"orc_array";
-        methodWatcher.executeUpdate(String.format("create external table orc_array (col1 int array, col2 varchar(24))" +
-                " STORED AS ORC LOCATION '%s'",tablePath));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into orc_array values ([1,1,1],'XXXX')," +
-                "([2,2,2],'YYYY')," +
-                "([3,3,3],'ZZZZ')"));
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
-        ResultSet rs = methodWatcher.executeQuery("select * from orc_array");
-        Assert.assertEquals("COL1    |COL2 |\n" +
-                "-----------------\n" +
-                "[1, 1, 1] |XXXX |\n" +
-                "[2, 2, 2] |YYYY |\n" +
-                "[3, 3, 3] |ZZZZ |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select distinct col1 from orc_array");
-        Assert.assertEquals("COL1    |\n" +
-                "-----------\n" +
-                "[1, 1, 1] |\n" +
-                "[2, 2, 2] |\n" +
-                "[3, 3, 3] |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-
-        //Make sure empty file is created
-        Assert.assertTrue(String.format("Table %s hasn't been created",tablePath), new File(tablePath).exists());
-
+                //Make sure empty file is created
+                Assert.assertTrue(String.format("Table %s hasn't been created", tablePath), new File(tablePath).exists());
+            }
+        }
     }
 
 

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
@@ -69,45 +69,6 @@ public class ExternalTablePartitionIT extends SpliceUnitTest {
     }
 
     @Test
-    public void testParquetPartitionFirst() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/parquet_partition_first";
-        methodWatcher.executeUpdate(String.format("create external table parquet_part_1st (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col1) STORED AS PARQUET LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into parquet_part_1st values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_1st");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_1st");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_1st");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_1st");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_1st");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-
-    @Test
     public void testSparkGeneratesFewParquetFiles() throws Exception {
         testSparkGeneratesFewFiles("parquet");
     }
@@ -150,1211 +111,244 @@ public class ExternalTablePartitionIT extends SpliceUnitTest {
         assertEquals(11, getNumberOfFiles(tablePath));
     }
 
+    String[] fileFormatsText = { "PARQUET", "ORC", "AVRO", "TEXTFILE" };
 
-    @Test
-    public void testAvroPartitionFirst() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/avro_partition_first";
-        methodWatcher.executeUpdate(String.format("create external table avro_part_1st (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col1) STORED AS AVRO LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into avro_part_1st values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from avro_part_1st");
+    private void checkPartitionInsertSelect(String testName, String fileFormat, String partitionedBy) throws Exception {
+        String name = testName + "_" + fileFormat;
+        String tablePath = getExternalResourceDirectory() + "/" + name;
+        methodWatcher.executeUpdate(String.format("create external table " + name + " (col1 int, col2 int, col3 varchar(10)) " +
+                "partitioned by (" + partitionedBy + ") STORED AS " + fileFormat + " LOCATION '%s'", tablePath));
+
+        methodWatcher.executeUpdate("insert into " + name  + " values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+
+        ResultSet rs = methodWatcher.executeQuery("select * from " + name );
         assertEquals("COL1 |COL2 |COL3 |\n" +
                 "------------------\n" +
                 "  1  |  2  | AAA |\n" +
                 "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_1st");
+                "  5  |  6  | CCC |", TestUtils.FormattedResult.ResultFactory.toString(rs));
+        ResultSet rs1 = methodWatcher.executeQuery("select col1 from " + name );
         assertEquals("COL1 |\n" +
                 "------\n" +
                 "  1  |\n" +
                 "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_1st");
+                "  5  |", TestUtils.FormattedResult.ResultFactory.toString(rs1));
+        ResultSet rs2 = methodWatcher.executeQuery("select col2 from " + name );
         assertEquals("COL2 |\n" +
                 "------\n" +
                 "  2  |\n" +
                 "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_1st");
+                "  6  |", TestUtils.FormattedResult.ResultFactory.toString(rs2));
+        ResultSet rs3 = methodWatcher.executeQuery("select col3 from " + name );
         assertEquals("COL3 |\n" +
                 "------\n" +
                 " AAA |\n" +
                 " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_1st");
+                " CCC |", TestUtils.FormattedResult.ResultFactory.toString(rs3));
+        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from " + name );
         assertEquals("COL2 |COL3 |\n" +
                 "------------\n" +
                 "  2  | AAA |\n" +
                 "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-    @Test
-    public void testOrcPartitionFirst() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/orc_partition_first";
-        methodWatcher.executeUpdate(String.format("create external table orc_part_1st (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col1) STORED AS ORC LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into orc_part_1st values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from orc_part_1st");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_1st");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_1st");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_1st");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_1st");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+                "  6  | CCC |", TestUtils.FormattedResult.ResultFactory.toString(rs4));
 
         /* test query with predicates */
-        ResultSet rs5 = methodWatcher.executeQuery("select * from orc_part_1st where col1=3");
+        ResultSet rs5 = methodWatcher.executeQuery("select * from " + name  + " where col1=3");
         assertEquals("COL1 |COL2 |COL3 |\n" +
                 "------------------\n" +
                 "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs5));
 
         /* test query with predicate on partitioning column and non-partitioning column */
-        ResultSet rs51 = methodWatcher.executeQuery("select * from orc_part_1st where col1>=3 and col1<4 and col3='BBB'");
+        ResultSet rs51 = methodWatcher.executeQuery("select * from " + name  + " where col1>=3 and col1<4 and col3='BBB'");
         assertEquals("COL1 |COL2 |COL3 |\n" +
                 "------------------\n" +
                 "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs51));
 
 
-        ResultSet rs6 = methodWatcher.executeQuery("select * from orc_part_1st where col2=4");
+        ResultSet rs6 = methodWatcher.executeQuery("select * from " + name  + " where col2=4");
         assertEquals("COL1 |COL2 |COL3 |\n" +
                 "------------------\n" +
                 "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs6));
 
-        ResultSet rs7 = methodWatcher.executeQuery("select * from orc_part_1st where col3='CCC'");
+        ResultSet rs7 = methodWatcher.executeQuery("select * from " + name  + " where col3='CCC'");
         assertEquals("COL1 |COL2 |COL3 |\n" +
                 "------------------\n" +
                 "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs7));
+
+
+        ResultSet rs8 = methodWatcher.executeQuery("select * from " + name + " where col3='AAA'");
+        assertEquals("COL1 |COL2 |COL3 |\n" +
+                "------------------\n" +
+                "  1  |  2  | AAA |", TestUtils.FormattedResult.ResultFactory.toString(rs8));
     }
 
     @Test
-    public void testTextfilePartitionFirst() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/textfile_partition_first";
-        methodWatcher.executeUpdate(String.format("create external table textfile_part_1st (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col1) STORED AS TEXTFILE LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into textfile_part_1st values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_1st");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_1st");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_1st");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_1st");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_1st");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+    public void testPartitionFirst() throws Exception {
+        for( String fileFormat : fileFormatsText) {
+            checkPartitionInsertSelect( "partition_first", fileFormat, "col1");
+        }
     }
 
     @Test
-    public void testParquetPartitionFirstSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/parquet_partition_first_second";
-        methodWatcher.executeUpdate(String.format("create external table parquet_part_1st_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col1,col2) STORED AS PARQUET LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into parquet_part_1st_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_1st_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_1st_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_1st_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_1st_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_1st_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+    public void testPartitionFirstSecond() throws Exception {
+        for( String fileFormat : fileFormatsText) {
+            checkPartitionInsertSelect( "partition_first_second", fileFormat, "col1, col2");
+        }
     }
 
     @Test
-    public void testAvroPartitionFirstSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/avro_partition_first_second";
-        methodWatcher.executeUpdate(String.format("create external table avro_part_1st_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col1,col2) STORED AS AVRO LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into avro_part_1st_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from avro_part_1st_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_1st_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_1st_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_1st_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_1st_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+    public void testPartitionSecond() throws Exception {
+        for( String fileFormat : fileFormatsText) {
+            checkPartitionInsertSelect( "partition_second", fileFormat, "col2");
+        }
     }
 
     @Test
-    public void testOrcPartitionFirstSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/orc_partition_first_second";
-        methodWatcher.executeUpdate(String.format("create external table orc_part_1st_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col1,col2) STORED AS ORC LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into orc_part_1st_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from orc_part_1st_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_1st_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_1st_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_1st_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_1st_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-
-        // test query with predicate
-        ResultSet rs5 = methodWatcher.executeQuery("select * from orc_part_1st_2nd where col1=3");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs5));
-
-        ResultSet rs6 = methodWatcher.executeQuery("select * from orc_part_1st_2nd where col2=4");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs6));
-
-        ResultSet rs7 = methodWatcher.executeQuery("select * from orc_part_1st_2nd where col3='AAA'");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |",TestUtils.FormattedResult.ResultFactory.toString(rs7));
+    public void testPartitionLast() throws Exception {
+        for (String fileFormat : fileFormatsText) {
+            checkPartitionInsertSelect( "partition_last", fileFormat, "col3");
+        }
     }
 
     @Test
-    public void testTextfilePartitionFirstSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/textfile_partition_first_second";
-        methodWatcher.executeUpdate(String.format("create external table textfile_part_1st_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col1,col2) STORED AS TEXTFILE LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into textfile_part_1st_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_1st_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_1st_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_1st_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_1st_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_1st_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+    public void testPartitionThirdSecond() throws Exception {
+        for (String fileFormat : fileFormatsText) {
+            checkPartitionInsertSelect( "partition_third_second", fileFormat, "col3, col2");
+        }
     }
 
     @Test
-    public void testParquetPartitionSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/parquet_partition_second";
-        methodWatcher.executeUpdate(String.format("create external table parquet_part_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col2) STORED AS PARQUET LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into parquet_part_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+    public void testAggressive() throws Exception {
+        for (String fileFormat : fileFormatsText) {
+            String name = "orc_aggressive_" + fileFormat;
+            String tablePath = getExternalResourceDirectory() + "/" + name;
+            methodWatcher.executeUpdate(String.format("create external table " + name +
+                    " (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char) " +
+                    "partitioned by (col4, col6, col2) STORED AS " + fileFormat + " LOCATION '%s'", tablePath));
+            methodWatcher.executeUpdate("insert into " + name + " values " +
+                    "(111,'AAA',true,111, 1.1, 'a'),(222,'BBB',false,222, 2.2, 'b'),(333,'CCC',true,333, 3.3, 'c')");
+            ResultSet rs = methodWatcher.executeQuery("select * from " + name );
+            assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
+                    "-------------------------------------\n" +
+                    " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
+                    " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
+                    " 333 | CCC |true  | 333 | 3.3 |  c  |", TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from " + name);
+            assertEquals("COL5 |COL2 |COL6 |\n" +
+                    "------------------\n" +
+                    " 1.1 | AAA |  a  |\n" +
+                    " 2.2 | BBB |  b  |\n" +
+                    " 3.3 | CCC |  c  |", TestUtils.FormattedResult.ResultFactory.toString(rs2));
+        }
     }
 
     @Test
-    public void testAvroPartitionSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/avro_partition_second";
-        methodWatcher.executeUpdate(String.format("create external table avro_part_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col2) STORED AS AVRO LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into avro_part_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from avro_part_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
+    public void testAggressive2() throws Exception{
+        for (String format : fileFormatsText) {
+            String tablePath0 = String.format(getExternalResourceDirectory() + "/%s_aggressive_2_0", format);
+            String tablePath1 = String.format(getExternalResourceDirectory() + "/%s_aggressive_2_1", format);
+            String tablePath2 = String.format(getExternalResourceDirectory() + "/%s_aggressive_2_2", format);
 
+            methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_0 " +
+                    "(col1 varchar(10), col2 double, col3 int, col4 varchar(10), col5 int) " +
+                    "partitioned by (col1, col2, col4, col5) stored as %s location '%s'", format, format, tablePath0));
+            methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_0 values " +
+                    "('whoa',77.7,444,'crazy',21),('hey',11.11,222,'crazier',10)", format));
+            ResultSet rs0 = methodWatcher.executeQuery(String.format("select col4, col2, col3 from %s_aggressive_2_0 where col5 = 21", format));
+            assertEquals("COL4  |COL2 |COL3 |\n" +
+                    "-------------------\n" +
+                    "crazy |77.7 | 444 |", TestUtils.FormattedResult.ResultFactory.toString(rs0));
 
-    @Test
-    public void testOrcPartitionSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/orc_partition_second";
-        methodWatcher.executeUpdate(String.format("create external table orc_part_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col2) STORED AS ORC LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into orc_part_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from orc_part_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+            methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_1 " +
+                    "(col1 int, col2 double, col3 char, col4 varchar(10), col5 int) " +
+                    "partitioned by (col3, col1, col2) stored as %s location '%s'", format, format, tablePath1));
+            methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_1 values " +
+                    "(666,66.666,'z','zing',20),(555,55.555,'y','yowza',40),(1,1.1,'g','garish',7)", format));
+            ResultSet rs1 = methodWatcher.executeQuery(String.format("select col2,col4 from %s_aggressive_2_1", format));
+            assertEquals("COL2  | COL4  |\n" +
+                    "----------------\n" +
+                    "  1.1  |garish |\n" +
+                    "55.555 | yowza |\n" +
+                    "66.666 | zing  |", TestUtils.FormattedResult.ResultFactory.toString(rs1));
 
-        // test query with predicates
-        ResultSet rs5 = methodWatcher.executeQuery("select * from orc_part_2nd where col1=3");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs5));
-        ResultSet rs6 = methodWatcher.executeQuery("select * from orc_part_2nd where col2=4");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs6));
-        ResultSet rs7 = methodWatcher.executeQuery("select * from orc_part_2nd where col3='CCC'");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs7));
-    }
-
-
-    @Test
-    public void testTextfilePartitionSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/textfile_partition_second_";
-        methodWatcher.executeUpdate(String.format("create external table textfile_part_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col2) STORED AS TEXTFILE LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into textfile_part_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-    @Test
-    public void testParquetPartitionLast() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/parquet_partition_last";
-        methodWatcher.executeUpdate(String.format("create external table parquet_part_last (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col3) STORED AS PARQUET LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into parquet_part_last values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_last");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_last");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_last");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_last");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_last");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-
-    @Test
-    public void testAvroPartitionLast() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/avro_partition_last";
-        methodWatcher.executeUpdate(String.format("create external table avro_part_last (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col3) STORED AS AVRO LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into avro_part_last values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from avro_part_last");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_last");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_last");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_last");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_last");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-    @Test
-    public void testOrcPartitionLast() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/orc_partition_last";
-        methodWatcher.executeUpdate(String.format("create external table orc_part_last (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col3) STORED AS ORC LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into orc_part_last values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from orc_part_last");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_last");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_last");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_last");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_last");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-
-        // test query with predicate
-        ResultSet rs5 = methodWatcher.executeQuery("select * from orc_part_last where col1=3");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs5));
-        ResultSet rs6 = methodWatcher.executeQuery("select * from orc_part_last where col2=4");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs6));
-        ResultSet rs7 = methodWatcher.executeQuery("select * from orc_part_last where col3='CCC'");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs7));
-    }
-
-    @Test
-    public void testTextfilePartitionLast() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/textfile_partition_last";
-        methodWatcher.executeUpdate(String.format("create external table textfile_part_last (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col3) STORED AS TEXTFILE LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into textfile_part_last values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_last");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_last");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_last");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_last");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_last");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-    @Test
-    public void testParquetPartitionThirdSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/parquet_partition_third_second";
-        methodWatcher.executeUpdate(String.format("create external table parquet_part_3rd_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col3,col2) STORED AS PARQUET LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into parquet_part_3rd_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_3rd_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_3rd_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_3rd_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_3rd_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_3rd_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-    @Test
-    public void testAvroPartitionThirdSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/avro_partition_third_second";
-        methodWatcher.executeUpdate(String.format("create external table avro_part_3rd_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col3,col2) STORED AS AVRO LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into avro_part_3rd_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from avro_part_3rd_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_3rd_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_3rd_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_3rd_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_3rd_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-    @Test
-    public void testOrcPartitionThirdSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/orc_partition_third_second";
-        methodWatcher.executeUpdate(String.format("create external table orc_part_3rd_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col3,col2) STORED AS ORC LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into orc_part_3rd_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from orc_part_3rd_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_3rd_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_3rd_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_3rd_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_3rd_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-
-        //test query with prediate
-        ResultSet rs5 = methodWatcher.executeQuery("select * from orc_part_3rd_2nd where col1=3");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs5));
-        ResultSet rs6 = methodWatcher.executeQuery("select * from orc_part_3rd_2nd where col2=4");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs6));
-        ResultSet rs7 = methodWatcher.executeQuery("select * from orc_part_3rd_2nd where col3='CCC'");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs7));
-    }
-
-    @Test
-    public void testTextfilePartitionThirdSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/textfile_partition_third_second";
-        methodWatcher.executeUpdate(String.format("create external table textfile_part_3rd_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col3,col2) STORED AS TEXTFILE LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into textfile_part_3rd_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_3rd_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_3rd_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_3rd_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_3rd_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_3rd_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-    @Test
-    public void testOrcAggressive() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/orc_aggressive";
-        methodWatcher.executeUpdate(String.format("create external table orc_aggressive (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char) " +
-                "partitioned by (col4, col6, col2) STORED AS ORC LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into orc_aggressive values " +
-                "(111,'AAA',true,111, 1.1, 'a'),(222,'BBB',false,222, 2.2, 'b'),(333,'CCC',true,333, 3.3, 'c')");
-        ResultSet rs = methodWatcher.executeQuery("select * from orc_aggressive");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from orc_aggressive");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testParquetAggressive() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/parquet_aggressive";
-        methodWatcher.executeUpdate(String.format("create external table parquet_aggressive (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char) " +
-                "partitioned by (col4, col6, col2) STORED AS PARQUET LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into parquet_aggressive values " +
-                "(111,'AAA',true,111, 1.1, 'a'),(222,'BBB',false,222, 2.2, 'b'),(333,'CCC',true,333, 3.3, 'c')");
-        ResultSet rs = methodWatcher.executeQuery("select * from parquet_aggressive");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from parquet_aggressive");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testAvroAggressive() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/avro_aggressive";
-        methodWatcher.executeUpdate(String.format("create external table avro_aggressive (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char) " +
-                "partitioned by (col4, col6, col2) STORED AS AVRO LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into avro_aggressive values " +
-                "(111,'AAA',true,111, 1.1, 'a'),(222,'BBB',false,222, 2.2, 'b'),(333,'CCC',true,333, 3.3, 'c')");
-        ResultSet rs = methodWatcher.executeQuery("select * from avro_aggressive");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from avro_aggressive");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testTextfileAggressive() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/textfile_aggressive";
-        methodWatcher.executeUpdate(String.format("create external table textfile_aggressive (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char) " +
-                "partitioned by (col4, col6, col2) STORED AS TEXTFILE LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into textfile_aggressive values " +
-                "(111,'AAA',true,111, 1.1, 'a'),(222,'BBB',false,222, 2.2, 'b'),(333,'CCC',true,333, 3.3, 'c')");
-        ResultSet rs = methodWatcher.executeQuery("select * from textfile_aggressive");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from textfile_aggressive");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testParquetAggressive2() throws Exception{
-        String format = "parquet";
-        String tablePath0 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_0",format);
-        String tablePath1 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_1",format);
-        String tablePath2 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_2",format);
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_0 (col1 varchar(10), col2 double, col3 int, col4 varchar(10), col5 int) " +
-                "partitioned by (col1, col2, col4, col5) stored as %s location '%s'",format,format,tablePath0));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_0 values " +
-                "('whoa',77.7,444,'crazy',21),('hey',11.11,222,'crazier',10)",format));
-        ResultSet rs0 = methodWatcher.executeQuery(String.format("select col4, col2, col3 from %s_aggressive_2_0 where col5 = 21",format));
-        assertEquals("COL4  |COL2 |COL3 |\n" +
-                "-------------------\n" +
-                "crazy |77.7 | 444 |",TestUtils.FormattedResult.ResultFactory.toString(rs0));
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_1 (col1 int, col2 double, col3 char, col4 varchar(10), col5 int) " +
-                "partitioned by (col3, col1, col2) stored as %s location '%s'",format,format,tablePath1));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_1 values " +
-                "(666,66.666,'z','zing',20),(555,55.555,'y','yowza',40),(1,1.1,'g','garish',7)",format));
-        ResultSet rs1 = methodWatcher.executeQuery(String.format("select col2,col4 from %s_aggressive_2_1",format));
-        assertEquals("COL2  | COL4  |\n" +
-                "----------------\n" +
-                "  1.1  |garish |\n" +
-                "55.555 | yowza |\n" +
-                "66.666 | zing  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_2 (col1 varchar(10), col2 double, col3 varchar(10), col4 varchar(10), col5 int) " +
-                "partitioned by (col5, col4, col3) stored as %s location '%s'",format,format,tablePath2));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_2 values " +
-                "('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1)",format));
-        ResultSet rs2 = methodWatcher.executeQuery(String.format("select col2 from %s_aggressive_2_2",format));
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                " 1.1 |\n" +
-                " 1.1 |\n" +
-                " 1.1 |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testAvroAggressive2() throws Exception{
-        String format = "avro";
-        String tablePath0 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_0",format);
-        String tablePath1 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_1",format);
-        String tablePath2 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_2",format);
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_0 (col1 varchar(10), col2 double, col3 int, col4 varchar(10), col5 int) " +
-                "partitioned by (col1, col2, col4, col5) stored as %s location '%s'",format,format,tablePath0));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_0 values " +
-                "('whoa',77.7,444,'crazy',21),('hey',11.11,222,'crazier',10)",format));
-        ResultSet rs0 = methodWatcher.executeQuery(String.format("select col4, col2, col3 from %s_aggressive_2_0 where col5 = 21",format));
-        assertEquals("COL4  |COL2 |COL3 |\n" +
-                "-------------------\n" +
-                "crazy |77.7 | 444 |",TestUtils.FormattedResult.ResultFactory.toString(rs0));
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_1 (col1 int, col2 double, col3 char, col4 varchar(10), col5 int) " +
-                "partitioned by (col3, col1, col2) stored as %s location '%s'",format,format,tablePath1));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_1 values " +
-                "(666,66.666,'z','zing',20),(555,55.555,'y','yowza',40),(1,1.1,'g','garish',7)",format));
-        ResultSet rs1 = methodWatcher.executeQuery(String.format("select col2,col4 from %s_aggressive_2_1",format));
-        assertEquals("COL2  | COL4  |\n" +
-                "----------------\n" +
-                "  1.1  |garish |\n" +
-                "55.555 | yowza |\n" +
-                "66.666 | zing  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_2 (col1 varchar(10), col2 double, col3 varchar(10), col4 varchar(10), col5 int) " +
-                "partitioned by (col5, col4, col3) stored as %s location '%s'",format,format,tablePath2));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_2 values " +
-                "('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1)",format));
-        ResultSet rs2 = methodWatcher.executeQuery(String.format("select col2 from %s_aggressive_2_2",format));
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                " 1.1 |\n" +
-                " 1.1 |\n" +
-                " 1.1 |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testOrcAggressive2() throws Exception{
-        String format = "orc";
-        String tablePath0 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_0",format);
-        String tablePath1 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_1",format);
-        String tablePath2 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_2",format);
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_0 (col1 varchar(10), col2 double, col3 int, col4 varchar(10), col5 int) " +
-                "partitioned by (col1, col2, col4, col5) stored as %s location '%s'",format,format,tablePath0));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_0 values " +
-                "('whoa',77.7,444,'crazy',21),('hey',11.11,222,'crazier',10)",format));
-        ResultSet rs0 = methodWatcher.executeQuery(String.format("select col4, col2, col3 from %s_aggressive_2_0 where col5 = 21",format));
-        assertEquals("COL4  |COL2 |COL3 |\n" +
-                "-------------------\n" +
-                "crazy |77.7 | 444 |",TestUtils.FormattedResult.ResultFactory.toString(rs0));
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_1 (col1 int, col2 double, col3 char, col4 varchar(10), col5 int) " +
-                "partitioned by (col3, col1, col2) stored as %s location '%s'",format,format,tablePath1));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_1 values " +
-                "(666,66.666,'z','zing',20),(555,55.555,'y','yowza',40),(1,1.1,'g','garish',7)",format));
-        ResultSet rs1 = methodWatcher.executeQuery(String.format("select col2,col4 from %s_aggressive_2_1",format));
-        assertEquals("COL2  | COL4  |\n" +
-                "----------------\n" +
-                "  1.1  |garish |\n" +
-                "55.555 | yowza |\n" +
-                "66.666 | zing  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_2 (col1 varchar(10), col2 double, col3 varchar(10), col4 varchar(10), col5 int) " +
-                "partitioned by (col5, col4, col3) stored as %s location '%s'",format,format,tablePath2));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_2 values " +
-                "('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1)",format));
-        ResultSet rs2 = methodWatcher.executeQuery(String.format("select col2 from %s_aggressive_2_2",format));
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                " 1.1 |\n" +
-                " 1.1 |\n" +
-                " 1.1 |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testTextfileAggressive2() throws Exception{
-        String format = "textfile";
-        String tablePath0 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_0",format);
-        String tablePath1 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_1",format);
-        String tablePath2 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_2",format);
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_0 (col1 varchar(10), col2 double, col3 int, col4 varchar(10), col5 int) " +
-                "partitioned by (col1, col2, col4, col5) stored as %s location '%s'",format,format,tablePath0));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_0 values " +
-                "('whoa',77.7,444,'crazy',21),('hey',11.11,222,'crazier',10)",format));
-        ResultSet rs0 = methodWatcher.executeQuery(String.format("select col4, col2, col3 from %s_aggressive_2_0 where col5 = 21",format));
-        assertEquals("COL4  |COL2 |COL3 |\n" +
-                "-------------------\n" +
-                "crazy |77.7 | 444 |",TestUtils.FormattedResult.ResultFactory.toString(rs0));
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_1 (col1 int, col2 double, col3 char, col4 varchar(10), col5 int) " +
-                "partitioned by (col3, col1, col2) stored as %s location '%s'",format,format,tablePath1));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_1 values " +
-                "(666,66.666,'z','zing',20),(555,55.555,'y','yowza',40),(1,1.1,'g','garish',7)",format));
-        ResultSet rs1 = methodWatcher.executeQuery(String.format("select col2,col4 from %s_aggressive_2_1",format));
-        assertEquals("COL2  | COL4  |\n" +
-                "----------------\n" +
-                "  1.1  |garish |\n" +
-                "55.555 | yowza |\n" +
-                "66.666 | zing  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_2 (col1 varchar(10), col2 double, col3 varchar(10), col4 varchar(10), col5 int) " +
-                "partitioned by (col5, col4, col3) stored as %s location '%s'",format,format,tablePath2));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_2 values " +
-                "('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1)",format));
-        ResultSet rs2 = methodWatcher.executeQuery(String.format("select col2 from %s_aggressive_2_2",format));
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                " 1.1 |\n" +
-                " 1.1 |\n" +
-                " 1.1 |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_2 " +
+                    "(col1 varchar(10), col2 double, col3 varchar(10), col4 varchar(10), col5 int) " +
+                    "partitioned by (col5, col4, col3) stored as %s location '%s'", format, format, tablePath2));
+            methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_2 values " +
+                    "('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1)", format));
+            ResultSet rs2 = methodWatcher.executeQuery(String.format("select col2 from %s_aggressive_2_2", format));
+            assertEquals("COL2 |\n" +
+                    "------\n" +
+                    " 1.1 |\n" +
+                    " 1.1 |\n" +
+                    " 1.1 |", TestUtils.FormattedResult.ResultFactory.toString(rs2));
+        }
     }
 
     // tests for creating an external table from an existing file:
 
     @Test
-    public void testParquetPartitionExisting() throws Exception {
-        methodWatcher.executeUpdate(String.format("create external table parquet_partition_existing (\"c0\" int, \"c1\" varchar(10), \"c2\" boolean, \"c3\" int, \"c4\" double, \"c5\" char)" +
-                "partitioned by (\"c3\", \"c1\") STORED AS PARQUET LOCATION '%s'", getResourceDirectory()+"parquet_partition_existing"));
-        ResultSet rs = methodWatcher.executeQuery("select * from parquet_partition_existing order by 1");
-        assertEquals("c0  |c1  | c2   |c3  |c4  |c5 |\n" +
-                "-------------------------------\n" +
-                "111 |AAA |true  |111 |1.1 | a |\n" +
-                "222 |BBB |false |222 |2.2 | b |\n" +
-                "333 |CCC |true  |333 |3.3 | c |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select \"c4\", \"c1\", \"c5\" from parquet_partition_existing");
-        assertEquals("c4  |c1  |c5 |\n" +
-                "--------------\n" +
-                "1.1 |AAA | a |\n" +
-                "2.2 |BBB | b |\n" +
-                "3.3 |CCC | c |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+    public void testPartitionExisting() throws Exception {
+        for (String fileFormat : fileFormatsText)
+        {
+            String name = "partition_existing_" + fileFormat;
+            // parquet_partition_existing, orc_partition_existing, avro_partition_existing, textfile_partition_existing
+            String tablePath = getResourceDirectory() + fileFormat.toLowerCase() + "_partition_existing";
+            methodWatcher.executeUpdate(String.format("create external table " + name +
+                    " (\"c0\" int, \"c1\" varchar(10), \"c2\" boolean, \"c3\" int, \"c4\" double, \"c5\" char)" +
+                    "partitioned by (\"c3\", \"c1\") STORED AS " + fileFormat + " LOCATION '%s'", tablePath));
+            ResultSet rs = methodWatcher.executeQuery("select * from " + name + " order by 1");
+            assertEquals("c0  |c1  | c2   |c3  |c4  |c5 |\n" +
+                    "-------------------------------\n" +
+                    "111 |AAA |true  |111 |1.1 | a |\n" +
+                    "222 |BBB |false |222 |2.2 | b |\n" +
+                    "333 |CCC |true  |333 |3.3 | c |", TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs2 = methodWatcher.executeQuery("select \"c4\", \"c1\", \"c5\" from " + name);
+            assertEquals("c4  |c1  |c5 |\n" +
+                    "--------------\n" +
+                    "1.1 |AAA | a |\n" +
+                    "2.2 |BBB | b |\n" +
+                    "3.3 |CCC | c |", TestUtils.FormattedResult.ResultFactory.toString(rs2));
 
-        methodWatcher.execute("drop table parquet_partition_existing");
+            methodWatcher.execute("drop table " + name);
 
-        methodWatcher.executeUpdate(String.format("create external table parquet_partition_existing (\"c0\" int, \"c1\" varchar(10), \"c2\" boolean, \"c3\" int, \"c4\" double, \"c5\" char)" +
-                "partitioned by (\"c3\", \"c1\") STORED AS PARQUET LOCATION '%s' merge schema", getResourceDirectory()+"parquet_partition_existing"));
-        rs = methodWatcher.executeQuery("select * from parquet_partition_existing order by 1");
-        assertEquals("c0  |c1  | c2   |c3  |c4  |c5 |\n" +
-                "-------------------------------\n" +
-                "111 |AAA |true  |111 |1.1 | a |\n" +
-                "222 |BBB |false |222 |2.2 | b |\n" +
-                "333 |CCC |true  |333 |3.3 | c |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        rs2 = methodWatcher.executeQuery("select \"c4\", \"c1\", \"c5\" from parquet_partition_existing");
-        assertEquals("c4  |c1  |c5 |\n" +
-                "--------------\n" +
-                "1.1 |AAA | a |\n" +
-                "2.2 |BBB | b |\n" +
-                "3.3 |CCC | c |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-
-    }
-
-    @Test
-    public void testAvroPartitionExisting() throws Exception {
-        methodWatcher.executeUpdate(String.format("create external table avro_partition_existing (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char)" +
-                "partitioned by (col4, col2) STORED AS AVRO LOCATION '%s'", getResourceDirectory() +"avro_partition_existing"));
-        ResultSet rs = methodWatcher.executeQuery("select * from avro_partition_existing order by 1");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from avro_partition_existing");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-
-        methodWatcher.execute("drop table avro_partition_existing");
-        methodWatcher.executeUpdate(String.format("create external table avro_partition_existing (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char)" +
-                "partitioned by (col4, col2) STORED AS AVRO LOCATION '%s' merge schema", getResourceDirectory() +"avro_partition_existing"));
-        rs = methodWatcher.executeQuery("select * from avro_partition_existing order by 1");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        rs2 = methodWatcher.executeQuery("select col5, col2, col6 from avro_partition_existing");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            methodWatcher.executeUpdate(String.format("create external table " + name +
+                    " (\"c0\" int, \"c1\" varchar(10), \"c2\" boolean, \"c3\" int, \"c4\" double, \"c5\" char)" +
+                    "partitioned by (\"c3\", \"c1\") STORED AS " + fileFormat + " LOCATION '%s' merge schema", tablePath));
+            rs = methodWatcher.executeQuery("select * from " + name + " order by 1");
+            assertEquals("c0  |c1  | c2   |c3  |c4  |c5 |\n" +
+                    "-------------------------------\n" +
+                    "111 |AAA |true  |111 |1.1 | a |\n" +
+                    "222 |BBB |false |222 |2.2 | b |\n" +
+                    "333 |CCC |true  |333 |3.3 | c |", TestUtils.FormattedResult.ResultFactory.toString(rs));
+            rs2 = methodWatcher.executeQuery("select \"c4\", \"c1\", \"c5\" from " + name );
+            assertEquals("c4  |c1  |c5 |\n" +
+                    "--------------\n" +
+                    "1.1 |AAA | a |\n" +
+                    "2.2 |BBB | b |\n" +
+                    "3.3 |CCC | c |", TestUtils.FormattedResult.ResultFactory.toString(rs2));
+        }
 
     }
 
     @Test
-    public void testOrcPartitionExisting() throws Exception {
-        methodWatcher.executeUpdate(String.format("create external table orc_partition_existing (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char)" +
-                "partitioned by (col4, col2) STORED AS ORC LOCATION '%s'", getResourceDirectory() +"orc_partition_existing"));
-        ResultSet rs = methodWatcher.executeQuery("select * from orc_partition_existing order by 1");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from orc_partition_existing order by 1");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-
-        methodWatcher.execute("drop table orc_partition_existing");
-        methodWatcher.executeUpdate(String.format("create external table orc_partition_existing (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char)" +
-                "partitioned by (col4, col2) STORED AS ORC LOCATION '%s' merge schema", getResourceDirectory() +"orc_partition_existing"));
-        rs = methodWatcher.executeQuery("select * from orc_partition_existing order by 1");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        rs2 = methodWatcher.executeQuery("select col5, col2, col6 from orc_partition_existing order by 1");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testTextfilePartitionExisting() throws Exception {
-
-        methodWatcher.executeUpdate(String.format("create external table textfile_partition_existing (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char)" +
-                "partitioned by (col4, col2, col1) STORED AS TEXTFILE LOCATION '%s'", SpliceUnitTest.getResourceDirectory() + "textfile_partition_existing"));
-        ResultSet rs = methodWatcher.executeQuery("select * from textfile_partition_existing");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |", TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from textfile_partition_existing");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |", TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testInsertionToHiveParquetData() throws Exception {
-        String tmp = getTempCopyOfResourceDirectory(tempDir, "pt_parquet" );
-        methodWatcher.executeUpdate(
-                String.format("create external table pt_parquet(\"name\" varchar(10), \"age\" int, \"state\" char(2)) partitioned by (\"state\") stored as parquet location '%s'",
-                        tmp));
-        methodWatcher.execute("insert into pt_parquet values ('Kate', 19, 'HI')");
-        ResultSet rs = methodWatcher.executeQuery("select * from pt_parquet order by 1");
-        String actual = TestUtils.FormattedResult.ResultFactory.toString(rs);
-        String expected = "name | age | state |\n" +
-                "--------------------\n" +
-                "Kate | 19  |  HI   |\n" +
-                " Sam | 20  |  CA   |\n" +
-                " Tom | 21  |  NY   |";
-        assertEquals(actual, expected, actual);
-    }
-
-    @Test
-    public void testInsertionToHiveAvroData() throws Exception {
-        String tmp = getTempCopyOfResourceDirectory(tempDir, "pt_avro" );
-        methodWatcher.executeUpdate( String.format(
-                "create external table pt_avro(col1 varchar(10), col2 int, col3 char(2)) " +
-                        "partitioned by (col3) stored as avro location '%s'", tmp) );
-        methodWatcher.execute("insert into pt_avro values ('Kate', 19, 'HI')");
-        ResultSet rs = methodWatcher.executeQuery("select * from pt_avro order by 1");
-        String actual = TestUtils.FormattedResult.ResultFactory.toString(rs);
-        String expected = "COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "Kate | 19  | HI  |\n" +
-                " Sam | 20  | CA  |\n" +
-                " Tom | 21  | NY  |";
-        assertEquals(actual, expected, actual);
+    public void testInsertionToHiveData() throws Exception {
+        for (String fileFormat : new String[] {"PARQUET", "AVRO"} ) {
+            String name = "insertion_to_hive_" + fileFormat;
+            String tmpPath = getTempCopyOfResourceDirectory(tempDir, "pt_" + fileFormat.toLowerCase() );
+            methodWatcher.executeUpdate(String.format("create external table " + name +
+                            "(\"name\" varchar(10), \"age\" int, \"state\" char(2)) " +
+                            "partitioned by (\"state\") stored as " + fileFormat + " location '%s'", tmpPath));
+            methodWatcher.execute("insert into " + name + " values ('Kate', 19, 'HI')");
+            ResultSet rs = methodWatcher.executeQuery("select * from " + name + " order by 1");
+            String actual = TestUtils.FormattedResult.ResultFactory.toString(rs);
+            String expected = "name | age | state |\n" +
+                    "--------------------\n" +
+                    "Kate | 19  |  HI   |\n" +
+                    " Sam | 20  |  CA   |\n" +
+                    " Tom | 21  |  NY   |";
+            assertEquals(actual, expected, actual);
+        }
     }
 
     @Test


### PR DESCRIPTION
- tests like testAbcParquet, testAbcORC, testAbcAvro have been unified to  testAbc.
- removed code duplication, especially in tests for syntax error handling
- testWriteReadFromSimpleExternalTable will now tests ALL available column types
- added CreateTableTypeHelper to make testing multiple column, values and null values types easier, even if Parquet, ORC and Avro sometimes support different types.
