### PR TITLE
DB-9782 improve ExternalTableIT to handle more column types / unify tests (2.8)

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableTypeHelper.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableTypeHelper.java
@@ -84,7 +84,7 @@ public class CreateTableTypeHelper {
         return new int[]{
                 Types.VARCHAR, Types.CHAR,
                 // Types.DATE, Types.TIME // not supported
-                Types.TIMESTAMP,
+                // Types.TIMESTAMP, // Will be written as BIGINT, not working in 2.8
                 //Types.TINYINT, Types.SMALLINT, // not supported
                 Types.INTEGER, Types.BIGINT,
                 Types.DOUBLE, Types.REAL,

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableTypeHelper.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableTypeHelper.java
@@ -1,0 +1,247 @@
+package com.splicemachine.derby.impl.sql.execute.operations;
+
+import org.junit.Assert;
+
+import java.sql.Clob;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Locale;
+
+/// a helper class to define column types, and then create external tables and insert data into them
+/// to make writing tests for all column types easier.
+
+public class CreateTableTypeHelper {
+    /// @param types: an array of Types that should be used
+    /// @param ivalues: an array of values to use. 0 is NULL value, all other values will
+    /// generate corresponding entries that are somewhat associated with the integer val
+    /// e.g. mostly if the int values increase, the corresponding e.g. date value also increases.
+    public CreateTableTypeHelper(int[] types, int[] ivalues)
+    {
+        for( int i = 0; i < types.length; i++ )
+        {
+            String comma = i > 0 ? ", " : "";
+            int t = types[i];
+            schema = schema + comma + getTypesName(t);
+            suggestedTypes = suggestedTypes + comma + getTypesNameInfered(t);
+        }
+
+        for( int i = 0; i < ivalues.length; i++ ) {
+            insertValues = insertValues + (i > 0 ? ", " : "") + "(";
+            StringBuilder sb = new StringBuilder();
+            for (int j = 0; j < types.length; j++) {
+                sb.append( j > 0 ? ", " : "");
+                sb.append( getTypeValue(types[j], ivalues[i]) );
+            }
+            values2.add( sb.toString() );
+            insertValues = insertValues + sb.toString() + ")";
+        }
+        values2.sort(String::compareTo);
+    }
+
+    public String getInsertValues() {
+        return insertValues;
+    }
+
+    /// @return schema as to be used in `create external table <NAME> ( <SCHEMA> ) ...`
+    public String getSchema()
+    {
+        return schema;
+    }
+
+    /// @return schema that will be returned when suggesting a schema to the user.
+    public String getSuggestedTypes() {
+        return suggestedTypes;
+    }
+
+
+    /// @return types that are supported by Parquet
+    static public int[] getParquetTypes() {
+        return new int[]{
+                Types.VARCHAR, Types.CHAR,
+                Types.DATE, Types.TIMESTAMP,
+                // Types.TIME, // supported, but will be written as TIMESTAMP
+                Types.TINYINT, Types.SMALLINT, Types.INTEGER, Types.BIGINT,
+                Types.DOUBLE, Types.REAL, Types.DECIMAL, Types.BOOLEAN
+        };
+    }
+
+    /// @return types that are supported by ORC
+    static public int[] getORCTypes() {
+        return new int[]{
+                Types.VARCHAR, Types.CHAR,
+                Types.DATE, Types.TIMESTAMP,
+                // Types.TIME, // supported, but will be written as TIMESTAMP
+                Types.TINYINT, Types.SMALLINT, Types.INTEGER, Types.BIGINT,
+                Types.DOUBLE, Types.REAL, Types.DECIMAL, Types.BOOLEAN
+        };
+    }
+
+    /// @return types that are supported by Avro
+    static public int[] getAvroTypes() {
+        return new int[]{
+                Types.VARCHAR, Types.CHAR,
+                // Types.DATE, Types.TIME // not supported
+                Types.TIMESTAMP,
+                //Types.TINYINT, Types.SMALLINT, // not supported
+                Types.INTEGER, Types.BIGINT,
+                Types.DOUBLE, Types.REAL,
+                // Types.DECIMAL, // not supported
+                Types.BOOLEAN
+        };
+    }
+
+    /// @return supported types by fileFormat PARQUET, ORC or AVRO
+    static public int[] getTypes(String fileFormat) {
+        if(fileFormat.equalsIgnoreCase("PARQUET"))
+            return getParquetTypes();
+        else if(fileFormat.equalsIgnoreCase("ORC"))
+            return getORCTypes();
+        else if(fileFormat.equalsIgnoreCase("AVRO"))
+            return getAvroTypes();
+        throw new RuntimeException("unsupported fileformat " + fileFormat);
+    }
+
+    /// compare that result in ResultSet rs is the same as from the generated insert values.
+    public void checkResultSetSelectAll(ResultSet rs) throws SQLException {
+        ArrayList<String> results = new ArrayList<>();
+        int nCols = rs.getMetaData().getColumnCount();
+        int rows = 0;
+        while (rs.next()) {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 1; i <= nCols; i++) {
+                Object value = rs.getObject(i);
+                if (value != null && value instanceof Clob) {
+                    throw new RuntimeException("Clob not supported");
+                } else {
+                    if( i > 1 ) sb.append(", ");
+                    if( value != null && value.toString() != null ) {
+                        sb.append("'");
+                        sb.append(value.toString());
+                        sb.append("'");
+                    }
+                    else {
+                        sb.append("NULL");
+                    }
+                }
+            }
+            results.add(sb.toString());
+        }
+        results.sort(String::compareTo);
+        Assert.assertEquals( values2.size(), results.size() );
+        for( int i = 0; i < results.size(); i++ ) {
+            Assert.assertEquals( values2.get(i), results.get(i) );
+        }
+    }
+
+    private String getTypesName(int type) {
+        switch (type) {
+            case Types.CHAR:
+                return "COL_CHAR CHAR(10)";
+            case Types.VARCHAR:
+                return "COL_VARCHAR VARCHAR(10)";
+            case Types.DATE:
+                return "COL_DATE DATE";
+            case Types.TIME:
+                return "COL_TIME TIME";
+            case Types.TIMESTAMP:
+                return "COL_TIMESTAMP TIMESTAMP";
+            case Types.TINYINT:
+                return "COL_TINYINT TINYINT";
+            case Types.SMALLINT:
+                return "COL_SMALLINT SMALLINT";
+            case Types.INTEGER:
+                return "COL_INTEGER INT";
+            case Types.BIGINT:
+                return "COL_BIGINT BIGINT";
+            //case Types.NUMERIC: Decimal and Numeric should be the same
+            case Types.DECIMAL:
+                return "COL_DECIMAL DECIMAL(7,2)";
+            case Types.DOUBLE:
+                return "COL_DOUBLE DOUBLE";
+            case Types.REAL:
+                return "COL_REAL REAL";
+            case Types.BOOLEAN:
+                return "COL_BOOLEAN BOOLEAN";
+            default:
+                throw new RuntimeException("unsupported type " + type);
+        }
+    }
+
+    private String getTypesNameInfered(int type) {
+        switch (type) {
+            case Types.CHAR:
+                return "COL_CHAR CHAR/VARCHAR(x)";
+            case Types.VARCHAR:
+                return "COL_VARCHAR CHAR/VARCHAR(x)";
+            default:
+                return getTypesName(type);
+        }
+    }
+    private String getTime( int val ){
+        if( val < 0 ) val = -val;
+        int seconds = val;
+        int minutes = seconds / 60;
+        int hours = minutes / 60;
+        seconds %= 60;
+        minutes %= 60;
+        hours %= 60;
+        return String.format("%d:%02d:%02d", hours, minutes, seconds);
+    }
+    private String getDate( int val ){
+        int days = val;
+        int months = days / 28;
+        int years = months / 12;
+        days = days%28 + 1;
+        months = months%12 + 1;
+        years += 2000;
+        return String.format("%d-%02d-%02d", years, months, days);
+    }
+
+    private String getTypeValue(int type, int val) {
+        // DB-9829: BOOLEAN can't use NULL together with non-null
+        // ERROR 42X61: Types 'CHAR' and 'BOOLEAN' are not UNION compatible.
+        // Note this is not a problem with external tables
+        if( type != Types.BOOLEAN
+                && val == 0 ) { return "NULL"; }
+        switch (type) {
+            case Types.CHAR:
+                return "'" + padSpaces("AAAA " + Integer.toString(val), 10) + "'";
+            case Types.VARCHAR:
+                return "'AAAA " + Integer.toString(val) + "'";
+            case Types.TIME:
+                return "'" + getTime(val) + "'";
+            case Types.DATE:
+                return "'" + getDate(val) + "'";
+            case Types.TIMESTAMP:
+                return "'" + getDate(val) + " 09:45:01.123'";
+            case Types.TINYINT:
+            case Types.SMALLINT:
+            case Types.INTEGER:
+            case Types.BIGINT:
+                return "'" + Integer.toString(val) + "'";
+            case Types.DOUBLE:
+            case Types.REAL:
+                return "'" + Double.toString(val * 0.001 + 1.5) + "'";
+            case Types.DECIMAL:
+                return "'" + Double.toString((val % 10000) * 0.01 + 1.5) + "'";
+            case Types.BOOLEAN:
+                return val % 2 == 0 ? "'true'" : "'false'";
+            default:
+                throw new RuntimeException("unsupported type " + type);
+        }
+    }
+
+    private String padSpaces(String s, int i) {
+        while( s.length() < i ) s = s + " ";
+        return s;
+    }
+
+    DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ENGLISH);
+    private ArrayList<String> values2= new ArrayList<>();
+    private String schema = "";
+    private String suggestedTypes = "";
+    private String insertValues = "";
+}

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableTypeHelper.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableTypeHelper.java
@@ -8,7 +8,12 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
 
 /// a helper class to define column types, and then create external tables and insert data into them
 /// to make writing tests for all column types easier.
@@ -20,25 +25,15 @@ public class CreateTableTypeHelper {
     /// e.g. mostly if the int values increase, the corresponding e.g. date value also increases.
     public CreateTableTypeHelper(int[] types, int[] ivalues)
     {
-        for( int i = 0; i < types.length; i++ )
-        {
-            String comma = i > 0 ? ", " : "";
-            int t = types[i];
-            schema = schema + comma + getTypesName(t);
-            suggestedTypes = suggestedTypes + comma + getTypesNameInfered(t);
-        }
+        schema = Arrays.stream(types).mapToObj(this::getTypesName).collect(Collectors.joining(", "));
+        suggestedTypes = Arrays.stream(types).mapToObj(this::getTypesNameInfered).collect(Collectors.joining(", "));
 
-        for( int i = 0; i < ivalues.length; i++ ) {
-            insertValues = insertValues + (i > 0 ? ", " : "") + "(";
-            StringBuilder sb = new StringBuilder();
-            for (int j = 0; j < types.length; j++) {
-                sb.append( j > 0 ? ", " : "");
-                sb.append( getTypeValue(types[j], ivalues[i]) );
-            }
-            values2.add( sb.toString() );
-            insertValues = insertValues + sb.toString() + ")";
-        }
-        values2.sort(String::compareTo);
+        IntFunction<String> iValueStringFunc = ivalue -> Arrays.stream(types)
+                .mapToObj(type -> getTypeValue(type, ivalue))
+                .collect(Collectors.joining(", "));
+
+        values2 = Arrays.stream(ivalues).mapToObj(iValueStringFunc).sorted().collect(Collectors.toList());
+        insertValues = Arrays.stream(ivalues).mapToObj(iValueStringFunc).map(s -> "(" + s + ")").collect(Collectors.joining(", "));
     }
 
     public String getInsertValues() {
@@ -108,7 +103,6 @@ public class CreateTableTypeHelper {
     public void checkResultSetSelectAll(ResultSet rs) throws SQLException {
         ArrayList<String> results = new ArrayList<>();
         int nCols = rs.getMetaData().getColumnCount();
-        int rows = 0;
         while (rs.next()) {
             StringBuilder sb = new StringBuilder();
             for (int i = 1; i <= nCols; i++) {
@@ -208,9 +202,9 @@ public class CreateTableTypeHelper {
                 && val == 0 ) { return "NULL"; }
         switch (type) {
             case Types.CHAR:
-                return "'" + padSpaces("AAAA " + Integer.toString(val), 10) + "'";
+                return "'" + padSpaces("AAAA " + val, 10) + "'";
             case Types.VARCHAR:
-                return "'AAAA " + Integer.toString(val) + "'";
+                return "'AAAA " + val + "'";
             case Types.TIME:
                 return "'" + getTime(val) + "'";
             case Types.DATE:
@@ -221,12 +215,12 @@ public class CreateTableTypeHelper {
             case Types.SMALLINT:
             case Types.INTEGER:
             case Types.BIGINT:
-                return "'" + Integer.toString(val) + "'";
+                return "'" + val + "'";
             case Types.DOUBLE:
             case Types.REAL:
-                return "'" + Double.toString(val * 0.001 + 1.5) + "'";
+                return "'" + (val * 0.001 + 1.5) + "'";
             case Types.DECIMAL:
-                return "'" + Double.toString((val % 10000) * 0.01 + 1.5) + "'";
+                return "'" + ((val % 10000) * 0.01 + 1.5) + "'";
             case Types.BOOLEAN:
                 return val % 2 == 0 ? "'true'" : "'false'";
             default:
@@ -235,13 +229,15 @@ public class CreateTableTypeHelper {
     }
 
     private String padSpaces(String s, int i) {
-        while( s.length() < i ) s = s + " ";
+        StringBuilder sBuilder = new StringBuilder(s);
+        while( sBuilder.length() < i ) sBuilder.append(" ");
+        s = sBuilder.toString();
         return s;
     }
 
     DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ENGLISH);
-    private ArrayList<String> values2= new ArrayList<>();
-    private String schema = "";
-    private String suggestedTypes = "";
-    private String insertValues = "";
+    private final List<String> values2;
+    private final String schema;
+    private final String suggestedTypes;
+    private final String insertValues;
 }

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableTypeHelper.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/CreateTableTypeHelper.java
@@ -15,14 +15,18 @@ import java.util.function.Consumer;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 
-/// a helper class to define column types, and then create external tables and insert data into them
-/// to make writing tests for all column types easier.
-
+/**
+ * a helper class to define column types, and then create external tables and insert data into them
+ * to make writing tests for all column types easier.
+ */
 public class CreateTableTypeHelper {
-    /// @param types: an array of Types that should be used
-    /// @param ivalues: an array of values to use. 0 is NULL value, all other values will
-    /// generate corresponding entries that are somewhat associated with the integer val
-    /// e.g. mostly if the int values increase, the corresponding e.g. date value also increases.
+    /**
+     *
+     * @param types     an array of Types that should be used
+     * @param ivalues   an array of values to use. 0 is NULL value, all other values will
+     * generate corresponding entries that are somewhat associated with the integer val
+     * e.g. mostly if the int values increase, the corresponding e.g. date value also increases.
+     */
     public CreateTableTypeHelper(int[] types, int[] ivalues)
     {
         schema = Arrays.stream(types).mapToObj(this::getTypesName).collect(Collectors.joining(", "));
@@ -40,19 +44,28 @@ public class CreateTableTypeHelper {
         return insertValues;
     }
 
-    /// @return schema as to be used in `create external table <NAME> ( <SCHEMA> ) ...`
+
+
+    /**
+     * @return schema as to be used in `create external table <NAME> ( <SCHEMA> ) ...`
+     */
     public String getSchema()
     {
         return schema;
     }
 
-    /// @return schema that will be returned when suggesting a schema to the user.
+    /**
+     *
+     * @return schema that will be returned when suggesting a schema to the user.
+     */
     public String getSuggestedTypes() {
         return suggestedTypes;
     }
 
 
-    /// @return types that are supported by Parquet
+    /**
+     * @return types that are supported by Parquet
+     */
     static public int[] getParquetTypes() {
         return new int[]{
                 Types.VARCHAR, Types.CHAR,
@@ -63,7 +76,9 @@ public class CreateTableTypeHelper {
         };
     }
 
-    /// @return types that are supported by ORC
+    /**
+     * @return types that are supported by ORC
+     */
     static public int[] getORCTypes() {
         return new int[]{
                 Types.VARCHAR, Types.CHAR,
@@ -74,7 +89,10 @@ public class CreateTableTypeHelper {
         };
     }
 
-    /// @return types that are supported by Avro
+    /**
+     *
+     * @return types that are supported by Avro
+     */
     static public int[] getAvroTypes() {
         return new int[]{
                 Types.VARCHAR, Types.CHAR,
@@ -88,7 +106,12 @@ public class CreateTableTypeHelper {
         };
     }
 
-    /// @return supported types by fileFormat PARQUET, ORC or AVRO
+    ///
+
+    /**
+     * @param fileFormat "PARQUET", "ORC" or "AVRO"
+     * @return supported types by fileFormat PARQUET, ORC or AVRO
+     */
     static public int[] getTypes(String fileFormat) {
         if(fileFormat.equalsIgnoreCase("PARQUET"))
             return getParquetTypes();
@@ -99,7 +122,11 @@ public class CreateTableTypeHelper {
         throw new RuntimeException("unsupported fileformat " + fileFormat);
     }
 
-    /// compare that result in ResultSet rs is the same as from the generated insert values.
+    /**
+     * compare that result in ResultSet rs is the same as from the generated insert values.
+     * @param rs ResultSet from a select *.
+     * @throws SQLException
+     */
     public void checkResultSetSelectAll(ResultSet rs) throws SQLException {
         ArrayList<String> results = new ArrayList<>();
         int nCols = rs.getMetaData().getColumnCount();

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -73,7 +73,9 @@ public class ExternalTableIT extends SpliceUnitTest {
         deleteTempDirectory(tempDir);
     }
 
-    /// this will return the temp directory, that is created on demand once for each test
+    /**
+     * @return this will return the temp directory, that is created on demand once for each test
+     */
     public String getExternalResourceDirectory() throws Exception
     {
         return tempDir.toString() + "/";

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -2298,15 +2298,9 @@ public class ExternalTableIT extends SpliceUnitTest {
 
     @Test
     public void testFaultyCompressionAvro() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/compression";
-            methodWatcher.executeUpdate(String.format("CREATE EXTERNAL TABLE bad_compression_avro (col1 int) " +
-                    "COMPRESSED WITH TURD " +
-                    "STORED AS AVRO LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","42X01",e.getSQLState());
-        }
+        assureFails(String.format("CREATE EXTERNAL TABLE bad_compression_avro (col1 int) " +
+                        "COMPRESSED WITH TURD STORED AS AVRO LOCATION '%s'",
+                getExternalResourceDirectory()+"/compression"), "42X01", "");
     }
 
     // tests for avro support of date type:
@@ -2414,6 +2408,7 @@ public class ExternalTableIT extends SpliceUnitTest {
         rs3.close();
     }
 
+    @Test
     public void testBroadcastJoinOrcTablesOnSpark() throws Exception {
         methodWatcher.executeUpdate(String.format("create external table l (col1 int)" +
                 " STORED AS ORC LOCATION '%s'", getExternalResourceDirectory()+"left"));
@@ -2704,42 +2699,27 @@ public class ExternalTableIT extends SpliceUnitTest {
     }
 
     @Test
-    public void testShowCreateTableOrcExternalTable() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"show_orc";
-        methodWatcher.execute(String.format("CREATE EXTERNAL TABLE myOrcTable\n" +
-                "                    (col1 INT, col2 VARCHAR(24))\n" +
-                "                    PARTITIONED BY (col1)\n" +
-                "                    STORED AS ORC\n" +
-                "                    LOCATION '%s'", tablePath));
-        ResultSet rs = methodWatcher.executeQuery("CALL SYSCS_UTIL.SHOW_CREATE_TABLE('EXTERNALTABLEIT','MYORCTABLE')");
-        rs.next();
-        Assert.assertEquals("CREATE EXTERNAL TABLE \"EXTERNALTABLEIT\".\"MYORCTABLE\" (\n" +
-                "\"COL1\" INTEGER\n" +
-                ",\"COL2\" VARCHAR(24)\n" +
-                ") \n" +
-                "PARTITIONED BY (COL1)\n" +
-                "STORED AS ORC\n" +
-                "LOCATION '" + tablePath + "';" , rs.getString(1));
+    public void testShowCreateTableExternalTable() throws Exception {
+        for( String fileFormat : new String[]{"ORC", "PARQUET", "AVRO", "TEXTFILE"}) {
+            String name = "TEST_SHOW_TABLE_" + fileFormat;
+            String tablePath = getExternalResourceDirectory() + name;
 
-    }
+            methodWatcher.execute(String.format("CREATE EXTERNAL TABLE " + name + "\n" +
+                    "                    (col1 INT, col2 VARCHAR(24))\n" +
+                    "                    PARTITIONED BY (col1)\n" +
+                    "                    STORED AS " + fileFormat + "\n" +
+                    "                    LOCATION '%s'", tablePath));
+            ResultSet rs = methodWatcher.executeQuery("CALL SYSCS_UTIL.SHOW_CREATE_TABLE('EXTERNALTABLEIT','" + name + "')");
+            rs.next();
+            Assert.assertEquals("CREATE EXTERNAL TABLE \"EXTERNALTABLEIT\".\"" + name + "\" (\n" +
+                    "\"COL1\" INTEGER\n" +
+                    ",\"COL2\" VARCHAR(24)\n" +
+                    ") \n" +
+                    "PARTITIONED BY (COL1)\n" +
+                    "STORED AS " + fileFormat  + "\n" +
+                    "LOCATION '" + tablePath + "';", rs.getString(1));
+        }
 
-    @Test
-    public void testShowCreateTableParquetExternalTable() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"show_parquet";
-        methodWatcher.execute(String.format("CREATE EXTERNAL TABLE myParquetTable\n" +
-                "                    (col1 INT, col2 VARCHAR(24))\n" +
-                "                    PARTITIONED BY (col2)\n" +
-                "                    STORED AS PARQUET\n" +
-                "                    LOCATION '%s'" , tablePath));
-        ResultSet rs = methodWatcher.executeQuery("CALL SYSCS_UTIL.SHOW_CREATE_TABLE('EXTERNALTABLEIT','MYPARQUETTABLE')");
-        rs.next();
-        Assert.assertEquals("CREATE EXTERNAL TABLE \"EXTERNALTABLEIT\".\"MYPARQUETTABLE\" (\n" +
-                "\"COL1\" INTEGER\n" +
-                ",\"COL2\" VARCHAR(24)\n" +
-                ") \n" +
-                "PARTITIONED BY (COL2)\n" +
-                "STORED AS PARQUET\n" +
-                "LOCATION '" + tablePath + "';", rs.getString(1));
     }
 
     @Test
@@ -2763,25 +2743,6 @@ public class ExternalTableIT extends SpliceUnitTest {
                 "STORED AS PARQUET\n" +
                 "LOCATION '" + tablePath + "';", rs.getString(1));
 
-    }
-
-    @Test
-    public void testShowCreateTableAvroExternalTable() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"show_avro";
-        methodWatcher.execute(String.format("CREATE EXTERNAL TABLE myAvroTable\n" +
-                "                    (col1 INT, col2 VARCHAR(24))\n" +
-                "                    PARTITIONED BY (col1)\n" +
-                "                    STORED AS AVRO\n" +
-                "                    LOCATION '%s'", tablePath));
-        ResultSet rs = methodWatcher.executeQuery("CALL SYSCS_UTIL.SHOW_CREATE_TABLE('EXTERNALTABLEIT','MYAVROTABLE')");
-        rs.next();
-        Assert.assertEquals("CREATE EXTERNAL TABLE \"EXTERNALTABLEIT\".\"MYAVROTABLE\" (\n" +
-                "\"COL1\" INTEGER\n" +
-                ",\"COL2\" VARCHAR(24)\n" +
-                ") \n" +
-                "PARTITIONED BY (COL1)\n" +
-                "STORED AS AVRO\n" +
-                "LOCATION '" + tablePath + "';", rs.getString(1));
     }
 
     @Test

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -1639,93 +1639,56 @@ public class ExternalTableIT extends SpliceUnitTest {
 
     @Test
     public void testWriteToWrongPartitionedParquetExternalTable() throws Exception {
-        try {
-            methodWatcher.executeUpdate(String.format("create external table w_partitioned_parquet (col1 int, col2 varchar(24))" +
-                    "partitioned by (col1) STORED AS PARQUET LOCATION '%s'", getExternalResourceDirectory() + "w_partitioned_parquet"));
-            methodWatcher.executeUpdate(String.format("insert into w_partitioned_parquet values (1,'XXXX')," +
-                    "(2,'YYYY')," +
-                    "(3,'ZZZZ')"));
-            methodWatcher.executeUpdate(String.format("create external table w_partitioned_parquet_2 (col1 int, col2 varchar(24))" +
-                    "partitioned by (col2) STORED AS PARQUET LOCATION '%s'", getExternalResourceDirectory() + "w_partitioned_parquet"));
-            methodWatcher.executeUpdate(String.format("insert into w_partitioned_parquet_2 values (1,'XXXX')," +
-                    "(2,'YYYY')," +
-                    "(3,'ZZZZ')"));
+        for( String fileFormat : fileFormats) {
+            try {
+                String name = "w_partitioned_" + fileFormat;
+                String tablePath = getExternalResourceDirectory() + name;
+                methodWatcher.executeUpdate(String.format("create external table " + name + " (col1 int, col2 varchar(24))" +
+                        "partitioned by (col1) STORED AS " + fileFormat + " LOCATION '%s'", tablePath));
+                methodWatcher.executeUpdate(String.format("insert into " + name + " values (1,'XXXX')," +
+                        "(2,'YYYY')," +
+                        "(3,'ZZZZ')"));
+                methodWatcher.executeUpdate(String.format("create external table " + name + "2 (col1 int, col2 varchar(24))" +
+                        "partitioned by (col2) STORED AS PARQUET LOCATION '%s'", getExternalResourceDirectory() + "w_partitioned_parquet"));
+                methodWatcher.executeUpdate(String.format("insert into " + name + "2 values (1,'XXXX')," +
+                        "(2,'YYYY')," +
+                        "(3,'ZZZZ')"));
+                Assert.fail("Exception not thrown");
 
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
+            } catch (Exception e) {
 
-    @Test
-    public void testWriteToWrongPartitionedAvroExternalTable() throws Exception {
-        try {
-            methodWatcher.executeUpdate(String.format("create external table w_partitioned_avro (col1 int, col2 varchar(24))" +
-                    "partitioned by (col1) STORED AS AVRO LOCATION '%s'", getExternalResourceDirectory() + "w_partitioned_avro"));
-            methodWatcher.executeUpdate(String.format("insert into w_partitioned_avro values (1,'XXXX')," +
-                    "(2,'YYYY')," +
-                    "(3,'ZZZZ')"));
-            methodWatcher.executeUpdate(String.format("create external table w_partitioned_avro_2 (col1 int, col2 varchar(24))" +
-                    "partitioned by (col2) STORED AS AVRO LOCATION '%s'", getExternalResourceDirectory() + "w_partitioned_avro"));
-            methodWatcher.executeUpdate(String.format("insert into w_partitioned_avro_2 values (1,'XXXX')," +
-                    "(2,'YYYY')," +
-                    "(3,'ZZZZ')"));
-
-        } catch (Exception e) {
-            e.printStackTrace();
+            }
         }
     }
 
     @Test
     public void testWriteToNotPermittedLocation() throws Exception{
+        for( String fileFormat : fileFormats) {
+            String name = "NO_PERMISSION_" + fileFormat;
+            String filename = getExternalResourceDirectory() + name;
+            methodWatcher.executeUpdate(String.format("create external table " + name + " (col1 int, col2 varchar(24), col3 boolean)" +
+                    " STORED AS " + fileFormat + " LOCATION '%s'", filename));
 
+            File file = new File(filename);
 
-        methodWatcher.executeUpdate(String.format("create external table PARQUET_NO_PERMISSION (col1 int, col2 varchar(24), col3 boolean)" +
-                " STORED AS PARQUET LOCATION '%s'", getExternalResourceDirectory()+"PARQUET_NO_PERMISSION"));
+            // this should be fine
+            methodWatcher.executeUpdate(String.format("insert into " + name + " values (1,'XXXX',true), " +
+                    "(2,'YYYY',false), (3,'ZZZZ', true)"));
+            try {
+                file.setWritable(false);
+                methodWatcher.executeUpdate(String.format("insert into " + name + " values (1,'XXXX',true), " +
+                        "(2,'YYYY',false), (3,'ZZZZ', true)"));
 
-        File file = new File(String.valueOf(getExternalResourceDirectory()+"PARQUET_NO_PERMISSION"));
-
-        try{
-
-            methodWatcher.executeUpdate(String.format("insert into PARQUET_NO_PERMISSION values (1,'XXXX',true), (2,'YYYY',false), (3,'ZZZZ', true)"));
-            file.setWritable(false);
-            methodWatcher.executeUpdate(String.format("insert into  PARQUET_NO_PERMISSION values (1,'XXXX',true), (2,'YYYY',false), (3,'ZZZZ', true)"));
-
-            // we don't want to have a unwritable file in the folder, clean it up
-            file.setWritable(true);
-            file.delete();
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            // we don't want to have a unwritable file in the folder, clean it up
-            file.setWritable(true);
-            file.delete();
-            Assert.assertEquals("Wrong Exception","SE010",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testWriteToNotPermittedLocationAvro() throws Exception{
-
-
-        methodWatcher.executeUpdate(String.format("create external table AVRO_NO_PERMISSION (col1 int, col2 varchar(24), col3 boolean)" +
-                " STORED AS AVRO LOCATION '%s'", getExternalResourceDirectory()+"AVRO_NO_PERMISSION"));
-
-        File file = new File(String.valueOf(getExternalResourceDirectory()+"AVRO_NO_PERMISSION"));
-
-        try{
-
-            methodWatcher.executeUpdate(String.format("insert into AVRO_NO_PERMISSION values (1,'XXXX',true), (2,'YYYY',false), (3,'ZZZZ', true)"));
-            file.setWritable(false);
-            methodWatcher.executeUpdate(String.format("insert into  AVRO_NO_PERMISSION values (1,'XXXX',true), (2,'YYYY',false), (3,'ZZZZ', true)"));
-
-            // we don't want to have a unwritable file in the folder, clean it up
-            file.setWritable(true);
-            file.delete();
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            // we don't want to have a unwritable file in the folder, clean it up
-            file.setWritable(true);
-            file.delete();
-            Assert.assertEquals("Wrong Exception","SE010",e.getSQLState());
+                // we don't want to have a unwritable file in the folder, clean it up
+                file.setWritable(true);
+                file.delete();
+                Assert.fail("Exception not thrown");
+            } catch (SQLException e) {
+                // we don't want to have a unwritable file in the folder, clean it up
+                file.setWritable(true);
+                file.delete();
+                Assert.assertEquals("Wrong Exception", "SE010", e.getSQLState());
+            }
         }
     }
 

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -1351,7 +1351,6 @@ public class ExternalTableIT extends SpliceUnitTest {
     @Test
     public void testWriteToWrongPartitionedParquetExternalTable() throws Exception {
         for( String fileFormat : fileFormats) {
-            try {
                 String name = "w_partitioned_" + fileFormat;
                 String tablePath = getExternalResourceDirectory() + name;
                 methodWatcher.executeUpdate(String.format("create external table " + name + " (col1 int, col2 varchar(24))" +
@@ -1359,16 +1358,8 @@ public class ExternalTableIT extends SpliceUnitTest {
                 methodWatcher.executeUpdate(String.format("insert into " + name + " values (1,'XXXX')," +
                         "(2,'YYYY')," +
                         "(3,'ZZZZ')"));
-                methodWatcher.executeUpdate(String.format("create external table " + name + "2 (col1 int, col2 varchar(24))" +
-                        "partitioned by (col2) STORED AS PARQUET LOCATION '%s'", getExternalResourceDirectory() + "w_partitioned_parquet"));
-                methodWatcher.executeUpdate(String.format("insert into " + name + "2 values (1,'XXXX')," +
-                        "(2,'YYYY')," +
-                        "(3,'ZZZZ')"));
-                Assert.fail("Exception not thrown");
-
-            } catch (Exception e) {
-
-            }
+                assureFails(String.format("create external table " + name + "2 (col1 int, col2 varchar(24))" +
+                        "partitioned by (col2) STORED AS " + fileFormat + " LOCATION '%s'", tablePath), "EXT24", "");
         }
     }
 

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -32,6 +32,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.splicemachine.db.shared.common.reference.SQLState.*;
 import static org.junit.Assert.assertEquals;
@@ -157,243 +159,70 @@ public class ExternalTableIT extends SpliceUnitTest {
     }
 
     @Test
-    public void testInvalidSyntaxParquet() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/foobar/foobar";
-            // Row Format not supported for Parquet
-            methodWatcher.executeUpdate(String.format("create external table foo (col1 int, col2 int) partitioned by (col1) " +
-                    "row format delimited fields terminated by ',' escaped by '\\' " +
-                    "lines terminated by '\\n' STORED AS PARQUET LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT01",e.getSQLState());
+    public void testInvalidSyntax() throws Exception {
+        Map<String, String> errorFor = new HashMap<String, String>() { {
+            put("PARQUET", "EXT01");
+            put("ORC", "EXT02");
+            put("AVRO", "EXT36");
+        } };
+
+        for( String fileFormat : fileFormats) {
+            try {
+                String tablePath = getExternalResourceDirectory() + "/foobar/foobar";
+                // Row Format not supported for Parquet/ORC/AVRO
+                methodWatcher.executeUpdate(String.format("create external table foo (col1 int, col2 int) partitioned by (col1) " +
+                        "row format delimited fields terminated by ',' escaped by '\\' " +
+                        "lines terminated by '\\n' STORED AS " + fileFormat + " LOCATION '%s'", tablePath));
+                Assert.fail("Exception not thrown");
+            } catch (SQLException e) {
+                Assert.assertEquals("Wrong Exception", errorFor.get(fileFormat), e.getSQLState());
+            }
+        }
+    }
+
+    void testCreateFails(String test, String tableStr, String exception) throws Exception {
+        String tablePath = getExternalResourceDirectory() + "/HUMPTY_DUMPTY_MOLITOR";
+        for( String fileFormat : fileFormats) {
+            assureFails(String.format("create external table foo " + tableStr +
+                    " STORED AS " + fileFormat + " LOCATION '%s'", tablePath), exception, test);
         }
     }
 
     @Test
-    public void testInvalidSyntaxAvro() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/foobar/foobar";
-            // Row Format not supported for Avro
-            methodWatcher.executeUpdate(String.format("create external table foo (col1 int, col2 int) partitioned by (col1) " +
-                    "row format delimited fields terminated by ',' escaped by '\\' " +
-                    "lines terminated by '\\n' STORED AS AVRO LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT36",e.getSQLState());
-        }
+    public void testCreateTableErrors() throws Exception {
+        methodWatcher.executeUpdate("create table Cities (col1 int, col2 int, primary key (col1))");
+
+        testCreateFails( "NoPrimaryKeysOnExternalTables",
+                "(col1 int, col2 int, primary key (col1))", "EXT06");
+
+        testCreateFails( "NoCheckConstraintsOnExternalTables",
+                "(col1 int, col2 int, SALARY DECIMAL(9,2) CONSTRAINT SAL_CK CHECK (SALARY >= 10000))", "EXT07");
+
+        testCreateFails( "NoReferenceConstraintsOnExternalTables",
+                "(col1 int, col2 int, CITY_ID INT CONSTRAINT city_foreign_key REFERENCES Cities)", "EXT08");
+
+        testCreateFails( "NoUniqueConstraintsOnExternalTables",
+                "(col1 int, col2 int unique)", "EXT09");
+
+        testCreateFails( "NoGenerationClausesOnExternalTables",
+                "(col1 int, col2 varchar(24), col3 GENERATED ALWAYS AS ( UPPER(col2) ))", "EXT10");
+
+        testCreateFails( "cannotUsePartitionUndefined", "(col1 int, col2 varchar(24)) PARTITIONED BY (col3))", "EXT21");
+
     }
 
     @Test
-    public void testInvalidSyntaxORC() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/foobar/foobar";
-            // Row Format not supported for Parquet
-            methodWatcher.executeUpdate(String.format("create external table foo (col1 int, col2 int) partitioned by (col1) " +
-                    "row format delimited fields terminated by ',' escaped by '\\' " +
-                    "lines terminated by '\\n' STORED AS ORC LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT02",e.getSQLState());
-        }
-    }
+    public void testCreateTableErrors2() throws Exception {
+        String tablePath = getExternalResourceDirectory() + "createTable2";
+        assureFails("create external table foo (col1 int, col2 int) LOCATION '" + tablePath + "'",
+                "EXT03", "StoredAsRequired");
 
+        for (String fileFormat : fileFormats) {
+            assureFails("create external table foo (col1 int, col2 int) STORED AS " + fileFormat,
+                    "EXT04", "locationMissing");
 
-    @Test
-    public void testStoredAsRequired() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/foobar/foobar";
-            // Location Required For Parquet
-            methodWatcher.executeUpdate(String.format("create external table foo (col1 int, col2 int) LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT03",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testLocationRequired() throws Exception {
-        try {
-            methodWatcher.executeUpdate("create external table foo (col1 int, col2 int) STORED AS PARQUET");
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT04",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testLocationRequiredAvro() throws Exception {
-        try {
-            methodWatcher.executeUpdate("create external table foo (col1 int, col2 int) STORED AS AVRO");
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT04",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testCannotUsePartitionUndefined() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_MOLITOR";
-            methodWatcher.executeUpdate(String.format("create external  table table_without_defined_partition (col1 int, col2 varchar(24))" +
-                    " PARTITIONED BY (col3) STORED AS PARQUET LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT21",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testCannotUsePartitionUndefinedAvro() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_AVRO";
-            methodWatcher.executeUpdate(String.format("create external  table table_without_defined_partition (col1 int, col2 varchar(24))" +
-                    " PARTITIONED BY (col3) STORED AS AVRO LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT21",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testNoPrimaryKeysOnExternalTables() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_MOLITOR";
-            methodWatcher.executeUpdate(String.format("create external table foo (col1 int, col2 int, primary key (col1)) STORED AS PARQUET LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT06",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testNoPrimaryKeysOnExternalTablesAvro() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_AVRO";
-            methodWatcher.executeUpdate(String.format("create external table foo (col1 int, col2 int, primary key (col1)) STORED AS AVRO LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT06",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testNoCheckConstraintsOnExternalTables() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_MOLITOR";
-            methodWatcher.executeUpdate(String.format("create external table foo (col1 int, col2 int, SALARY DECIMAL(9,2) CONSTRAINT SAL_CK CHECK (SALARY >= 10000)) STORED AS PARQUET LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT07",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testNoCheckConstraintsOnExternalTablesAvro() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_AVRO";
-            methodWatcher.executeUpdate(String.format("create external table foo (col1 int, col2 int, SALARY DECIMAL(9,2) CONSTRAINT SAL_CK CHECK (SALARY >= 10000)) STORED AS AVRO LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT07",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testNoReferenceConstraintsOnExternalTables() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_MOLITOR";
-            methodWatcher.executeUpdate("create table Cities (col1 int, col2 int, primary key (col1))");
-            methodWatcher.executeUpdate(String.format("create external table foo (col1 int, col2 int, CITY_ID INT CONSTRAINT city_foreign_key\n" +
-                    " REFERENCES Cities) STORED AS PARQUET LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT08",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testNoReferenceConstraintsOnExternalTablesAvro() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_AVRO_TEST";
-            methodWatcher.executeUpdate("create table Cities_avro (col1 int, col2 int, primary key (col1))");
-            methodWatcher.executeUpdate(String.format("create external table foo_avro (col1 int, col2 int, CITY_ID INT CONSTRAINT city_foreign_key\n" +
-                    " REFERENCES Cities_avro) STORED AS AVRO LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT08",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testNoUniqueConstraintsOnExternalTables() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_MOLITOR";
-            methodWatcher.executeUpdate(String.format("create external table foo (col1 int, col2 int unique)" +
-                    " STORED AS PARQUET LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT09",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testNoUniqueConstraintsOnExternalTablesAvro() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_AVRO";
-            methodWatcher.executeUpdate(String.format("create external table foo (col1 int, col2 int unique)" +
-                    " STORED AS AVRO LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT09",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testNoGenerationClausesOnExternalTables() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_MOLITOR";
-            methodWatcher.executeUpdate(String.format("create external table foo (col1 int, col2 varchar(24), col3 GENERATED ALWAYS AS ( UPPER(col2) ))" +
-                    " STORED AS PARQUET LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT10",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testNoGenerationClausesOnExternalTablesAvro() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_AVRO";
-            methodWatcher.executeUpdate(String.format("create external table foo (col1 int, col2 varchar(24), col3 GENERATED ALWAYS AS ( UPPER(col2) ))" +
-                    " STORED AS AVRO LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT10",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testMissingExternal() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_MOLITOR";
-            methodWatcher.executeUpdate(String.format("create table foo (col1 int, col2 varchar(24))" +
-                    " STORED AS PARQUET LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT18",e.getSQLState());
-        }
-    }
-
-    @Test
-    public void testMissingExternalAvro() throws Exception {
-        try {
-            String tablePath = getExternalResourceDirectory()+"/HUMPTY_DUMPTY_AVRO";
-            methodWatcher.executeUpdate(String.format("create table foo (col1 int, col2 varchar(24))" +
-                    " STORED AS AVRO LOCATION '%s'",tablePath));
-            Assert.fail("Exception not thrown");
-        } catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT18",e.getSQLState());
+            assureFails(String.format("create table foo (col1 int, col2 varchar(24))" +
+                    " STORED AS " + fileFormat + " LOCATION '%s'", tablePath), "EXT18", "missingExternal");
         }
     }
 

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -28,10 +28,7 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 import java.io.File;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -420,82 +417,56 @@ public class ExternalTableIT extends SpliceUnitTest {
 
     }
 
+    public void testWriteReadFromSimpleExternalTable(String fileFormat) throws Exception {
+        String name = "write_all_datatypes_" + fileFormat;
+        String file = getExternalResourceDirectory() + name;
+        int[] values = {1, 2, 3, 4, 0 /* = NULL */ };
+        int[] colTypes = CreateTableTypeHelper.getTypes(fileFormat);
+        CreateTableTypeHelper types = new CreateTableTypeHelper(colTypes, values);
 
-    @Test
-    public void testWriteReadNullValues() throws Exception {
+        String externalTableOptions = " COMPRESSED WITH SNAPPY STORED AS " + fileFormat + " LOCATION '"
+                + file + "'";
+        methodWatcher.executeUpdate("create external table " + name + " (" + types.getSchema() + ")" + externalTableOptions);
+        int insertCount = methodWatcher.executeUpdate( "insert into " + name + " values " + types.getInsertValues() + "");
+        Assert.assertEquals(fileFormat + ": insertCount is wrong", values.length, insertCount);
 
-        String tablePath = getExternalResourceDirectory()+"null_test_location";
-        methodWatcher.executeUpdate(String.format("create external table null_test (col1 int, col2 varchar(24))" +
-                " STORED AS PARQUET LOCATION '%s'",tablePath));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into null_test values (1,null)," +
-                "(2,'YYYY')," +
-                "(3,'ZZZZ')"));
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
-        ResultSet rs = methodWatcher.executeQuery("select * from null_test where col2 is null");
-        Assert.assertEquals("COL1 |COL2 |\n" +
-                "------------\n" +
-                "  1  |NULL |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select * from null_test where col2 is not null");
-        Assert.assertEquals("COL1 |COL2 |\n" +
-                "------------\n" +
-                "  2  |YYYY |\n" +
-                "  3  |ZZZZ |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+        // test select *, result matches expectations (= inserted values)
+        ResultSet rs = methodWatcher.executeQuery("select * from " + name );
+        types.checkResultSetSelectAll(rs);
 
-        //Make sure empty file is created
-        Assert.assertTrue(String.format("Table %s hasn't been created",tablePath), new File(tablePath).exists());
+        // test NULLs
+        ResultSet rs2 = methodWatcher.executeQuery("select COL_VARCHAR from " + name + " where COL_VARCHAR is null");
+        Assert.assertEquals(fileFormat, "COL_VARCHAR |\n" +
+                "--------------\n" +
+                "    NULL     |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+        if( !fileFormat.equals("ORC") ) { // this doesn't work for ORC?!
+            ResultSet rs3 = methodWatcher.executeQuery("select COL_VARCHAR from " + name + " where COL_VARCHAR is not null");
+            Assert.assertEquals(fileFormat, "COL_VARCHAR |\n" +
+                    "--------------\n" +
+                    "   AAAA 1    |\n" +
+                    "   AAAA 2    |\n" +
+                    "   AAAA 3    |\n" +
+                    "   AAAA 4    |", TestUtils.FormattedResult.ResultFactory.toString(rs3));
+        }
 
+        // test schema suggestion when we're using a wrong schema
+        try {
+            methodWatcher.executeUpdate("create external table all_datatypes_wrong ( i int )" + externalTableOptions);
+            Assert.fail( fileFormat + ": Exception not thrown");
+        } catch (SQLException e) {
+            Assert.assertEquals(fileFormat + ": Wrong Exception", INCONSISTENT_NUMBER_OF_ATTRIBUTE, e.getSQLState());
+            Assert.assertEquals(fileFormat + ": wrong exception message",
+                    "Only '1' attributes defined but '" + colTypes.length + "' present in the external file : '" + file + "'. " +
+                            "Suggested Schema is 'CREATE EXTERNAL TABLE T (" + types.getSuggestedTypes() + ");'.",
+                    e.getMessage());
+        }
     }
 
+    // tests writing all columns types, null values, suggesting schema.
     @Test
-    public void testWriteReadNullValuesAvro() throws Exception {
-
-        String tablePath = getExternalResourceDirectory()+"null_test_location_avro";
-        methodWatcher.executeUpdate(String.format("create external table null_test_avro (col1 int, col2 varchar(24))" +
-                " STORED AS AVRO LOCATION '%s'",tablePath));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into null_test_avro values (1,null)," +
-                "(2,'YYYY')," +
-                "(3,'ZZZZ')"));
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
-        ResultSet rs = methodWatcher.executeQuery("select * from null_test_avro where col2 is null");
-        Assert.assertEquals("COL1 |COL2 |\n" +
-                "------------\n" +
-                "  1  |NULL |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select * from null_test_avro where col2 is not null");
-        Assert.assertEquals("COL1 |COL2 |\n" +
-                "------------\n" +
-                "  2  |YYYY |\n" +
-                "  3  |ZZZZ |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-
-        //Make sure empty file is created
-        Assert.assertTrue(String.format("Table %s hasn't been created",tablePath), new File(tablePath).exists());
-
-    }
-
-
-    @Test
-    public void testWriteReadFromSimpleParquetExternalTable() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"simple_parquet";
-        methodWatcher.executeUpdate(String.format("create external table simple_parquet (col1 int, col2 varchar(24))" +
-                " STORED AS PARQUET LOCATION '%s'",tablePath));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into simple_parquet values (1,'XXXX')," +
-                "(2,'YYYY')," +
-                "(3,'ZZZZ')"));
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
-        ResultSet rs = methodWatcher.executeQuery("select * from simple_parquet");
-        Assert.assertEquals("COL1 |COL2 |\n" +
-                "------------\n" +
-                "  1  |XXXX |\n" +
-                "  2  |YYYY |\n" +
-                "  3  |ZZZZ |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select distinct col1 from simple_parquet");
-        Assert.assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  2  |\n" +
-                "  3  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-
-        //Make sure empty file is created
-        Assert.assertTrue(String.format("Table %s hasn't been created",tablePath), new File(tablePath).exists());
+    public void testWriteReadFromSimpleExternalTable() throws Exception {
+        for( String fileFormat : fileFormats )
+            testWriteReadFromSimpleExternalTable(fileFormat);
 
     }
 
@@ -534,34 +505,7 @@ public class ExternalTableIT extends SpliceUnitTest {
         Assert.assertEquals("", TestUtils.FormattedResult.ResultFactory.toString(rs));
     }
 
-    @Test
-    public void testWriteReadFromSimpleAvroExternalTable() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"simple_avro";
-        methodWatcher.executeUpdate(String.format("create external table simple_avro (col1 int, col2 varchar(24))" +
-                " STORED AS AVRO LOCATION '%s'",tablePath));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into simple_avro values (1,'XXXX')," +
-                "(2,'YYYY')," +
-                "(3,'ZZZZ')"));
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
-        ResultSet rs = methodWatcher.executeQuery("select * from simple_avro");
-        Assert.assertEquals("COL1 |COL2 |\n" +
-                "------------\n" +
-                "  1  |XXXX |\n" +
-                "  2  |YYYY |\n" +
-                "  3  |ZZZZ |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select distinct col1 from simple_avro");
-        Assert.assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  2  |\n" +
-                "  3  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-
-        //Make sure empty file is created
-        Assert.assertTrue(String.format("Table %s hasn't been created",tablePath), new File(tablePath).exists());
-
-    }
-
-
+    // todo: move to testWriteReadFromSimpleExternalTablefor( String storedAs : fileFormats )
     @Test
     public void testWriteReadFromSimpleCsvExternalTable() throws Exception {
         String tablePath = getExternalResourceDirectory()+"dt_txt";
@@ -572,8 +516,6 @@ public class ExternalTableIT extends SpliceUnitTest {
         Assert.assertEquals("A     |\n" +
                 "------------\n" +
                 "2017-01-25 |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-
-
     }
 
 
@@ -682,79 +624,26 @@ public class ExternalTableIT extends SpliceUnitTest {
 
 
     @Test
-    public void testWriteReadFromPartitionedParquetExternalTable() throws Exception {
-        String tablePath =  getExternalResourceDirectory()+"partitioned_parquet";
-                methodWatcher.executeUpdate(String.format("create external table partitioned_parquet (col1 int, col2 varchar(24))" +
-                "partitioned by (col2) STORED AS PARQUET LOCATION '%s'", getExternalResourceDirectory()+"partitioned_parquet"));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into partitioned_parquet values (1,'XXXX')," +
-                "(2,'YYYY')," +
-                "(3,'ZZZZ')"));
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
-        ResultSet rs = methodWatcher.executeQuery("select * from partitioned_parquet");
-        Assert.assertEquals("COL1 |COL2 |\n" +
-                "------------\n" +
-                "  1  |XXXX |\n" +
-                "  2  |YYYY |\n" +
-                "  3  |ZZZZ |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+    public void testWriteReadFromPartitionedExternalTable() throws Exception {
+        for( String fileFormat : fileFormats ) {
+            String name = "partitioned_" + fileFormat;
+            String tablePath = getExternalResourceDirectory() + name;
+            methodWatcher.executeUpdate(String.format("create external table " + name + " (col1 int, col2 varchar(24))" +
+                    "partitioned by (col2) STORED AS " + fileFormat + " LOCATION '%s'", tablePath));
+            int insertCount = methodWatcher.executeUpdate(String.format("insert into " + name + " values (1,'XXXX')," +
+                    "(2,'YYYY')," +
+                    "(3,'ZZZZ')"));
+            Assert.assertEquals("insertCount is wrong", 3, insertCount);
+            ResultSet rs = methodWatcher.executeQuery("select * from " + name );
+            Assert.assertEquals("COL1 |COL2 |\n" +
+                    "------------\n" +
+                    "  1  |XXXX |\n" +
+                    "  2  |YYYY |\n" +
+                    "  3  |ZZZZ |", TestUtils.FormattedResult.ResultFactory.toString(rs));
 
-        //Make sure empty file is created
-        Assert.assertTrue(String.format("Table %s hasn't been created",tablePath), new File(tablePath).exists());
-    }
-
-    @Test
-    public void testWriteReadFromPartitionedAvroExternalTable() throws Exception {
-        String tablePath =  getExternalResourceDirectory()+"partitioned_avro";
-        methodWatcher.executeUpdate(String.format("create external table partitioned_avro (col1 int, col2 varchar(24))" +
-                "partitioned by (col2) STORED AS AVRO LOCATION '%s'", getExternalResourceDirectory()+"partitioned_avro"));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into partitioned_avro values (1,'XXXX')," +
-                "(2,'YYYY')," +
-                "(3,'ZZZZ')"));
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
-        ResultSet rs = methodWatcher.executeQuery("select * from partitioned_avro");
-        Assert.assertEquals("COL1 |COL2 |\n" +
-                "------------\n" +
-                "  1  |XXXX |\n" +
-                "  2  |YYYY |\n" +
-                "  3  |ZZZZ |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-
-        //Make sure empty file is created
-        Assert.assertTrue(String.format("Table %s hasn't been created",tablePath), new File(tablePath).exists());
-    }
-
-    @Test
-    public void testWriteReadFromSimpleORCExternalTable() throws Exception {
-        methodWatcher.executeUpdate(String.format("create external table simple_orc (col1 int, col2 varchar(24), col3 NUMERIC)" +
-                " STORED AS ORC LOCATION '%s'", getExternalResourceDirectory()+"simple_orc"));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into simple_orc values (1,'XXXX',13691)," +
-                "(2,'YYYY',2345)," +
-                "(3,'ZZZZ',12345)"));
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
-        ResultSet rs = methodWatcher.executeQuery("select * from simple_orc");
-        Assert.assertEquals("COL1 |COL2 |COL3  |\n" +
-                "-------------------\n" +
-                "  1  |XXXX |13691 |\n" +
-                "  2  |YYYY |2345  |\n" +
-                "  3  |ZZZZ |12345 |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-    }
-
-    @Test
-    public void testWriteReadFromPartitionedORCExternalTable() throws Exception {
-        methodWatcher.executeUpdate(String.format("create external table partitioned_orc (col1 int, col2 varchar(24))" +
-                "partitioned by (col2) STORED AS ORC LOCATION '%s'", getExternalResourceDirectory()+"partitioned_orc"));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into partitioned_orc values (1,'XXXX')," +
-                "(2,'YYYY')," +
-                "(3,'ZZZZ')"));
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
-        ResultSet rs = methodWatcher.executeQuery("select * from partitioned_orc");
-        Assert.assertEquals("COL1 |COL2 |\n" +
-                "------------\n" +
-                "  1  |XXXX |\n" +
-                "  2  |YYYY |\n" +
-                "  3  |ZZZZ |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet r2 = methodWatcher.executeQuery("select count(*) from partitioned_orc");
-        Assert.assertEquals("1 |\n" +
-                "----\n" +
-                " 3 |",TestUtils.FormattedResult.ResultFactory.toString(r2));
+            //Make sure empty file is created
+            Assert.assertTrue(String.format("Table %s hasn't been created", tablePath), new File(tablePath).exists());
+        }
     }
 
     @Test
@@ -878,14 +767,13 @@ public class ExternalTableIT extends SpliceUnitTest {
         String[] compressionTypes = { "", // no compression
                 "COMPRESSED WITH SNAPPY",
                 "COMPRESSED WITH ZLIB"};
-        String[] storedAsArray = { "PARQUET", "ORC", "AVRO" };
         for( String compression : compressionTypes )
         {
-            for( String storedAs : storedAsArray )
+            for( String fileFormat : fileFormats )
             {
                 String path = getExternalResourceDirectory() + "compressed_test";
                 String createSql = "create external table compressed_test (col1 int, col2 varchar(24)) "
-                        + compression + " STORED AS " + storedAs + " LOCATION '" + path + "'";
+                        + compression + " STORED AS " + fileFormat + " LOCATION '" + path + "'";
                 try {
                     FileUtils.deleteDirectory(new File(path));
                     methodWatcher.executeUpdate(createSql);
@@ -1057,15 +945,9 @@ public class ExternalTableIT extends SpliceUnitTest {
 
     @Test
     public void testWriteReadFromCompressedErrorTextExternalTable() throws Exception {
-        try{
-
-                methodWatcher.executeUpdate(String.format("create external table compressed_ignored_text (col1 int, col2 varchar(24))" +
-                        "COMPRESSED WITH SNAPPY STORED AS TEXTFILE LOCATION '%s'", getExternalResourceDirectory()+"compressed_ignored_text"));
-
-                Assert.fail("Exception not thrown");
-            } catch (SQLException e) {
-                Assert.assertEquals("Wrong Exception","EXT17",e.getSQLState());
-            }
+        assureFails(String.format("create external table compressed_ignored_text (col1 int, col2 varchar(24))" +
+                        "COMPRESSED WITH SNAPPY STORED AS TEXTFILE LOCATION '%s'", getExternalResourceDirectory()+"compressed_ignored_text"),
+                "EXT17", "");
     }
 
     @Test
@@ -1576,6 +1458,7 @@ public class ExternalTableIT extends SpliceUnitTest {
         }
     }
 
+    // rather slow test (20s). maybe combine with testWriteReadArrays?
     @Test
     public void testCollectStats() throws Exception {
         for( String fileFormat : new String[]{"ORC", "PARQUET", "AVRO", "TEXTFILE"}) {
@@ -1647,6 +1530,7 @@ public class ExternalTableIT extends SpliceUnitTest {
         }
     }
 
+    // rather slow test (20s)
     @Test
     public void testWriteReadArrays() throws Exception {
         for( String fileFormat : fileFormats) {

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
@@ -69,45 +69,6 @@ public class ExternalTablePartitionIT extends SpliceUnitTest {
     }
 
     @Test
-    public void testParquetPartitionFirst() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/parquet_partition_first";
-        methodWatcher.executeUpdate(String.format("create external table parquet_part_1st (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col1) STORED AS PARQUET LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into parquet_part_1st values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_1st");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_1st");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_1st");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_1st");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_1st");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-
-    @Test
     public void testSparkGeneratesFewParquetFiles() throws Exception {
         testSparkGeneratesFewFiles("parquet");
     }
@@ -150,1211 +111,244 @@ public class ExternalTablePartitionIT extends SpliceUnitTest {
         assertEquals(11, getNumberOfFiles(tablePath));
     }
 
+    String[] fileFormatsText = { "PARQUET", "ORC", "AVRO", "TEXTFILE" };
 
-    @Test
-    public void testAvroPartitionFirst() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/avro_partition_first";
-        methodWatcher.executeUpdate(String.format("create external table avro_part_1st (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col1) STORED AS AVRO LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into avro_part_1st values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from avro_part_1st");
+    private void checkPartitionInsertSelect(String testName, String fileFormat, String partitionedBy) throws Exception {
+        String name = testName + "_" + fileFormat;
+        String tablePath = getExternalResourceDirectory() + "/" + name;
+        methodWatcher.executeUpdate(String.format("create external table " + name + " (col1 int, col2 int, col3 varchar(10)) " +
+                "partitioned by (" + partitionedBy + ") STORED AS " + fileFormat + " LOCATION '%s'", tablePath));
+
+        methodWatcher.executeUpdate("insert into " + name  + " values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+
+        ResultSet rs = methodWatcher.executeQuery("select * from " + name );
         assertEquals("COL1 |COL2 |COL3 |\n" +
                 "------------------\n" +
                 "  1  |  2  | AAA |\n" +
                 "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_1st");
+                "  5  |  6  | CCC |", TestUtils.FormattedResult.ResultFactory.toString(rs));
+        ResultSet rs1 = methodWatcher.executeQuery("select col1 from " + name );
         assertEquals("COL1 |\n" +
                 "------\n" +
                 "  1  |\n" +
                 "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_1st");
+                "  5  |", TestUtils.FormattedResult.ResultFactory.toString(rs1));
+        ResultSet rs2 = methodWatcher.executeQuery("select col2 from " + name );
         assertEquals("COL2 |\n" +
                 "------\n" +
                 "  2  |\n" +
                 "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_1st");
+                "  6  |", TestUtils.FormattedResult.ResultFactory.toString(rs2));
+        ResultSet rs3 = methodWatcher.executeQuery("select col3 from " + name );
         assertEquals("COL3 |\n" +
                 "------\n" +
                 " AAA |\n" +
                 " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_1st");
+                " CCC |", TestUtils.FormattedResult.ResultFactory.toString(rs3));
+        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from " + name );
         assertEquals("COL2 |COL3 |\n" +
                 "------------\n" +
                 "  2  | AAA |\n" +
                 "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-    @Test
-    public void testOrcPartitionFirst() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/orc_partition_first";
-        methodWatcher.executeUpdate(String.format("create external table orc_part_1st (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col1) STORED AS ORC LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into orc_part_1st values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from orc_part_1st");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_1st");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_1st");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_1st");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_1st");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+                "  6  | CCC |", TestUtils.FormattedResult.ResultFactory.toString(rs4));
 
         /* test query with predicates */
-        ResultSet rs5 = methodWatcher.executeQuery("select * from orc_part_1st where col1=3");
+        ResultSet rs5 = methodWatcher.executeQuery("select * from " + name  + " where col1=3");
         assertEquals("COL1 |COL2 |COL3 |\n" +
                 "------------------\n" +
                 "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs5));
 
         /* test query with predicate on partitioning column and non-partitioning column */
-        ResultSet rs51 = methodWatcher.executeQuery("select * from orc_part_1st where col1>=3 and col1<4 and col3='BBB'");
+        ResultSet rs51 = methodWatcher.executeQuery("select * from " + name  + " where col1>=3 and col1<4 and col3='BBB'");
         assertEquals("COL1 |COL2 |COL3 |\n" +
                 "------------------\n" +
                 "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs51));
 
 
-        ResultSet rs6 = methodWatcher.executeQuery("select * from orc_part_1st where col2=4");
+        ResultSet rs6 = methodWatcher.executeQuery("select * from " + name  + " where col2=4");
         assertEquals("COL1 |COL2 |COL3 |\n" +
                 "------------------\n" +
                 "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs6));
 
-        ResultSet rs7 = methodWatcher.executeQuery("select * from orc_part_1st where col3='CCC'");
+        ResultSet rs7 = methodWatcher.executeQuery("select * from " + name  + " where col3='CCC'");
         assertEquals("COL1 |COL2 |COL3 |\n" +
                 "------------------\n" +
                 "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs7));
+
+
+        ResultSet rs8 = methodWatcher.executeQuery("select * from " + name + " where col3='AAA'");
+        assertEquals("COL1 |COL2 |COL3 |\n" +
+                "------------------\n" +
+                "  1  |  2  | AAA |", TestUtils.FormattedResult.ResultFactory.toString(rs8));
     }
 
     @Test
-    public void testTextfilePartitionFirst() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/textfile_partition_first";
-        methodWatcher.executeUpdate(String.format("create external table textfile_part_1st (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col1) STORED AS TEXTFILE LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into textfile_part_1st values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_1st");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_1st");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_1st");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_1st");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_1st");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+    public void testPartitionFirst() throws Exception {
+        for( String fileFormat : fileFormatsText) {
+            checkPartitionInsertSelect( "partition_first", fileFormat, "col1");
+        }
     }
 
     @Test
-    public void testParquetPartitionFirstSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/parquet_partition_first_second";
-        methodWatcher.executeUpdate(String.format("create external table parquet_part_1st_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col1,col2) STORED AS PARQUET LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into parquet_part_1st_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_1st_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_1st_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_1st_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_1st_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_1st_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+    public void testPartitionFirstSecond() throws Exception {
+        for( String fileFormat : fileFormatsText) {
+            checkPartitionInsertSelect( "partition_first_second", fileFormat, "col1, col2");
+        }
     }
 
     @Test
-    public void testAvroPartitionFirstSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/avro_partition_first_second";
-        methodWatcher.executeUpdate(String.format("create external table avro_part_1st_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col1,col2) STORED AS AVRO LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into avro_part_1st_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from avro_part_1st_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_1st_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_1st_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_1st_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_1st_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+    public void testPartitionSecond() throws Exception {
+        for( String fileFormat : fileFormatsText) {
+            checkPartitionInsertSelect( "partition_second", fileFormat, "col2");
+        }
     }
 
     @Test
-    public void testOrcPartitionFirstSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/orc_partition_first_second";
-        methodWatcher.executeUpdate(String.format("create external table orc_part_1st_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col1,col2) STORED AS ORC LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into orc_part_1st_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from orc_part_1st_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_1st_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_1st_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_1st_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_1st_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-
-        // test query with predicate
-        ResultSet rs5 = methodWatcher.executeQuery("select * from orc_part_1st_2nd where col1=3");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs5));
-
-        ResultSet rs6 = methodWatcher.executeQuery("select * from orc_part_1st_2nd where col2=4");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs6));
-
-        ResultSet rs7 = methodWatcher.executeQuery("select * from orc_part_1st_2nd where col3='AAA'");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |",TestUtils.FormattedResult.ResultFactory.toString(rs7));
+    public void testPartitionLast() throws Exception {
+        for (String fileFormat : fileFormatsText) {
+            checkPartitionInsertSelect( "partition_last", fileFormat, "col3");
+        }
     }
 
     @Test
-    public void testTextfilePartitionFirstSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/textfile_partition_first_second";
-        methodWatcher.executeUpdate(String.format("create external table textfile_part_1st_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col1,col2) STORED AS TEXTFILE LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into textfile_part_1st_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_1st_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_1st_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_1st_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_1st_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_1st_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+    public void testPartitionThirdSecond() throws Exception {
+        for (String fileFormat : fileFormatsText) {
+            checkPartitionInsertSelect( "partition_third_second", fileFormat, "col3, col2");
+        }
     }
 
     @Test
-    public void testParquetPartitionSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/parquet_partition_second";
-        methodWatcher.executeUpdate(String.format("create external table parquet_part_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col2) STORED AS PARQUET LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into parquet_part_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+    public void testAggressive() throws Exception {
+        for (String fileFormat : fileFormatsText) {
+            String name = "orc_aggressive_" + fileFormat;
+            String tablePath = getExternalResourceDirectory() + "/" + name;
+            methodWatcher.executeUpdate(String.format("create external table " + name +
+                    " (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char) " +
+                    "partitioned by (col4, col6, col2) STORED AS " + fileFormat + " LOCATION '%s'", tablePath));
+            methodWatcher.executeUpdate("insert into " + name + " values " +
+                    "(111,'AAA',true,111, 1.1, 'a'),(222,'BBB',false,222, 2.2, 'b'),(333,'CCC',true,333, 3.3, 'c')");
+            ResultSet rs = methodWatcher.executeQuery("select * from " + name );
+            assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
+                    "-------------------------------------\n" +
+                    " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
+                    " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
+                    " 333 | CCC |true  | 333 | 3.3 |  c  |", TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from " + name);
+            assertEquals("COL5 |COL2 |COL6 |\n" +
+                    "------------------\n" +
+                    " 1.1 | AAA |  a  |\n" +
+                    " 2.2 | BBB |  b  |\n" +
+                    " 3.3 | CCC |  c  |", TestUtils.FormattedResult.ResultFactory.toString(rs2));
+        }
     }
 
     @Test
-    public void testAvroPartitionSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/avro_partition_second";
-        methodWatcher.executeUpdate(String.format("create external table avro_part_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col2) STORED AS AVRO LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into avro_part_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from avro_part_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
+    public void testAggressive2() throws Exception{
+        for (String format : fileFormatsText) {
+            String tablePath0 = String.format(getExternalResourceDirectory() + "/%s_aggressive_2_0", format);
+            String tablePath1 = String.format(getExternalResourceDirectory() + "/%s_aggressive_2_1", format);
+            String tablePath2 = String.format(getExternalResourceDirectory() + "/%s_aggressive_2_2", format);
 
+            methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_0 " +
+                    "(col1 varchar(10), col2 double, col3 int, col4 varchar(10), col5 int) " +
+                    "partitioned by (col1, col2, col4, col5) stored as %s location '%s'", format, format, tablePath0));
+            methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_0 values " +
+                    "('whoa',77.7,444,'crazy',21),('hey',11.11,222,'crazier',10)", format));
+            ResultSet rs0 = methodWatcher.executeQuery(String.format("select col4, col2, col3 from %s_aggressive_2_0 where col5 = 21", format));
+            assertEquals("COL4  |COL2 |COL3 |\n" +
+                    "-------------------\n" +
+                    "crazy |77.7 | 444 |", TestUtils.FormattedResult.ResultFactory.toString(rs0));
 
-    @Test
-    public void testOrcPartitionSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/orc_partition_second";
-        methodWatcher.executeUpdate(String.format("create external table orc_part_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col2) STORED AS ORC LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into orc_part_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from orc_part_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
+            methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_1 " +
+                    "(col1 int, col2 double, col3 char, col4 varchar(10), col5 int) " +
+                    "partitioned by (col3, col1, col2) stored as %s location '%s'", format, format, tablePath1));
+            methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_1 values " +
+                    "(666,66.666,'z','zing',20),(555,55.555,'y','yowza',40),(1,1.1,'g','garish',7)", format));
+            ResultSet rs1 = methodWatcher.executeQuery(String.format("select col2,col4 from %s_aggressive_2_1", format));
+            assertEquals("COL2  | COL4  |\n" +
+                    "----------------\n" +
+                    "  1.1  |garish |\n" +
+                    "55.555 | yowza |\n" +
+                    "66.666 | zing  |", TestUtils.FormattedResult.ResultFactory.toString(rs1));
 
-        // test query with predicates
-        ResultSet rs5 = methodWatcher.executeQuery("select * from orc_part_2nd where col1=3");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs5));
-        ResultSet rs6 = methodWatcher.executeQuery("select * from orc_part_2nd where col2=4");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs6));
-        ResultSet rs7 = methodWatcher.executeQuery("select * from orc_part_2nd where col3='CCC'");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs7));
-    }
-
-
-    @Test
-    public void testTextfilePartitionSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/textfile_partition_second_";
-        methodWatcher.executeUpdate(String.format("create external table textfile_part_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col2) STORED AS TEXTFILE LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into textfile_part_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-    @Test
-    public void testParquetPartitionLast() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/parquet_partition_last";
-        methodWatcher.executeUpdate(String.format("create external table parquet_part_last (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col3) STORED AS PARQUET LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into parquet_part_last values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_last");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_last");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_last");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_last");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_last");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-
-    @Test
-    public void testAvroPartitionLast() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/avro_partition_last";
-        methodWatcher.executeUpdate(String.format("create external table avro_part_last (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col3) STORED AS AVRO LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into avro_part_last values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from avro_part_last");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_last");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_last");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_last");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_last");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-    @Test
-    public void testOrcPartitionLast() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/orc_partition_last";
-        methodWatcher.executeUpdate(String.format("create external table orc_part_last (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col3) STORED AS ORC LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into orc_part_last values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from orc_part_last");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_last");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_last");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_last");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_last");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-
-        // test query with predicate
-        ResultSet rs5 = methodWatcher.executeQuery("select * from orc_part_last where col1=3");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs5));
-        ResultSet rs6 = methodWatcher.executeQuery("select * from orc_part_last where col2=4");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs6));
-        ResultSet rs7 = methodWatcher.executeQuery("select * from orc_part_last where col3='CCC'");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs7));
-    }
-
-    @Test
-    public void testTextfilePartitionLast() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/textfile_partition_last";
-        methodWatcher.executeUpdate(String.format("create external table textfile_part_last (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col3) STORED AS TEXTFILE LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into textfile_part_last values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_last");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_last");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_last");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_last");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_last");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-    @Test
-    public void testParquetPartitionThirdSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/parquet_partition_third_second";
-        methodWatcher.executeUpdate(String.format("create external table parquet_part_3rd_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col3,col2) STORED AS PARQUET LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into parquet_part_3rd_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from parquet_part_3rd_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from parquet_part_3rd_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from parquet_part_3rd_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from parquet_part_3rd_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from parquet_part_3rd_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-    @Test
-    public void testAvroPartitionThirdSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/avro_partition_third_second";
-        methodWatcher.executeUpdate(String.format("create external table avro_part_3rd_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col3,col2) STORED AS AVRO LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into avro_part_3rd_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from avro_part_3rd_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from avro_part_3rd_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from avro_part_3rd_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from avro_part_3rd_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from avro_part_3rd_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-    @Test
-    public void testOrcPartitionThirdSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/orc_partition_third_second";
-        methodWatcher.executeUpdate(String.format("create external table orc_part_3rd_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col3,col2) STORED AS ORC LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into orc_part_3rd_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from orc_part_3rd_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from orc_part_3rd_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from orc_part_3rd_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from orc_part_3rd_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from orc_part_3rd_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-
-        //test query with prediate
-        ResultSet rs5 = methodWatcher.executeQuery("select * from orc_part_3rd_2nd where col1=3");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs5));
-        ResultSet rs6 = methodWatcher.executeQuery("select * from orc_part_3rd_2nd where col2=4");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  3  |  4  | BBB |",TestUtils.FormattedResult.ResultFactory.toString(rs6));
-        ResultSet rs7 = methodWatcher.executeQuery("select * from orc_part_3rd_2nd where col3='CCC'");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs7));
-    }
-
-    @Test
-    public void testTextfilePartitionThirdSecond() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/textfile_partition_third_second";
-        methodWatcher.executeUpdate(String.format("create external table textfile_part_3rd_2nd (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (col3,col2) STORED AS TEXTFILE LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into textfile_part_3rd_2nd values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
-        ResultSet rs = methodWatcher.executeQuery("select * from textfile_part_3rd_2nd");
-        assertEquals("COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "  1  |  2  | AAA |\n" +
-                "  3  |  4  | BBB |\n" +
-                "  5  |  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs1 = methodWatcher.executeQuery("select col1 from textfile_part_3rd_2nd");
-        assertEquals("COL1 |\n" +
-                "------\n" +
-                "  1  |\n" +
-                "  3  |\n" +
-                "  5  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-        ResultSet rs2 = methodWatcher.executeQuery("select col2 from textfile_part_3rd_2nd");
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                "  2  |\n" +
-                "  4  |\n" +
-                "  6  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-        ResultSet rs3 = methodWatcher.executeQuery("select col3 from textfile_part_3rd_2nd");
-        assertEquals("COL3 |\n" +
-                "------\n" +
-                " AAA |\n" +
-                " BBB |\n" +
-                " CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs3));
-        ResultSet rs4 = methodWatcher.executeQuery("select col2, col3 from textfile_part_3rd_2nd");
-        assertEquals("COL2 |COL3 |\n" +
-                "------------\n" +
-                "  2  | AAA |\n" +
-                "  4  | BBB |\n" +
-                "  6  | CCC |",TestUtils.FormattedResult.ResultFactory.toString(rs4));
-    }
-
-    @Test
-    public void testOrcAggressive() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/orc_aggressive";
-        methodWatcher.executeUpdate(String.format("create external table orc_aggressive (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char) " +
-                "partitioned by (col4, col6, col2) STORED AS ORC LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into orc_aggressive values " +
-                "(111,'AAA',true,111, 1.1, 'a'),(222,'BBB',false,222, 2.2, 'b'),(333,'CCC',true,333, 3.3, 'c')");
-        ResultSet rs = methodWatcher.executeQuery("select * from orc_aggressive");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from orc_aggressive");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testParquetAggressive() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/parquet_aggressive";
-        methodWatcher.executeUpdate(String.format("create external table parquet_aggressive (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char) " +
-                "partitioned by (col4, col6, col2) STORED AS PARQUET LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into parquet_aggressive values " +
-                "(111,'AAA',true,111, 1.1, 'a'),(222,'BBB',false,222, 2.2, 'b'),(333,'CCC',true,333, 3.3, 'c')");
-        ResultSet rs = methodWatcher.executeQuery("select * from parquet_aggressive");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from parquet_aggressive");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testAvroAggressive() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/avro_aggressive";
-        methodWatcher.executeUpdate(String.format("create external table avro_aggressive (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char) " +
-                "partitioned by (col4, col6, col2) STORED AS AVRO LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into avro_aggressive values " +
-                "(111,'AAA',true,111, 1.1, 'a'),(222,'BBB',false,222, 2.2, 'b'),(333,'CCC',true,333, 3.3, 'c')");
-        ResultSet rs = methodWatcher.executeQuery("select * from avro_aggressive");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from avro_aggressive");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testTextfileAggressive() throws Exception {
-        String tablePath = getExternalResourceDirectory()+"/textfile_aggressive";
-        methodWatcher.executeUpdate(String.format("create external table textfile_aggressive (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char) " +
-                "partitioned by (col4, col6, col2) STORED AS TEXTFILE LOCATION '%s'",tablePath));
-        methodWatcher.executeUpdate("insert into textfile_aggressive values " +
-                "(111,'AAA',true,111, 1.1, 'a'),(222,'BBB',false,222, 2.2, 'b'),(333,'CCC',true,333, 3.3, 'c')");
-        ResultSet rs = methodWatcher.executeQuery("select * from textfile_aggressive");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from textfile_aggressive");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testParquetAggressive2() throws Exception{
-        String format = "parquet";
-        String tablePath0 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_0",format);
-        String tablePath1 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_1",format);
-        String tablePath2 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_2",format);
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_0 (col1 varchar(10), col2 double, col3 int, col4 varchar(10), col5 int) " +
-                "partitioned by (col1, col2, col4, col5) stored as %s location '%s'",format,format,tablePath0));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_0 values " +
-                "('whoa',77.7,444,'crazy',21),('hey',11.11,222,'crazier',10)",format));
-        ResultSet rs0 = methodWatcher.executeQuery(String.format("select col4, col2, col3 from %s_aggressive_2_0 where col5 = 21",format));
-        assertEquals("COL4  |COL2 |COL3 |\n" +
-                "-------------------\n" +
-                "crazy |77.7 | 444 |",TestUtils.FormattedResult.ResultFactory.toString(rs0));
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_1 (col1 int, col2 double, col3 char, col4 varchar(10), col5 int) " +
-                "partitioned by (col3, col1, col2) stored as %s location '%s'",format,format,tablePath1));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_1 values " +
-                "(666,66.666,'z','zing',20),(555,55.555,'y','yowza',40),(1,1.1,'g','garish',7)",format));
-        ResultSet rs1 = methodWatcher.executeQuery(String.format("select col2,col4 from %s_aggressive_2_1",format));
-        assertEquals("COL2  | COL4  |\n" +
-                "----------------\n" +
-                "  1.1  |garish |\n" +
-                "55.555 | yowza |\n" +
-                "66.666 | zing  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_2 (col1 varchar(10), col2 double, col3 varchar(10), col4 varchar(10), col5 int) " +
-                "partitioned by (col5, col4, col3) stored as %s location '%s'",format,format,tablePath2));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_2 values " +
-                "('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1)",format));
-        ResultSet rs2 = methodWatcher.executeQuery(String.format("select col2 from %s_aggressive_2_2",format));
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                " 1.1 |\n" +
-                " 1.1 |\n" +
-                " 1.1 |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testAvroAggressive2() throws Exception{
-        String format = "avro";
-        String tablePath0 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_0",format);
-        String tablePath1 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_1",format);
-        String tablePath2 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_2",format);
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_0 (col1 varchar(10), col2 double, col3 int, col4 varchar(10), col5 int) " +
-                "partitioned by (col1, col2, col4, col5) stored as %s location '%s'",format,format,tablePath0));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_0 values " +
-                "('whoa',77.7,444,'crazy',21),('hey',11.11,222,'crazier',10)",format));
-        ResultSet rs0 = methodWatcher.executeQuery(String.format("select col4, col2, col3 from %s_aggressive_2_0 where col5 = 21",format));
-        assertEquals("COL4  |COL2 |COL3 |\n" +
-                "-------------------\n" +
-                "crazy |77.7 | 444 |",TestUtils.FormattedResult.ResultFactory.toString(rs0));
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_1 (col1 int, col2 double, col3 char, col4 varchar(10), col5 int) " +
-                "partitioned by (col3, col1, col2) stored as %s location '%s'",format,format,tablePath1));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_1 values " +
-                "(666,66.666,'z','zing',20),(555,55.555,'y','yowza',40),(1,1.1,'g','garish',7)",format));
-        ResultSet rs1 = methodWatcher.executeQuery(String.format("select col2,col4 from %s_aggressive_2_1",format));
-        assertEquals("COL2  | COL4  |\n" +
-                "----------------\n" +
-                "  1.1  |garish |\n" +
-                "55.555 | yowza |\n" +
-                "66.666 | zing  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_2 (col1 varchar(10), col2 double, col3 varchar(10), col4 varchar(10), col5 int) " +
-                "partitioned by (col5, col4, col3) stored as %s location '%s'",format,format,tablePath2));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_2 values " +
-                "('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1)",format));
-        ResultSet rs2 = methodWatcher.executeQuery(String.format("select col2 from %s_aggressive_2_2",format));
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                " 1.1 |\n" +
-                " 1.1 |\n" +
-                " 1.1 |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testOrcAggressive2() throws Exception{
-        String format = "orc";
-        String tablePath0 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_0",format);
-        String tablePath1 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_1",format);
-        String tablePath2 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_2",format);
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_0 (col1 varchar(10), col2 double, col3 int, col4 varchar(10), col5 int) " +
-                "partitioned by (col1, col2, col4, col5) stored as %s location '%s'",format,format,tablePath0));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_0 values " +
-                "('whoa',77.7,444,'crazy',21),('hey',11.11,222,'crazier',10)",format));
-        ResultSet rs0 = methodWatcher.executeQuery(String.format("select col4, col2, col3 from %s_aggressive_2_0 where col5 = 21",format));
-        assertEquals("COL4  |COL2 |COL3 |\n" +
-                "-------------------\n" +
-                "crazy |77.7 | 444 |",TestUtils.FormattedResult.ResultFactory.toString(rs0));
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_1 (col1 int, col2 double, col3 char, col4 varchar(10), col5 int) " +
-                "partitioned by (col3, col1, col2) stored as %s location '%s'",format,format,tablePath1));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_1 values " +
-                "(666,66.666,'z','zing',20),(555,55.555,'y','yowza',40),(1,1.1,'g','garish',7)",format));
-        ResultSet rs1 = methodWatcher.executeQuery(String.format("select col2,col4 from %s_aggressive_2_1",format));
-        assertEquals("COL2  | COL4  |\n" +
-                "----------------\n" +
-                "  1.1  |garish |\n" +
-                "55.555 | yowza |\n" +
-                "66.666 | zing  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_2 (col1 varchar(10), col2 double, col3 varchar(10), col4 varchar(10), col5 int) " +
-                "partitioned by (col5, col4, col3) stored as %s location '%s'",format,format,tablePath2));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_2 values " +
-                "('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1)",format));
-        ResultSet rs2 = methodWatcher.executeQuery(String.format("select col2 from %s_aggressive_2_2",format));
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                " 1.1 |\n" +
-                " 1.1 |\n" +
-                " 1.1 |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testTextfileAggressive2() throws Exception{
-        String format = "textfile";
-        String tablePath0 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_0",format);
-        String tablePath1 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_1",format);
-        String tablePath2 = String.format(getExternalResourceDirectory()+"/%s_aggressive_2_2",format);
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_0 (col1 varchar(10), col2 double, col3 int, col4 varchar(10), col5 int) " +
-                "partitioned by (col1, col2, col4, col5) stored as %s location '%s'",format,format,tablePath0));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_0 values " +
-                "('whoa',77.7,444,'crazy',21),('hey',11.11,222,'crazier',10)",format));
-        ResultSet rs0 = methodWatcher.executeQuery(String.format("select col4, col2, col3 from %s_aggressive_2_0 where col5 = 21",format));
-        assertEquals("COL4  |COL2 |COL3 |\n" +
-                "-------------------\n" +
-                "crazy |77.7 | 444 |",TestUtils.FormattedResult.ResultFactory.toString(rs0));
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_1 (col1 int, col2 double, col3 char, col4 varchar(10), col5 int) " +
-                "partitioned by (col3, col1, col2) stored as %s location '%s'",format,format,tablePath1));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_1 values " +
-                "(666,66.666,'z','zing',20),(555,55.555,'y','yowza',40),(1,1.1,'g','garish',7)",format));
-        ResultSet rs1 = methodWatcher.executeQuery(String.format("select col2,col4 from %s_aggressive_2_1",format));
-        assertEquals("COL2  | COL4  |\n" +
-                "----------------\n" +
-                "  1.1  |garish |\n" +
-                "55.555 | yowza |\n" +
-                "66.666 | zing  |",TestUtils.FormattedResult.ResultFactory.toString(rs1));
-
-        methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_2 (col1 varchar(10), col2 double, col3 varchar(10), col4 varchar(10), col5 int) " +
-                "partitioned by (col5, col4, col3) stored as %s location '%s'",format,format,tablePath2));
-        methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_2 values " +
-                "('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1)",format));
-        ResultSet rs2 = methodWatcher.executeQuery(String.format("select col2 from %s_aggressive_2_2",format));
-        assertEquals("COL2 |\n" +
-                "------\n" +
-                " 1.1 |\n" +
-                " 1.1 |\n" +
-                " 1.1 |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            methodWatcher.executeUpdate(String.format("create external table %s_aggressive_2_2 " +
+                    "(col1 varchar(10), col2 double, col3 varchar(10), col4 varchar(10), col5 int) " +
+                    "partitioned by (col5, col4, col3) stored as %s location '%s'", format, format, tablePath2));
+            methodWatcher.executeUpdate(String.format("insert into %s_aggressive_2_2 values " +
+                    "('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1),('hello',1.1,'goodbye','farewell',1)", format));
+            ResultSet rs2 = methodWatcher.executeQuery(String.format("select col2 from %s_aggressive_2_2", format));
+            assertEquals("COL2 |\n" +
+                    "------\n" +
+                    " 1.1 |\n" +
+                    " 1.1 |\n" +
+                    " 1.1 |", TestUtils.FormattedResult.ResultFactory.toString(rs2));
+        }
     }
 
     // tests for creating an external table from an existing file:
 
     @Test
-    public void testParquetPartitionExisting() throws Exception {
-        methodWatcher.executeUpdate(String.format("create external table parquet_partition_existing (\"c0\" int, \"c1\" varchar(10), \"c2\" boolean, \"c3\" int, \"c4\" double, \"c5\" char)" +
-                "partitioned by (\"c3\", \"c1\") STORED AS PARQUET LOCATION '%s'", getResourceDirectory()+"parquet_partition_existing"));
-        ResultSet rs = methodWatcher.executeQuery("select * from parquet_partition_existing order by 1");
-        assertEquals("c0  |c1  | c2   |c3  |c4  |c5 |\n" +
-                "-------------------------------\n" +
-                "111 |AAA |true  |111 |1.1 | a |\n" +
-                "222 |BBB |false |222 |2.2 | b |\n" +
-                "333 |CCC |true  |333 |3.3 | c |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select \"c4\", \"c1\", \"c5\" from parquet_partition_existing");
-        assertEquals("c4  |c1  |c5 |\n" +
-                "--------------\n" +
-                "1.1 |AAA | a |\n" +
-                "2.2 |BBB | b |\n" +
-                "3.3 |CCC | c |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+    public void testPartitionExisting() throws Exception {
+        for (String fileFormat : fileFormatsText)
+        {
+            String name = "partition_existing_" + fileFormat;
+            // parquet_partition_existing, orc_partition_existing, avro_partition_existing, textfile_partition_existing
+            String tablePath = getResourceDirectory() + fileFormat.toLowerCase() + "_partition_existing";
+            methodWatcher.executeUpdate(String.format("create external table " + name +
+                    " (\"c0\" int, \"c1\" varchar(10), \"c2\" boolean, \"c3\" int, \"c4\" double, \"c5\" char)" +
+                    "partitioned by (\"c3\", \"c1\") STORED AS " + fileFormat + " LOCATION '%s'", tablePath));
+            ResultSet rs = methodWatcher.executeQuery("select * from " + name + " order by 1");
+            assertEquals("c0  |c1  | c2   |c3  |c4  |c5 |\n" +
+                    "-------------------------------\n" +
+                    "111 |AAA |true  |111 |1.1 | a |\n" +
+                    "222 |BBB |false |222 |2.2 | b |\n" +
+                    "333 |CCC |true  |333 |3.3 | c |", TestUtils.FormattedResult.ResultFactory.toString(rs));
+            ResultSet rs2 = methodWatcher.executeQuery("select \"c4\", \"c1\", \"c5\" from " + name);
+            assertEquals("c4  |c1  |c5 |\n" +
+                    "--------------\n" +
+                    "1.1 |AAA | a |\n" +
+                    "2.2 |BBB | b |\n" +
+                    "3.3 |CCC | c |", TestUtils.FormattedResult.ResultFactory.toString(rs2));
 
-        methodWatcher.execute("drop table parquet_partition_existing");
+            methodWatcher.execute("drop table " + name);
 
-        methodWatcher.executeUpdate(String.format("create external table parquet_partition_existing (\"c0\" int, \"c1\" varchar(10), \"c2\" boolean, \"c3\" int, \"c4\" double, \"c5\" char)" +
-                "partitioned by (\"c3\", \"c1\") STORED AS PARQUET LOCATION '%s' merge schema", getResourceDirectory()+"parquet_partition_existing"));
-        rs = methodWatcher.executeQuery("select * from parquet_partition_existing order by 1");
-        assertEquals("c0  |c1  | c2   |c3  |c4  |c5 |\n" +
-                "-------------------------------\n" +
-                "111 |AAA |true  |111 |1.1 | a |\n" +
-                "222 |BBB |false |222 |2.2 | b |\n" +
-                "333 |CCC |true  |333 |3.3 | c |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        rs2 = methodWatcher.executeQuery("select \"c4\", \"c1\", \"c5\" from parquet_partition_existing");
-        assertEquals("c4  |c1  |c5 |\n" +
-                "--------------\n" +
-                "1.1 |AAA | a |\n" +
-                "2.2 |BBB | b |\n" +
-                "3.3 |CCC | c |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-
-    }
-
-    @Test
-    public void testAvroPartitionExisting() throws Exception {
-        methodWatcher.executeUpdate(String.format("create external table avro_partition_existing (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char)" +
-                "partitioned by (col4, col2) STORED AS AVRO LOCATION '%s'", getResourceDirectory() +"avro_partition_existing"));
-        ResultSet rs = methodWatcher.executeQuery("select * from avro_partition_existing order by 1");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from avro_partition_existing");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-
-        methodWatcher.execute("drop table avro_partition_existing");
-        methodWatcher.executeUpdate(String.format("create external table avro_partition_existing (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char)" +
-                "partitioned by (col4, col2) STORED AS AVRO LOCATION '%s' merge schema", getResourceDirectory() +"avro_partition_existing"));
-        rs = methodWatcher.executeQuery("select * from avro_partition_existing order by 1");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        rs2 = methodWatcher.executeQuery("select col5, col2, col6 from avro_partition_existing");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
+            methodWatcher.executeUpdate(String.format("create external table " + name +
+                    " (\"c0\" int, \"c1\" varchar(10), \"c2\" boolean, \"c3\" int, \"c4\" double, \"c5\" char)" +
+                    "partitioned by (\"c3\", \"c1\") STORED AS " + fileFormat + " LOCATION '%s' merge schema", tablePath));
+            rs = methodWatcher.executeQuery("select * from " + name + " order by 1");
+            assertEquals("c0  |c1  | c2   |c3  |c4  |c5 |\n" +
+                    "-------------------------------\n" +
+                    "111 |AAA |true  |111 |1.1 | a |\n" +
+                    "222 |BBB |false |222 |2.2 | b |\n" +
+                    "333 |CCC |true  |333 |3.3 | c |", TestUtils.FormattedResult.ResultFactory.toString(rs));
+            rs2 = methodWatcher.executeQuery("select \"c4\", \"c1\", \"c5\" from " + name );
+            assertEquals("c4  |c1  |c5 |\n" +
+                    "--------------\n" +
+                    "1.1 |AAA | a |\n" +
+                    "2.2 |BBB | b |\n" +
+                    "3.3 |CCC | c |", TestUtils.FormattedResult.ResultFactory.toString(rs2));
+        }
 
     }
 
     @Test
-    public void testOrcPartitionExisting() throws Exception {
-        methodWatcher.executeUpdate(String.format("create external table orc_partition_existing (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char)" +
-                "partitioned by (col4, col2) STORED AS ORC LOCATION '%s'", getResourceDirectory() +"orc_partition_existing"));
-        ResultSet rs = methodWatcher.executeQuery("select * from orc_partition_existing order by 1");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from orc_partition_existing order by 1");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-
-        methodWatcher.execute("drop table orc_partition_existing");
-        methodWatcher.executeUpdate(String.format("create external table orc_partition_existing (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char)" +
-                "partitioned by (col4, col2) STORED AS ORC LOCATION '%s' merge schema", getResourceDirectory() +"orc_partition_existing"));
-        rs = methodWatcher.executeQuery("select * from orc_partition_existing order by 1");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
-        rs2 = methodWatcher.executeQuery("select col5, col2, col6 from orc_partition_existing order by 1");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |",TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testTextfilePartitionExisting() throws Exception {
-
-        methodWatcher.executeUpdate(String.format("create external table textfile_partition_existing (col1 int, col2 varchar(10), col3 boolean, col4 int, col5 double, col6 char)" +
-                "partitioned by (col4, col2, col1) STORED AS TEXTFILE LOCATION '%s'", getResourceDirectory() + "textfile_partition_existing"));
-        ResultSet rs = methodWatcher.executeQuery("select * from textfile_partition_existing");
-        assertEquals("COL1 |COL2 |COL3  |COL4 |COL5 |COL6 |\n" +
-                "-------------------------------------\n" +
-                " 111 | AAA |true  | 111 | 1.1 |  a  |\n" +
-                " 222 | BBB |false | 222 | 2.2 |  b  |\n" +
-                " 333 | CCC |true  | 333 | 3.3 |  c  |", TestUtils.FormattedResult.ResultFactory.toString(rs));
-        ResultSet rs2 = methodWatcher.executeQuery("select col5, col2, col6 from textfile_partition_existing");
-        assertEquals("COL5 |COL2 |COL6 |\n" +
-                "------------------\n" +
-                " 1.1 | AAA |  a  |\n" +
-                " 2.2 | BBB |  b  |\n" +
-                " 3.3 | CCC |  c  |", TestUtils.FormattedResult.ResultFactory.toString(rs2));
-    }
-
-    @Test
-    public void testInsertionToHiveParquetData() throws Exception {
-        String tmp = getTempCopyOfResourceDirectory(tempDir, "pt_parquet" );
-        methodWatcher.executeUpdate(
-                String.format("create external table pt_parquet(\"name\" varchar(10), \"age\" int, \"state\" char(2)) partitioned by (\"state\") stored as parquet location '%s'",
-                        tmp));
-        methodWatcher.execute("insert into pt_parquet values ('Kate', 19, 'HI')");
-        ResultSet rs = methodWatcher.executeQuery("select * from pt_parquet order by 1");
-        String actual = TestUtils.FormattedResult.ResultFactory.toString(rs);
-        String expected = "name | age | state |\n" +
-                "--------------------\n" +
-                "Kate | 19  |  HI   |\n" +
-                " Sam | 20  |  CA   |\n" +
-                " Tom | 21  |  NY   |";
-        assertEquals(actual, expected, actual);
-    }
-
-    @Test
-    public void testInsertionToHiveAvroData() throws Exception {
-        String tmp = getTempCopyOfResourceDirectory(tempDir, "pt_avro" );
-        methodWatcher.executeUpdate( String.format(
-                "create external table pt_avro(col1 varchar(10), col2 int, col3 char(2)) " +
-                        "partitioned by (col3) stored as avro location '%s'", tmp) );
-        methodWatcher.execute("insert into pt_avro values ('Kate', 19, 'HI')");
-        ResultSet rs = methodWatcher.executeQuery("select * from pt_avro order by 1");
-        String actual = TestUtils.FormattedResult.ResultFactory.toString(rs);
-        String expected = "COL1 |COL2 |COL3 |\n" +
-                "------------------\n" +
-                "Kate | 19  | HI  |\n" +
-                " Sam | 20  | CA  |\n" +
-                " Tom | 21  | NY  |";
-        assertEquals(actual, expected, actual);
+    public void testInsertionToHiveData() throws Exception {
+        for (String fileFormat : new String[] {"PARQUET", "AVRO"} ) {
+            String name = "insertion_to_hive_" + fileFormat;
+            String tmpPath = getTempCopyOfResourceDirectory(tempDir, "pt_" + fileFormat.toLowerCase() );
+            methodWatcher.executeUpdate(String.format("create external table " + name +
+                            "(\"name\" varchar(10), \"age\" int, \"state\" char(2)) " +
+                            "partitioned by (\"state\") stored as " + fileFormat + " location '%s'", tmpPath));
+            methodWatcher.execute("insert into " + name + " values ('Kate', 19, 'HI')");
+            ResultSet rs = methodWatcher.executeQuery("select * from " + name + " order by 1");
+            String actual = TestUtils.FormattedResult.ResultFactory.toString(rs);
+            String expected = "name | age | state |\n" +
+                    "--------------------\n" +
+                    "Kate | 19  |  HI   |\n" +
+                    " Sam | 20  |  CA   |\n" +
+                    " Tom | 21  |  NY   |";
+            assertEquals(actual, expected, actual);
+        }
     }
 
     @Test


### PR DESCRIPTION
- tests like testAbcParquet, testAbcORC, testAbcAvro have been unified to  testAbc.
- removed code duplication, especially in tests for syntax error handling
- testWriteReadFromSimpleExternalTable will now tests ALL available column types
- added CreateTableTypeHelper to make testing multiple column, values and null values types easier, even if Parquet, ORC and Avro sometimes support different types.
