### PR TITLE
DB-9843 External Tables: Own directory partition parsing

### DIFF
--- a/findbugs-exclude-filter.xml
+++ b/findbugs-exclude-filter.xml
@@ -127,6 +127,9 @@
     <Match>
         <Class name="com.splicemachine.spark2.splicemachine.package$"/>
         <Bug pattern="NM_METHOD_NAMING_CONVENTION"/>
+    <!-- SplicePartitioningUtils is external code <Class name="~SplicePartitioningUtils"/> -->
+    <Match>
+        <Class name="~com\.splicemachine\.spark\.splicemachine\.SplicePartitioningUtils.*"/>
     </Match>
 
 </FindBugsFilter>

--- a/findbugs-exclude-filter.xml
+++ b/findbugs-exclude-filter.xml
@@ -127,6 +127,7 @@
     <Match>
         <Class name="com.splicemachine.spark2.splicemachine.package$"/>
         <Bug pattern="NM_METHOD_NAMING_CONVENTION"/>
+    </Match>
     <!-- SplicePartitioningUtils is external code <Class name="~SplicePartitioningUtils"/> -->
     <Match>
         <Class name="~com\.splicemachine\.spark\.splicemachine\.SplicePartitioningUtils.*"/>

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
@@ -984,7 +984,7 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
                                              String compression, OperationContext context) throws StandardException {
         compression = SparkExternalTableUtil.getParquetCompression( compression );
         try( CountingListener counter = new CountingListener(context) ) {
-            getDataFrameWriter(dataset, generateTableSchema(context), partitionBy)
+            getDataFrameWriter(dataset, generateTableSchema(context), partitionBy, context)
                     .option(SPARK_COMPRESSION_OPTION, compression)
                     .parquet(location);
         }
@@ -1014,7 +1014,7 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
                                           OperationContext context) throws StandardException {
         compression = SparkExternalTableUtil.getAvroCompression(compression);
         try( CountingListener counter = new CountingListener(context) ) {
-            getDataFrameWriter(dataset, tableSchema, partitionBy)
+            getDataFrameWriter(dataset, tableSchema, partitionBy, context)
                     .option(SPARK_COMPRESSION_OPTION, compression)
                     .format("com.databricks.spark.avro").save(location);
         }
@@ -1025,7 +1025,7 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     public DataSet<ExecRow> writeTextFile(int[] partitionBy, String location, CsvOptions csvOptions,
                                           OperationContext context) throws StandardException {
         try( CountingListener counter = new CountingListener(context) ) {
-            getDataFrameWriter(dataset, generateTableSchema(context), partitionBy)
+            getDataFrameWriter(dataset, generateTableSchema(context), partitionBy, context)
                     .options(getCsvOptions(csvOptions))
                     .csv(location);
         }
@@ -1035,7 +1035,7 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     public DataSet<ExecRow> writeORCFile(int[] baseColumnMap, int[] partitionBy, String location,  String compression,
                                                     OperationContext context) throws StandardException {
         try( CountingListener counter = new CountingListener(context) ) {
-            getDataFrameWriter(dataset, generateTableSchema(context), partitionBy)
+            getDataFrameWriter(dataset, generateTableSchema(context), partitionBy, context)
                     .option(SPARK_COMPRESSION_OPTION, compression)
                     .orc(location);
         }
@@ -1082,7 +1082,8 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     }
 
     static private DataFrameWriter getDataFrameWriter(Dataset<Row> dataset, StructType tableSchema,
-                                                      int[] partitionBy) throws StandardException {
+                                                      int[] partitionBy, OperationContext context) throws StandardException {
+        // OperationContext context is used in 2.8
         Dataset<Row> insertDF = SpliceSpark.getSession().createDataFrame(
                 dataset.rdd(),
                 tableSchema);

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
@@ -26,9 +26,6 @@ import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.SpliceSpark;
 import com.splicemachine.derby.impl.sql.execute.operations.*;
-import com.splicemachine.derby.impl.sql.execute.operations.export.ExportExecRowWriter;
-import com.splicemachine.derby.impl.sql.execute.operations.export.ExportFile.COMPRESSION;
-import com.splicemachine.derby.impl.sql.execute.operations.export.ExportOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.framework.SpliceGenericAggregator;
 import com.splicemachine.derby.impl.sql.execute.operations.window.WindowAggregator;
 import com.splicemachine.derby.impl.sql.execute.operations.window.WindowContext;
@@ -39,22 +36,8 @@ import com.splicemachine.pipeline.Exceptions;
 import com.splicemachine.spark.splicemachine.ShuffleUtils;
 import com.splicemachine.sparksql.ParserUtils;
 import com.splicemachine.system.CsvOptions;
-import com.splicemachine.utils.ByteDataInput;
 import com.splicemachine.utils.Pair;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.apache.commons.codec.binary.Base64;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.io.compress.CompressionCodecFactory;
-import org.apache.hadoop.mapred.FileAlreadyExistsException;
-import org.apache.hadoop.mapred.InvalidJobConfException;
-import org.apache.hadoop.mapreduce.JobContext;
-import org.apache.hadoop.mapreduce.RecordWriter;
-import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
-import org.apache.hadoop.mapreduce.security.TokenCache;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.FlatMapFunction;
@@ -66,13 +49,11 @@ import org.apache.spark.storage.StorageLevel;
 import scala.collection.JavaConverters;
 
 import javax.annotation.Nullable;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.util.*;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
-import java.util.zip.GZIPOutputStream;
 
+import static com.splicemachine.derby.stream.spark.SparkDataSet.generateTableSchema;
 import static com.splicemachine.derby.stream.spark.SparkDataSetProcessor.getCsvOptions;
 import static org.apache.spark.sql.functions.*;
 
@@ -124,15 +105,6 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
         this.context = context;
     }
 
-    public NativeSparkDataSet(Dataset<Row> dataset, ExecRow execRow) {
-        this(dataset);
-        this.execRow = execRow;
-    }
-
-    public NativeSparkDataSet(Dataset<Row> dataset, String rddname) {
-        this(dataset);
-    }
-
     public NativeSparkDataSet(JavaRDD<V> rdd, String ignored, OperationContext context) {
         this(NativeSparkDataSet.<V>toSparkRow(rdd, context), context);
         try {
@@ -170,11 +142,8 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     }
 
     /**
-     *
      * Execute the job and materialize the results as a List.  Be careful, all
      * data must be held in memory.
-     *
-     * @return
      */
     @Override
     public List<V> collect() {
@@ -185,12 +154,6 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
      *
      * Perform the execution asynchronously and returns a Future<List>.  Be careful, all
      * data must be held in memory.
-     *
-     * @param isLast
-     * @param context
-     * @param pushScope
-     * @param scopeDetail
-     * @return
      */
     @Override
     public Future<List<V>> collectAsync(boolean isLast, OperationContext context, boolean pushScope, String scopeDetail) {
@@ -198,15 +161,8 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     }
 
     /**
-     *
      * Wraps a function on an entire partition.
-     *
      * @see JavaRDD#mapPartitions(FlatMapFunction)
-     *
-     * @param f
-     * @param <Op>
-     * @param <U>
-     * @return
      */
     @Override
     public <Op extends SpliceOperation, U> DataSet<U> mapPartitions(SpliceFlatMapFunction<Op,Iterator<V>, U> f) {
@@ -224,14 +180,7 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     }
 
     /**
-     *
      * Wraps a function on an entire partition.  IsLast is used for visualizing results.
-     *
-     * @param f
-     * @param isLast
-     * @param <Op>
-     * @param <U>
-     * @return
      */
     @Override
     public <Op extends SpliceOperation, U> DataSet<U> mapPartitions(SpliceFlatMapFunction<Op,Iterator<V>, U> f, boolean isLast) {
@@ -526,7 +475,6 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
      * @param scopeDetail
      * @return
      */
-
     public DataSet<V> windows(WindowContext windowContext, OperationContext context,  boolean pushScope, String scopeDetail) {
         pushScopeIfNeeded(context, pushScope, scopeDetail);
         try {
@@ -671,7 +619,6 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     
     @Override
     public void close() {
-
     }
 
     @Override
@@ -694,82 +641,6 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
             return new SparkDataSet<>(NativeSparkDataSet.<V>toSpliceLocatedRow(dataset, this.context)).writeToKafka();
         } catch (Exception e) {
             throw Exceptions.throwAsRuntime(e);
-        }
-    }
-
-    public static class EOutputFormat extends FileOutputFormat<Void, ExecRow> {
-
-        /**
-         * Overridden to avoid throwing an exception if the specified directory
-         * for export already exists.
-         */
-        @Override
-        public void checkOutputSpecs(JobContext job) throws FileAlreadyExistsException, IOException {
-            Path outDir = getOutputPath(job);
-            if(outDir == null) {
-                throw new InvalidJobConfException("Output directory not set.");
-            } else {
-                TokenCache.obtainTokensForNamenodes(job.getCredentials(), new Path[]{outDir}, job.getConfiguration());
-                /*
-                if(outDir.getFileSystem(job.getConfiguration()).exists(outDir)) {
-                    System.out.println("Output dir already exists, no problem");
-                    throw new FileAlreadyExistsException("Output directory " + outDir + " already exists");
-                }
-                */
-            }
-        }
-
-        @Override
-        public RecordWriter<Void, ExecRow> getRecordWriter(TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
-            Configuration conf = taskAttemptContext.getConfiguration();
-            String encoded = conf.get("exportFunction");
-            ByteDataInput bdi = new ByteDataInput(
-            Base64.decodeBase64(encoded));
-            SpliceFunction2<ExportOperation, OutputStream, Iterator<ExecRow>, Void> exportFunction;
-            try {
-                exportFunction = (SpliceFunction2<ExportOperation, OutputStream, Iterator<ExecRow>, Void>) bdi.readObject();
-            } catch (ClassNotFoundException e) {
-                throw new IOException(e);
-            }
-
-            final ExportOperation op = exportFunction.getOperation();
-            CompressionCodec codec = null;
-            String extension = ".csv";
-            COMPRESSION compression = op.getExportParams().getCompression();
-            if (compression == COMPRESSION.BZ2) {
-                extension += ".bz2";
-            }
-            else if (compression == COMPRESSION.GZ) {
-                extension += ".gz";
-            }
-
-            Path file = getDefaultWorkFile(taskAttemptContext, extension);
-            FileSystem fs = file.getFileSystem(conf);
-            OutputStream fileOut = fs.create(file, false);
-            if (compression == COMPRESSION.BZ2) {
-                CompressionCodecFactory factory = new CompressionCodecFactory(conf);
-                codec = factory.getCodecByClassName("org.apache.hadoop.io.compress.BZip2Codec");
-                fileOut = codec.createOutputStream(fileOut);
-            }
-            else if (compression == COMPRESSION.GZ) {
-                fileOut = new GZIPOutputStream(fileOut);
-            }
-            final ExportExecRowWriter rowWriter = ExportFunction.initializeRowWriter(fileOut, op.getExportParams(), op.getSourceResultColumnDescriptors());
-            return new RecordWriter<Void, ExecRow>() {
-                @Override
-                public void write(Void _, ExecRow locatedRow) throws IOException, InterruptedException {
-                    try {
-                        rowWriter.writeRow(locatedRow, op.getSourceResultColumnDescriptors());
-                    } catch (StandardException e) {
-                        throw new IOException(e);
-                    }
-                }
-
-                @Override
-                public void close(TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
-                    rowWriter.close();
-                }
-            };
         }
     }
 
@@ -870,7 +741,7 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     // If the left DataSet defines more columns than the left DataFrame,
     // the column names will be off.  Let's fill the gaps to match the
     // ExecRowDefinition.
-    private Dataset<Row> fixupColumnNames(JoinOperation op, JoinType joinType,
+    static private Dataset<Row> fixupColumnNames(JoinOperation op, JoinType joinType,
                                           Dataset<Row> leftDF, Dataset<Row> rightDF,
                                           Dataset<Row> joinedDF,
                                           SpliceOperation leftOp,
@@ -1079,25 +950,6 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     }
 
     /**
-     * Take a Splice SparkDataSet (RDD) in the consumer's context, with a single source,
-     * and convert it to a NativeSparkDataSet (Dataset<Row>) doing a map.
-     * @param context
-     * @return
-     * @throws Exception
-     */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    static <V> Dataset<Row> sourceRDDToSparkRow(JavaRDD<V> rdd, OperationContext context) {
-        try {
-            return SpliceSpark.getSession()
-                    .createDataFrame(
-                            rdd.map(new LocatedRowToRowFunction()),
-                            context.getOperation().getLeftOperation().schema());
-        } catch (Exception e) {
-            throw Exceptions.throwAsRuntime(e);
-        }
-    }
-
-    /**
      * Take a spark dataset and translate that to Splice format
      * @param dataSet
      * @param context
@@ -1126,8 +978,9 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     @Override
     public DataSet<ExecRow> writeParquetFile(DataSetProcessor dsp, int[] partitionBy, String location,
                                              String compression, OperationContext context) throws StandardException {
+        compression = SparkExternalTableUtil.getParquetCompression( compression );
         try( CountingListener counter = new CountingListener(context) ) {
-            getDataFrameWriter(partitionBy, context)
+            getDataFrameWriter(generateTableSchema(context), partitionBy, context)
                     .option(SPARK_COMPRESSION_OPTION, compression)
                     .parquet(location);
         }
@@ -1136,11 +989,29 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public DataSet<ExecRow> writeAvroFile(DataSetProcessor dsp, int[] partitionBy, String location,
-                                          String compression, OperationContext context) throws StandardException {
+    public DataSet<ExecRow> writeAvroFile(DataSetProcessor dsp,
+                                          int[] partitionBy,
+                                          String location,
+                                          String compression,
+                                          OperationContext context) throws StandardException
+    {
+        StructType tableSchema = generateTableSchema(context);
+        StructType dataSchema = SparkExternalTableUtil.getDataSchemaAvro(dsp, tableSchema, partitionBy, location);
+        if (dataSchema == null)
+            dataSchema = tableSchema;
+        return writeAvroFile(dsp, dataSchema, partitionBy, location, compression, context);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public DataSet<ExecRow> writeAvroFile(DataSetProcessor dsp,
+                                          StructType tableSchema,
+                                          int[] partitionBy,
+                                          String location,
+                                          String compression,
+                                          OperationContext context) throws StandardException {
+        compression = SparkExternalTableUtil.getAvroCompression(compression);
         try( CountingListener counter = new CountingListener(context) ) {
-            compression = SparkDataSet.getAvroCompression(compression);
-            getDataFrameWriter(partitionBy, context)
+            getDataFrameWriter(tableSchema, partitionBy, context)
                     .option(SPARK_COMPRESSION_OPTION, compression)
                     .format("com.databricks.spark.avro").save(location);
         }
@@ -1151,7 +1022,7 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     public DataSet<ExecRow> writeTextFile(int[] partitionBy, String location, CsvOptions csvOptions,
                                           OperationContext context) throws StandardException {
         try( CountingListener counter = new CountingListener(context) ) {
-            getDataFrameWriter(partitionBy, context)
+            getDataFrameWriter(generateTableSchema(context), partitionBy, context)
                     .options(getCsvOptions(csvOptions))
                     .csv(location);
         }
@@ -1161,7 +1032,7 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     public DataSet<ExecRow> writeORCFile(int[] baseColumnMap, int[] partitionBy, String location,  String compression,
                                                     OperationContext context) throws StandardException {
         try( CountingListener counter = new CountingListener(context) ) {
-            getDataFrameWriter(partitionBy, context)
+            getDataFrameWriter(generateTableSchema(context), partitionBy, context)
                     .option(SPARK_COMPRESSION_OPTION, compression)
                     .orc(location);
         }
@@ -1207,9 +1078,8 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
         }
     }
 
-    private DataFrameWriter getDataFrameWriter(int[] partitionBy, OperationContext context) throws StandardException {
-        StructType tableSchema = SparkDataSet.generateTableSchema(context);
-
+    private DataFrameWriter getDataFrameWriter(StructType tableSchema, int[] partitionBy,
+                                               OperationContext context) throws StandardException {
         Dataset<Row> insertDF = SpliceSpark.getSession().createDataFrame(
                 dataset.rdd(),
                 tableSchema);

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
@@ -54,7 +54,7 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 import static com.splicemachine.derby.stream.spark.SparkDataSet.generateTableSchema;
-import static com.splicemachine.derby.stream.spark.SparkDataSetProcessor.getCsvOptions;
+import static com.splicemachine.derby.stream.spark.SparkExternalTableUtil.getCsvOptions;
 import static org.apache.spark.sql.functions.*;
 
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
@@ -783,7 +783,7 @@ public class SparkDataSet<V> implements DataSet<V> {
                 dataSchema);
 
         return new NativeSparkDataSet<>(insertDF, context)
-                .writeAvroFile(dsp, dataSchema, partitionBy, location, compression, context);
+                .writeAvroFile(dataSchema, partitionBy, location, compression, context);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
@@ -19,9 +19,7 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.ResultColumnDescriptor;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
-import com.splicemachine.db.iapi.types.SQLLongint;
 import com.splicemachine.db.impl.sql.compile.ExplainNode;
-import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.SpliceSpark;
 import com.splicemachine.derby.impl.sql.execute.operations.DMLWriteOperation;
@@ -31,18 +29,7 @@ import com.splicemachine.derby.impl.sql.execute.operations.export.ExportFile.COM
 import com.splicemachine.derby.impl.sql.execute.operations.export.ExportOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.framework.SpliceGenericAggregator;
 import com.splicemachine.derby.impl.sql.execute.operations.window.WindowContext;
-import com.splicemachine.derby.stream.function.AbstractSpliceFunction;
-import com.splicemachine.derby.stream.function.CountWriteFunction;
-import com.splicemachine.derby.stream.function.ExportFunction;
-import com.splicemachine.derby.stream.function.LocatedRowToRowFunction;
-import com.splicemachine.derby.stream.function.LocatedRowToRowAvroFunction;
-import com.splicemachine.derby.stream.function.RowToLocatedRowFunction;
-import com.splicemachine.derby.stream.function.SpliceFlatMapFunction;
-import com.splicemachine.derby.stream.function.SpliceFunction;
-import com.splicemachine.derby.stream.function.SpliceFunction2;
-import com.splicemachine.derby.stream.function.SplicePairFunction;
-import com.splicemachine.derby.stream.function.SplicePredicateFunction;
-import com.splicemachine.derby.stream.function.TakeFunction;
+import com.splicemachine.derby.stream.function.*;
 import com.splicemachine.derby.stream.iapi.*;
 import com.splicemachine.derby.stream.output.BulkDeleteDataSetWriterBuilder;
 import com.splicemachine.derby.stream.output.BulkInsertDataSetWriterBuilder;
@@ -51,7 +38,6 @@ import com.splicemachine.derby.stream.output.ExportDataSetWriterBuilder;
 import com.splicemachine.derby.stream.output.InsertDataSetWriterBuilder;
 import com.splicemachine.derby.stream.output.UpdateDataSetWriterBuilder;
 import com.splicemachine.derby.stream.output.*;
-import com.splicemachine.derby.stream.utils.ExternalTableUtils;
 import com.splicemachine.spark.splicemachine.ShuffleUtils;
 import com.splicemachine.system.CsvOptions;
 import com.splicemachine.utils.ByteDataInput;
@@ -70,10 +56,8 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.security.TokenCache;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.FlatMapFunction;
-import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -789,43 +773,17 @@ public class SparkDataSet<V> implements DataSet<V> {
                                           String compression,
                                           OperationContext context) throws StandardException
     {
-        compression = SparkDataSet.getAvroCompression(compression);
 
-        StructType dataSchema = null;
         StructType tableSchema = generateTableSchema(context);
-
-        // what is this? why is this so different from parquet/orc ?
-        // actually very close to NativeSparkDataSet.writeFile
-        dataSchema = ExternalTableUtils.getDataSchema(dsp, tableSchema, partitionBy, location, "a");
-
+        StructType dataSchema = SparkExternalTableUtil.getDataSchemaAvro(dsp, tableSchema, partitionBy, location);
         if (dataSchema == null)
             dataSchema = tableSchema;
-
         Dataset<Row> insertDF = SpliceSpark.getSession().createDataFrame(
-                rdd.map(new SparkSpliceFunctionWrapper<>(new CountWriteFunction(context))).map(new LocatedRowToRowAvroFunction()),
+                rdd.map(new SparkSpliceFunctionWrapper<>(new EmptyFunction())).map(new LocatedRowToRowAvroFunction()),
                 dataSchema);
 
-
-        // We duplicate the code in NativeSparkDataset.writeAvroFile here to avoid calling  ExternalTableUtils.getDataSchema() twice
-        List<String> partitionByCols = new ArrayList();
-        for (int i = 0; i < partitionBy.length; i++) {
-            partitionByCols.add(dataSchema.fields()[partitionBy[i]].name());
-        }
-        if (partitionBy.length > 0) {
-            List<Column> repartitionCols = new ArrayList();
-            for (int i = 0; i < partitionBy.length; i++) {
-                repartitionCols.add(new Column(dataSchema.fields()[partitionBy[i]].name()));
-            }
-            insertDF = insertDF.repartition(scala.collection.JavaConversions.asScalaBuffer(repartitionCols).toList());
-        }
-        if (compression.equals("none")) {
-            compression = "uncompressed";
-        }
-        insertDF.write().option(SPARK_COMPRESSION_OPTION,compression).partitionBy(partitionByCols.toArray(new String[partitionByCols.size()]))
-                .mode(SaveMode.Append).format("com.databricks.spark.avro").save(location);
-        ValueRow valueRow=new ValueRow(1);
-        valueRow.setColumn(1,new SQLLongint(context.getRecordsWritten()));
-        return new SparkDataSet<>(SpliceSpark.getContext().parallelize(Collections.singletonList(valueRow), 1));
+        return new NativeSparkDataSet<>(insertDF, context)
+                .writeAvroFile(dsp, dataSchema, partitionBy, location, compression, context);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -838,23 +796,6 @@ public class SparkDataSet<V> implements DataSet<V> {
         return new NativeSparkDataSet<>(insertDF, context);
     }
 
-    static String getParquetCompression(String compression )
-    {
-        // parquet in spark supports: lz4, gzip, lzo, snappy, none, zstd.
-        if( compression.equals("zlib") )
-            compression = "gzip";
-        return compression;
-    }
-
-    public static String getAvroCompression(String compression) {
-        // avro supports uncompressed, snappy, deflate, bzip2 and xz
-        if (compression.equals("none"))
-            compression = "uncompressed";
-        else if( compression.equals("zlib"))
-            compression = "deflate";
-        return compression;
-    }
-
     @Override
     public DataSet<ExecRow> writeParquetFile(DataSetProcessor dsp,
                                              int[] partitionBy,
@@ -862,7 +803,6 @@ public class SparkDataSet<V> implements DataSet<V> {
                                              String compression,
                                              OperationContext context) throws StandardException {
 
-        compression = getParquetCompression( compression );
         return getNativeSparkDataSet( context )
                 .writeParquetFile(dsp, partitionBy, location, compression, context);
     }

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -566,27 +566,25 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                 partitionByCols.add(fields[partitionBy[i]].name());
             }
             if (storedAs!=null) {
+                String[] partitions = partitionByCols.toArray(new String[partitionByCols.size()]);
                 if (storedAs.toLowerCase().equals("p")) {
                     compression = getParquetCompression(compression);
-                    empty.write().option("compression",compression).partitionBy(partitionByCols.toArray(new String[partitionByCols.size()]))
+                    empty.write().option("compression",compression).partitionBy(partitions)
                             .mode(SaveMode.Append).parquet(location);
                 }
                 else if (storedAs.toLowerCase().equals("a")) {
                     compression = getAvroCompression(compression);
-                    /*
-                    empty.write().option("compression",compression).partitionBy(partitionByCols.toArray(new String[partitionByCols.size()]))
-                            .mode(SaveMode.Append).format("com.databricks.spark.avro").save(location);
-                     */
-                    empty.write().option("compression",compression).partitionBy(partitionByCols.toArray(new String[partitionByCols.size()]))
+                    empty.write().option("compression",compression).partitionBy(partitions)
                             .mode(SaveMode.Append).format("com.databricks.spark.avro").save(location);
                 }
                 else if (storedAs.toLowerCase().equals("o")) {
-                    empty.write().option("compression",compression).partitionBy(partitionByCols.toArray(new String[partitionByCols.size()]))
+                    empty.write().option("compression",compression).partitionBy(partitions)
                             .mode(SaveMode.Append).orc(location);
                 }
                 else if (storedAs.toLowerCase().equals("t")) {
                     // spark-2.2.0: commons-lang3-3.3.2 does not support 'XXX' timezone, specify 'ZZ' instead
-                    empty.write().option("compression",compression).option("timestampFormat", "yyyy-MM-dd'T'HH:mm:ss.SSSZZ").mode(SaveMode.Append).csv(location);
+                    empty.write().option("compression",compression).option("timestampFormat", "yyyy-MM-dd'T'HH:mm:ss.SSSZZ")
+                            .partitionBy(partitions).mode(SaveMode.Append).csv(location);
                 }
             }
         }

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -509,7 +509,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         try {
             partitionSpec = SparkExternalTableUtil.parsePartitionsFromFiles(files,
                     true, basePaths, givenPartitionColumns, null);
-        } catch(Exception e)
+        } catch( IllegalArgumentException e)
         {
             // wasn't able to use the given partition columns.
             partitionSpec = SparkExternalTableUtil.parsePartitionsFromFiles(files,

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -77,8 +77,7 @@ import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static com.splicemachine.derby.stream.spark.SparkExternalTableUtil.getAvroCompression;
-import static com.splicemachine.derby.stream.spark.SparkExternalTableUtil.getParquetCompression;
+import static com.splicemachine.derby.stream.spark.SparkExternalTableUtil.*;
 
 /**
  * Spark-based DataSetProcessor.
@@ -91,7 +90,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
     private String statusDirectory;
     private String importFileName;
     private static final Joiner CSV_JOINER = Joiner.on(",").skipNulls();
-    private final String TEMP_DIR_PREFIX = "_temp";
+    private static final String TEMP_DIR_PREFIX = "_temp";
 
     private static final Logger LOG = Logger.getLogger(SparkDataSetProcessor.class);
 
@@ -502,7 +501,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
      *         if we can't apply partitionColumns (e.g. have column2=HELLO, but we want column2 to be INT),
      *         we infere the schema without the given information, which is then used for suggest schema.
      */
-    private StructType getDirectoryPartitions(StructType givenPartitionColumns, String rootPath, String fileName) {
+    static private StructType getDirectoryPartitions(StructType givenPartitionColumns, String rootPath, String fileName) {
         StructType partition_schema;
         List<Path> files = Collections.singletonList(new Path(fileName));
         Set<Path> basePaths = Collections.singleton(new Path(rootPath));
@@ -527,7 +526,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
      * @return
      * @throws IOException
      */
-    private String getFile(FileSystem fs, String location) throws IOException {
+    static private String getFile(FileSystem fs, String location) throws IOException {
 
         Path path = new Path(location);
         String name = path.getName();
@@ -697,7 +696,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                                       double sampleFraction) throws StandardException {
         try {
             Dataset<Row> table = null;
-            ExternalTableUtils.preSortColumns(tableSchema.fields(), partitionColumnMap);
+            SparkExternalTableUtil.preSortColumns(tableSchema.fields(), partitionColumnMap);
 
             try {
                 table = SpliceSpark.getSession()
@@ -709,25 +708,13 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             }
 
             checkNumColumns(location, baseColumnMap, table);
-            ExternalTableUtils.sortColumns(table.schema().fields(), partitionColumnMap);
+            SparkExternalTableUtil.sortColumns(table.schema().fields(), partitionColumnMap);
             return externalTablesPostProcess(baseColumnMap, context, qualifiers, probeValue,
                     execRow, useSample, sampleFraction, table);
         } catch (Exception e) {
             throw StandardException.newException(
                     SQLState.EXTERNAL_TABLES_READ_FAILURE, e, e.getMessage());
         }
-    }
-
-    private String intArrayToString(int[] ints) {
-        StringBuilder sb = new StringBuilder();
-        boolean first = true;
-        for (int i = 0 ; i < ints.length; i++) {
-            if (!first)
-                sb.append(",");
-            sb.append(ints[i]);
-            first = false;
-        }
-        return sb.toString();
     }
 
     @Override
@@ -760,42 +747,6 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             throw StandardException.newException(
                     SQLState.EXTERNAL_TABLES_READ_FAILURE, e, e.getMessage());
         }
-    }
-
-    static String unescape(String type, String in) throws StandardException {
-        try{
-            return ImportUtils.unescape(in);
-        }
-        catch( IOException e)
-        {
-            throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION, e, type + ". " + e.getMessage());
-        }
-    }
-
-    /**
-     * @param csvOptions
-     * @return spark dataframereader options, see
-     *         https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/DataFrameReader.html#csv-scala.collection.Seq-
-     * @throws IOException
-     */
-    public static HashMap<String, String> getCsvOptions(CsvOptions csvOptions) throws StandardException {
-        HashMap<String, String> options = new HashMap<String, String>();
-
-        // spark-2.2.0: commons-lang3-3.3.2 does not support 'XXX' timezone, specify 'ZZ' instead
-        String timestampFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
-        options.put("timestampFormat", timestampFormat);
-
-        String delimited = unescape("TERMINATED BY", csvOptions.columnDelimiter);
-        String escaped = unescape( "ESCAPED BY", csvOptions.escapeCharacter);
-        String lines = unescape( "LINES SEPARATED BY", csvOptions.lineTerminator);
-
-        if (delimited != null) // default ,
-            options.put("sep", delimited);
-        if (escaped != null)
-            options.put("escape", escaped); // default \
-        if( lines != null ) // default \n
-            options.put("lineSep", lines);
-        return options;
     }
 
     /// check that we don't access a column that's not there with baseColumnMap

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -564,27 +564,25 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             for (int i = 0; i < partitionBy.length; i++) {
                 partitionByCols.add(fields[partitionBy[i]].name());
             }
-            if (storedAs!=null) {
-                String[] partitions = partitionByCols.toArray(new String[partitionByCols.size()]);
-                if (storedAs.toLowerCase().equals("p")) {
-                    compression = getParquetCompression(compression);
-                    empty.write().option("compression",compression).partitionBy(partitions)
-                            .mode(SaveMode.Append).parquet(location);
-                }
-                else if (storedAs.toLowerCase().equals("a")) {
-                    compression = getAvroCompression(compression);
-                    empty.write().option("compression",compression).partitionBy(partitions)
-                            .mode(SaveMode.Append).format("com.databricks.spark.avro").save(location);
-                }
-                else if (storedAs.toLowerCase().equals("o")) {
-                    empty.write().option("compression",compression).partitionBy(partitions)
-                            .mode(SaveMode.Append).orc(location);
-                }
-                else if (storedAs.toLowerCase().equals("t")) {
-                    // spark-2.2.0: commons-lang3-3.3.2 does not support 'XXX' timezone, specify 'ZZ' instead
-                    empty.write().option("compression",compression).option("timestampFormat", "yyyy-MM-dd'T'HH:mm:ss.SSSZZ")
-                            .partitionBy(partitions).mode(SaveMode.Append).csv(location);
-                }
+            String[] partitions = partitionByCols.toArray(new String[partitionByCols.size()]);
+            if (storedAs.toLowerCase().equals("p")) {
+                compression = getParquetCompression(compression);
+                empty.write().option("compression",compression).partitionBy(partitions)
+                        .mode(SaveMode.Append).parquet(location);
+            }
+            else if (storedAs.toLowerCase().equals("a")) {
+                compression = getAvroCompression(compression);
+                empty.write().option("compression",compression).partitionBy(partitions)
+                        .mode(SaveMode.Append).format("com.databricks.spark.avro").save(location);
+            }
+            else if (storedAs.toLowerCase().equals("o")) {
+                empty.write().option("compression",compression).partitionBy(partitions)
+                        .mode(SaveMode.Append).orc(location);
+            }
+            else if (storedAs.toLowerCase().equals("t")) {
+                // spark-2.2.0: commons-lang3-3.3.2 does not support 'XXX' timezone, specify 'ZZ' instead
+                empty.write().option("compression",compression).option("timestampFormat", "yyyy-MM-dd'T'HH:mm:ss.SSSZZ")
+                        .partitionBy(partitions).mode(SaveMode.Append).csv(location);
             }
         }
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -40,19 +40,19 @@ import com.splicemachine.derby.impl.store.access.BaseSpliceTransaction;
 import com.splicemachine.derby.stream.function.Partitioner;
 import com.splicemachine.derby.stream.function.RowToLocatedRowFunction;
 import com.splicemachine.derby.stream.iapi.*;
-import com.splicemachine.derby.stream.utils.ExternalTableUtils;
 import com.splicemachine.derby.stream.utils.StreamUtils;
 import com.splicemachine.derby.utils.marshall.KeyHashDecoder;
 import com.splicemachine.mrio.api.core.SMTextInputFormat;
+import com.splicemachine.procedures.external.GetSchemaExternalResult;
 import com.splicemachine.si.api.txn.TxnView;
 import com.splicemachine.system.CsvOptions;
+import com.splicemachine.spark.splicemachine.PartitionSpec;
 import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.utils.SpliceLogUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
@@ -76,6 +76,9 @@ import java.io.Serializable;
 import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
+
+import static com.splicemachine.derby.stream.spark.SparkExternalTableUtil.getAvroCompression;
+import static com.splicemachine.derby.stream.spark.SparkExternalTableUtil.getParquetCompression;
 
 /**
  * Spark-based DataSetProcessor.
@@ -335,7 +338,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                                           double sampleFraction) throws StandardException {
         try {
             Dataset<Row> table = null;
-            ExternalTableUtils.preSortColumns(tableSchema.fields(), partitionColumnMap);
+            SparkExternalTableUtil.preSortColumns(tableSchema.fields(), partitionColumnMap);
 
             try {
                 table = SpliceSpark.getSession()
@@ -347,7 +350,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             }
 
             checkNumColumns(location, baseColumnMap, table);
-            ExternalTableUtils.sortColumns(table.schema().fields(), partitionColumnMap);
+            SparkExternalTableUtil.sortColumns(table.schema().fields(), partitionColumnMap);
             return externalTablesPostProcess(baseColumnMap, context, qualifiers, probeValue,
                     execRow, useSample, sampleFraction, table);
         } catch (Exception e) {
@@ -369,7 +372,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             // Infer schema from external files
             // todo: this is slow on bigger directories, as it's calling getExternalFileSchema,
             // which will do a spark.read() before doing the spark.read() here ...
-            StructType dataSchema = ExternalTableUtils.getDataSchema(this, tableSchema, partitionColumnMap, location, "a");
+            StructType dataSchema = SparkExternalTableUtil.getDataSchemaAvro(this, tableSchema, partitionColumnMap, location);
             if(dataSchema == null)
                 return getEmpty(RDDName.EMPTY_DATA_SET.displayName(), context);
 
@@ -381,8 +384,8 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                 return handleExceptionSparkRead(e, location, false);
             }
             checkNumColumns(location, baseColumnMap, table);
-            table = ExternalTableUtils.castDateTypeInAvroDataSet(table, tableSchemaCopy);
-            ExternalTableUtils.sortColumns(table.schema().fields(), partitionColumnMap);
+            table = SparkExternalTableUtil.castDateTypeInAvroDataSet(table, tableSchemaCopy);
+            SparkExternalTableUtil.sortColumns(table.schema().fields(), partitionColumnMap);
 
             return externalTablesPostProcess(baseColumnMap, context, qualifiers, probeValue,
                     execRow, useSample, sampleFraction, table);
@@ -407,7 +410,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         if ((e instanceof AnalysisException || e instanceof FileNotFoundException) && e.getMessage() != null &&
                 (e.getMessage().startsWith("Unable to infer schema") || e.getMessage().startsWith("No Avro files found"))) {
             // Lets check if there are existing files...
-           if (ExternalTableUtils.isEmptyDirectory(location)) // Handle Empty Directory
+           if (SparkExternalTableUtil.isEmptyDirectory(location)) // Handle Empty Directory
                 return getEmpty();
         }
         throw e;
@@ -419,7 +422,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         {
             if( e.getMessage().startsWith("Path does not exist"))
                 throw StandardException.newException(SQLState.EXTERNAL_TABLES_LOCATION_NOT_EXIST, location);
-            if( checkEmpty && e.getMessage().startsWith("Unable to infer schema") && ExternalTableUtils.isEmptyDirectory(location))
+            if( checkEmpty && e.getMessage().startsWith("Unable to infer schema") && SparkExternalTableUtil.isEmptyDirectory(location))
                 return getEmpty();
 
         }
@@ -428,54 +431,37 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
 
     @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH",justification = "Intentional")
     @Override
-    public StructType getExternalFileSchema(String storedAs, String location, boolean mergeSchema, CsvOptions csvOptions) throws StandardException {
+    public GetSchemaExternalResult getExternalFileSchema(String storedAs, String location, boolean mergeSchema,
+                                                         CsvOptions csvOptions, StructType nonPartitionColumns,
+                                                         StructType partitionColumns) throws StandardException {
         StructType schema = null;
+        StructType partition_schema = null;
+
         Configuration conf = HConfiguration.unwrapDelegate();
-        FileSystem fs = null;
-        Path temp = null;
         // normalize location string
         location = new Path(location).toString();
         try {
-
             if (!mergeSchema) {
-                fs = FileSystem.get(URI.create(location), conf);
+                // get one file out of the directory tree
+                FileSystem fs = FileSystem.get(URI.create(location), conf);
                 String fileName = getFile(fs, location);
-                boolean canWrite = true;
-                if( (fileName == null || (fs.getFileStatus(new Path(location)).getPermission().toShort() & 0222) == 0 )) {
-                    canWrite = false;
-                }
-                else {
-                    temp = new Path(location, TEMP_DIR_PREFIX + "_" + UUID.randomUUID().toString().replaceAll("-", ""));
-
+                if( fileName != null ) {
+                    // analyze the directory partitions
+                    List<Path> files = Collections.singletonList(new Path(fileName));
+                    Set<Path> basePaths = Collections.singleton(new Path(location));
+                    PartitionSpec partitionSpec;
                     try {
-                        fs.mkdirs(temp);
-                    } catch (IOException e) {
-                        canWrite = false;
-                        temp = null;
+                        partitionSpec = SparkExternalTableUtil.parsePartitionsFromFiles(files,
+                                true, basePaths, partitionColumns, null);
+                    } catch(Exception e)
+                    {
+                        // wasn't able to use the given partition columns.
+                        partitionSpec = SparkExternalTableUtil.parsePartitionsFromFiles(files,
+                                true, basePaths, null, null);
                     }
-                }
-
-                if( canWrite )
-                {
-                    SpliceLogUtils.info(LOG, "created temporary directory %s", temp);
-                    // Copy a data file to temp directory
-                    int index = fileName.indexOf(location);
-                    if (index != -1) {
-                        String s = fileName.substring(index + location.length() + 1);
-                        Path destDir = new Path(temp, s);
-                        try {
-                            FileUtil.copy(fs, new Path(fileName), fs, destDir, false, conf);
-                            location = temp.toString();
-                        } catch (IOException e) {
-                            canWrite = false;
-                        }
-                    }
-                }
-
-                if( !canWrite )
-                {
-                    SpliceLogUtils.info(LOG, "couldn't create temporary directory %s, " +
-                            "will read schema from whole directory", temp);
+                    partition_schema = partitionSpec.partitionColumns();
+                    // use Spark to only analyze this one file
+                    location = fileName;
                 }
             }
             try {
@@ -505,22 +491,17 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                     } else {
                         throw new UnsupportedOperationException("Unsupported storedAs " + storedAs);
                     }
-                    dataset.printSchema();
+                    //dataset.printSchema();
                     schema = dataset.schema();
                 }
             } catch (Exception e) {
                 handleExceptionInferSchema(e, location);
-            } finally {
-                if (!mergeSchema && fs != null && temp!= null && fs.exists(temp)){
-                    fs.delete(temp, true);
-                    SpliceLogUtils.info(LOG, "deleted temporary directory %s", temp);
-                }
             }
         }catch (Exception e) {
             throw StandardException.newException(SQLState.EXTERNAL_TABLES_READ_FAILURE, e, e.getMessage());
         }
 
-        return schema;
+        return new GetSchemaExternalResult(partition_schema, schema);
     }
 
     /**
@@ -558,7 +539,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
     @Override
     public void createEmptyExternalFile(StructField[] fields, int[] baseColumnMap, int[] partitionBy, String storedAs, String location, String compression) throws StandardException {
         try{
-            StructType nschema = ExternalTableUtils.supportAvroDateType(DataTypes.createStructType(fields),storedAs);
+            StructType nschema = SparkExternalTableUtil.supportAvroDateType(DataTypes.createStructType(fields),storedAs);
 
             Dataset<Row> empty = SpliceSpark.getSession()
                         .createDataFrame(new ArrayList<Row>(), nschema);
@@ -570,12 +551,12 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             }
             if (storedAs!=null) {
                 if (storedAs.toLowerCase().equals("p")) {
-                    compression = SparkDataSet.getParquetCompression(compression);
+                    compression = getParquetCompression(compression);
                     empty.write().option("compression",compression).partitionBy(partitionByCols.toArray(new String[partitionByCols.size()]))
                             .mode(SaveMode.Append).parquet(location);
                 }
                 else if (storedAs.toLowerCase().equals("a")) {
-                    compression = SparkDataSet.getAvroCompression(compression);
+                    compression = getAvroCompression(compression);
                     /*
                     empty.write().option("compression",compression).partitionBy(partitionByCols.toArray(new String[partitionByCols.size()]))
                             .mode(SaveMode.Append).format("com.databricks.spark.avro").save(location);
@@ -663,7 +644,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
      *   e.g. the single character U+1F602 (https://www.fileformat.info/info/unicode/char/1f602/index.htm)
      *   is encoded as 0xD83D 0xDE02 and therefore has length 2.
      */
-    private Column convertSparkStringColToCharVarchar(Column col, DataValueDescriptor dvd, String name) {
+    static private Column convertSparkStringColToCharVarchar(Column col, DataValueDescriptor dvd, String name) {
         //
         if (dvd instanceof SQLChar &&
                 !(dvd instanceof SQLVarchar)) {
@@ -745,7 +726,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
 
         try {
             Dataset<Row> table = null;
-            ExternalTableUtils.preSortColumns(tableSchema.fields(), partitionColumnMap);
+            SparkExternalTableUtil.preSortColumns(tableSchema.fields(), partitionColumnMap);
             try {
                 table = SpliceSpark.getSession().read()
                         .options(getCsvOptions(csvOptions))
@@ -757,7 +738,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             }
 
             checkNumColumns(location, baseColumnMap, table);
-            ExternalTableUtils.sortColumns(table.schema().fields(), partitionColumnMap);
+            SparkExternalTableUtil.sortColumns(table.schema().fields(), partitionColumnMap);
 
             return externalTablesPostProcess(baseColumnMap, context, qualifiers, probeValue,
                     execRow, useSample, sampleFraction, table);
@@ -804,11 +785,12 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
     }
 
     /// check that we don't access a column that's not there with baseColumnMap
-    private static void checkNumColumns(String location, int[] baseColumnMap, Dataset<Row> table) throws StandardException {
+    private static void checkNumColumns(String location, int[] baseColumnMap, Dataset<Row> table)
+            throws StandardException {
         if( baseColumnMap.length > table.schema().fields().length) {
             throw StandardException.newException(SQLState.INCONSISTENT_NUMBER_OF_ATTRIBUTE,
                     baseColumnMap.length, table.schema().fields().length,
-                    location, ExternalTableUtils.getSuggestedSchema(table.schema()));
+                    location, SparkExternalTableUtil.getSuggestedSchema(table.schema(), location));
         }
     }
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -431,37 +431,24 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
 
     @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH",justification = "Intentional")
     @Override
-    public GetSchemaExternalResult getExternalFileSchema(String storedAs, String location, boolean mergeSchema,
+    public GetSchemaExternalResult getExternalFileSchema(String storedAs, String rootPath, boolean mergeSchema,
                                                          CsvOptions csvOptions, StructType nonPartitionColumns,
                                                          StructType partitionColumns) throws StandardException {
         StructType schema = null;
         StructType partition_schema = null;
 
         Configuration conf = HConfiguration.unwrapDelegate();
-        // normalize location string
-        location = new Path(location).toString();
+        // normalize rootPath string
+        rootPath = new Path(rootPath).toString();
         try {
             if (!mergeSchema) {
                 // get one file out of the directory tree
-                FileSystem fs = FileSystem.get(URI.create(location), conf);
-                String fileName = getFile(fs, location);
+                String fileName = getFile(FileSystem.get(URI.create(rootPath), conf), rootPath);
                 if( fileName != null ) {
                     // analyze the directory partitions
-                    List<Path> files = Collections.singletonList(new Path(fileName));
-                    Set<Path> basePaths = Collections.singleton(new Path(location));
-                    PartitionSpec partitionSpec;
-                    try {
-                        partitionSpec = SparkExternalTableUtil.parsePartitionsFromFiles(files,
-                                true, basePaths, partitionColumns, null);
-                    } catch(Exception e)
-                    {
-                        // wasn't able to use the given partition columns.
-                        partitionSpec = SparkExternalTableUtil.parsePartitionsFromFiles(files,
-                                true, basePaths, null, null);
-                    }
-                    partition_schema = partitionSpec.partitionColumns();
+                    partition_schema = getDirectoryPartitions(partitionColumns, rootPath, fileName);
                     // use Spark to only analyze this one file
-                    location = fileName;
+                    rootPath = fileName;
                 }
             }
             try {
@@ -472,22 +459,22 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                         dataset = SpliceSpark.getSession()
                                 .read()
                                 .option("mergeSchema", mergeSchemaOption)
-                                .parquet(location);
+                                .parquet(rootPath);
                     } else if (storedAs.toLowerCase().equals("a")) {
                         // spark does not support schema merging for avro
                         dataset = SpliceSpark.getSession()
                                 .read()
                                 .option("ignoreExtension", false)
                                 .format("com.databricks.spark.avro")
-                                .load(location);
+                                .load(rootPath);
                     } else if (storedAs.toLowerCase().equals("o")) {
                         // spark does not support schema merging for orc
                         dataset = SpliceSpark.getSession()
                                 .read()
-                                .orc(location);
+                                .orc(rootPath);
                     } else if (storedAs.toLowerCase().equals("t")) {
                         // spark-2.2.0: commons-lang3-3.3.2 does not support 'XXX' timezone, specify 'ZZ' instead
-                        dataset = SpliceSpark.getSession().read().options(getCsvOptions(csvOptions)).csv(location);
+                        dataset = SpliceSpark.getSession().read().options(getCsvOptions(csvOptions)).csv(rootPath);
                     } else {
                         throw new UnsupportedOperationException("Unsupported storedAs " + storedAs);
                     }
@@ -495,13 +482,42 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                     schema = dataset.schema();
                 }
             } catch (Exception e) {
-                handleExceptionInferSchema(e, location);
+                handleExceptionInferSchema(e, rootPath);
             }
         }catch (Exception e) {
             throw StandardException.newException(SQLState.EXTERNAL_TABLES_READ_FAILURE, e, e.getMessage());
         }
 
         return new GetSchemaExternalResult(partition_schema, schema);
+    }
+
+    /**
+     * get the directory partitioning
+     * @param rootPath root path of the dataset e.g. hdfs://cluster:123/path/to/directory
+     * @param fileName file name below that path (including directories), e.g. firstCol=34/column2=HELLO/file.parquet
+     * @param givenPartitionColumns the types as specified in CREATE TABLE ... PARTITIONED BY ( X ).
+     *                              this is important as you can have e.g. firstCol = VARCHAR, and without this
+     *                              we would infere firstCol=34 to be INTEGER.
+     * @return if successful, the StructType for the partitioned columns compatible with partitionColumns.
+     *         if we can't apply partitionColumns (e.g. have column2=HELLO, but we want column2 to be INT),
+     *         we infere the schema without the given information, which is then used for suggest schema.
+     */
+    private StructType getDirectoryPartitions(StructType givenPartitionColumns, String rootPath, String fileName) {
+        StructType partition_schema;
+        List<Path> files = Collections.singletonList(new Path(fileName));
+        Set<Path> basePaths = Collections.singleton(new Path(rootPath));
+        PartitionSpec partitionSpec;
+        try {
+            partitionSpec = SparkExternalTableUtil.parsePartitionsFromFiles(files,
+                    true, basePaths, givenPartitionColumns, null);
+        } catch(Exception e)
+        {
+            // wasn't able to use the given partition columns.
+            partitionSpec = SparkExternalTableUtil.parsePartitionsFromFiles(files,
+                    true, basePaths, null, null);
+        }
+        partition_schema = partitionSpec.partitionColumns();
+        return partition_schema;
     }
 
     /**

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkExternalTableUtil.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkExternalTableUtil.java
@@ -1,0 +1,289 @@
+package com.splicemachine.derby.stream.spark;
+
+import com.splicemachine.access.api.DistributedFileSystem;
+import com.splicemachine.access.api.FileInfo;
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.derby.impl.load.ImportUtils;
+import com.splicemachine.derby.stream.iapi.DataSetProcessor;
+import com.splicemachine.derby.stream.utils.ExternalTableUtils;
+import com.splicemachine.si.impl.driver.SIDriver;
+import com.splicemachine.spark.splicemachine.PartitionSpec;
+import com.splicemachine.spark.splicemachine.SplicePartitioningUtils;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.*;
+import scala.Option;
+import scala.collection.JavaConverters;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.*;
+import java.util.function.Supplier;
+
+import static java.util.stream.Collectors.toList;
+
+public class SparkExternalTableUtil {
+
+    public static void checkSchemaAvro(StructType tableSchema,
+                                       StructType externalSchema,
+                                       int[] partitionColumnMap,
+                                       String location) throws StandardException {
+
+        // only access filesystem if necessary
+        Supplier<FileInfo> getFile = () -> {
+            try {
+                DistributedFileSystem fileSystem = SIDriver.driver().getFileSystem(location);
+                return fileSystem.getInfo(location);
+            } catch (IOException | URISyntaxException e) {
+                return null;
+            }
+        };
+
+        StructField[] tableFields = tableSchema.fields();
+        StructField[] externalFields = externalSchema.fields();
+
+        if (tableFields.length != externalFields.length) {
+            throw StandardException.newException(SQLState.INCONSISTENT_NUMBER_OF_ATTRIBUTE,
+                    tableFields.length, externalFields.length, location,
+                    getSuggestedSchema(externalSchema, getFile.get()) );
+        }
+
+        StructField[] partitionedTableFields = new StructField[tableSchema.fields().length];
+        Set<Integer> partitionColumns = new HashSet<>();
+        for (int pos : partitionColumnMap) {
+            partitionColumns.add(pos);
+        }
+        int index = 0;
+        for (int i = 0; i < tableFields.length; ++i) {
+            if (!partitionColumns.contains(i)) {
+                partitionedTableFields[index++] = tableFields[i];
+            }
+        }
+
+        for (int i = 0; i < tableFields.length - partitionColumnMap.length; ++i) {
+
+            String tableFiledTypeName = partitionedTableFields[i].dataType().typeName();
+            String dataFieldTypeName = externalFields[i].dataType().typeName();
+            if (!tableFiledTypeName.equals(dataFieldTypeName)){
+                throw StandardException.newException(SQLState.INCONSISTENT_DATATYPE_ATTRIBUTES,
+                        tableFields[i].name(), ExternalTableUtils.getSqlTypeName(tableFields[i].dataType()),
+                        externalFields[i].name(), ExternalTableUtils.getSqlTypeName(externalFields[i].dataType()),
+                        location, getSuggestedSchema(externalSchema, getFile.get()) );
+            }
+        }
+    }
+
+
+    public static void setPartitionColumnTypes (StructType dataSchema,int[] baseColumnMap, StructType tableSchema){
+
+        int ncolumns = dataSchema.fields().length;
+        int nPartitions = baseColumnMap.length;
+        for (int i = 0; i < baseColumnMap.length; ++i) {
+            String name = dataSchema.fields()[ncolumns - i - 1].name();
+            org.apache.spark.sql.types.DataType type = tableSchema.fields()[baseColumnMap[nPartitions - i - 1]].dataType();
+            boolean nullable = tableSchema.fields()[baseColumnMap[nPartitions - i - 1]].nullable();
+            Metadata metadata = tableSchema.fields()[baseColumnMap[nPartitions - i - 1]].metadata();
+            StructField field = new StructField(name, type, nullable, metadata);
+            dataSchema.fields()[ncolumns - i - 1] = field;
+        }
+    }
+
+    private static StructType getDataSchemaAvro(DataSetProcessor dsp, StructType tableSchema, int[] partitionColumnMap,
+                                                String location, boolean mergeSchema) throws StandardException {
+        String storeAs = "a";
+        StructType dataSchema =dsp.getExternalFileSchema(storeAs, location, mergeSchema, null,
+                null, null).getFullSchema();
+        tableSchema =  supportAvroDateType(tableSchema, storeAs);
+        if (dataSchema != null) {
+            SparkExternalTableUtil.checkSchemaAvro(tableSchema, dataSchema, partitionColumnMap, location);
+
+            // set partition column datatype, because the inferred type is not always correct
+            setPartitionColumnTypes(dataSchema, partitionColumnMap, tableSchema);
+        }
+        return dataSchema;
+    }
+
+    public static StructType getDataSchemaAvro(DataSetProcessor dsp, StructType tableSchema, int[] partitionColumnMap,
+                                               String location) throws StandardException {
+        // Infer schema from external files\
+        StructType dataSchema = null;
+        try {
+            dataSchema = getDataSchemaAvro(dsp, tableSchema, partitionColumnMap, location, false);
+        }
+        catch (StandardException e) {
+            String sqlState = e.getSqlState();
+            if (sqlState.equals(SQLState.INCONSISTENT_NUMBER_OF_ATTRIBUTE) ||
+                    sqlState.equals(SQLState.INCONSISTENT_DATATYPE_ATTRIBUTES)) {
+                dataSchema = getDataSchemaAvro(dsp, tableSchema, partitionColumnMap, location, true);
+            }
+            else {
+                throw e;
+            }
+        }
+        return dataSchema;
+    }
+
+    /**
+     * check for Avro date type conversion. Databricks' spark-avro support does not handle date.
+     */
+    public static StructType supportAvroDateType(StructType schema, String storedAs) {
+        if (storedAs.toLowerCase().equals("a")) {
+            for (int i = 0; i < schema.size(); i++) {
+                StructField column = schema.fields()[i];
+                if (column.dataType().equals(DataTypes.DateType)) {
+                    StructField replace = DataTypes.createStructField(column.name(), DataTypes.StringType, column.nullable(), column.metadata());
+                    schema.fields()[i] = replace;
+                }
+            }
+        }
+        return schema;
+    }
+
+    public static void preSortColumns(StructField[] schema, int[] partitionColumnMap) {
+        if (partitionColumnMap.length > 0) {
+            // get the partitioned columns and map them to their correct indexes
+            HashMap<Integer, StructField> partitions = new HashMap<>();
+
+            // sort the partitioned columns back into their correct respective indexes in schema
+            StructField[] schemaCopy = schema.clone();
+            for (int i = 0; i < partitionColumnMap.length; ++i) {
+                partitions.put(partitionColumnMap[i], schemaCopy[partitionColumnMap[i]]);
+            }
+
+            int schemaIndex = 0;
+            for (int i = 0; i < schemaCopy.length; i++) {
+                if (partitions.containsKey(i)) {
+                    continue;
+                } else {
+                    schema[schemaIndex++] = schemaCopy[i];
+                }
+            }
+            for (int i = 0; i < partitionColumnMap.length; ++i) {
+                schema[schemaIndex++] = partitions.get(partitionColumnMap[i]);
+            }
+        }
+    }
+
+    public static boolean isEmptyDirectory(String location) throws Exception {
+        DistributedFileSystem dfs = ImportUtils.getFileSystem(location);
+        return dfs.getInfo(location).isEmptyDirectory();
+    }
+
+    public static void sortColumns(StructField[] schema, int[] partitionColumnMap) {
+        if (partitionColumnMap.length > 0) {
+            // get the partitioned columns and map them to their correct indexes
+            HashMap<Integer, StructField> partitions = new HashMap<>();
+            int schemaColumnIndex = schema.length - 1;
+            for (int i = partitionColumnMap.length - 1; i >= 0; i--) {
+                partitions.put(partitionColumnMap[i], schema[schemaColumnIndex]);
+                schemaColumnIndex--;
+            }
+
+            // sort the partitioned columns back into their correct respective indexes in schema
+            StructField[] schemaCopy = schema.clone();
+            int schemaCopyIndex = 0;
+            for (int i = 0; i < schema.length; i++) {
+                if (partitions.containsKey(i)) {
+                    schema[i] = partitions.get(i);
+                } else {
+                    schema[i] = schemaCopy[schemaCopyIndex++];
+                }
+            }
+        }
+    }
+
+    // todo(martinrupp): docu
+    public static PartitionSpec parsePartitionsFromFiles(List<Path> files,
+                                                         boolean typeInference,
+                                                         Set<Path> basePaths,
+                                                         StructType userSpecifiedDataTypes,
+                                                         TimeZone timeZone) {
+        List<Path> directories = getDistinctSubdirectoriesOf(files, basePaths);
+        return parsePartitions( directories, typeInference, basePaths, userSpecifiedDataTypes, timeZone);
+    }
+
+    // todo(martinrupp): docu
+    public static List<Path> getDistinctSubdirectoriesOf(List<Path> files, Set<Path> basePaths)
+    {
+        return files.stream()
+                .map( s -> s.getParent() ).distinct()
+                .filter( s -> !basePaths.contains(s) ).collect(toList());
+    }
+
+    public static PartitionSpec parsePartitions(List<Path> directories,
+                                                boolean typeInference,
+                                                Set<Path> basePaths,
+                                                StructType userDefTypeStruct,
+                                                TimeZone timeZone) {
+
+        scala.collection.Seq<Path> scala_directories =
+                scala.collection.JavaConverters.collectionAsScalaIterableConverter(directories).asScala().toList();
+        scala.collection.immutable.Set<Path> scala_basePaths =
+                JavaConverters.collectionAsScalaIterableConverter(basePaths).asScala().toSet();
+
+        Option<StructType> scala_userSpecifiedDataTypes = Option.apply(userDefTypeStruct);
+
+        if (timeZone == null) timeZone = TimeZone.getDefault();
+        boolean caseSensitive = true;
+        return SplicePartitioningUtils.parsePartitions(scala_directories, typeInference,
+                scala_basePaths, scala_userSpecifiedDataTypes, caseSensitive, timeZone);
+    }
+
+    public static Dataset<Row> castDateTypeInAvroDataSet(Dataset<Row> dataset, StructType tableSchema) {
+        int i = 0;
+        for (StructField sf : tableSchema.fields()) {
+            if (sf.dataType().sameType(DataTypes.DateType)) {
+                String colName = dataset.schema().fields()[i].name();
+                dataset = dataset.withColumn(colName, dataset.col(colName).cast(DataTypes.DateType));
+            }
+            i++;
+        }
+        return dataset;
+    }
+
+    static String getParquetCompression(String compression )
+    {
+        // parquet in spark supports: lz4, gzip, lzo, snappy, none, zstd.
+        if( compression.equals("zlib") )
+            compression = "gzip";
+        return compression;
+    }
+
+    public static String getAvroCompression(String compression) {
+        // avro supports uncompressed, snappy, deflate, bzip2 and xz
+        if (compression.equals("none"))
+            compression = "uncompressed";
+        else if( compression.equals("zlib"))
+            compression = "deflate";
+        return compression;
+    }
+
+    /// returns a suggested schema for this schema, e.g. `CREATE EXTERNAL TABLE T (a_float REAL, a_double DOUBLE);`
+    public static String getSuggestedSchema(StructType externalSchema, FileInfo fileInfo) {
+        StructType partition_schema = null;
+        if( fileInfo != null ) {
+            FileInfo[] fileInfos = fileInfo.listRecursive();
+            List<Path> files = Arrays.stream(fileInfos).map(s -> new Path(s.fullPath())).collect(toList());
+            Set<Path> basePaths = Collections.singleton(new Path(fileInfo.fullPath()));
+            PartitionSpec partitionSpec = parsePartitionsFromFiles(files, true, basePaths,
+                    null, null);
+            partition_schema = partitionSpec.partitionColumns();
+        }
+        String res = ExternalTableUtils.getSuggestedSchema(externalSchema, partition_schema);
+        if( fileInfo == null ) {
+            res = res + " (note: could not check path, so no PARTITIONED BY information available)";
+        }
+        return res;
+    }
+
+    static String getSuggestedSchema(StructType externalSchema, String location) {
+        try {
+            DistributedFileSystem fileSystem = SIDriver.driver().getFileSystem(location);
+            return getSuggestedSchema(externalSchema, fileSystem.getInfo(location));
+        } catch (IOException | URISyntaxException e) {
+            return getSuggestedSchema(externalSchema, (FileInfo) null);
+        }
+    }
+}

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkExternalTableUtil.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkExternalTableUtil.java
@@ -148,7 +148,7 @@ public class SparkExternalTableUtil {
                                                          boolean typeInference,
                                                          Set<Path> basePaths,
                                                          StructType userSpecifiedDataTypes,
-                                                         TimeZone timeZone) {
+                                                         TimeZone timeZone) throws IllegalArgumentException {
         List<Path> directories = getDistinctSubdirectoriesOf(files, basePaths);
         return parsePartitions( directories, typeInference, basePaths, userSpecifiedDataTypes, timeZone);
     }
@@ -165,7 +165,7 @@ public class SparkExternalTableUtil {
                                                 boolean typeInference,
                                                 Set<Path> basePaths,
                                                 StructType userDefTypeStruct,
-                                                TimeZone timeZone) {
+                                                TimeZone timeZone) throws IllegalArgumentException {
 
         scala.collection.Seq<Path> scala_directories =
                 scala.collection.JavaConverters.collectionAsScalaIterableConverter(directories).asScala().toList();

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkExternalTableUtil.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkExternalTableUtil.java
@@ -36,6 +36,8 @@ import scala.collection.JavaConverters;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.function.Supplier;
 
@@ -173,9 +175,11 @@ public class SparkExternalTableUtil {
         Option<StructType> scala_userSpecifiedDataTypes = Option.apply(userDefTypeStruct);
 
         if (timeZone == null) timeZone = TimeZone.getDefault();
+        DateFormat dateFormat = new SimpleDateFormat();
+        dateFormat.setTimeZone(timeZone);
         boolean caseSensitive = true;
         return SplicePartitioningUtils.parsePartitions(scala_directories, typeInference,
-                scala_basePaths, scala_userSpecifiedDataTypes, caseSensitive, timeZone);
+                scala_basePaths, scala_userSpecifiedDataTypes, caseSensitive, dateFormat, dateFormat);
     }
 
     public static Dataset<Row> castDateTypeInAvroDataSet(Dataset<Row> dataset, StructType tableSchema) {

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkUtils.java
@@ -27,6 +27,7 @@ import com.splicemachine.derby.stream.function.LocatedRowToRowFunction;
 import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
 import com.splicemachine.si.impl.driver.SIDriver;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
@@ -204,6 +205,7 @@ public class SparkUtils {
         public Keyer() {
         }
 
+        @SuppressFBWarnings("EI_EXPOSE_REP2")
         public Keyer(int[] keyColumns) {
             this.keyColumns = keyColumns;
         }

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkUtils.java
@@ -250,7 +250,7 @@ public class SparkUtils {
             JavaRDD<ExecRow> rdd = ((SparkDataSet)spliceDataSet).rdd;
             return SpliceSpark.getSession().createDataFrame(rdd.map(new LocatedRowToRowFunction()), schema);
         } else {
-            return ((NativeSparkDataSet) spliceDataSet).dataset.toDF( schema.fieldNames() );
+            return ((NativeSparkDataSet) spliceDataSet).getDataset().toDF( schema.fieldNames() );
         }
     }
 

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -752,7 +752,7 @@ public class ExternalTableIT extends SpliceUnitTest {
 
         String file = getResourceDirectory() + "parquet_sample_one";
         String suggested = " Suggested Schema is 'CREATE EXTERNAL TABLE T (column1 CHAR/VARCHAR(x), " +
-                "column2 CHAR/VARCHAR(x), partition1 CHAR/VARCHAR(x)) PARTITIONED BY(partition1 );'.";
+                "column2 CHAR/VARCHAR(x), partition1 CHAR/VARCHAR(x)) PARTITIONED BY(partition1);'.";
         try{
             methodWatcher.executeUpdate("create external table testParquetErrorSuggestSchemaGiven" +
                                          " (col1 INTEGER) STORED AS PARQUET LOCATION '" + file + "'");
@@ -2653,7 +2653,7 @@ public class ExternalTableIT extends SpliceUnitTest {
 
             String expectedError = "The field 'COLUMN_TWO':'%s' defined in the table is not compatible with the field " +
                     "'COLUMN_TWO':'INT' defined in the external file '%s'. " +
-                    "Suggested Schema is 'CREATE EXTERNAL TABLE T (COLUMN_ONE INT, COLUMN_TWO INT) PARTITIONED BY(COLUMN_TWO );'.";
+                    "Suggested Schema is 'CREATE EXTERNAL TABLE T (COLUMN_ONE INT, COLUMN_TWO INT) PARTITIONED BY(COLUMN_TWO);'.";
             assureFailsMsg(String.format(create, "DATE", path), SQLState.INCONSISTENT_DATATYPE_ATTRIBUTES, "date",
                     String.format(expectedError, "DATE", path));
             assureFailsMsg(String.format(create, "BOOLEAN", path), SQLState.INCONSISTENT_DATATYPE_ATTRIBUTES, "boolean",

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -2630,12 +2630,12 @@ public class ExternalTableIT extends SpliceUnitTest {
         String create = "create external table sipartitioning (COLUMN_ONE INT, COLUMN_TWO %s) " +
                 "PARTITIONED BY (COLUMN_TWO) STORED AS PARQUET LOCATION '%s'";
         methodWatcher.executeUpdate( String.format(create, "VARCHAR(20)", path) );
-        methodWatcher.executeUpdate("INSERT INTO sipartitioning VALUES (1, '1'), (2, '2')");
+        methodWatcher.executeUpdate("INSERT INTO sipartitioning VALUES (11, '11'), (22, '22')");
 
         String[] files = new File(path).list();
         if( files != null ) {
             Arrays.sort(files);
-            Assert.assertEquals("[._SUCCESS.crc, COLUMN_TWO=1, COLUMN_TWO=2, _SUCCESS]", Arrays.toString(files));
+            Assert.assertEquals("[._SUCCESS.crc, COLUMN_TWO=11, COLUMN_TWO=22, _SUCCESS]", Arrays.toString(files));
             String drop = "drop table sipartitioning";
             methodWatcher.executeUpdate(drop);
 

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -16,6 +16,7 @@ package com.splicemachine.derby.impl.sql.execute.operations;
 
 import splice.com.google.common.collect.ImmutableList;
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.derby.test.framework.*;
 import com.splicemachine.homeless.TestUtils;
 import com.splicemachine.test_dao.TriggerBuilder;
@@ -33,10 +34,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
 import java.sql.*;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.splicemachine.db.shared.common.reference.SQLState.*;
 import static org.junit.Assert.assertEquals;
@@ -337,6 +335,16 @@ public class ExternalTableIT extends SpliceUnitTest {
             Assert.assertEquals(test + ": Wrong Exception (" + e.getMessage() + ")", exceptionType, e.getSQLState());
         }
     }
+    void assureFailsMsg(String query, String exceptionType, String test, String msg) throws Exception {
+        try {
+            methodWatcher.executeUpdate(query);
+            Assert.fail(test + ": Exception not thrown");
+        } catch (SQLException e) {
+            Assert.assertEquals(test + ": Wrong Exception (" + e.getMessage() + ")", exceptionType, e.getSQLState());
+            Assert.assertEquals(test + ": Wrong Message", msg, e.getMessage());
+
+        }
+    }
 
     void assureQueryFails(String query, String exceptionType, String test) throws Exception {
         try {
@@ -582,6 +590,7 @@ public class ExternalTableIT extends SpliceUnitTest {
     public void testPartitionThirdSecond() throws Exception {
         for (String fileFormat : fileFormatsText) {
             ExternalTablePartitionIT.checkPartitionInsertSelect(  methodWatcher, getExternalResourceDirectory(),
+                    "(col1 int, col2 int, col3 varchar(10))",
                     "partition_third_second", fileFormat, "col3, col2");
         }
     }
@@ -742,7 +751,8 @@ public class ExternalTableIT extends SpliceUnitTest {
         // test schema suggestion on a given file
 
         String file = getResourceDirectory() + "parquet_sample_one";
-        String suggested = " Suggested Schema is 'CREATE EXTERNAL TABLE T (column1 CHAR/VARCHAR(x), column2 CHAR/VARCHAR(x), partition1 CHAR/VARCHAR(x));'.";
+        String suggested = " Suggested Schema is 'CREATE EXTERNAL TABLE T (column1 CHAR/VARCHAR(x), " +
+                "column2 CHAR/VARCHAR(x), partition1 CHAR/VARCHAR(x)) PARTITIONED BY(partition1 );'.";
         try{
             methodWatcher.executeUpdate("create external table testParquetErrorSuggestSchemaGiven" +
                                          " (col1 INTEGER) STORED AS PARQUET LOCATION '" + file + "'");
@@ -937,7 +947,7 @@ public class ExternalTableIT extends SpliceUnitTest {
             Assert.fail("Exception not thrown");
         } catch (SQLException e) {
 
-            Assert.assertEquals("Wrong Exception","EXT24",e.getSQLState());
+            Assert.assertEquals("Wrong Exception",SQLState.INCONSISTENT_DATATYPE_ATTRIBUTES, e.getSQLState());
         }
     }
 
@@ -953,7 +963,7 @@ public class ExternalTableIT extends SpliceUnitTest {
             Assert.fail("Exception not thrown");
         } catch (SQLException e) {
 
-            Assert.assertEquals("Wrong Exception","EXT24",e.getSQLState());
+            Assert.assertEquals("Wrong Exception",SQLState.INCONSISTENT_DATATYPE_ATTRIBUTES, e.getSQLState());
         }
     }
 
@@ -1398,7 +1408,8 @@ public class ExternalTableIT extends SpliceUnitTest {
                         "(2,'YYYY')," +
                         "(3,'ZZZZ')"));
                 assureFails(String.format("create external table " + name + "2 (col1 int, col2 varchar(24))" +
-                        "partitioned by (col2) STORED AS " + fileFormat + " LOCATION '%s'", tablePath), "EXT24", "");
+                        "partitioned by (col2) STORED AS " + fileFormat + " LOCATION '%s'", tablePath),
+                        SQLState.INCONSISTENT_DATATYPE_ATTRIBUTES, "");
         }
     }
 
@@ -2610,6 +2621,46 @@ public class ExternalTableIT extends SpliceUnitTest {
             } catch (SQLException e) {
                 throw new RuntimeException(e);
             }
+        }
+    }
+
+    @Test
+    public void testStringIntPartitionParsing() throws Exception {
+        String path = getExternalResourceDirectory() + "string_int_partitioning";
+        String create = "create external table sipartitioning (COLUMN_ONE INT, COLUMN_TWO %s) " +
+                "PARTITIONED BY (COLUMN_TWO) STORED AS PARQUET LOCATION '%s'";
+        methodWatcher.executeUpdate( String.format(create, "VARCHAR(20)", path) );
+        methodWatcher.executeUpdate("INSERT INTO sipartitioning VALUES (1, '1'), (2, '2')");
+
+        String[] files = new File(path).list();
+        if( files != null ) {
+            Arrays.sort(files);
+            Assert.assertEquals("[._SUCCESS.crc, COLUMN_TWO=1, COLUMN_TWO=2, _SUCCESS]", Arrays.toString(files));
+            String drop = "drop table sipartitioning";
+            methodWatcher.executeUpdate(drop);
+
+            // shouldn't fail, even though the directory partitions might be infered as integer (since 1 = '1')
+            methodWatcher.executeUpdate(String.format(create, "VARCHAR(20)", path));
+            methodWatcher.executeUpdate(drop);
+
+            // we can also read the directory partitioned with INT (since it's just 1, 2)
+            methodWatcher.executeUpdate(String.format(create, "INT", path));
+            methodWatcher.executeUpdate(drop);
+
+            // we can also read the directory partitioned with DOUBLE
+            methodWatcher.executeUpdate(String.format(create, "DOUBLE", path));
+            methodWatcher.executeUpdate(drop);
+
+            String expectedError = "The field 'COLUMN_TWO':'%s' defined in the table is not compatible with the field " +
+                    "'COLUMN_TWO':'INT' defined in the external file '%s'. " +
+                    "Suggested Schema is 'CREATE EXTERNAL TABLE T (COLUMN_ONE INT, COLUMN_TWO INT) PARTITIONED BY(COLUMN_TWO );'.";
+            assureFailsMsg(String.format(create, "DATE", path), SQLState.INCONSISTENT_DATATYPE_ATTRIBUTES, "date",
+                    String.format(expectedError, "DATE", path));
+            assureFailsMsg(String.format(create, "BOOLEAN", path), SQLState.INCONSISTENT_DATATYPE_ATTRIBUTES, "boolean",
+                    String.format(expectedError, "BOOLEAN", path));
+        }
+        else {
+            Assert.fail("can't list " + path);
         }
     }
 }

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
@@ -91,7 +91,7 @@ public class ExternalTablePartitionIT extends SpliceUnitTest {
 
 
         methodWatcher.executeUpdate(String.format("insert into %1$s_number_files " +
-                "select * from %1$s_number_files_orig --splice-properties useSpark=true \n" +
+                "select * from %1$s_number_files_orig --splice-properties useSpark=true %n" +
                 "union all select * from %1$s_number_files_orig " +
                 "union all select * from %1$s_number_files_orig " +
                 "union all select * from %1$s_number_files_orig " +

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTablePartitionIT.java
@@ -114,14 +114,23 @@ public class ExternalTablePartitionIT extends SpliceUnitTest {
     String[] fileFormatsText = { "PARQUET", "ORC", "AVRO", "TEXTFILE" };
 
     static public void checkPartitionInsertSelect(SpliceWatcher methodWatcher, String externalResourceDirectory,
+                                                  String schema,
                                                   String testName,
                                                   String fileFormat, String partitionedBy) throws Exception {
         String name = testName + "_" + fileFormat;
         String tablePath = externalResourceDirectory + "/" + name;
-        methodWatcher.executeUpdate(String.format("create external table " + name + " (col1 int, col2 int, col3 varchar(10)) " +
-                "partitioned by (" + partitionedBy + ") STORED AS " + fileFormat + " LOCATION '%s'", tablePath));
+        String s = String.format("create external table " + name + " " + schema + " " +
+                "partitioned by (" + partitionedBy + ") STORED AS " + fileFormat + " LOCATION '%s'", tablePath);
+        methodWatcher.executeUpdate(s);
 
         methodWatcher.executeUpdate("insert into " + name  + " values (1,2,'AAA'),(3,4,'BBB'),(5,6,'CCC')");
+
+        methodWatcher.execute("drop table " + name);
+
+        methodWatcher.executeUpdate(String.format("create external table " + name + " " + schema + " " +
+                "partitioned by (" + partitionedBy + ") STORED AS " + fileFormat + " LOCATION '%s'", tablePath));
+
+
 
         ResultSet rs = methodWatcher.executeQuery("select * from " + name );
         assertEquals("COL1 |COL2 |COL3 |\n" +
@@ -188,6 +197,7 @@ public class ExternalTablePartitionIT extends SpliceUnitTest {
     public void testPartitionFirst() throws Exception {
         for( String fileFormat : fileFormatsText) {
             checkPartitionInsertSelect( methodWatcher, getExternalResourceDirectory(),
+                    "(col1 int, col2 int, col3 varchar(10))",
                     "partition_first", fileFormat, "col1");
         }
     }
@@ -196,6 +206,7 @@ public class ExternalTablePartitionIT extends SpliceUnitTest {
     public void testPartitionFirstSecond() throws Exception {
         for( String fileFormat : fileFormatsText) {
             checkPartitionInsertSelect( methodWatcher, getExternalResourceDirectory(),
+                    "(col1 varchar(10), col2 int, col3 varchar(10))",
                     "partition_first_second", fileFormat, "col1, col2");
         }
     }
@@ -204,6 +215,7 @@ public class ExternalTablePartitionIT extends SpliceUnitTest {
     public void testPartitionSecond() throws Exception {
         for( String fileFormat : fileFormatsText) {
             checkPartitionInsertSelect( methodWatcher, getExternalResourceDirectory(),
+                    "(col1 varchar(10), col2 varchar(10), col3 varchar(10))",
                     "partition_second", fileFormat, "col2");
         }
     }
@@ -212,6 +224,7 @@ public class ExternalTablePartitionIT extends SpliceUnitTest {
     public void testPartitionLast() throws Exception {
         for (String fileFormat : fileFormatsText) {
             checkPartitionInsertSelect( methodWatcher, getExternalResourceDirectory(),
+                    "(col1 int, col2 int, col3 varchar(10))",
                     "partition_last", fileFormat, "col3");
         }
     }

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableUnitTests.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableUnitTests.java
@@ -1,6 +1,7 @@
 package com.splicemachine.derby.impl.sql.execute.operations;
 
 import com.splicemachine.derby.stream.spark.SparkExternalTableUtil;
+import com.splicemachine.derby.stream.utils.ExternalTableUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
@@ -15,11 +16,6 @@ import static java.util.stream.Collectors.toList;
 
 public class ExternalTableUnitTests {
 
-    // todo: add error test for
-    // "hdfs://host:123/partition_test/web_sales5/ws_sold_date_sk=2450817/c=3.14/part-01434.c000.snappy.parquet",
-    // "hdfs://host:123/partition_test/web_sales5/ws_sold_date_sk=2450817/c=3.14/part-01434.c000.snappy.parquet",
-    // -> Conflicting partition column names detected
-    // todo: add test for more types (date, decimal, string etc.)
     @Test
     public void testParsePartitionsFromFiles() {
         String root = "hdfs://host:123/partition_test/web_sales5/";
@@ -39,14 +35,15 @@ public class ExternalTableUnitTests {
         List<Path> files = Arrays.stream(spaths).map(Path::new).collect(toList());
 
         com.splicemachine.spark.splicemachine.PartitionSpec ps = SparkExternalTableUtil.parsePartitionsFromFiles(
-                files, true, basePaths, null,
-                null );
-        Assert.assertEquals(ps.partitions().size(), 4);
-        Assert.assertEquals(ps.partitionColumns().fields().length, 2);
-        Assert.assertEquals(ps.partitionColumns().fields()[0].toString(), "StructField(c,DoubleType,true)");
-        Assert.assertEquals(ps.partitionColumns().fields()[1].toString(), "StructField(ws_sold_date_sk,IntegerType,true)");
-        Assert.assertEquals(ps.partitions().toList().last().toString(),
-                "PartitionPath([3.14,2450818]," + root + "c=3.14/ws_sold_date_sk=2450818)");
+                files, true, basePaths, null, null );
+        Assert.assertEquals("StructType(StructField(c,DoubleType,true), StructField(ws_sold_date_sk,IntegerType,true))",
+                ps.partitionColumns().toString());
+        Assert.assertEquals("List(" +
+                "PartitionPath([3.14,null]," + root + "c=3.14/ws_sold_date_sk=__HIVE_DEFAULT_PARTITION__), " +
+                "PartitionPath([3.14,2450817]," + root + "c=3.14/ws_sold_date_sk=2450817), " +
+                "PartitionPath([3.14,2450816]," + root + "c=3.14/ws_sold_date_sk=2450816), " +
+                "PartitionPath([3.14,2450818]," + root + "c=3.14/ws_sold_date_sk=2450818))",
+                ps.partitions().toString());
     }
 
     @Test
@@ -65,14 +62,11 @@ public class ExternalTableUnitTests {
         s = s.add("ws_sold_date_sk", DataTypes.DoubleType);
 
         com.splicemachine.spark.splicemachine.PartitionSpec ps = SparkExternalTableUtil.parsePartitionsFromFiles(
-                files, true, basePaths, s,
-                null );
-        Assert.assertEquals(1, ps.partitions().size(),1);
-        Assert.assertEquals(2, ps.partitionColumns().fields().length);
-        Assert.assertEquals("StructField(c,StringType,true)", ps.partitionColumns().fields()[0].toString());
-        Assert.assertEquals("StructField(ws_sold_date_sk,DoubleType,true)", ps.partitionColumns().fields()[1].toString());
-        Assert.assertEquals("PartitionPath([3.14,2450818.0]," + root + "c=3.14/ws_sold_date_sk=2450818)",
-                ps.partitions().toList().last().toString());
+                files, true, basePaths, s, null );
+        Assert.assertEquals("StructType(StructField(c,StringType,true), StructField(ws_sold_date_sk,DoubleType,true))",
+                ps.partitionColumns().toString());
+        Assert.assertEquals("List(PartitionPath([3.14,2450818.0]," + root + "c=3.14/ws_sold_date_sk=2450818))",
+                ps.partitions().toString());
     }
 
     @Test
@@ -118,11 +112,64 @@ public class ExternalTableUnitTests {
         com.splicemachine.spark.splicemachine.PartitionSpec ps = SparkExternalTableUtil.parsePartitionsFromFiles(
                 files, true, basePaths, s, null);
 
-        Assert.assertEquals(1, ps.partitions().size());
-        Assert.assertEquals(2, ps.partitionColumns().fields().length);
-        Assert.assertEquals("StructField(c,DoubleType,true)", ps.partitionColumns().fields()[0].toString());
-        Assert.assertEquals("StructField(ws_sold_date_sk,DoubleType,true)", ps.partitionColumns().fields()[1].toString());
-        Assert.assertEquals("PartitionPath([3.14,null]," + root + "c=3.14/ws_sold_date_sk=__HIVE_DEFAULT_PARTITION__)",
-                ps.partitions().toList().last().toString());
+        Assert.assertEquals("StructType(StructField(c,DoubleType,true), StructField(ws_sold_date_sk,DoubleType,true))",
+                ps.partitionColumns().toString());
+        Assert.assertEquals("List(PartitionPath([3.14,null]," + root + "c=3.14/ws_sold_date_sk=__HIVE_DEFAULT_PARTITION__))",
+                ps.partitions().toString());
+    }
+
+    StructType structTypeSample1()
+    {
+        StructType s = new StructType();
+        s = s.add("col0", DataTypes.DoubleType);
+        s = s.add("col1", DataTypes.IntegerType);
+        s = s.add("col2", DataTypes.BooleanType);
+        s = s.add("col3", DataTypes.LongType);
+        return s;
+    }
+
+    void testSort(int[] partition, int[] expected)
+    {
+        StructType s = structTypeSample1();
+        StructType original = structTypeSample1();
+
+        SparkExternalTableUtil.preSortColumns(s.fields(), partition);
+        assert s.length() == original.length();
+        for(int i = 0; i < s.length(); i++) {
+            Assert.assertEquals( s.fields()[i].toString(), original.fields()[expected[i]].toString());
+        }
+
+        // use sortColumns to reverse the sorting done by preSortColumns
+        SparkExternalTableUtil.sortColumns(s.fields(), partition);
+        Assert.assertEquals(original.toString(), s.toString());
+    }
+
+    @Test
+    public void testSortColumns()
+    {
+        testSort( new int[]{0, 2}, new int[]{1, 3, 0, 2} );
+        testSort( new int[]{0},    new int[]{1, 2, 3, 0} );
+        testSort( new int[]{3},    new int[]{0, 1, 2, 3} );
+        testSort( new int[]{},     new int[]{0, 1, 2, 3} );
+    }
+
+    @Test
+    public void testGetSuggestedSchema()
+    {
+        Assert.assertEquals( "CREATE EXTERNAL TABLE T (col0 DOUBLE, col1 INT, col2 BOOLEAN, col3 BIGINT); " +
+                        "(note: could not check path, so no PARTITIONED BY information available)",
+                SparkExternalTableUtil.getSuggestedSchema(structTypeSample1(), null).toString() );
+
+        StructType s = new StructType();
+        s = s.add("col0", DataTypes.DoubleType);
+        s = s.add("col3", DataTypes.StringType);
+
+        StructType part = new StructType();
+        part = part.add("col1", DataTypes.IntegerType);
+        part = part.add("col2", DataTypes.FloatType);
+        Assert.assertEquals( "CREATE EXTERNAL TABLE T (col0 DOUBLE, col3 CHAR/VARCHAR(x), col1 INT, col2 REAL) " +
+                        "PARTITIONED BY(col1, col2);",
+                ExternalTableUtils.getSuggestedSchema(s, part).toString() );
+
     }
 }

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableUnitTests.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableUnitTests.java
@@ -103,13 +103,12 @@ public class ExternalTableUnitTests {
         s = s.add("ws_sold_date_sk", DataTypes.DoubleType);
 
         try {
-            com.splicemachine.spark.splicemachine.PartitionSpec ps = SparkExternalTableUtil.parsePartitionsFromFiles(
-                    files, true, basePaths, s,null);
+            SparkExternalTableUtil.parsePartitionsFromFiles(files, true, basePaths, s,null);
             Assert.fail("no exception");
         }
-        catch(Exception e)
+        catch( Exception e)
         {
-
+            Assert.assertEquals(e.toString(), "java.lang.IllegalArgumentException: Column ws_sold_date_sk is double, can't parse HELLO");
         }
     }
 

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableUnitTests.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableUnitTests.java
@@ -1,0 +1,128 @@
+package com.splicemachine.derby.impl.sql.execute.operations;
+
+import com.splicemachine.derby.stream.spark.SparkExternalTableUtil;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+public class ExternalTableUnitTests {
+
+    // todo: add error test for
+    // "hdfs://host:123/partition_test/web_sales5/ws_sold_date_sk=2450817/c=3.14/part-01434.c000.snappy.parquet",
+    // "hdfs://host:123/partition_test/web_sales5/ws_sold_date_sk=2450817/c=3.14/part-01434.c000.snappy.parquet",
+    // -> Conflicting partition column names detected
+    // todo: add test for more types (date, decimal, string etc.)
+    @Test
+    public void testParsePartitionsFromFiles() {
+        String root = "hdfs://host:123/partition_test/web_sales5/";
+        String[] spaths = {
+                root + ".DS_Store",
+                root + "c=3.14/ws_sold_date_sk=__HIVE_DEFAULT_PARTITION__/part-00042.c000.snappy.parquet",
+                root + "_SUCCESS",
+                root + "c=3.14/ws_sold_date_sk=2450817/part-01434.c000.snappy.parquet",
+                root + "c=3.14/ws_sold_date_sk=2450816/part-00026.c000.snappy.parquet",
+                root + "c=3.14/ws_sold_date_sk=2450818/part-00780.c000.snappy.parquet",
+                root + "c=3.14/ws_sold_date_sk=2450818/part-00780.c001.snappy.parquet",
+                root + "c=3.14/ws_sold_date_sk=2450818/part-00780.c002.snappy.parquet"
+        };
+        Path basePath = new Path( root );
+        HashSet<Path> basePaths = new HashSet<>(); basePaths.add(basePath);
+
+        List<Path> files = Arrays.stream(spaths).map(Path::new).collect(toList());
+
+        com.splicemachine.spark.splicemachine.PartitionSpec ps = SparkExternalTableUtil.parsePartitionsFromFiles(
+                files, true, basePaths, null,
+                null );
+        Assert.assertEquals(ps.partitions().size(), 4);
+        Assert.assertEquals(ps.partitionColumns().fields().length, 2);
+        Assert.assertEquals(ps.partitionColumns().fields()[0].toString(), "StructField(c,DoubleType,true)");
+        Assert.assertEquals(ps.partitionColumns().fields()[1].toString(), "StructField(ws_sold_date_sk,IntegerType,true)");
+        Assert.assertEquals(ps.partitions().toList().last().toString(),
+                "PartitionPath([3.14,2450818]," + root + "c=3.14/ws_sold_date_sk=2450818)");
+    }
+
+    @Test
+    public void testParsePartitionsFromFiles_one_userDefined() {
+        String root = "hdfs://host:123/partition_test/web_sales5/";
+        String[] spaths = {
+                root + "c=3.14/ws_sold_date_sk=2450818/part-00780.c002.snappy.parquet"
+        };
+        Path basePath = new Path( root );
+        HashSet<Path> basePaths = new HashSet<>(); basePaths.add(basePath);
+
+        List<Path> files = Arrays.stream(spaths).map(Path::new).collect(toList());
+
+        StructType s = new StructType();
+        s = s.add("c", DataTypes.StringType);
+        s = s.add("ws_sold_date_sk", DataTypes.DoubleType);
+
+        com.splicemachine.spark.splicemachine.PartitionSpec ps = SparkExternalTableUtil.parsePartitionsFromFiles(
+                files, true, basePaths, s,
+                null );
+        Assert.assertEquals(1, ps.partitions().size(),1);
+        Assert.assertEquals(2, ps.partitionColumns().fields().length);
+        Assert.assertEquals("StructField(c,StringType,true)", ps.partitionColumns().fields()[0].toString());
+        Assert.assertEquals("StructField(ws_sold_date_sk,DoubleType,true)", ps.partitionColumns().fields()[1].toString());
+        Assert.assertEquals("PartitionPath([3.14,2450818.0]," + root + "c=3.14/ws_sold_date_sk=2450818)",
+                ps.partitions().toList().last().toString());
+    }
+
+    @Test
+    public void testParsePartitionsFromFiles_wrong_type() {
+        String root = "hdfs://host:123/partition_test/web_sales5/";
+        String[] spaths = {
+                root + "c=3.14/ws_sold_date_sk=__HIVE_DEFAULT_PARTITION__/part-00780.c002.snappy.parquet",
+                root + "c=3.14/ws_sold_date_sk=HELLO/part-00780.c002.snappy.parquet"
+        };
+        Path basePath = new Path( "hdfs://host:123/partition_test/web_sales5/" );
+        HashSet<Path> basePaths = new HashSet<>(); basePaths.add(basePath);
+
+        List<Path> files = Arrays.stream(spaths).map(Path::new).collect(toList());
+
+        StructType s = new StructType();
+        s = s.add("ws_sold_date_sk", DataTypes.DoubleType);
+
+        try {
+            com.splicemachine.spark.splicemachine.PartitionSpec ps = SparkExternalTableUtil.parsePartitionsFromFiles(
+                    files, true, basePaths, s,null);
+            Assert.fail("no exception");
+        }
+        catch(Exception e)
+        {
+
+        }
+    }
+
+    @Test
+    public void testParsePartitionsFromFiles_wrong_type2() {
+        String root = "hdfs://host:123/partition_test/web_sales5/";
+        String[] spaths = {
+                root + "c=3.14/ws_sold_date_sk=__HIVE_DEFAULT_PARTITION__/part-00780.c002.snappy.parquet"
+        };
+        Path basePath = new Path( root );
+        HashSet<Path> basePaths = new HashSet<>(); basePaths.add(basePath);
+
+        List<Path> files = Arrays.stream(spaths).map(Path::new).collect(toList());
+
+        StructType s = new StructType();
+        s = s.add("ws_sold_date_sk", DataTypes.DoubleType);
+
+        com.splicemachine.spark.splicemachine.PartitionSpec ps = SparkExternalTableUtil.parsePartitionsFromFiles(
+                files, true, basePaths, s, null);
+
+        Assert.assertEquals(1, ps.partitions().size());
+        Assert.assertEquals(2, ps.partitionColumns().fields().length);
+        Assert.assertEquals("StructField(c,DoubleType,true)", ps.partitionColumns().fields()[0].toString());
+        Assert.assertEquals("StructField(ws_sold_date_sk,DoubleType,true)", ps.partitionColumns().fields()[1].toString());
+        Assert.assertEquals("PartitionPath([3.14,null]," + root + "c=3.14/ws_sold_date_sk=__HIVE_DEFAULT_PARTITION__)",
+                ps.partitions().toList().last().toString());
+    }
+}

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableUnitTests.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableUnitTests.java
@@ -1,13 +1,31 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package com.splicemachine.derby.impl.sql.execute.operations;
 
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.derby.stream.spark.SparkExternalTableUtil;
 import com.splicemachine.derby.stream.utils.ExternalTableUtils;
+import com.splicemachine.system.CsvOptions;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.*;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -171,5 +189,26 @@ public class ExternalTableUnitTests {
                         "PARTITIONED BY(col1, col2);",
                 ExternalTableUtils.getSuggestedSchema(s, part).toString() );
 
+    }
+
+    @Test
+    public void testGetCsvOptions() throws StandardException, IOException {
+        CsvOptions opt = new CsvOptions("#", "!", "\n");
+
+        String expected = "{lineSep=\n" +
+                ", timestampFormat=yyyy-MM-dd'T'HH:mm:ss.SSSZZ, escape=!, sep=#}";
+        Assert.assertEquals(expected, SparkExternalTableUtil.getCsvOptions(opt).toString());
+
+        // test serde
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(stream);
+        opt.writeExternal(oos);
+        oos.flush();
+
+        ByteArrayInputStream in = new ByteArrayInputStream(stream.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(in);
+        CsvOptions opt2 = new CsvOptions(ois);
+
+        Assert.assertEquals(expected, SparkExternalTableUtil.getCsvOptions(opt2).toString());
     }
 }

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
@@ -176,6 +176,27 @@ public class HNIOFileSystem extends DistributedFileSystem{
             }
         }
 
+        public HFileInfo(FileStatus fileStatus) {
+            this.fileStatus = fileStatus;
+            this.path = fileStatus.getPath();
+        }
+
+        @Override
+        public FileInfo[] listRecursive() {
+            if( !exists() ) return new FileInfo[] {};
+            if( !isDirectory() ) return new FileInfo[] { this };
+            try {
+                listRoot();
+            } catch (IOException e) {
+                return new FileInfo[] {};
+            }
+            FileInfo[] res = new FileInfo[rootFileStatusList.size()];
+            for( int i=0; i < rootFileStatusList.size(); i++ ) {
+                res[i] = new HFileInfo(rootFileStatusList.get(i));
+            }
+            return res;
+        }
+
         // these two methods are to avoid having to re-calculate the list of files in the directory
         // for isEmptyDirectory, size() and fileCount()
         private List<LocatedFileStatus> listRoot() throws IOException {

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/ControlOnlyDataSetProcessorFactory.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/ControlOnlyDataSetProcessorFactory.java
@@ -27,6 +27,7 @@ import com.splicemachine.derby.stream.iapi.DataSetProcessor;
 import com.splicemachine.derby.stream.iapi.DistributedDataSetProcessor;
 import com.splicemachine.derby.stream.iapi.RemoteQueryClient;
 import com.splicemachine.derby.stream.utils.ForwardingDataSetProcessor;
+import com.splicemachine.procedures.external.GetSchemaExternalResult;
 import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.utils.SpliceLogUtils;
 import com.splicemachine.system.CsvOptions;
@@ -143,9 +144,11 @@ public class ControlOnlyDataSetProcessorFactory implements DataSetProcessorFacto
         }
 
         @Override
-        public StructType getExternalFileSchema(String storedAs, String location, boolean mergeSchema, CsvOptions csvOptions) {
+        public GetSchemaExternalResult getExternalFileSchema(String storedAs, String location, boolean mergeSchema,
+                                                             CsvOptions csvOptions, StructType nonPartitionColumns,
+                                                             StructType partitionColumns) {
             if (LOG.isTraceEnabled())
-            SpliceLogUtils.trace(LOG, "DistributedWrapper#getExternalFileSchema()");
+                SpliceLogUtils.trace(LOG, "DistributedWrapper#getExternalFileSchema()");
             //no-op
             return null;
         }

--- a/mem_storage/src/main/java/com/splicemachine/storage/MemFileSystem.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MemFileSystem.java
@@ -255,5 +255,10 @@ public class MemFileSystem extends DistributedFileSystem{
         public boolean exists(){
             return Files.exists(p);
         }
+
+        @Override
+        public FileInfo[] listRecursive(){
+            throw new UnsupportedOperationException("IMPLEMENT");
+        }
     }
 }

--- a/scala_util/src/main/scala/com/splicemachine/spark/splicemachine/SplicePartitioningUtils.scala
+++ b/scala_util/src/main/scala/com/splicemachine/spark/splicemachine/SplicePartitioningUtils.scala
@@ -1,0 +1,487 @@
+package com.splicemachine.spark.splicemachine
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import java.lang.{Double => JDouble, Long => JLong}
+import java.math.{BigDecimal => JBigDecimal}
+import java.util.{Locale, TimeZone}
+
+import scala.collection.mutable.ArrayBuffer
+import scala.util.Try
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.{Resolver, TypeCoercion}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Literal}
+import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
+import org.apache.spark.sql.types._
+
+// TODO: We should tighten up visibility of the classes here once we clean up Hive coupling.
+
+object PartitionPath {
+  def apply(values: InternalRow, path: String): PartitionPath =
+    apply(values, new Path(path))
+}
+
+/**
+ * Holds a directory in a partitioned collection of files as well as the partition values
+ * in the form of a Row.  Before scanning, the files at `path` need to be enumerated.
+ */
+case class PartitionPath(values: InternalRow, path: Path)
+
+case class PartitionSpec(
+                          partitionColumns: StructType,
+                          partitions: Seq[PartitionPath])
+
+object PartitionSpec {
+  val emptySpec = PartitionSpec(StructType(Seq.empty[StructField]), Seq.empty[PartitionPath])
+}
+
+object SplicePartitioningUtils {
+
+  case class PartitionValues(columnNames: Seq[String], literals: Seq[Literal])
+  {
+    require(columnNames.size == literals.size)
+  }
+
+  import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils.DEFAULT_PARTITION_NAME
+  import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils.escapePathName
+  import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils.unescapePathName
+
+  /**
+   * Given a group of qualified paths, tries to parse them and returns a partition specification.
+   * For example, given:
+   * {{{
+   *   hdfs://<host>:<port>/path/to/partition/a=1/b=hello/c=3.14
+   *   hdfs://<host>:<port>/path/to/partition/a=2/b=world/c=6.28
+   * }}}
+   * it returns:
+   * {{{
+   *   PartitionSpec(
+   *     partitionColumns = StructType(
+   *       StructField(name = "a", dataType = IntegerType, nullable = true),
+   *       StructField(name = "b", dataType = StringType, nullable = true),
+   *       StructField(name = "c", dataType = DoubleType, nullable = true)),
+   *     partitions = Seq(
+   *       Partition(
+   *         values = Row(1, "hello", 3.14),
+   *         path = "hdfs://<host>:<port>/path/to/partition/a=1/b=hello/c=3.14"),
+   *       Partition(
+   *         values = Row(2, "world", 6.28),
+   *         path = "hdfs://<host>:<port>/path/to/partition/a=2/b=world/c=6.28")))
+   * }}}
+   */
+  def parsePartitions(
+                                            paths: Seq[Path],
+                                            typeInference: Boolean,
+                                            basePaths: Set[Path],
+                                            userSpecifiedSchema: Option[StructType],
+                                            caseSensitive: Boolean,
+                                            timeZoneId: String): PartitionSpec = {
+    parsePartitions(paths, typeInference, basePaths, userSpecifiedSchema,
+      caseSensitive, DateTimeUtils.getTimeZone(timeZoneId))
+  }
+
+  def parsePartitions(
+                                            paths: Seq[Path],
+                                            typeInference: Boolean,
+                                            basePaths: Set[Path],
+                                            userSpecifiedSchema: Option[StructType],
+                                            caseSensitive: Boolean,
+                                            timeZone: TimeZone): PartitionSpec = {
+    val userSpecifiedDataTypes = if (userSpecifiedSchema.isDefined) {
+      val nameToDataType = userSpecifiedSchema.get.fields.map(f => f.name -> f.dataType).toMap
+      if (!caseSensitive) {
+        CaseInsensitiveMap(nameToDataType)
+      } else {
+        nameToDataType
+      }
+    } else {
+      Map.empty[String, DataType]
+    }
+
+    // SPARK-26990: use user specified field names if case insensitive.
+    val userSpecifiedNames = if (userSpecifiedSchema.isDefined && !caseSensitive) {
+      CaseInsensitiveMap(userSpecifiedSchema.get.fields.map(f => f.name -> f.name).toMap)
+    } else {
+      Map.empty[String, String]
+    }
+
+    // First, we need to parse every partition's path and see if we can find partition values.
+    val (partitionValues, optDiscoveredBasePaths) = paths.map { path =>
+      parsePartition(path, typeInference, basePaths, userSpecifiedDataTypes, timeZone)
+    }.unzip
+
+    // We create pairs of (path -> path's partition value) here
+    // If the corresponding partition value is None, the pair will be skipped
+    val pathsWithPartitionValues = paths.zip(partitionValues).flatMap(x => x._2.map(x._1 -> _))
+
+    if (pathsWithPartitionValues.isEmpty) {
+      // This dataset is not partitioned.
+      PartitionSpec.emptySpec
+    } else {
+      // This dataset is partitioned. We need to check whether all partitions have the same
+      // partition columns and resolve potential type conflicts.
+
+      // Check if there is conflicting directory structure.
+      // For the paths such as:
+      // var paths = Seq(
+      //   "hdfs://host:9000/invalidPath",
+      //   "hdfs://host:9000/path/a=10/b=20",
+      //   "hdfs://host:9000/path/a=10.5/b=hello")
+      // It will be recognised as conflicting directory structure:
+      //   "hdfs://host:9000/invalidPath"
+      //   "hdfs://host:9000/path"
+      // TODO: Selective case sensitivity.
+      val discoveredBasePaths = optDiscoveredBasePaths.flatten.map(_.toString.toLowerCase())
+      assert(
+        discoveredBasePaths.distinct.size == 1,
+        "Conflicting directory structures detected. Suspicious paths:\b" +
+          discoveredBasePaths.distinct.mkString("\n\t", "\n\t", "\n\n") +
+          "If provided paths are partition directories, please set " +
+          "\"basePath\" in the options of the data source to specify the " +
+          "root directory of the table. If there are multiple root directories, " +
+          "please load them separately and then union them.")
+
+      val resolvedPartitionValues = resolvePartitions(pathsWithPartitionValues, timeZone)
+
+      // Creates the StructType which represents the partition columns.
+      val fields = {
+        val PartitionValues(columnNames, literals) = resolvedPartitionValues.head
+        columnNames.zip(literals).map { case (name, Literal(_, dataType)) =>
+          // We always assume partition columns are nullable since we've no idea whether null values
+          // will be appended in the future.
+          val resultName = userSpecifiedNames.getOrElse(name, name)
+          val resultDataType = userSpecifiedDataTypes.getOrElse(name, dataType)
+          StructField(resultName, resultDataType, nullable = true)
+        }
+      }
+
+      // Finally, we create `Partition`s based on paths and resolved partition values.
+      val partitions = resolvedPartitionValues.zip(pathsWithPartitionValues).map {
+        case (PartitionValues(_, literals), (path, _)) =>
+          PartitionPath(InternalRow.fromSeq(literals.map(_.value)), path)
+      }
+
+      PartitionSpec(StructType(fields), partitions)
+    }
+  }
+
+  /**
+   * Parses a single partition, returns column names and values of each partition column, also
+   * the path when we stop partition discovery.  For example, given:
+   * {{{
+   *   path = hdfs://<host>:<port>/path/to/partition/a=42/b=hello/c=3.14
+   * }}}
+   * it returns the partition:
+   * {{{
+   *   PartitionValues(
+   *     Seq("a", "b", "c"),
+   *     Seq(
+   *       Literal.create(42, IntegerType),
+   *       Literal.create("hello", StringType),
+   *       Literal.create(3.14, DoubleType)))
+   * }}}
+   * and the path when we stop the discovery is:
+   * {{{
+   *   hdfs://<host>:<port>/path/to/partition
+   * }}}
+   */
+  def parsePartition(
+                                           path: Path,
+                                           typeInference: Boolean,
+                                           basePaths: Set[Path],
+                                           userSpecifiedDataTypes: Map[String, DataType],
+                                           timeZone: TimeZone): (Option[PartitionValues], Option[Path]) = {
+    val columns = ArrayBuffer.empty[(String, Literal)]
+    // Old Hadoop versions don't have `Path.isRoot`
+    var finished = path.getParent == null
+    // currentPath is the current path that we will use to parse partition column value.
+    var currentPath: Path = path
+
+    while (!finished) {
+      // Sometimes (e.g., when speculative task is enabled), temporary directories may be left
+      // uncleaned. Here we simply ignore them.
+      if (currentPath.getName.toLowerCase(Locale.ROOT) == "_temporary") {
+        return (None, None)
+      }
+
+      if (basePaths.contains(currentPath)) {
+        // If the currentPath is one of base paths. We should stop.
+        finished = true
+      } else {
+        // Let's say currentPath is a path of "/table/a=1/", currentPath.getName will give us a=1.
+        // Once we get the string, we try to parse it and find the partition column and value.
+        val maybeColumn =
+        parsePartitionColumn(currentPath.getName, typeInference, userSpecifiedDataTypes, timeZone)
+        maybeColumn.foreach(columns += _)
+
+        // Now, we determine if we should stop.
+        // When we hit any of the following cases, we will stop:
+        //  - In this iteration, we could not parse the value of partition column and value,
+        //    i.e. maybeColumn is None, and columns is not empty. At here we check if columns is
+        //    empty to handle cases like /table/a=1/_temporary/something (we need to find a=1 in
+        //    this case).
+        //  - After we get the new currentPath, this new currentPath represent the top level dir
+        //    i.e. currentPath.getParent == null. For the example of "/table/a=1/",
+        //    the top level dir is "/table".
+        finished =
+          (maybeColumn.isEmpty && !columns.isEmpty) || currentPath.getParent == null
+
+        if (!finished) {
+          // For the above example, currentPath will be "/table/".
+          currentPath = currentPath.getParent
+        }
+      }
+    }
+
+    if (columns.isEmpty) {
+      (None, Some(path))
+    } else {
+      val (columnNames, values) = columns.reverse.unzip
+      (Some(PartitionValues(columnNames, values)), Some(currentPath))
+    }
+  }
+
+  private def parsePartitionColumn(
+                                    columnSpec: String,
+                                    typeInference: Boolean,
+                                    userSpecifiedDataTypes: Map[String, DataType],
+                                    timeZone: TimeZone): Option[(String, Literal)] = {
+    val equalSignIndex = columnSpec.indexOf('=')
+    if (equalSignIndex == -1) {
+      None
+    } else {
+      val columnName = unescapePathName(columnSpec.take(equalSignIndex))
+      assert(columnName.nonEmpty, s"Empty partition column name in '$columnSpec'")
+
+      val rawColumnValue = columnSpec.drop(equalSignIndex + 1)
+      assert(rawColumnValue.nonEmpty, s"Empty partition column value in '$columnSpec'")
+
+      val literal = if (userSpecifiedDataTypes.contains(columnName)) {
+        // SPARK-26188: if user provides corresponding column schema, get the column value without
+        //              inference, and then cast it as user specified data type.
+        val columnValue = inferPartitionColumnValue(rawColumnValue, false, timeZone)
+        val userType = userSpecifiedDataTypes(columnName);
+
+        // modified martinrupp {
+        val castedValue =
+          Cast(columnValue, userType, Option(timeZone.getID)).eval()
+
+        if(castedValue == null && rawColumnValue != "__HIVE_DEFAULT_PARTITION__") {
+          throw new IllegalArgumentException("Column " + columnName + " is " + userType.simpleString + ", can't parse " + rawColumnValue)
+        }
+        else {
+          Literal.create(castedValue, userSpecifiedDataTypes(columnName))
+        }
+        // modified martinrupp }
+      } else {
+        inferPartitionColumnValue(rawColumnValue, typeInference, timeZone)
+      }
+      Some(columnName -> literal)
+    }
+  }
+
+  /**
+   * Resolves possible type conflicts between partitions by up-casting "lower" types using
+   * [[findWiderTypeForPartitionColumn]].
+   */
+  def resolvePartitions(
+                         pathsWithPartitionValues: Seq[(Path, PartitionValues)],
+                         timeZone: TimeZone): Seq[PartitionValues] = {
+    if (pathsWithPartitionValues.isEmpty) {
+      Seq.empty
+    } else {
+      // TODO: Selective case sensitivity.
+      val distinctPartColNames =
+        pathsWithPartitionValues.map(_._2.columnNames.map(_.toLowerCase())).distinct
+      assert(
+        distinctPartColNames.size == 1,
+        listConflictingPartitionColumns(pathsWithPartitionValues))
+
+      // Resolves possible type conflicts for each column
+      val values = pathsWithPartitionValues.map(_._2)
+      val columnCount = values.head.columnNames.size
+      val resolvedValues = (0 until columnCount).map { i =>
+        resolveTypeConflicts(values.map(_.literals(i)), timeZone)
+      }
+
+      // Fills resolved literals back to each partition
+      values.zipWithIndex.map { case (d, index) =>
+        d.copy(literals = resolvedValues.map(_(index)))
+      }
+    }
+  }
+
+  def listConflictingPartitionColumns(
+                                                            pathWithPartitionValues: Seq[(Path, PartitionValues)]): String = {
+    val distinctPartColNames = pathWithPartitionValues.map(_._2.columnNames).distinct
+
+    def groupByKey[K, V](seq: Seq[(K, V)]): Map[K, Iterable[V]] =
+      seq.groupBy { case (key, _) => key }.mapValues(_.map { case (_, value) => value })
+
+    val partColNamesToPaths = groupByKey(pathWithPartitionValues.map {
+      case (path, partValues) => partValues.columnNames -> path
+    })
+
+    val distinctPartColLists = distinctPartColNames.map(_.mkString(", ")).zipWithIndex.map {
+      case (names, index) =>
+        s"Partition column name list #$index: $names"
+    }
+
+    // Lists out those non-leaf partition directories that also contain files
+    val suspiciousPaths = distinctPartColNames.sortBy(_.length).flatMap(partColNamesToPaths)
+
+    s"Conflicting partition column names detected:\n" +
+      distinctPartColLists.mkString("\n\t", "\n\t", "\n\n") +
+      "For partitioned table directories, data files should only live in leaf directories.\n" +
+      "And directories at the same level should have the same partition column name.\n" +
+      "Please check the following directories for unexpected files or " +
+      "inconsistent partition column names:\n" +
+      suspiciousPaths.map("\t" + _).mkString("\n", "\n", "")
+  }
+
+  // scalastyle:off line.size.limit
+  /**
+   * Converts a string to a [[Literal]] with automatic type inference. Currently only supports
+   * [[NullType]], [[IntegerType]], [[LongType]], [[DoubleType]], [[DecimalType]], [[DateType]]
+   * [[TimestampType]], and [[StringType]].
+   *
+   * When resolving conflicts, it follows the table below:
+   *
+   * +--------------------+-------------------+-------------------+-------------------+--------------------+------------+---------------+---------------+------------+
+   * | InputA \ InputB    | NullType          | IntegerType       | LongType          | DecimalType(38,0)* | DoubleType | DateType      | TimestampType | StringType |
+   * +--------------------+-------------------+-------------------+-------------------+--------------------+------------+---------------+---------------+------------+
+   * | NullType           | NullType          | IntegerType       | LongType          | DecimalType(38,0)  | DoubleType | DateType      | TimestampType | StringType |
+   * | IntegerType        | IntegerType       | IntegerType       | LongType          | DecimalType(38,0)  | DoubleType | StringType    | StringType    | StringType |
+   * | LongType           | LongType          | LongType          | LongType          | DecimalType(38,0)  | StringType | StringType    | StringType    | StringType |
+   * | DecimalType(38,0)* | DecimalType(38,0) | DecimalType(38,0) | DecimalType(38,0) | DecimalType(38,0)  | StringType | StringType    | StringType    | StringType |
+   * | DoubleType         | DoubleType        | DoubleType        | StringType        | StringType         | DoubleType | StringType    | StringType    | StringType |
+   * | DateType           | DateType          | StringType        | StringType        | StringType         | StringType | DateType      | TimestampType | StringType |
+   * | TimestampType      | TimestampType     | StringType        | StringType        | StringType         | StringType | TimestampType | TimestampType | StringType |
+   * | StringType         | StringType        | StringType        | StringType        | StringType         | StringType | StringType    | StringType    | StringType |
+   * +--------------------+-------------------+-------------------+-------------------+--------------------+------------+---------------+---------------+------------+
+   * Note that, for DecimalType(38,0)*, the table above intentionally does not cover all other
+   * combinations of scales and precisions because currently we only infer decimal type like
+   * `BigInteger`/`BigInt`. For example, 1.1 is inferred as double type.
+   */
+  // scalastyle:on line.size.limit
+  def inferPartitionColumnValue(
+                                                      raw: String,
+                                                      typeInference: Boolean,
+                                                      timeZone: TimeZone): Literal = {
+    val decimalTry = Try {
+      // `BigDecimal` conversion can fail when the `field` is not a form of number.
+      val bigDecimal = new JBigDecimal(raw)
+      // It reduces the cases for decimals by disallowing values having scale (eg. `1.1`).
+      require(bigDecimal.scale <= 0)
+      // `DecimalType` conversion can fail when
+      //   1. The precision is bigger than 38.
+      //   2. scale is bigger than precision.
+      Literal(bigDecimal)
+    }
+
+    val dateTry = Try {
+      // try and parse the date, if no exception occurs this is a candidate to be resolved as
+      // DateType
+      DateTimeUtils.getThreadLocalDateFormat(DateTimeUtils.defaultTimeZone()).parse(raw)
+      // SPARK-23436: Casting the string to date may still return null if a bad Date is provided.
+      // This can happen since DateFormat.parse  may not use the entire text of the given string:
+      // so if there are extra-characters after the date, it returns correctly.
+      // We need to check that we can cast the raw string since we later can use Cast to get
+      // the partition values with the right DataType (see
+      // org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex.inferPartitioning)
+      val dateValue = Cast(Literal(raw), DateType).eval()
+      // Disallow DateType if the cast returned null
+      require(dateValue != null)
+      Literal.create(dateValue, DateType)
+    }
+
+    val timestampTry = Try {
+      val unescapedRaw = unescapePathName(raw)
+      // try and parse the date, if no exception occurs this is a candidate to be resolved as
+      // TimestampType
+      DateTimeUtils.getThreadLocalTimestampFormat(timeZone).parse(unescapedRaw)
+      // SPARK-23436: see comment for date
+      val timestampValue = Cast(Literal(unescapedRaw), TimestampType, Some(timeZone.getID)).eval()
+      // Disallow TimestampType if the cast returned null
+      require(timestampValue != null)
+      Literal.create(timestampValue, TimestampType)
+    }
+
+    if (typeInference) {
+      // First tries integral types
+      Try(Literal.create(Integer.parseInt(raw), IntegerType))
+        .orElse(Try(Literal.create(JLong.parseLong(raw), LongType)))
+        .orElse(decimalTry)
+        // Then falls back to fractional types
+        .orElse(Try(Literal.create(JDouble.parseDouble(raw), DoubleType)))
+        // Then falls back to date/timestamp types
+        .orElse(timestampTry)
+        .orElse(dateTry)
+        // Then falls back to string
+        .getOrElse {
+          if (raw == DEFAULT_PARTITION_NAME) {
+            Literal.create(null, NullType)
+          } else {
+            Literal.create(unescapePathName(raw), StringType)
+          }
+        }
+    } else {
+      if (raw == DEFAULT_PARTITION_NAME) {
+        Literal.create(null, NullType)
+      } else {
+        Literal.create(unescapePathName(raw), StringType)
+      }
+    }
+  }
+
+  private def columnNameEquality(caseSensitive: Boolean): (String, String) => Boolean = {
+    if (caseSensitive) {
+      org.apache.spark.sql.catalyst.analysis.caseSensitiveResolution
+    } else {
+      org.apache.spark.sql.catalyst.analysis.caseInsensitiveResolution
+    }
+  }
+
+  /**
+   * Given a collection of [[Literal]]s, resolves possible type conflicts by
+   * [[findWiderTypeForPartitionColumn]].
+   */
+  private def resolveTypeConflicts(literals: Seq[Literal], timeZone: TimeZone): Seq[Literal] = {
+    val litTypes = literals.map(_.dataType)
+    val desiredType = litTypes.reduce(findWiderTypeForPartitionColumn)
+
+    literals.map { case l @ Literal(_, dataType) =>
+      Literal.create(Cast(l, desiredType, Some(timeZone.getID)).eval(), desiredType)
+    }
+  }
+
+  /**
+   * Type widening rule for partition column types. It is similar to
+   * [[TypeCoercion.findWiderTypeForTwo]] but the main difference is that here we disallow
+   * precision loss when widening double/long and decimal, and fall back to string.
+   */
+  private val findWiderTypeForPartitionColumn: (DataType, DataType) => DataType = {
+    case (DoubleType, _: DecimalType) | (_: DecimalType, DoubleType) => StringType
+    case (DoubleType, LongType) | (LongType, DoubleType) => StringType
+    case (t1, t2) => TypeCoercion.findWiderTypeForTwo(t1, t2).getOrElse(StringType)
+  }
+}

--- a/scala_util/src/main/scala/com/splicemachine/spark/splicemachine/SplicePartitioningUtils.scala
+++ b/scala_util/src/main/scala/com/splicemachine/spark/splicemachine/SplicePartitioningUtils.scala
@@ -1,15 +1,3 @@
-package com.splicemachine.spark.splicemachine
-
-// note: this is marked as private in package org.apache.spark.sql.execution.datasources,
-// so we had to copy this out.
-// see
-// spark/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
-
-// this file is marked as excluded from spotbugs, see splice_protocol/findbugs-exclude.xml
-// to be able to detect wrong types for directory partitioning, we modified some part of the code, marked with
-// modified splicemachine { ... }
-// other changes: changed input of timezone/date format to get passed in from outside as DateFormat (date and time)
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -26,6 +14,18 @@ package com.splicemachine.spark.splicemachine
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package com.splicemachine.spark.splicemachine
+
+// note: this is marked as private in package org.apache.spark.sql.execution.datasources,
+// so we had to copy this out.
+// see
+// spark/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+
+// this file is marked as excluded from spotbugs, see splice_protocol/findbugs-exclude.xml
+// to be able to detect wrong types for directory partitioning, we modified some part of the code, marked with
+// modified splicemachine { ... }
+// other changes: changed input of timezone/date format to get passed in from outside as DateFormat (date and time)
 
 
 import java.lang.{Double => JDouble, Long => JLong}

--- a/scala_util/src/main/scala/com/splicemachine/spark/splicemachine/SplicePartitioningUtils.scala
+++ b/scala_util/src/main/scala/com/splicemachine/spark/splicemachine/SplicePartitioningUtils.scala
@@ -1,5 +1,13 @@
 package com.splicemachine.spark.splicemachine
 
+// note: this is marked as private in package org.apache.spark.sql.execution.datasources,
+// so we had to copy this out.
+// see
+// https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+// this file is marked as excluded from spotbugs, see splice_protocol/findbugs-exclude.xml
+// to be able to detect wrong types for directory partitioning, we modified some part of the code, marked with
+// modified splicemachine { ... }
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -281,7 +289,7 @@ object SplicePartitioningUtils {
         val columnValue = inferPartitionColumnValue(rawColumnValue, false, timeZone)
         val userType = userSpecifiedDataTypes(columnName);
 
-        // modified martinrupp {
+        // modified splicemachine {
         val castedValue =
           Cast(columnValue, userType, Option(timeZone.getID)).eval()
 
@@ -291,7 +299,7 @@ object SplicePartitioningUtils {
         else {
           Literal.create(castedValue, userSpecifiedDataTypes(columnName))
         }
-        // modified martinrupp }
+        // modified splicemachine }
       } else {
         inferPartitionColumnValue(rawColumnValue, typeInference, timeZone)
       }

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/FileInfo.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/FileInfo.java
@@ -51,6 +51,11 @@ public interface FileInfo{
     long spaceConsumed();
 
     /**
+     * list recursively all files
+     */
+    FileInfo[] listRecursive();
+
+    /**
      *  Note: this is SLOW on big directory trees when using remote filesystems like S3,
      * since requiring a full recursive listdir
      */

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
@@ -30,6 +30,7 @@ import com.splicemachine.derby.stream.iapi.*;
 import com.splicemachine.derby.stream.iterator.TableScannerIterator;
 import com.splicemachine.derby.utils.marshall.KeyHashDecoder;
 import com.splicemachine.pipeline.Exceptions;
+import com.splicemachine.procedures.external.GetSchemaExternalResult;
 import com.splicemachine.si.api.data.TxnOperationFactory;
 import com.splicemachine.si.api.server.Transactor;
 import com.splicemachine.si.api.txn.TxnSupplier;
@@ -374,9 +375,12 @@ public class ControlDataSetProcessor implements DataSetProcessor{
     }
 
     @Override
-    public StructType getExternalFileSchema(String storedAs, String location, boolean mergeSchema, CsvOptions csvOptions) throws StandardException {
+    public GetSchemaExternalResult getExternalFileSchema(String storedAs, String location, boolean mergeSchema,
+                                                         CsvOptions csvOptions, StructType nonPartitionColumns,
+                                                         StructType partitionColumns) throws StandardException {
         DistributedDataSetProcessor proc = EngineDriver.driver().processorFactory().distributedProcessor();
-        return proc.getExternalFileSchema(storedAs,location,mergeSchema, csvOptions);
+        return proc.getExternalFileSchema(storedAs,location,mergeSchema, csvOptions,
+                nonPartitionColumns, partitionColumns);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
@@ -23,6 +23,7 @@ import com.splicemachine.db.impl.sql.compile.ExplainNode;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.stream.function.Partitioner;
 import com.splicemachine.derby.utils.marshall.KeyHashDecoder;
+import com.splicemachine.procedures.external.GetSchemaExternalResult;
 import com.splicemachine.si.api.txn.TxnView;
 import com.splicemachine.system.CsvOptions;
 import org.apache.spark.sql.types.StructField;
@@ -187,7 +188,9 @@ public interface DataSetProcessor {
      * @param csvOptions
      * @return
      */
-    StructType getExternalFileSchema(String storedAs, String location, boolean mergeSchema, CsvOptions csvOptions) throws StandardException;
+    GetSchemaExternalResult getExternalFileSchema(String storedAs, String location, boolean mergeSchema,
+                                                  CsvOptions csvOptions, StructType nonPartitionColumns,
+                                                  StructType partitionColumns) throws StandardException;
     /**
      * This is used when someone modify the external table outside of Splice.
      * One need to refresh the schema table if the underlying file have been modify outside Splice because

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ExternalTableUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ExternalTableUtils.java
@@ -129,7 +129,7 @@ public class ExternalTableUtils {
             for( int i =0 ; i < partitionSchema.fields().length; i++)
             {
                 if( i > 0 ) sb.append( ", " );
-                sb.append( partitionSchema.fields()[i].name() + " ");
+                sb.append( partitionSchema.fields()[i].name());
             }
             sb.append( ")" );
         }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ExternalTableUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ExternalTableUtils.java
@@ -15,67 +15,27 @@
 
 package com.splicemachine.derby.stream.utils;
 
-import com.splicemachine.access.api.DistributedFileSystem;
-import com.splicemachine.access.api.FileInfo;
 import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
-import com.splicemachine.derby.impl.load.ImportUtils;
 import com.splicemachine.derby.jdbc.SpliceTransactionResourceImpl;
-import com.splicemachine.derby.stream.iapi.DataSetProcessor;
 import com.splicemachine.si.api.txn.Txn;
 import com.splicemachine.si.impl.driver.SIDriver;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Created by tgildersleeve on 8/2/17.
  */
 public class ExternalTableUtils {
-
-    /**
-     * check for Avro date type conversion. Databricks' spark-avro support does not handle date.
-     */
-    public static StructType supportAvroDateType(StructType schema, String storedAs) {
-        if (storedAs.toLowerCase().equals("a")) {
-            for (int i = 0; i < schema.size(); i++) {
-                StructField column = schema.fields()[i];
-                if (column.dataType().equals(DataTypes.DateType)) {
-                    StructField replace = DataTypes.createStructField(column.name(), DataTypes.StringType, column.nullable(), column.metadata());
-                    schema.fields()[i] = replace;
-                }
-            }
-        }
-        return schema;
-    }
-
-    public static Dataset<Row> castDateTypeInAvroDataSet(Dataset<Row> dataset, StructType tableSchema) {
-        int i = 0;
-        for (StructField sf : tableSchema.fields()) {
-            if (sf.dataType().sameType(DataTypes.DateType)) {
-                String colName = dataset.schema().fields()[i].name();
-                dataset = dataset.withColumn(colName, dataset.col(colName).cast(DataTypes.DateType));
-            }
-            i++;
-        }
-        return dataset;
-    }
 
     public static StructType getSchema(Activation activation, long conglomerateId) throws StandardException {
 
@@ -139,175 +99,45 @@ public class ExternalTableUtils {
         }
         else return datatype.sql();
     }
-    /// returns a suggested schema for this schema, e.g. `CREATE EXTERNAL TABLE T (a_float REAL, a_double DOUBLE);`
-    public static String getSuggestedSchema(StructType externalSchema) {
-        StringBuilder sb = new StringBuilder();
-        sb.append( "CREATE EXTERNAL TABLE T (" );
-        for( int i =0 ; i < externalSchema.fields().length; i++)
+
+    private static boolean addTypes(StructType types, StringBuilder sb, boolean first)
+    {
+        for( int i =0 ; i < types.fields().length; i++)
         {
-            StructField f = externalSchema.fields()[i];
-            if( i > 0 ) sb.append( ", " );
+            StructField f = types.fields()[i];
+            if( !first ) {
+                sb.append(", ");
+            }
+            first = false;
             sb.append( f.name() + " ");
             sb.append( getSqlTypeName( f.dataType() ) );
             if( !f.nullable() )
                 sb.append(" NOT NULL");
         }
-        sb.append( ");" );
+        return first;
+    }
+
+    public static String getSuggestedSchema(StructType externalSchema, StructType partitionSchema) {
+        StringBuilder sb = new StringBuilder();
+        sb.append( "CREATE EXTERNAL TABLE T (" );
+        boolean first = addTypes(externalSchema, sb, true);
+        if( partitionSchema != null && partitionSchema.size() > 0 ) {
+            addTypes(partitionSchema, sb, first);
+            sb.append( ")" );
+
+            sb.append( " PARTITIONED BY(" );
+            for( int i =0 ; i < partitionSchema.fields().length; i++)
+            {
+                if( i > 0 ) sb.append( ", " );
+                sb.append( partitionSchema.fields()[i].name() + " ");
+            }
+            sb.append( ")" );
+        }
+        else {
+            sb.append( ")" );
+        }
+        sb.append( ";" );
         return sb.toString();
     }
 
-    public static void checkSchema(StructType tableSchema,
-                                   StructType externalSchema,
-                                   int[] partitionColumnMap,
-                                   String location) throws StandardException{
-
-
-        StructField[] tableFields = tableSchema.fields();
-        StructField[] externalFields = externalSchema.fields();
-
-        if (tableFields.length != externalFields.length) {
-            throw StandardException.newException(SQLState.INCONSISTENT_NUMBER_OF_ATTRIBUTE,
-                    tableFields.length, externalFields.length, location, getSuggestedSchema(externalSchema) );
-        }
-
-        StructField[] partitionedTableFields = new StructField[tableSchema.fields().length];
-        Set<Integer> partitionColumns = new HashSet<>();
-        for (int pos : partitionColumnMap) {
-            partitionColumns.add(pos);
-        }
-        int index = 0;
-        for (int i = 0; i < tableFields.length; ++i) {
-            if (!partitionColumns.contains(i)) {
-                partitionedTableFields[index++] = tableFields[i];
-            }
-        }
-
-        for (int i = 0; i < tableFields.length - partitionColumnMap.length; ++i) {
-
-            String tableFiledTypeName = partitionedTableFields[i].dataType().typeName();
-            String dataFieldTypeName = externalFields[i].dataType().typeName();
-            if (!tableFiledTypeName.equals(dataFieldTypeName)){
-                throw StandardException.newException(SQLState.INCONSISTENT_DATATYPE_ATTRIBUTES,
-                        tableFields[i].name(), getSqlTypeName(tableFields[i].dataType()),
-                        externalFields[i].name(), getSqlTypeName(externalFields[i].dataType()),
-                        location, getSuggestedSchema(externalSchema) );
-            }
-        }
-    }
-
-    private static StructType getDataSchema(DataSetProcessor dsp, StructType tableSchema, int[] partitionColumnMap,
-                                     String location, String storeAs, boolean mergeSchema) throws StandardException {
-        StructType dataSchema =dsp.getExternalFileSchema(storeAs, location, mergeSchema, null);
-        tableSchema =  ExternalTableUtils.supportAvroDateType(tableSchema, storeAs);
-        if (dataSchema != null) {
-            ExternalTableUtils.checkSchema(tableSchema, dataSchema, partitionColumnMap, location);
-
-            // set partition column datatype, because the inferred type is not always correct
-            setPartitionColumnTypes(dataSchema, partitionColumnMap, tableSchema);
-        }
-        return dataSchema;
-    }
-
-    public static StructType getDataSchema(DataSetProcessor dsp, StructType tableSchema, int[] partitionColumnMap,
-                                           String location, String storeAs) throws StandardException {
-        // Infer schema from external files\
-        StructType dataSchema = null;
-        try {
-            dataSchema = getDataSchema(dsp, tableSchema, partitionColumnMap, location, storeAs, false);
-        }
-        catch (StandardException e) {
-            String sqlState = e.getSqlState();
-            if (sqlState.equals(SQLState.INCONSISTENT_NUMBER_OF_ATTRIBUTE) ||
-                    sqlState.equals(SQLState.INCONSISTENT_DATATYPE_ATTRIBUTES)) {
-                dataSchema = getDataSchema(dsp, tableSchema, partitionColumnMap, location, storeAs, true);
-            }
-            else {
-                throw e;
-            }
-        }
-        return dataSchema;
-    }
-
-    public static void setPartitionColumnTypes (StructType dataSchema,int[] baseColumnMap, StructType tableSchema){
-
-            int ncolumns = dataSchema.fields().length;
-            int nPartitions = baseColumnMap.length;
-            for (int i = 0; i < baseColumnMap.length; ++i) {
-                String name = dataSchema.fields()[ncolumns - i - 1].name();
-                org.apache.spark.sql.types.DataType type = tableSchema.fields()[baseColumnMap[nPartitions - i - 1]].dataType();
-                boolean nullable = tableSchema.fields()[baseColumnMap[nPartitions - i - 1]].nullable();
-                Metadata metadata = tableSchema.fields()[baseColumnMap[nPartitions - i - 1]].metadata();
-                StructField field = new StructField(name, type, nullable, metadata);
-                dataSchema.fields()[ncolumns - i - 1] = field;
-            }
-        }
-
-    /*
-     if the external table is partitioned, its partitioned columns will be placed after all non-partitioned columns in StructField[] schema
-     sort the columns so that partitioned columns are in their correct place
-     */
-
-    public static void sortColumns(StructField[] schema, int[] partitionColumnMap) {
-        if (partitionColumnMap.length > 0) {
-            // get the partitioned columns and map them to their correct indexes
-            HashMap<Integer, StructField> partitions = new HashMap<>();
-            int schemaColumnIndex = schema.length - 1;
-            for (int i = partitionColumnMap.length - 1; i >= 0; i--) {
-                partitions.put(partitionColumnMap[i], schema[schemaColumnIndex]);
-                schemaColumnIndex--;
-            }
-
-            // sort the partitioned columns back into their correct respective indexes in schema
-            StructField[] schemaCopy = schema.clone();
-            int schemaCopyIndex = 0;
-            for (int i = 0; i < schema.length; i++) {
-                if (partitions.containsKey(i)) {
-                    schema[i] = partitions.get(i);
-                } else {
-                    schema[i] = schemaCopy[schemaCopyIndex++];
-                }
-            }
-        }
-    }
-
-    public static void preSortColumns(StructField[] schema, int[] partitionColumnMap) {
-        if (partitionColumnMap.length > 0) {
-            // get the partitioned columns and map them to their correct indexes
-            HashMap<Integer, StructField> partitions = new HashMap<>();
-
-            // sort the partitioned columns back into their correct respective indexes in schema
-            StructField[] schemaCopy = schema.clone();
-            for (int i = 0; i < partitionColumnMap.length; ++i) {
-                partitions.put(partitionColumnMap[i], schemaCopy[partitionColumnMap[i]]);
-            }
-
-            int schemaIndex = 0;
-            for (int i = 0; i < schemaCopy.length; i++) {
-                if (partitions.containsKey(i)) {
-                    continue;
-                } else {
-                    schema[schemaIndex++] = schemaCopy[i];
-                }
-            }
-            for (int i = 0; i < partitionColumnMap.length; ++i) {
-                schema[schemaIndex++] = partitions.get(partitionColumnMap[i]);
-            }
-        }
-    }
-
-    public static boolean isEmptyDirectory(String location) throws Exception {
-        DistributedFileSystem dfs = ImportUtils.getFileSystem(location);
-        return dfs.getInfo(location).isEmptyDirectory();
-    }
-
-    public static boolean isExisting(String location) throws Exception {
-        FileInfo fileInfo = ImportUtils.getFileSystem(location).getInfo(location);
-        return fileInfo.exists();
-
-    }
-
-    public static String truncateFileNameFromFullPath(String file)
-    {
-        return file.substring(file.lastIndexOf(File.separator) + 1);
-    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/procedures/external/GetSchemaExternalJob.java
+++ b/splice_machine/src/main/java/com/splicemachine/procedures/external/GetSchemaExternalJob.java
@@ -48,9 +48,9 @@ public class GetSchemaExternalJob implements Callable<Void> {
         dsp.setSchedulerPool("admin");
         dsp.setJobGroup(request.getJobGroup(), "");
 
-        StructType externalSchema = dsp.getExternalFileSchema(request.getStoredAs(), request.getLocation(),
-                request.mergeSchema(), request.getCsvOptions() );
-        jobStatus.markCompleted(new GetSchemaExternalResult(externalSchema));
+        GetSchemaExternalResult externalSchema = dsp.getExternalFileSchema(request.getStoredAs(), request.getLocation(),
+                request.mergeSchema(), request.getCsvOptions(), request.getNonPartitionColumns(), request.getPartitionColumns() );
+        jobStatus.markCompleted(externalSchema);
         return null;
     }
 

--- a/splice_si_api/src/test/java/com/splicemachine/si/impl/TestingFileSystem.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/impl/TestingFileSystem.java
@@ -254,6 +254,11 @@ public class TestingFileSystem extends DistributedFileSystem{
             return Files.exists(p);
         }
 
+        @Override
+        public FileInfo[] listRecursive(){
+            throw new UnsupportedOperationException("IMPLEMENT");
+        }
+
     }
 }
 


### PR DESCRIPTION
fixing issues:
- DB-9843: Don't copy files for schema infer, but also don't check all files for schema -> overall faster
- DB-10568 Partitioned by using VARCHAR but value is 1 will be infered as INT and can't be read

currently we copy one file out of the directory to another directory, keeping the subdirectories like path/col1=22/col2=ABC/file.parquet . The idea behind this was that Spark should only have to look at ONE file, not ALL. However, we would still need directory partitioning information, so we had to COPY the file (couldn't just point at one file).
Now we can do directory partitioning ourselfs, we can skip the copy part.