### PR TITLE
DB-9835 reduce time spent in listdirs for isEmptyDirectory (2.8)

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -335,23 +335,17 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                                           double sampleFraction) throws StandardException {
         try {
             Dataset<Row> table = null;
+            ExternalTableUtils.preSortColumns(tableSchema.fields(), partitionColumnMap);
 
             try {
-                DataSet<V> empty_ds = checkExistingOrEmpty( location, context );
-                if( empty_ds != null ) return empty_ds;
-
-                ExternalTableUtils.preSortColumns(tableSchema.fields(), partitionColumnMap);
-
                 table = SpliceSpark.getSession()
                         .read()
                         .schema(tableSchema)
                         .parquet(location);
-
-                ExternalTableUtils.sortColumns(table.schema().fields(), partitionColumnMap);
-
             } catch (Exception e) {
-                return handleExceptionInCaseOfEmptySet(e,location);
+                return handleExceptionSparkRead(e, location, false);
             }
+            ExternalTableUtils.sortColumns(table.schema().fields(), partitionColumnMap);
             table = processExternalDataset(execRow, table, baseColumnMap, qualifiers, probeValue);
 
             if (useSample) {
@@ -375,33 +369,34 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                                        boolean useSample, double sampleFraction) throws StandardException {
         try {
             Dataset<Row> table = null;
+            StructType copy = new StructType(Arrays.copyOf(tableSchema.fields(), tableSchema.fields().length));
+
+            // Infer schema from external files
+            // todo: this is slow on bigger directories, as it's calling getExternalFileSchema,
+            // which will do a spark.read() before doing the spark.read() here ...
+            StructType dataSchema = ExternalTableUtils.getDataSchema(this, tableSchema, partitionColumnMap, location, "a");
+            if(dataSchema == null)
+                return getEmpty(RDDName.EMPTY_DATA_SET.displayName(), context);
+
             try {
-                DataSet<V> empty_ds = checkExistingOrEmpty( location, context );
-                if( empty_ds != null ) return empty_ds;
-
-                StructType copy = new StructType(Arrays.copyOf(tableSchema.fields(), tableSchema.fields().length));
-
-                // Infer schema from external files\
-                StructType dataSchema = ExternalTableUtils.getDataSchema(this, tableSchema, partitionColumnMap, location, "a");
-
                 SparkSession spark = SpliceSpark.getSession();
                 // Creates a DataFrame from a specified file
                 table = spark.read().schema(dataSchema).format("com.databricks.spark.avro").load(location);
-
-                int i = 0;
-                for (StructField sf : copy.fields()) {
-                    if (sf.dataType().sameType(DataTypes.DateType)) {
-                        String colName = table.schema().fields()[i].name();
-                        table = table.withColumn(colName, table.col(colName).cast(DataTypes.DateType));
-                    }
-                    i++;
-                }
-
-                ExternalTableUtils.sortColumns(table.schema().fields(), partitionColumnMap);
-
             } catch (Exception e) {
-                return handleExceptionInCaseOfEmptySet(e,location);
+                return handleExceptionSparkRead(e, location, false);
             }
+
+            // todo: find out what this is doing and comment it
+            int i = 0;
+            for (StructField sf : copy.fields()) {
+                if (sf.dataType().sameType(DataTypes.DateType)) {
+                    String colName = table.schema().fields()[i].name();
+                    table = table.withColumn(colName, table.col(colName).cast(DataTypes.DateType));
+                }
+                i++;
+            }
+
+            ExternalTableUtils.sortColumns(table.schema().fields(), partitionColumnMap);
             table = processExternalDataset(execRow, table,baseColumnMap,qualifiers,probeValue);
 
             if (useSample) {
@@ -426,7 +421,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
      * @return
      * @throws Exception
      */
-    private <V> DataSet<V> handleExceptionInCaseOfEmptySet(Exception e, String location) throws Exception {
+    private <V> DataSet<V> handleExceptionInferSchema(Exception e, String location) throws Exception {
         // Cannot Infer Schema, Argh
         if ((e instanceof AnalysisException || e instanceof FileNotFoundException) && e.getMessage() != null &&
                 (e.getMessage().startsWith("Unable to infer schema") || e.getMessage().startsWith("No Avro files found"))) {
@@ -435,6 +430,19 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                 return getEmpty();
         }
         throw e;
+    }
+
+    private <V> DataSet<V> handleExceptionSparkRead(Exception e, String location, boolean checkEmpty) throws Exception {
+        // Cannot Infer Schema, Argh
+        if( e instanceof org.apache.spark.sql.AnalysisException )
+        {
+            if( e.getMessage().startsWith("Path does not exist"))
+                throw StandardException.newException(SQLState.EXTERNAL_TABLES_LOCATION_NOT_EXIST, location);
+            if( checkEmpty && e.getMessage().startsWith("Unable to infer schema") && ExternalTableUtils.isEmptyDirectory(location))
+                return getEmpty();
+
+        }
+        throw StandardException.newException(SQLState.EXTERNAL_TABLES_READ_FAILURE, e, e.getMessage());
     }
 
     @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH",justification = "Intentional")
@@ -519,7 +527,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                     schema = dataset.schema();
                 }
             } catch (Exception e) {
-                handleExceptionInCaseOfEmptySet(e, location);
+                handleExceptionInferSchema(e, location);
             } finally {
                 if (!mergeSchema && fs != null && temp!= null && fs.exists(temp)){
                     fs.delete(temp, true);
@@ -694,6 +702,10 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         assert baseColumnMap != null:"baseColumnMap Null";
         assert partitionColumnMap != null:"partitionColumnMap Null";
         try {
+            // todo: check why we're using our own reader here.
+            // this has some drawbacks e.g. we have to do this empty check before reading since our reader is doing reading
+            // later, also as filter() will be done SparkScanSetBuilder, and then only fails when doing
+            // sparkDataSet.rdd.rdd().getNumPartitions() in QueryJob.
             DataSet<V> empty_ds = checkExistingOrEmpty( location, context );
             if( empty_ds != null ) return empty_ds;
 
@@ -706,13 +718,19 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             if (statsjob)
                 configuration.set(SpliceOrcNewInputFormat.SPLICE_COLLECTSTATS, "true");
 
-            JavaRDD<Row> rows = SpliceSpark.getContext().newAPIHadoopFile(
-                    location,
-                    SpliceOrcNewInputFormat.class,
-                    NullWritable.class,
-                    Row.class,
-                    configuration)
-                            .values();
+            JavaRDD<Row> rows;
+            try {
+                rows = SpliceSpark.getContext().newAPIHadoopFile(
+                        location,
+                        SpliceOrcNewInputFormat.class,
+                        NullWritable.class,
+                        Row.class,
+                        configuration)
+                        .values();
+            }
+            catch (Exception e) {
+                return handleExceptionSparkRead(e, location, false);
+            }
 
             if (useSample) {
                 return new SparkDataSet(rows.sample(false,sampleFraction).map(new RowToLocatedRowFunction(context, execRow)));
@@ -781,7 +799,7 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
 
 
             } catch (Exception e) {
-                return handleExceptionInCaseOfEmptySet(e,location);
+                return handleExceptionSparkRead(e, location, true);
             }
             table = processExternalDataset(execRow, table,baseColumnMap,qualifiers,probeValue);
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -345,22 +345,15 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             } catch (Exception e) {
                 return handleExceptionSparkRead(e, location, false);
             }
-            ExternalTableUtils.sortColumns(table.schema().fields(), partitionColumnMap);
-            table = processExternalDataset(execRow, table, baseColumnMap, qualifiers, probeValue);
 
-            if (useSample) {
-                return new NativeSparkDataSet(table
-                        .sample(false, sampleFraction), context);
-            } else {
-                return new NativeSparkDataSet(table, context);
-            }
+            ExternalTableUtils.sortColumns(table.schema().fields(), partitionColumnMap);
+            return externalTablesPostProcess(baseColumnMap, context, qualifiers, probeValue,
+                    execRow, useSample, sampleFraction, table);
         } catch (Exception e) {
             throw StandardException.newException(
                     SQLState.EXTERNAL_TABLES_READ_FAILURE, e, e.getMessage());
         }
     }
-
-
 
     @Override
     public <V> DataSet<V> readAvroFile(StructType tableSchema, int[] baseColumnMap, int[] partitionColumnMap,
@@ -369,7 +362,8 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                                        boolean useSample, double sampleFraction) throws StandardException {
         try {
             Dataset<Row> table = null;
-            StructType copy = new StructType(Arrays.copyOf(tableSchema.fields(), tableSchema.fields().length));
+            StructType tableSchemaCopy =
+                    new StructType(Arrays.copyOf(tableSchema.fields(), tableSchema.fields().length));
 
             // Infer schema from external files
             // todo: this is slow on bigger directories, as it's calling getExternalFileSchema,
@@ -386,25 +380,11 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                 return handleExceptionSparkRead(e, location, false);
             }
 
-            // todo: find out what this is doing and comment it
-            int i = 0;
-            for (StructField sf : copy.fields()) {
-                if (sf.dataType().sameType(DataTypes.DateType)) {
-                    String colName = table.schema().fields()[i].name();
-                    table = table.withColumn(colName, table.col(colName).cast(DataTypes.DateType));
-                }
-                i++;
-            }
-
+            table = ExternalTableUtils.castDateTypeInAvroDataSet(table, tableSchemaCopy);
             ExternalTableUtils.sortColumns(table.schema().fields(), partitionColumnMap);
-            table = processExternalDataset(execRow, table,baseColumnMap,qualifiers,probeValue);
 
-            if (useSample) {
-                return new NativeSparkDataSet(table
-                        .sample(false, sampleFraction), context);
-            } else {
-                return new NativeSparkDataSet(table, context);
-            }
+            return externalTablesPostProcess(baseColumnMap, context, qualifiers, probeValue,
+                    execRow, useSample, sampleFraction, table);
         } catch (Exception e) {
             throw StandardException.newException(
                     SQLState.EXTERNAL_TABLES_READ_FAILURE, e, e.getMessage());
@@ -667,6 +647,20 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
 
     }
 
+    private <V> DataSet<V> externalTablesPostProcess(int[] baseColumnMap, OperationContext context,
+                                                     Qualifier[][] qualifiers, DataValueDescriptor probeValue, ExecRow execRow,
+                                                     boolean useSample, double sampleFraction, Dataset<Row> table) throws StandardException {
+
+        table = processExternalDataset(execRow, table, baseColumnMap, qualifiers, probeValue);
+
+        if (useSample) {
+            return new NativeSparkDataSet(table
+                    .sample(false, sampleFraction), context);
+        } else {
+            return new NativeSparkDataSet(table, context);
+        }
+    }
+
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public <V> DataSet<V> readPinnedTable(
@@ -702,10 +696,6 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         assert baseColumnMap != null:"baseColumnMap Null";
         assert partitionColumnMap != null:"partitionColumnMap Null";
         try {
-            // todo: check why we're using our own reader here.
-            // this has some drawbacks e.g. we have to do this empty check before reading since our reader is doing reading
-            // later, also as filter() will be done SparkScanSetBuilder, and then only fails when doing
-            // sparkDataSet.rdd.rdd().getNumPartitions() in QueryJob.
             DataSet<V> empty_ds = checkExistingOrEmpty( location, context );
             if( empty_ds != null ) return empty_ds;
 
@@ -801,14 +791,9 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             } catch (Exception e) {
                 return handleExceptionSparkRead(e, location, true);
             }
-            table = processExternalDataset(execRow, table,baseColumnMap,qualifiers,probeValue);
 
-            if (useSample) {
-                return new NativeSparkDataSet(table
-                        .sample(false, sampleFraction), context);
-            } else {
-                return new NativeSparkDataSet(table, context);
-            }
+            return externalTablesPostProcess(baseColumnMap, context, qualifiers, probeValue,
+                    execRow, useSample, sampleFraction, table);
         } catch (Exception e) {
             throw StandardException.newException(
                     SQLState.EXTERNAL_TABLES_READ_FAILURE, e, e.getMessage());

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -328,7 +328,16 @@ public class ExternalTableIT extends SpliceUnitTest {
             methodWatcher.executeUpdate(query);
             Assert.fail(test + ": Exception not thrown");
         } catch (SQLException e) {
-            Assert.assertEquals(test + ": Wrong Exception", exceptionType, e.getSQLState());
+            Assert.assertEquals(test + ": Wrong Exception (" + e.getMessage() + ")", exceptionType, e.getSQLState());
+        }
+    }
+
+    void assureQueryFails(String query, String exceptionType, String test) throws Exception {
+        try {
+            methodWatcher.executeQuery(query);
+            Assert.fail(test + ": Exception not thrown");
+        } catch (SQLException e) {
+            Assert.assertEquals(test + ": Wrong Exception (" + e.getMessage() + ")", exceptionType, e.getSQLState());
         }
     }
 
@@ -374,6 +383,7 @@ public class ExternalTableIT extends SpliceUnitTest {
             }
         }
     }
+
 
     @Test
     public void testLocationCannotBeAFile() throws  Exception{
@@ -2229,35 +2239,24 @@ public class ExternalTableIT extends SpliceUnitTest {
     }
 
     @Test
-    public void testPureEmptyDirectory() throws  Exception{
-        String tablePath = getExternalResourceDirectory()+"pure_empty_directory";
-        File path =  new File(tablePath);
-        path.mkdir();
-        methodWatcher.executeUpdate(String.format("create external table pure_empty_directory (col1 varchar(24), col2 varchar(24), col3 varchar(24))" +
-                    " STORED AS PARQUET LOCATION '%s'",tablePath));
-        FileUtils.cleanDirectory(path);
-
-        ResultSet rs = methodWatcher.executeQuery("select * from pure_empty_directory");
-        String actual = TestUtils.FormattedResult.ResultFactory.toString(rs);
-        String expected = "";
-        Assert.assertEquals(actual, expected, actual);
-    }
-
-    @Test
-    public void testNotExistDirectory() throws  Exception{
-        try {
-            String tablePath = getExternalResourceDirectory()+"empty_directory_not_exist";
+    public void testNotExistAndEmptyDirectory() throws Exception {
+        for( String fileFormat : new String[]{"PARQUET", "ORC",  "AVRO", "TEXTFILE"})
+        {
+            String name = "empty_directory_not_exist_" + fileFormat;
+            String tablePath = getExternalResourceDirectory() + name;
             File path =  new File(tablePath);
             path.mkdir();
-            methodWatcher.executeUpdate(String.format("create external table empty_directory_not_exist (col1 varchar(24), col2 varchar(24), col3 varchar(24))" +
-                    " STORED AS PARQUET LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate(String.format("create external table " + name + " (col1 varchar(24), col2 varchar(24), col3 varchar(24))" +
+                    " STORED AS " + fileFormat + " LOCATION '%s'",tablePath));
             FileUtils.deleteDirectory(path);
+            assureQueryFails("select * from " + name, "EXT11", fileFormat + ": testNotExistDir");
 
-            methodWatcher.executeQuery("select * from empty_directory_not_exist");
-            Assert.fail("Exception not thrown");
-        }
-        catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT11",e.getSQLState());
+            path.mkdir();
+            ResultSet rs = methodWatcher.executeQuery("select count(*) from " + name);
+            String expected = "1 |\n----\n 0 |";
+            String resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            assertEquals(expected, resultString);
+            rs.close();
         }
     }
 

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
@@ -237,12 +237,23 @@ public class HNIOFileSystem extends DistributedFileSystem{
         // Note: we need to be sure that the underlying filesystem can support recursive listdir efficiently.
         // this is done for S3 and HDFS has this anyhow. If this is not the case, it would be better to not use
         // (cached, but recursive) listRoot() here, but to just list the root (without recursive).
+        private List<FileStatus> rootFileStatusFlat;
+
         @Override
         public boolean isEmptyDirectory() {
             if( !exists() ) return false;
             if( !isDirectory() ) return false;
             try {
-                for (FileStatus s : listRoot() ) {
+                List<? extends FileStatus> files;
+                if(rootFileStatusList != null )
+                    files = rootFileStatusList;
+                else
+                {
+                    if( rootFileStatusFlat == null )
+                        rootFileStatusFlat = Arrays.asList(fs.listStatus(path));
+                    files = rootFileStatusFlat;
+                }
+                for (FileStatus s : files ) {
                     if (s.getPath().getName().equals("_SUCCESS") || s.getPath().getName().equals("_SUCCESS.crc") ) continue;
                     return false;
                 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
@@ -381,6 +381,10 @@ public class TableScanOperation extends ScanOperation{
     public DataSet<ExecRow> getTableScannerBuilder(DataSetProcessor dsp) throws StandardException{
         TxnView txn = getTransaction();
         operationContext = dsp.createOperationContext(this);
+
+        // we currently don't support external tables in Control, so this shouldn't happen
+        assert storedAs == null || !( dsp.getType() == DataSetProcessor.Type.CONTROL && !storedAs.isEmpty() )
+                : "tried to access external table " + tableDisplayName + ":" + tableName + " over control/OLTP";
         return dsp.<TableScanOperation,ExecRow>newScanSet(this,tableName)
                 .tableDisplayName(tableDisplayName)
                 .activation(activation)


### PR DESCRIPTION
- avoid to check for empty directory if spark does it
- dont use recursive listdir for isEmptyDirectory if FileSystem doesnt implement efficiently