### PR TITLE
DB-9835 reduce time spent in listdirs for isEmptyDirectory (3.0)

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -354,22 +354,15 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             } catch (Exception e) {
                 return handleExceptionSparkRead(e, location, false);
             }
-            ExternalTableUtils.sortColumns(table.schema().fields(), partitionColumnMap);
-            table = processExternalDataset(execRow, table, baseColumnMap, qualifiers, probeValue);
 
-            if (useSample) {
-                return new NativeSparkDataSet(table
-                        .sample(false, sampleFraction), context);
-            } else {
-                return new NativeSparkDataSet(table, context);
-            }
+            ExternalTableUtils.sortColumns(table.schema().fields(), partitionColumnMap);
+            return externalTablesPostProcess(baseColumnMap, context, qualifiers, probeValue,
+                    execRow, useSample, sampleFraction, table);
         } catch (Exception e) {
             throw StandardException.newException(
                     SQLState.EXTERNAL_TABLES_READ_FAILURE, e, e.getMessage());
         }
     }
-
-
 
     @Override
     public <V> DataSet<V> readAvroFile(StructType tableSchema, int[] baseColumnMap, int[] partitionColumnMap,
@@ -378,7 +371,8 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                                        boolean useSample, double sampleFraction) throws StandardException {
         try {
             Dataset<Row> table = null;
-            StructType copy = new StructType(Arrays.copyOf(tableSchema.fields(), tableSchema.fields().length));
+            StructType tableSchemaCopy =
+                    new StructType(Arrays.copyOf(tableSchema.fields(), tableSchema.fields().length));
 
             // Infer schema from external files
             // todo: this is slow on bigger directories, as it's calling getExternalFileSchema,
@@ -395,25 +389,11 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
                 return handleExceptionSparkRead(e, location, false);
             }
 
-            // todo: find out what this is doing and comment it
-            int i = 0;
-            for (StructField sf : copy.fields()) {
-                if (sf.dataType().sameType(DataTypes.DateType)) {
-                    String colName = table.schema().fields()[i].name();
-                    table = table.withColumn(colName, table.col(colName).cast(DataTypes.DateType));
-                }
-                i++;
-            }
-
+            table = ExternalTableUtils.castDateTypeInAvroDataSet(table, tableSchemaCopy);
             ExternalTableUtils.sortColumns(table.schema().fields(), partitionColumnMap);
-            table = processExternalDataset(execRow, table,baseColumnMap,qualifiers,probeValue);
 
-            if (useSample) {
-                return new NativeSparkDataSet(table
-                        .sample(false, sampleFraction), context);
-            } else {
-                return new NativeSparkDataSet(table, context);
-            }
+            return externalTablesPostProcess(baseColumnMap, context, qualifiers, probeValue,
+                    execRow, useSample, sampleFraction, table);
         } catch (Exception e) {
             throw StandardException.newException(
                     SQLState.EXTERNAL_TABLES_READ_FAILURE, e, e.getMessage());
@@ -681,6 +661,20 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
 
     }
 
+    private <V> DataSet<V> externalTablesPostProcess(int[] baseColumnMap, OperationContext context,
+                                                     Qualifier[][] qualifiers, DataValueDescriptor probeValue, ExecRow execRow,
+                                                     boolean useSample, double sampleFraction, Dataset<Row> table) throws StandardException {
+
+        table = processExternalDataset(execRow, table, baseColumnMap, qualifiers, probeValue);
+
+        if (useSample) {
+            return new NativeSparkDataSet(table
+                    .sample(false, sampleFraction), context);
+        } else {
+            return new NativeSparkDataSet(table, context);
+        }
+    }
+
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public <V> DataSet<V> readPinnedTable(
@@ -716,10 +710,6 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         assert baseColumnMap != null:"baseColumnMap Null";
         assert partitionColumnMap != null:"partitionColumnMap Null";
         try {
-            // todo: check why we're using our own reader here.
-            // this has some drawbacks e.g. we have to do this empty check before reading since our reader is doing reading
-            // later, also as filter() will be done SparkScanSetBuilder, and then only fails when doing
-            // sparkDataSet.rdd.rdd().getNumPartitions() in QueryJob.
             DataSet<V> empty_ds = checkExistingOrEmpty( location, context );
             if( empty_ds != null ) return empty_ds;
 
@@ -815,14 +805,9 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
             } catch (Exception e) {
                 return handleExceptionSparkRead(e, location, true);
             }
-            table = processExternalDataset(execRow, table,baseColumnMap,qualifiers,probeValue);
 
-            if (useSample) {
-                return new NativeSparkDataSet(table
-                        .sample(false, sampleFraction), context);
-            } else {
-                return new NativeSparkDataSet(table, context);
-            }
+            return externalTablesPostProcess(baseColumnMap, context, qualifiers, probeValue,
+                    execRow, useSample, sampleFraction, table);
         } catch (Exception e) {
             throw StandardException.newException(
                     SQLState.EXTERNAL_TABLES_READ_FAILURE, e, e.getMessage());

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -327,7 +327,16 @@ public class ExternalTableIT extends SpliceUnitTest {
             methodWatcher.executeUpdate(query);
             Assert.fail(test + ": Exception not thrown");
         } catch (SQLException e) {
-            Assert.assertEquals(test + ": Wrong Exception", exceptionType, e.getSQLState());
+            Assert.assertEquals(test + ": Wrong Exception (" + e.getMessage() + ")", exceptionType, e.getSQLState());
+        }
+    }
+
+    void assureQueryFails(String query, String exceptionType, String test) throws Exception {
+        try {
+            methodWatcher.executeQuery(query);
+            Assert.fail(test + ": Exception not thrown");
+        } catch (SQLException e) {
+            Assert.assertEquals(test + ": Wrong Exception (" + e.getMessage() + ")", exceptionType, e.getSQLState());
         }
     }
 
@@ -373,6 +382,7 @@ public class ExternalTableIT extends SpliceUnitTest {
             }
         }
     }
+
 
     @Test
     public void testLocationCannotBeAFile() throws  Exception{
@@ -2228,35 +2238,24 @@ public class ExternalTableIT extends SpliceUnitTest {
     }
 
     @Test
-    public void testPureEmptyDirectory() throws  Exception{
-        String tablePath = getExternalResourceDirectory()+"pure_empty_directory";
-        File path =  new File(tablePath);
-        path.mkdir();
-        methodWatcher.executeUpdate(String.format("create external table pure_empty_directory (col1 varchar(24), col2 varchar(24), col3 varchar(24))" +
-                    " STORED AS PARQUET LOCATION '%s'",tablePath));
-        FileUtils.cleanDirectory(path);
-
-        ResultSet rs = methodWatcher.executeQuery("select * from pure_empty_directory");
-        String actual = TestUtils.FormattedResult.ResultFactory.toString(rs);
-        String expected = "";
-        Assert.assertEquals(actual, expected, actual);
-    }
-
-    @Test
-    public void testNotExistDirectory() throws  Exception{
-        try {
-            String tablePath = getExternalResourceDirectory()+"empty_directory_not_exist";
+    public void testNotExistAndEmptyDirectory() throws Exception {
+        for( String fileFormat : new String[]{"PARQUET", "ORC",  "AVRO", "TEXTFILE"})
+        {
+            String name = "empty_directory_not_exist_" + fileFormat;
+            String tablePath = getExternalResourceDirectory() + name;
             File path =  new File(tablePath);
             path.mkdir();
-            methodWatcher.executeUpdate(String.format("create external table empty_directory_not_exist (col1 varchar(24), col2 varchar(24), col3 varchar(24))" +
-                    " STORED AS PARQUET LOCATION '%s'",tablePath));
+            methodWatcher.executeUpdate(String.format("create external table " + name + " (col1 varchar(24), col2 varchar(24), col3 varchar(24))" +
+                    " STORED AS " + fileFormat + " LOCATION '%s'",tablePath));
             FileUtils.deleteDirectory(path);
+            assureQueryFails("select * from " + name, "EXT11", fileFormat + ": testNotExistDir");
 
-            methodWatcher.executeQuery("select * from empty_directory_not_exist");
-            Assert.fail("Exception not thrown");
-        }
-        catch (SQLException e) {
-            Assert.assertEquals("Wrong Exception","EXT11",e.getSQLState());
+            path.mkdir();
+            ResultSet rs = methodWatcher.executeQuery("select count(*) from " + name);
+            String expected = "1 |\n----\n 0 |";
+            String resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            assertEquals(expected, resultString);
+            rs.close();
         }
     }
 

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HNIOFileSystem.java
@@ -237,12 +237,23 @@ public class HNIOFileSystem extends DistributedFileSystem{
         // Note: we need to be sure that the underlying filesystem can support recursive listdir efficiently.
         // this is done for S3 and HDFS has this anyhow. If this is not the case, it would be better to not use
         // (cached, but recursive) listRoot() here, but to just list the root (without recursive).
+        private List<FileStatus> rootFileStatusFlat;
+
         @Override
         public boolean isEmptyDirectory() {
             if( !exists() ) return false;
             if( !isDirectory() ) return false;
             try {
-                for (FileStatus s : listRoot() ) {
+                List<? extends FileStatus> files;
+                if(rootFileStatusList != null )
+                    files = rootFileStatusList;
+                else
+                {
+                    if( rootFileStatusFlat == null )
+                        rootFileStatusFlat = Arrays.asList(fs.listStatus(path));
+                    files = rootFileStatusFlat;
+                }
+                for (FileStatus s : files ) {
                     if (s.getPath().getName().equals("_SUCCESS") || s.getPath().getName().equals("_SUCCESS.crc") ) continue;
                     return false;
                 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
@@ -381,6 +381,10 @@ public class TableScanOperation extends ScanOperation{
     public DataSet<ExecRow> getTableScannerBuilder(DataSetProcessor dsp) throws StandardException{
         TxnView txn = getTransaction();
         operationContext = dsp.createOperationContext(this);
+
+        // we currently don't support external tables in Control, so this shouldn't happen
+        assert storedAs == null || !( dsp.getType() == DataSetProcessor.Type.CONTROL && !storedAs.isEmpty() )
+                : "tried to access external table " + tableDisplayName + ":" + tableName + " over control/OLTP";
         return dsp.<TableScanOperation,ExecRow>newScanSet(this,tableName)
                 .tableDisplayName(tableDisplayName)
                 .activation(activation)


### PR DESCRIPTION
- avoid to check for empty directory if spark does it
- dont use recursive listdir for isEmptyDirectory if FileSystem doesnt implement efficiently