### PR TITLE
DB-9939 Memory leak caused by unclosed scanners (3.0)

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/hbase/MemstoreAwareObserver.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/MemstoreAwareObserver.java
@@ -199,6 +199,8 @@ public class MemstoreAwareObserver implements RegionCoprocessor, RegionObserver,
                     InternalScan iscan = new InternalScan(scan);
                     iscan.checkOnlyMemStore();
                     HRegion region = (HRegion) c.getEnvironment().getRegion();
+                    // We substitute the pre-created scanner, must close it to avoid a memory leak
+                    s.close();
                     return new MemStoreFlushAwareScanner(region, store, ((HStore)store).getScanInfo(), iscan, targetCols, getReadpoint(region), memstoreAware, memstoreAware.get());
                 } else { // Partition Miss
                     while (true) {


### PR DESCRIPTION
MemstoreAwareObserver.postScannerOpenAction() does not close the passed RegionScanner when it returns a new MemStoreFlushAwareScanner. The dropped scanner gets leaked via HRegion.scannerReadPoints.