### PR TITLE
DB-10026 Make derbyclient dependency test only

### DIFF
--- a/splice_machine/pom.xml
+++ b/splice_machine/pom.xml
@@ -152,6 +152,7 @@
             <groupId>org.apache.derby</groupId>
             <artifactId>derbyclient</artifactId>
             <version>10.9.1.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.splicemachine</groupId>


### PR DESCRIPTION
The dependency is used in TestUnknownClient only and should be in the _test_ scope.