### PR TITLE
Revert "DB-10026 Make derbyclient dependency test only"

### DIFF
--- a/splice_machine/pom.xml
+++ b/splice_machine/pom.xml
@@ -145,7 +145,6 @@
             <groupId>org.apache.derby</groupId>
             <artifactId>derbyclient</artifactId>
             <version>10.9.1.0</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.splicemachine</groupId>


### PR DESCRIPTION
Reverts splicemachine/spliceengine#4000

Mem profile build in Jenkins has failed twice with:
com.splicemachine.derby.client.TestUnknownClient.testDerbyDriverFails
Error Details
Unexpected exception, expected<java.sql.SQLNonTransientConnectionException> but was<java.lang.ClassNotFoundException>