### PR TITLE
DB-9749 sync user roles before running remote queries.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -1154,6 +1154,14 @@ public interface LanguageConnectionContext extends Context {
      * @return List of roleids
      */
     List<String> getCurrentRoles(Activation a);
+
+    /**
+     * Removes all revoked roles from the list of current roles of the dynamic
+     * call context associated with this activation.
+     * @param a activation of the statement wanting to refresh the roles.
+     */
+    void refreshCurrentRoles(Activation a) throws StandardException;
+
     /**
      * Get the current role authorization identifier in external delimited form
      * (not case normal form) of the dynamic call context associated with this

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -3305,6 +3305,26 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     }
 
     @Override
+    public void refreshCurrentRoles(Activation a) throws StandardException {
+        List<String> roles = getCurrentSQLSessionContext(a).getRoles();
+        List<String> rolesToRemove = new ArrayList<>();
+        for (String role : roles) {
+            if (role != null) {
+                beginNestedTransaction(true);
+                try {
+                    if (!roleIsSettable(a, role)) {
+                        // invalid role, so remove it from the currentRoles list in SQLSessionContext
+                        rolesToRemove.add(role);
+                    }
+                } finally {
+                    commitNestedTransaction();
+                }
+            }
+        }
+        removeRoles(a, rolesToRemove);
+    }
+
+    @Override
     public String getCurrentUserId(Activation a) {
         return getCurrentSQLSessionContext(a).getCurrentUser();
     }
@@ -3365,23 +3385,9 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
 
         List<String> roles=getCurrentSQLSessionContext(a).getRoles();
 
-        List<String > rolesToRemove = new ArrayList<>();
+        refreshCurrentRoles(a);
         String roleListString = null;
         for (String role : roles) {
-            if (role != null) {
-                beginNestedTransaction(true);
-
-                try {
-                    if (!roleIsSettable(a, role)) {
-                        // invalid role, so remove it from the currentRoles list in SQLSessionContext
-                        rolesToRemove.add(role);
-                        role = null;
-                    }
-                } finally {
-                    commitNestedTransaction();
-                }
-            }
-
             if (role != null) {
                 if (roleListString == null)
                     roleListString = IdUtil.normalToDelimited(role);
@@ -3389,7 +3395,6 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
                     roleListString = roleListString + ", " + IdUtil.normalToDelimited(role);
             }
         }
-        removeRoles(a, rolesToRemove);
         return roleListString;
     }
 

--- a/hbase_sql/src/main/java/com/splicemachine/stream/RemoteQueryClientImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/RemoteQueryClientImpl.java
@@ -22,6 +22,7 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.ResultColumnDescriptor;
+import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.conn.SessionProperties;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
@@ -107,13 +108,14 @@ public class RemoteQueryClientImpl implements RemoteQueryClient {
 
             String sql = activation.getPreparedStatement().getSource();
             sql = sql == null ? root.toString() : sql;
-            String userId = activation.getLanguageConnectionContext().getCurrentUserId(activation);
+            LanguageConnectionContext lcc = activation.getLanguageConnectionContext();
+            String userId = lcc.getCurrentUserId(activation);
             int localPort = config.getNetworkBindPort();
-            int sessionId = activation.getLanguageConnectionContext().getInstanceNumber();
-            Integer parallelPartitionsProperty = (Integer) activation.getLanguageConnectionContext().getSessionProperties()
+            int sessionId = lcc.getInstanceNumber();
+            Integer parallelPartitionsProperty = (Integer) lcc.getSessionProperties()
                     .getProperty(SessionProperties.PROPERTYNAME.OLAPPARALLELPARTITIONS);
             int parallelPartitions = parallelPartitionsProperty == null ? StreamableRDD.DEFAULT_PARALLEL_PARTITIONS : parallelPartitionsProperty;
-            Integer shufflePartitionsProperty = (Integer) activation.getLanguageConnectionContext().getSessionProperties()
+            Integer shufflePartitionsProperty = (Integer) lcc.getSessionProperties()
                     .getProperty(SessionProperties.PROPERTYNAME.OLAPSHUFFLEPARTITIONS);
             String opUuid = root.getUuid() != null ? "," + root.getUuid().toString() : "";
             String session = hostname + ":" + localPort + "," + sessionId + opUuid;
@@ -121,13 +123,8 @@ public class RemoteQueryClientImpl implements RemoteQueryClient {
             RemoteQueryJob jobRequest = new RemoteQueryJob(ah, root.getResultSetNumber(), uuid, host, port, session, userId, sql,
                     streamingBatches, streamingBatchSize, parallelPartitions, shufflePartitionsProperty);
 
-            String requestedQueue = (String) activation.getLanguageConnectionContext().getSessionProperties().getProperty(SessionProperties.PROPERTYNAME.OLAPQUEUE);
-            // remove any stale revoked roles (DB-9749)
-            activation.getLanguageConnectionContext().refreshCurrentRoles(activation);
-            List<String> roles = activation.getLanguageConnectionContext().getCurrentRoles(activation);
-
-            String queue = chooseQueue(requestedQueue, roles, config.getOlapServerIsolatedRoles());
-            
+            String requestedQueue = (String) lcc.getSessionProperties().getProperty(SessionProperties.PROPERTYNAME.OLAPQUEUE);
+            String queue = chooseQueue(activation, requestedQueue, config.getOlapServerIsolatedRoles());
             olapFuture = EngineDriver.driver().getOlapClient().submit(jobRequest, queue);
             olapFuture.addListener(new Runnable() {
                 @Override
@@ -138,7 +135,7 @@ public class RemoteQueryClientImpl implements RemoteQueryClient {
                     } catch (ExecutionException e) {
                         LOG.warn("Execution failed", e);
                         Throwable cause = e.getCause();
-                        if (cause instanceof IOException || cause instanceof ConnectException) {
+                        if (cause instanceof IOException) { // including ConnectException
                             streamListener.failed(StandardException.newException(SQLState.OLAP_SERVER_CONNECTION, cause));
                         } else {
                             streamListener.failed(cause);
@@ -168,21 +165,39 @@ public class RemoteQueryClientImpl implements RemoteQueryClient {
     }
 
     /**
-     * If requestedQueue is null, return the assigned queue for any of the active roles. If none match return the default queue
-     * If requestedQueue is not null, make sure the requestedQueue is assigned to any of this users's roles and return it if there's a match. If it's not return the default queue
+     * If user is current data base owner:
+     *      - if `requestedQueue` is not null -> return it
+     *      - if `requestedQueue` is null -> return the default queue.
+     * If user is normal user:
+     *      - If requestedQueue is null, return the assigned queue for any of the active roles.
+     *        If none match return the default queue
+     *      - If requestedQueue is not null, make sure the requestedQueue is assigned to any of this users's roles and
+     *        return it if there's a match. If it's not return the default queue with the side effect of refreshing
+     *        the list of user roles.
      */
-    private String chooseQueue(String requestedQueue, List<String> roles, Map<String, String> olapServerIsolatedRoles) {
-        if (requestedQueue != null) {
-            // make sure the requested queue is available for the user roles
-            for (String role: roles) {
-                if (requestedQueue.equals(olapServerIsolatedRoles.get(role))) {
-                    return requestedQueue;
-                }
+    private String chooseQueue(Activation activation, String requestedQueue,
+                               Map<String, String> olapServerIsolatedRoles) throws StandardException {
+        LanguageConnectionContext lcc = activation.getLanguageConnectionContext();
+        if(lcc.getDataDictionary().getAuthorizationDatabaseOwner().equals(lcc.getCurrentUserId(activation))) {
+            if(requestedQueue != null) {
+                return requestedQueue;
             }
         } else {
-            for (String role : roles) {
-                if (olapServerIsolatedRoles.get(role) != null) {
-                    return olapServerIsolatedRoles.get(role);
+            // remove any stale revoked roles (DB-9749)
+            lcc.refreshCurrentRoles(activation);
+            List<String> roles = lcc.getCurrentRoles(activation);
+            if (requestedQueue != null) {
+                // make sure the requested queue is available for the user roles
+                for (String role: roles) {
+                    if (requestedQueue.equals(olapServerIsolatedRoles.get(role))) {
+                        return requestedQueue;
+                    }
+                }
+            } else {
+                for (String role : roles) {
+                    if (olapServerIsolatedRoles.get(role) != null) {
+                        return olapServerIsolatedRoles.get(role);
+                    }
                 }
             }
         }

--- a/hbase_sql/src/main/java/com/splicemachine/stream/RemoteQueryClientImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/RemoteQueryClientImpl.java
@@ -122,6 +122,8 @@ public class RemoteQueryClientImpl implements RemoteQueryClient {
                     streamingBatches, streamingBatchSize, parallelPartitions, shufflePartitionsProperty);
 
             String requestedQueue = (String) activation.getLanguageConnectionContext().getSessionProperties().getProperty(SessionProperties.PROPERTYNAME.OLAPQUEUE);
+            // remove any stale revoked roles (DB-9749)
+            activation.getLanguageConnectionContext().refreshCurrentRoles(activation);
             List<String> roles = activation.getLanguageConnectionContext().getCurrentRoles(activation);
 
             String queue = chooseQueue(requestedQueue, roles, config.getOlapServerIsolatedRoles());

--- a/hbase_sql/src/main/java/com/splicemachine/stream/RemoteQueryClientImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/RemoteQueryClientImpl.java
@@ -178,7 +178,10 @@ public class RemoteQueryClientImpl implements RemoteQueryClient {
     private String chooseQueue(Activation activation, String requestedQueue,
                                Map<String, String> olapServerIsolatedRoles) throws StandardException {
         LanguageConnectionContext lcc = activation.getLanguageConnectionContext();
-        if(lcc.getDataDictionary().getAuthorizationDatabaseOwner().equals(lcc.getCurrentUserId(activation))) {
+
+        List<String> userGroups = lcc.getCurrentGroupUser(activation);
+        String dbo = lcc.getDataDictionary().getAuthorizationDatabaseOwner();
+        if(lcc.getCurrentUserId(activation).equals(dbo) || (userGroups != null && userGroups.contains(dbo))) {
             if(requestedQueue != null) {
                 return requestedQueue;
             }


### PR DESCRIPTION
Previously, certain code paths that run remote jobs such as ASQ where getting the user roles as-is from the current SQL session context. Problem is, the retrieved list of roles is not kept up to date, meaning if the DBA revoked some roles from the user running ASQ, it wouldn't have any effect since the list of roles is not updated and the revoked role is not removed from it.

With this fix, we always refresh the list of roles before retrieving it.

I chose not to make refresh logic part of `LanguageConnectionContext.getCurrentRoles` as it might affect performance since it is used in many other locations that does proper cleansing of the role list already.