### PR TITLE
DB-10026 Make derbyclient dependency test only (redux)

### DIFF
--- a/mem_sql/pom.xml
+++ b/mem_sql/pom.xml
@@ -104,9 +104,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <dependenciesToScan>
-                        <dependency>com.splicemachine:splice_machine</dependency>
-                    </dependenciesToScan>
                     <excludedGroups>com.splicemachine.si.testenv.ArchitectureIndependent, ${excluded.longerthan}</excludedGroups>
                     <argLine>-Xmx512m</argLine>
                 </configuration>

--- a/splice_machine/pom.xml
+++ b/splice_machine/pom.xml
@@ -145,6 +145,7 @@
             <groupId>org.apache.derby</groupId>
             <artifactId>derbyclient</artifactId>
             <version>10.9.1.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.splicemachine</groupId>


### PR DESCRIPTION
Don’t rerun splice_machine unit tests from mem_sql: that is redundant and the classpath is not right.