### PR TITLE
DB-9705 reduce the amount of self-inserted rows in DefaultSourceIT (3.0)

### DIFF
--- a/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceIT.scala
+++ b/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceIT.scala
@@ -159,7 +159,7 @@ class DefaultSourceIT extends FunSuite with TestContext with BeforeAndAfter with
     val conn = JdbcUtils.createConnectionFactory(internalJDBCOptions)()
     conn.createStatement().execute(s"create table $schema.T(id INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1), c1 double, c2 double, c3 double, primary key(id))")
     conn.createStatement().execute(s"insert into $schema.T(c1,c2,c3) values (100, 100, 100), (200, 200, 200), (300, 300, 300), (400, 400, 400)");
-    for (i <- 0 to 20) {
+    for (i <- 0 to 18) {
       conn.createStatement().execute(s"insert into $schema.T(c1,c2,c3) select c1,c2,c3 from $schema.t")
     }
     conn.createStatement().execute(s"create table $schema.T2(id int, c1 double, c2 double, c3 double, primary key(id))")
@@ -175,7 +175,7 @@ class DefaultSourceIT extends FunSuite with TestContext with BeforeAndAfter with
     )
     splicemachineContext.splitAndInsert(df, schema+"."+"T2", 0.001)
     val newDF = sqlContext.read.options(options2).splicemachine
-    assert(newDF.count == 8388608)
+    assert(newDF.count == 2097152)
   }
 
   test("insertion using RDD") {


### PR DESCRIPTION
- Adding too many rows seems to cause memory pressure in Jenkins environment
  causing builds to fail sporadically.
- We should move this test to a performance benchmark where we have more
  suitable infrastructure.