### PR TITLE
Redo DB-10231 better CSV format support in external tables (3.0)

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
@@ -18,6 +18,7 @@ package com.splicemachine.derby.stream.spark;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.SQLLongint;
 import com.splicemachine.db.impl.sql.compile.ExplainNode;
@@ -38,8 +39,10 @@ import com.splicemachine.derby.stream.output.*;
 import com.splicemachine.pipeline.Exceptions;
 import com.splicemachine.spark.splicemachine.ShuffleUtils;
 import com.splicemachine.sparksql.ParserUtils;
+import com.splicemachine.system.CsvOptions;
 import com.splicemachine.utils.ByteDataInput;
 import com.splicemachine.utils.Pair;
+import com.sun.xml.bind.api.impl.NameConverter;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.conf.Configuration;
@@ -68,6 +71,7 @@ import java.util.*;
 import java.util.concurrent.Future;
 import java.util.zip.GZIPOutputStream;
 
+import static com.splicemachine.derby.stream.spark.SparkDataSetProcessor.getCsvOptions;
 import static org.apache.spark.sql.functions.*;
 
 
@@ -1191,15 +1195,14 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public DataSet<ExecRow> writeTextFile(SpliceOperation op, String location, String characterDelimiter, String columnDelimiter,
-                                                int[] baseColumnMap,
-                                                OperationContext context) {
+    public DataSet<ExecRow> writeTextFile(String location, CsvOptions csvOptions,
+                                          OperationContext context) throws StandardException {
         Dataset<Row> insertDF = dataset;
         // spark-2.2.0: commons-lang3-3.3.2 does not support 'XXX' timezone, specify 'ZZ' instead
-        insertDF.write().option("timestampFormat", "yyyy-MM-dd'T'HH:mm:ss.SSSZZ")
+        insertDF.write().options(getCsvOptions(csvOptions))
                 .mode(SaveMode.Append).csv(location);
-        ValueRow valueRow=new ValueRow(1);
-        valueRow.setColumn(1,new SQLLongint(context.getRecordsWritten()));
+        ValueRow valueRow = new ValueRow(1);
+        valueRow.setColumn(1, new SQLLongint(context.getRecordsWritten()));
         return new SparkDataSet<>(SpliceSpark.getContext().parallelize(Collections.singletonList(valueRow), 1));
     }
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
@@ -54,6 +54,7 @@ import com.splicemachine.derby.stream.output.UpdateDataSetWriterBuilder;
 import com.splicemachine.derby.stream.output.*;
 import com.splicemachine.derby.stream.utils.ExternalTableUtils;
 import com.splicemachine.spark.splicemachine.ShuffleUtils;
+import com.splicemachine.system.CsvOptions;
 import com.splicemachine.utils.ByteDataInput;
 import com.splicemachine.utils.Pair;
 import org.apache.commons.codec.binary.Base64;
@@ -877,15 +878,14 @@ public class SparkDataSet<V> implements DataSet<V> {
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public DataSet<ExecRow> writeTextFile(SpliceOperation op, String location, String characterDelimiter, String columnDelimiter,
-                                                int[] baseColumnMap,
+    public DataSet<ExecRow> writeTextFile(String location, CsvOptions csvOptions,
                                                 OperationContext context) throws StandardException {
 
         Dataset<Row> insertDF = SpliceSpark.getSession().createDataFrame(
                 rdd.map(new SparkSpliceFunctionWrapper<>(new CountWriteFunction(context))).map(new LocatedRowToRowFunction()),
                 context.getOperation().schema());
 
-        return new NativeSparkDataSet<>(insertDF, context).writeTextFile(op, location, characterDelimiter, columnDelimiter, baseColumnMap, context);
+        return new NativeSparkDataSet<>(insertDF, context).writeTextFile(location, csvOptions, context);
     }
 
     @Override @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -788,25 +788,14 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
     }
 
     @Override
-    public <V> DataSet<ExecRow> readTextFile(SpliceOperation op, String location, String characterDelimiter, String columnDelimiter, int[] baseColumnMap,
+    public <V> DataSet<ExecRow> readTextFile(SpliceOperation op, String location, CsvOptions csvOptions, int[] baseColumnMap,
                                       OperationContext context, Qualifier[][] qualifiers, DataValueDescriptor probeValue, ExecRow execRow,
                                                 boolean useSample, double sampleFraction) throws StandardException {
         assert baseColumnMap != null:"baseColumnMap Null";
         try {
             Dataset<Row> table = null;
             try {
-                HashMap<String, String> options = new HashMap<String, String>();
-                // spark-2.2.0: commons-lang3-3.3.2 does not support 'XXX' timezone, specify 'ZZ' instead
-                options.put("timestampFormat","yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
-
-                characterDelimiter = ImportUtils.unescape(characterDelimiter);
-                columnDelimiter = ImportUtils.unescape(columnDelimiter);
-                if (characterDelimiter!=null)
-                    options.put("escape", characterDelimiter);
-                if (columnDelimiter != null)
-                    options.put("sep", columnDelimiter);
-
-                table = SpliceSpark.getSession().read().options(options).csv(location);
+                table = SpliceSpark.getSession().read().options(getCsvOptions(csvOptions)).csv(location);
                 if (table.schema().fields().length == 0)
                     return getEmpty();
             } catch (Exception e) {
@@ -840,22 +829,32 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         }
     }
 
+    static String unescape(String type, String in) throws StandardException {
+        try{
+            return ImportUtils.unescape(in);
+        }
+        catch( IOException e)
+        {
+            throw StandardException.newException(SQLState.LANG_FORMAT_EXCEPTION, e, type + ". " + e.getMessage());
+        }
+    }
+
     /**
      * @param csvOptions
      * @return spark dataframereader options, see
      *         https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/DataFrameReader.html#csv-scala.collection.Seq-
      * @throws IOException
      */
-    public static HashMap<String, String> getCsvOptions(CsvOptions csvOptions) throws IOException {
+    public static HashMap<String, String> getCsvOptions(CsvOptions csvOptions) throws StandardException {
         HashMap<String, String> options = new HashMap<String, String>();
 
         // spark-2.2.0: commons-lang3-3.3.2 does not support 'XXX' timezone, specify 'ZZ' instead
         String timestampFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
         options.put("timestampFormat", timestampFormat);
 
-        String delimited = ImportUtils.unescape(csvOptions.columnDelimiter);
-        String escaped = ImportUtils.unescape(csvOptions.escapeCharacter);
-        String lines = ImportUtils.unescape(csvOptions.lineTerminator);
+        String delimited = unescape("TERMINATED BY", csvOptions.columnDelimiter);
+        String escaped = unescape( "ESCAPED BY", csvOptions.escapeCharacter);
+        String lines = unescape( "LINES SEPARATED BY", csvOptions.lineTerminator);
 
         if (delimited != null) // default ,
             options.put("sep", delimited);

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkScanSetBuilder.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkScanSetBuilder.java
@@ -32,6 +32,7 @@ import com.splicemachine.derby.stream.utils.StreamUtils;
 import com.splicemachine.mrio.MRConstants;
 import com.splicemachine.mrio.api.core.SMInputFormat;
 import com.splicemachine.si.impl.driver.SIDriver;
+import com.splicemachine.system.CsvOptions;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -88,8 +89,10 @@ public class SparkScanSetBuilder<V> extends TableScannerBuilder<V> {
             ExecRow execRow = operation==null?template:op.getExecRowDefinition();
             Qualifier[][] qualifiers = operation == null?null:operation.getScanInformation().getScanQualifiers();
             DataSet locatedRows;
-            if (storedAs.equals("T"))
-                locatedRows = dsp.readTextFile(op,location,escaped,delimited,baseColumnMap,operationContext,qualifiers,null,execRow, useSample, sampleFraction);
+            if (storedAs.equals("T")) {
+                CsvOptions csvOptions = new CsvOptions(delimited, escaped, lines);
+                locatedRows = dsp.readTextFile(op, location, csvOptions, baseColumnMap, operationContext, qualifiers, null, execRow, useSample, sampleFraction);
+            }
             else if (storedAs.equals("P"))
                 locatedRows = dsp.readParquetFile(schema, baseColumnMap,partitionByColumns,location,operationContext,qualifiers,null,execRow, useSample, sampleFraction);
             else if (storedAs.equals("A")) {

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -21,6 +21,8 @@ import com.splicemachine.homeless.TestUtils;
 import com.splicemachine.test_dao.TriggerBuilder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.SparkSession;
 import org.junit.*;
@@ -28,6 +30,8 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -1639,6 +1643,54 @@ public class ExternalTableIT extends SpliceUnitTest {
         }
     }
 
+    private String concatAllCsvFiles(File path) throws Exception {
+        FileFilter fileFilter = new WildcardFileFilter("*.csv");
+        File[] files = path.listFiles(fileFilter);
+        if( files == null )
+            return "<FILE NOT FOUND>";
+
+        StringBuilder sb = new StringBuilder();
+        for ( File file : files ) {
+            FileInputStream stream = new FileInputStream( file );
+            sb.append( IOUtils.toString(stream, "UTF-8") );
+        }
+        return sb.toString();
+    }
+
+    @Test
+    public void testCsvOptions() throws Exception {
+        String tablePath = getExternalResourceDirectory() + "test_csv_options";
+        String csvOptions[] = {
+                // default
+                "",
+                "\"\\\"Hallo; #\\\"World\\\"!\\\"\",\";Ha#,\"\n",
+                // TERMINATED BY
+                "ROW FORMAT DELIMITED FIELDS TERMINATED BY ';'",
+                "\"\\\"Hallo; #\\\"World\\\"!\\\"\";\";Ha#,\"\n",
+                // ESCAPED BY
+                "ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' ESCAPED BY '#'",
+                "\"#\"Hallo; ###\"World#\"!#\"\",\";Ha##,\"\n",
+        };
+        for( int i = 0; i < csvOptions.length; i+=2 ) {
+            // Create an external table stored as text
+            methodWatcher.executeUpdate( "CREATE EXTERNAL TABLE TEST_CSV_OPTIONS (t1 varchar(30), t2 varchar(30)) \n" +
+                    csvOptions[i] + " STORED AS TEXTFILE\n" +
+                    "location '" + tablePath + "'");
+            Assert.assertEquals( methodWatcher.executeUpdate(
+                    "insert into TEST_CSV_OPTIONS values ('\"Hallo; #\"World\"!\"', ';Ha#,')"), 1);
+
+
+            ResultSet rs = methodWatcher.executeQuery("select * from TEST_CSV_OPTIONS");
+            Assert.assertEquals("T1         | T2   |\n" +
+                    "---------------------------\n" +
+                    "\"Hallo; #\"World\"!\" |;Ha#, |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+
+            File path = new File(tablePath);
+            Assert.assertEquals( csvOptions[i+1], concatAllCsvFiles(path) );
+            methodWatcher.execute("drop table TEST_CSV_OPTIONS" );
+            FileUtils.deleteDirectory( path );
+        }
+    }
 
     @Test
     public void testUsingExsitingCsvFile() throws Exception {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/InsertOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/InsertOperation.java
@@ -53,6 +53,7 @@ import com.splicemachine.si.api.txn.Txn;
 import com.splicemachine.si.api.txn.TxnView;
 import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.storage.Partition;
+import com.splicemachine.system.CsvOptions;
 import com.splicemachine.utils.IntArrays;
 import com.splicemachine.utils.Pair;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -233,12 +234,12 @@ public class InsertOperation extends DMLWriteOperation implements HasIncrement{
         long nextIdentityColumnValue;
         assert activation!=null && spliceSequences!=null:"activation or sequences are null";
         nextIdentityColumnValue=((BaseActivation)activation).ignoreSequence()?-1:spliceSequences[columnPosition-1].getNext();
-        this.getActivation().getLanguageConnectionContext().setIdentityValue(nextIncrement);
         if(rowTemplate==null)
             rowTemplate=getExecRowDefinition();
         DataValueDescriptor dvd=rowTemplate.cloneColumn(columnPosition);
         dvd.setValue(nextIdentityColumnValue);
         synchronized (this) {
+            this.getActivation().getLanguageConnectionContext().setIdentityValue(nextIncrement);
             if (increment > 0) {
                 if (nextIdentityColumnValue > nextIncrement)
                     nextIncrement = nextIdentityColumnValue;
@@ -408,9 +409,9 @@ public class InsertOperation extends DMLWriteOperation implements HasIncrement{
                 else if (storedAs.toLowerCase().equals("o"))
                     return set.writeORCFile(IntArrays.count(execRowTypeFormatIds.length),partitionBy,location, compression, operationContext);
                 else if (storedAs.toLowerCase().equals("t"))
-                    return set.writeTextFile(this,location,delimited,lines,IntArrays.count(execRowTypeFormatIds.length), operationContext);
+                    return set.writeTextFile(location, new CsvOptions(delimited, escaped, lines), operationContext);
                 else
-                    new RuntimeException("storedAs type not supported -> " + storedAs);
+                    throw new RuntimeException("storedAs type not supported -> " + storedAs);
             }
             InsertDataSetWriterBuilder writerBuilder = null;
             if (bulkImportDirectory!=null && bulkImportDirectory.compareToIgnoreCase("NULL") !=0) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
@@ -57,6 +57,7 @@ import com.splicemachine.derby.stream.output.update.UpdateTableWriterBuilder;
 import com.splicemachine.pipeline.Exceptions;
 import com.splicemachine.primitives.Bytes;
 import com.splicemachine.si.impl.driver.SIDriver;
+import com.splicemachine.system.CsvOptions;
 import com.splicemachine.utils.Pair;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.collections.IteratorUtils;
@@ -637,19 +638,10 @@ public class ControlDataSet<V> implements DataSet<V> {
     }
 
     /**
-     *
      * Not Supported
-     *
-     * @param op
-     * @param location
-     * @param characterDelimiter
-     * @param columnDelimiter
-     * @param baseColumnMap
-     * @param context
-     * @return
      */
     @Override
-    public DataSet<ExecRow> writeTextFile(SpliceOperation op, String location, String characterDelimiter, String columnDelimiter, int[] baseColumnMap,  OperationContext context) {
+    public DataSet<ExecRow> writeTextFile(String location, CsvOptions csvOptions, OperationContext context) {
         throw new UnsupportedOperationException("Cannot write text files");
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
@@ -347,11 +347,11 @@ public class ControlDataSetProcessor implements DataSetProcessor{
     }
 
     @Override
-    public <V> DataSet<ExecRow> readTextFile(SpliceOperation op, String location, String characterDelimiter, String columnDelimiter, int[] baseColumnMap,
+    public <V> DataSet<ExecRow> readTextFile(SpliceOperation op, String location, CsvOptions csvOptions, int[] baseColumnMap,
                                                 OperationContext context, Qualifier[][] qualifiers, DataValueDescriptor probeValue, ExecRow execRow,
                                                 boolean useSample, double sampleFraction) throws StandardException{
         DistributedDataSetProcessor proc = EngineDriver.driver().processorFactory().distributedProcessor();
-        return new ControlDataSet(proc.readTextFile(op,location,characterDelimiter,columnDelimiter,baseColumnMap, context, qualifiers, probeValue, execRow, useSample, sampleFraction).toLocalIterator());
+        return new ControlDataSet(proc.readTextFile(op,location,csvOptions,baseColumnMap, context, qualifiers, probeValue, execRow, useSample, sampleFraction).toLocalIterator());
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
@@ -23,6 +23,7 @@ import com.splicemachine.derby.impl.sql.execute.operations.framework.SpliceGener
 import com.splicemachine.derby.impl.sql.execute.operations.window.WindowContext;
 import com.splicemachine.derby.stream.function.*;
 import com.splicemachine.derby.stream.output.*;
+import com.splicemachine.system.CsvOptions;
 import com.splicemachine.utils.Pair;
 
 import java.io.Serializable;
@@ -335,16 +336,12 @@ public interface DataSet<V> extends //Iterable<V>,
      *
      * Write text file to the Hadoop compliant location.
      *
-     * @param op
      * @param location
-     * @param characterDelimiter
-     * @param columnDelimiter
-     * @param baseColumnMap
      * @param context
      * @return
      */
-    DataSet<ExecRow> writeTextFile(SpliceOperation op, String location, String characterDelimiter, String columnDelimiter, int[] baseColumnMap,
-                                      OperationContext context) throws StandardException;
+    DataSet<ExecRow> writeTextFile(String location, CsvOptions csvOptions,
+                                   OperationContext context) throws StandardException;
 
     /**
      *

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
@@ -238,18 +238,17 @@ public interface DataSetProcessor {
      * Reads Text files given the scan variables.  The qualifiers in conjunctive normal form
      * will be applied in the parquet storage layer.
      *
+     * @param <V>
      * @param op
      * @param location
-     * @param characterDelimiter
-     * @param columnDelimiter
-     * @param baseColumnMap
+     * @param csvOptions
      * @param context
      * @param execRow
-     * @param <V>
+     * @param baseColumnMap
      * @return
      * @throws StandardException
      */
-    <V> DataSet<ExecRow> readTextFile(SpliceOperation op, String location, String characterDelimiter, String columnDelimiter, int[] baseColumnMap,
+    <V> DataSet<ExecRow> readTextFile(SpliceOperation op, String location, CsvOptions csvOptions, int[] baseColumnMap,
                                          OperationContext context, Qualifier[][] qualifiers, DataValueDescriptor probeValue, ExecRow execRow,
                                          boolean useSample, double sampleFraction) throws StandardException;
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ForwardingDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ForwardingDataSetProcessor.java
@@ -25,6 +25,7 @@ import com.splicemachine.derby.stream.function.Partitioner;
 import com.splicemachine.derby.stream.iapi.*;
 import com.splicemachine.derby.utils.marshall.KeyHashDecoder;
 import com.splicemachine.si.api.txn.TxnView;
+import com.splicemachine.system.CsvOptions;
 import org.apache.spark.sql.types.StructType;
 
 import java.io.InputStream;
@@ -179,9 +180,9 @@ public abstract class ForwardingDataSetProcessor implements DataSetProcessor{
     }
 
     @Override
-    public <V> DataSet<ExecRow> readTextFile(SpliceOperation op, String location, String characterDelimiter, String columnDelimiter, int[] baseColumnMap, OperationContext context, Qualifier[][] qualifiers, DataValueDescriptor probeValue,ExecRow execRow,
+    public <V> DataSet<ExecRow> readTextFile(SpliceOperation op, String location, CsvOptions csvOptions, int[] baseColumnMap, OperationContext context, Qualifier[][] qualifiers, DataValueDescriptor probeValue,ExecRow execRow,
                                                 boolean useSample, double sampleFraction) throws StandardException {
-        return delegate.readTextFile(op, location, characterDelimiter, columnDelimiter, baseColumnMap, context,  qualifiers, probeValue, execRow, useSample, sampleFraction);
+        return delegate.readTextFile(op, location, csvOptions, baseColumnMap, context,  qualifiers, probeValue, execRow, useSample, sampleFraction);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsOperation.java
@@ -47,6 +47,7 @@ import com.splicemachine.derby.stream.iapi.OperationContext;
 import com.splicemachine.derby.stream.iapi.ScanSetBuilder;
 import com.splicemachine.derby.stream.utils.ExternalTableUtils;
 import com.splicemachine.pipeline.Exceptions;
+import com.splicemachine.system.CsvOptions;
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.log4j.Logger;
 import org.apache.spark.sql.types.StructType;
@@ -112,8 +113,10 @@ public class StatisticsOperation extends SpliceBaseOperation {
                 int[] zeroBased = Arrays.stream(builder.getColumnPositionMap()).map((int x) -> x - 1).toArray();
                 StructType schema = ExternalTableUtils.getSchema(activation, builder.getBaseTableConglomId());
                 String storedAs = scanSetBuilder.getStoredAs();
-                if (storedAs.equals("T"))
-                    statsDataSet = dsp.readTextFile(null, builder.getLocation(), builder.getEscaped(), builder.getDelimited(), zeroBased, operationContext, null, null, builder.getTemplate(), useSample, sampleFraction);
+                if (storedAs.equals("T")) {
+                    CsvOptions csvOptions = new CsvOptions(builder.getDelimited(), builder.getEscaped(), builder.getLines());
+                    statsDataSet = dsp.readTextFile(null, builder.getLocation(), csvOptions, zeroBased, operationContext, null, null, builder.getTemplate(), useSample, sampleFraction);
+                }
                 else if (storedAs.equals("P"))
                     statsDataSet = dsp.readParquetFile(schema, zeroBased, builder.getPartitionByColumnMap() , builder.getLocation(), operationContext, null, null, builder.getTemplate(), useSample, sampleFraction);
                 else if (storedAs.equals("A"))


### PR DESCRIPTION
INSERT into CSV external table now also respects ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' ESCAPED BY '#' (DB-10231) . See NativeSparkDataSet::writeTextFile and SparkDataSetProcessor::getCsvOptions .

This reverts commit dc7736bf19f0b36177ab9f5b180d29c271365f42, which reverted 61966fc855f0598e34ca7ccdf83c3cfa4f730ef6 .