### PR TITLE
DB-9770/DB-10267 Fix External Table Row Counts after cross-join insert (2.8)

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
@@ -59,10 +59,14 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.security.TokenCache;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.sql.*;
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder;
+import org.apache.spark.sql.catalyst.encoders.RowEncoder;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.storage.StorageLevel;
+import scala.Function1;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -1105,6 +1109,20 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
         return (JavaRDD<V>) dataSet.javaRDD().map(new RowToLocatedRowFunction(context));
     }
 
+    class CountingFunction implements MapFunction<Row, Row>
+    {
+        OperationContext<?> operationContext;
+        CountingFunction(OperationContext<?> operationContext)
+        {
+            this.operationContext = operationContext;
+        }
+        @Override
+        public Row call(Row row) throws Exception {
+            operationContext.recordWrite();
+            return row;
+        }
+    }
+
     @Override
     public DataSet<ExecRow> writeParquetFile(DataSetProcessor dsp,
                                              int[] partitionBy,
@@ -1128,6 +1146,9 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
             }
             insertDF = insertDF.repartition(scala.collection.JavaConversions.asScalaBuffer(repartitionCols).toList());
         }
+
+        insertDF = insertDF.map(new CountingFunction(context), RowEncoder.apply(tableSchema));
+
         insertDF.write().option(SPARK_COMPRESSION_OPTION,compression)
                 .partitionBy(partitionByCols.toArray(new String[partitionByCols.size()]))
                 .mode(SaveMode.Append).parquet(location);
@@ -1181,6 +1202,7 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
             }
             insertDF = insertDF.repartition(scala.collection.JavaConversions.asScalaBuffer(repartitionCols).toList());
         }
+        insertDF = insertDF.map(new CountingFunction(context), RowEncoder.apply(tableSchema));
         return insertDF.write().partitionBy(partitionByCols);
     }
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
@@ -55,20 +55,22 @@ import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.security.TokenCache;
+import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.FlatMapFunction;
-import org.apache.spark.api.java.function.MapFunction;
+import org.apache.spark.scheduler.*;
 import org.apache.spark.sql.*;
-import org.apache.spark.sql.catalyst.encoders.RowEncoder;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.storage.StorageLevel;
+import scala.collection.JavaConverters;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.*;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPOutputStream;
 
 import static com.splicemachine.derby.stream.spark.SparkDataSetProcessor.getCsvOptions;
@@ -1105,20 +1107,6 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
         return (JavaRDD<V>) dataSet.javaRDD().map(new RowToLocatedRowFunction(context));
     }
 
-    class CountingFunction implements MapFunction<Row, Row>
-    {
-        OperationContext<?> operationContext;
-        CountingFunction(OperationContext<?> operationContext)
-        {
-            this.operationContext = operationContext;
-        }
-        @Override
-        public Row call(Row row) throws Exception {
-            operationContext.recordWrite();
-            return row;
-        }
-    }
-
     private DataSet<ExecRow> getRowsWritten(OperationContext context) {
         ValueRow valueRow = new ValueRow(1);
         valueRow.setColumn(1, new SQLLongint(context.getRecordsWritten()));
@@ -1129,37 +1117,85 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     @Override
     public DataSet<ExecRow> writeParquetFile(DataSetProcessor dsp, int[] partitionBy, String location,
                                              String compression, OperationContext context) throws StandardException {
-        getDataFrameWriter(partitionBy, context)
-                .option(SPARK_COMPRESSION_OPTION,compression)
-                .parquet(location);
+        try( CountingListener counter = new CountingListener(context) ) {
+            getDataFrameWriter(partitionBy, context)
+                    .option(SPARK_COMPRESSION_OPTION, compression)
+                    .parquet(location);
+        }
+
         return getRowsWritten(context);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public DataSet<ExecRow> writeAvroFile(DataSetProcessor dsp, int[] partitionBy, String location,
                                           String compression, OperationContext context) throws StandardException {
-        compression = SparkDataSet.getAvroCompression(compression);
-        getDataFrameWriter(partitionBy, context)
-                .option(SPARK_COMPRESSION_OPTION,compression)
-                .format("com.databricks.spark.avro").save(location);
+        try( CountingListener counter = new CountingListener(context) ) {
+            compression = SparkDataSet.getAvroCompression(compression);
+            getDataFrameWriter(partitionBy, context)
+                    .option(SPARK_COMPRESSION_OPTION, compression)
+                    .format("com.databricks.spark.avro").save(location);
+        }
         return getRowsWritten(context);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public DataSet<ExecRow> writeTextFile(int[] partitionBy, String location, CsvOptions csvOptions,
                                           OperationContext context) throws StandardException {
-        getDataFrameWriter(partitionBy, context)
-                .options(getCsvOptions(csvOptions))
-                .csv(location);
+        try( CountingListener counter = new CountingListener(context) ) {
+            getDataFrameWriter(partitionBy, context)
+                    .options(getCsvOptions(csvOptions))
+                    .csv(location);
+        }
         return getRowsWritten(context);
     }
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public DataSet<ExecRow> writeORCFile(int[] baseColumnMap, int[] partitionBy, String location,  String compression,
                                                     OperationContext context) throws StandardException {
-        getDataFrameWriter(partitionBy, context)
-                .option(SPARK_COMPRESSION_OPTION,compression)
-                .orc(location);
+        try( CountingListener counter = new CountingListener(context) ) {
+            getDataFrameWriter(partitionBy, context)
+                    .option(SPARK_COMPRESSION_OPTION, compression)
+                    .orc(location);
+        }
         return getRowsWritten(context);
+    }
+
+    class CountingListener extends SparkListener implements AutoCloseable
+    {
+        OperationContext context;
+        SparkContext sc;
+        String uuid;
+        List<Integer> stageIdsToWatch;
+
+        public CountingListener(OperationContext context) {
+            this( context, UUID.randomUUID().toString() );
+        }
+        public CountingListener(OperationContext context, String uuid) {
+            sc = SpliceSpark.getSession().sparkContext();
+            sc.getLocalProperties().setProperty("operation-uuid", uuid);
+            sc.addSparkListener(this);
+            this.context = context;
+            this.uuid = uuid;
+        }
+
+        public void onJobStart(SparkListenerJobStart jobStart) {
+            if ( !jobStart.properties().getProperty("operation-uuid", "").equals(uuid) ) {
+                return;
+            }
+
+            List<StageInfo> stageInfos = JavaConverters.seqAsJavaListConverter(jobStart.stageInfos()).asJava();
+            stageIdsToWatch = stageInfos.stream().map(s -> s.stageId()).collect(Collectors.toList());
+        }
+
+        @Override
+        public void onTaskEnd(SparkListenerTaskEnd taskEnd) {
+            if( stageIdsToWatch != null && stageIdsToWatch.contains( taskEnd.stageId() ))
+                context.recordPipelineWrites( taskEnd.taskMetrics().outputMetrics().recordsWritten() );
+        }
+
+        @Override
+        public void close() {
+            sc.removeSparkListener(this);
+        }
     }
 
     private DataFrameWriter getDataFrameWriter(int[] partitionBy, OperationContext context) throws StandardException {
@@ -1181,7 +1217,6 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
             }
             insertDF = insertDF.repartition(scala.collection.JavaConversions.asScalaBuffer(repartitionCols).toList());
         }
-        insertDF = insertDF.map(new CountingFunction(context), RowEncoder.apply(tableSchema));
         return insertDF.write().partitionBy(partitionByCols).mode(SaveMode.Append);
     }
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
@@ -1164,7 +1164,7 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
         OperationContext context;
         SparkContext sc;
         String uuid;
-        List<Integer> stageIdsToWatch;
+        Set<Integer> stageIdsToWatch;
 
         public CountingListener(OperationContext context) {
             this( context, UUID.randomUUID().toString() );
@@ -1183,7 +1183,7 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
             }
 
             List<StageInfo> stageInfos = JavaConverters.seqAsJavaListConverter(jobStart.stageInfos()).asJava();
-            stageIdsToWatch = stageInfos.stream().map(s -> s.stageId()).collect(Collectors.toList());
+            stageIdsToWatch = stageInfos.stream().map(s -> s.stageId()).collect(Collectors.toSet());
         }
 
         @Override

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
@@ -18,7 +18,6 @@ package com.splicemachine.derby.stream.spark;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
 import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.SQLLongint;
 import com.splicemachine.db.impl.sql.compile.ExplainNode;
@@ -42,7 +41,6 @@ import com.splicemachine.sparksql.ParserUtils;
 import com.splicemachine.system.CsvOptions;
 import com.splicemachine.utils.ByteDataInput;
 import com.splicemachine.utils.Pair;
-import com.sun.xml.bind.api.impl.NameConverter;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.conf.Configuration;
@@ -61,12 +59,10 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.sql.*;
-import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder;
 import org.apache.spark.sql.catalyst.encoders.RowEncoder;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.storage.StorageLevel;
-import scala.Function1;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -1123,64 +1119,47 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
         }
     }
 
+    private DataSet<ExecRow> getRowsWritten(OperationContext context) {
+        ValueRow valueRow = new ValueRow(1);
+        valueRow.setColumn(1, new SQLLongint(context.getRecordsWritten()));
+        return new SparkDataSet<>(SpliceSpark.getContext()
+                .parallelize(Collections.singletonList(valueRow), 1));
+    }
+
     @Override
-    public DataSet<ExecRow> writeParquetFile(DataSetProcessor dsp,
-                                             int[] partitionBy,
-                                             String location,
-                                             String compression,
-                                             OperationContext context) throws StandardException {
-        StructType tableSchema = SparkDataSet.generateTableSchema(context);
-
-        // construct a DF using schema of data
-        Dataset<Row> insertDF = SpliceSpark.getSession()
-                .createDataFrame(dataset.rdd(), tableSchema);
-
-        List<String> partitionByCols = new ArrayList();
-        for (int i = 0; i < partitionBy.length; i++) {
-            partitionByCols.add(tableSchema.fields()[partitionBy[i]].name());
-        }
-        if (partitionBy.length > 0) {
-            List<Column> repartitionCols = new ArrayList();
-            for (int i = 0; i < partitionBy.length; i++) {
-                repartitionCols.add(new Column(tableSchema.fields()[partitionBy[i]].name()));
-            }
-            insertDF = insertDF.repartition(scala.collection.JavaConversions.asScalaBuffer(repartitionCols).toList());
-        }
-
-        insertDF = insertDF.map(new CountingFunction(context), RowEncoder.apply(tableSchema));
-
-        insertDF.write().option(SPARK_COMPRESSION_OPTION,compression)
-                .partitionBy(partitionByCols.toArray(new String[partitionByCols.size()]))
-                .mode(SaveMode.Append).parquet(location);
-        ValueRow valueRow=new ValueRow(1);
-        valueRow.setColumn(1,new SQLLongint(context.getRecordsWritten()));
-        return new SparkDataSet<>(SpliceSpark.getContext().parallelize(Collections.singletonList(valueRow), 1));
+    public DataSet<ExecRow> writeParquetFile(DataSetProcessor dsp, int[] partitionBy, String location,
+                                             String compression, OperationContext context) throws StandardException {
+        getDataFrameWriter(partitionBy, context)
+                .option(SPARK_COMPRESSION_OPTION,compression)
+                .parquet(location);
+        return getRowsWritten(context);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public DataSet<ExecRow> writeAvroFile(DataSetProcessor dsp,
-                                          int[] partitionBy,
-                                          String location,
-                                          String compression,
-                                          OperationContext context) throws StandardException
-    {
+    public DataSet<ExecRow> writeAvroFile(DataSetProcessor dsp, int[] partitionBy, String location,
+                                          String compression, OperationContext context) throws StandardException {
         compression = SparkDataSet.getAvroCompression(compression);
-        DataFrameWriter writer = getDataFrameWriter(partitionBy, context).option(SPARK_COMPRESSION_OPTION,compression);
-        writer.mode(SaveMode.Append).format("com.databricks.spark.avro").save(location);
-        ValueRow valueRow=new ValueRow(1);
-        valueRow.setColumn(1,new SQLLongint(context.getRecordsWritten()));
-        return new SparkDataSet<>(SpliceSpark.getContext().parallelize(Collections.singletonList(valueRow), 1));
+        getDataFrameWriter(partitionBy, context)
+                .option(SPARK_COMPRESSION_OPTION,compression)
+                .format("com.databricks.spark.avro").save(location);
+        return getRowsWritten(context);
     }
 
-
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public DataSet<ExecRow> writeTextFile(int[] partitionBy, String location, CsvOptions csvOptions,
+                                          OperationContext context) throws StandardException {
+        getDataFrameWriter(partitionBy, context)
+                .options(getCsvOptions(csvOptions))
+                .csv(location);
+        return getRowsWritten(context);
+    }
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public DataSet<ExecRow> writeORCFile(int[] baseColumnMap, int[] partitionBy, String location,  String compression,
                                                     OperationContext context) throws StandardException {
-        DataFrameWriter writer = getDataFrameWriter(partitionBy, context).option(SPARK_COMPRESSION_OPTION,compression);
-        writer.mode(SaveMode.Append).orc(location);
-        ValueRow valueRow=new ValueRow(1);
-        valueRow.setColumn(1,new SQLLongint(context.getRecordsWritten()));
-        return new SparkDataSet<>(SpliceSpark.getContext().parallelize(Collections.singletonList(valueRow), 1));
+        getDataFrameWriter(partitionBy, context)
+                .option(SPARK_COMPRESSION_OPTION,compression)
+                .orc(location);
+        return getRowsWritten(context);
     }
 
     private DataFrameWriter getDataFrameWriter(int[] partitionBy, OperationContext context) throws StandardException {
@@ -1203,17 +1182,7 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
             insertDF = insertDF.repartition(scala.collection.JavaConversions.asScalaBuffer(repartitionCols).toList());
         }
         insertDF = insertDF.map(new CountingFunction(context), RowEncoder.apply(tableSchema));
-        return insertDF.write().partitionBy(partitionByCols);
-    }
-
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public DataSet<ExecRow> writeTextFile(int[] partitionBy, String location, CsvOptions csvOptions,
-                                          OperationContext context) throws StandardException {
-        DataFrameWriter writer = getDataFrameWriter(partitionBy, context);
-        writer.options(getCsvOptions(csvOptions)).mode(SaveMode.Append).csv(location);
-        ValueRow valueRow = new ValueRow(1);
-        valueRow.setColumn(1, new SQLLongint(context.getRecordsWritten()));
-        return new SparkDataSet<>(SpliceSpark.getContext().parallelize(Collections.singletonList(valueRow), 1));
+        return insertDF.write().partitionBy(partitionByCols).mode(SaveMode.Append);
     }
 
     @Override @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
@@ -858,9 +858,8 @@ public class SparkDataSet<V> implements DataSet<V> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public DataSet<ExecRow> writeTextFile(int[] partitionBy, String location, CsvOptions csvOptions,
                                                 OperationContext context) throws StandardException {
-
         Dataset<Row> insertDF = SpliceSpark.getSession().createDataFrame(
-                rdd.map(new SparkSpliceFunctionWrapper<>(new CountWriteFunction(context))).map(new LocatedRowToRowFunction()),
+                rdd.map(new LocatedRowToRowFunction()),
                 context.getOperation().schema());
 
         return new NativeSparkDataSet<>(insertDF, context).writeTextFile(partitionBy, location, csvOptions, context);

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
@@ -813,9 +813,8 @@ public class SparkDataSet<V> implements DataSet<V> {
     {
         StructType tableSchema = generateTableSchema( context );
         Dataset<Row> insertDF = SpliceSpark.getSession().createDataFrame(
-                rdd.map(new SparkSpliceFunctionWrapper<>(new CountWriteFunction(context))).map(new LocatedRowToRowFunction()),
+                rdd.map(new LocatedRowToRowFunction()),
                 tableSchema);
-
         return new NativeSparkDataSet<>(insertDF, context);
     }
 

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -2289,15 +2289,15 @@ public class ExternalTableIT extends SpliceUnitTest {
             methodWatcher.executeUpdate(String.format("create external table r (col1 int)" +
                     " STORED AS " + fileFormat + " LOCATION '%s'", tablePath + "right"));
             int insertCount2 = methodWatcher.executeUpdate(String.format("insert into r values 1,2,3"));
-            Assert.assertEquals("insertCount is wrong", 3, insertCount);
-            Assert.assertEquals("insertCount is wrong", 3, insertCount2);
+            Assert.assertEquals("insertCount is wrong " + fileFormat, 3, insertCount);
+            Assert.assertEquals("insertCount is wrong " + fileFormat, 3, insertCount2);
 
             // test for SPLICE-1850
             ResultSet rs = methodWatcher.executeQuery("select * from \n" +
                     "l --splice-properties useSpark=true\n" +
                     ", r --splice-properties joinStrategy=broadcast\n" +
                     "where l.col1=r.col1");
-            Assert.assertEquals("COL1 |COL1 |\n" +
+            Assert.assertEquals( fileFormat, "COL1 |COL1 |\n" +
                     "------------\n" +
                     "  1  |  1  |\n" +
                     "  2  |  2  |\n" +
@@ -2309,7 +2309,7 @@ public class ExternalTableIT extends SpliceUnitTest {
             // test for DB-9770
             // using cross join will go over NativeSparkDataSet instead of SparkDataSet
             int insertCountJoin = methodWatcher.executeUpdate(String.format("insert into joined (select a.col1,b.col1 from l a, l b)"));
-            Assert.assertEquals("insertCount for cross join is wrong", 9, insertCountJoin);
+            Assert.assertEquals("insertCount for cross join is wrong " + fileFormat, 9, insertCountJoin);
             methodWatcher.execute("DROP TABLE l");
             methodWatcher.execute("DROP TABLE r");
             methodWatcher.execute("DROP TABLE joined");
@@ -2457,7 +2457,7 @@ public class ExternalTableIT extends SpliceUnitTest {
     public void testOrcColumnName() throws Exception {
         String tablePath = getExternalResourceDirectory()+"orc_colname";
         methodWatcher.execute(String.format("create external table t_orc (col1 int, col2 varchar(5))" +
-                " STORED AS ORC LOCATION '%s'", tablePath));
+                " STORED AS PARQUET LOCATION '%s'", tablePath));
         methodWatcher.execute("insert into t_orc values (3, 'C')");
         SparkSession spark = SparkSession.builder()
                 .master("local")
@@ -2465,7 +2465,7 @@ public class ExternalTableIT extends SpliceUnitTest {
                 .getOrCreate();
         Dataset dataset = spark
                 .read()
-                .orc(tablePath);
+                .parquet(tablePath);
         String actual = dataset.schema().toString();
         String expected = "StructType(StructField(COL1,IntegerType,true), StructField(COL2,StringType,true))";
         Assert.assertEquals(actual, expected, actual);

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -2457,7 +2457,7 @@ public class ExternalTableIT extends SpliceUnitTest {
     public void testOrcColumnName() throws Exception {
         String tablePath = getExternalResourceDirectory()+"orc_colname";
         methodWatcher.execute(String.format("create external table t_orc (col1 int, col2 varchar(5))" +
-                " STORED AS PARQUET LOCATION '%s'", tablePath));
+                " STORED AS ORC LOCATION '%s'", tablePath));
         methodWatcher.execute("insert into t_orc values (3, 'C')");
         SparkSession spark = SparkSession.builder()
                 .master("local")

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableIT.java
@@ -2279,26 +2279,41 @@ public class ExternalTableIT extends SpliceUnitTest {
     }
 
     @Test
-    public void testBroadcastJoinOrcTablesOnSpark() throws Exception {
-        methodWatcher.executeUpdate(String.format("create external table l (col1 int)" +
-                " STORED AS ORC LOCATION '%s'", getExternalResourceDirectory()+"left"));
-        int insertCount = methodWatcher.executeUpdate(String.format("insert into l values 1, 2, 3" ));
-        methodWatcher.executeUpdate(String.format("create external table r (col1 int)" +
-                " STORED AS ORC LOCATION '%s'", getExternalResourceDirectory()+"right"));
-        int insertCount2 = methodWatcher.executeUpdate(String.format("insert into r values 1,2,3"));
+    public void testJoin() throws Exception {
+        for( String fileFormat : fileFormats ) {
+            String name = "testJoin_" + fileFormat + "_";
+            String tablePath = getExternalResourceDirectory() + name;
+            methodWatcher.executeUpdate(String.format("create external table l (col1 int)" +
+                    " STORED AS " + fileFormat + " LOCATION '%s'", tablePath + "left"));
+            int insertCount = methodWatcher.executeUpdate(String.format("insert into l values 1, 2, 3"));
+            methodWatcher.executeUpdate(String.format("create external table r (col1 int)" +
+                    " STORED AS " + fileFormat + " LOCATION '%s'", tablePath + "right"));
+            int insertCount2 = methodWatcher.executeUpdate(String.format("insert into r values 1,2,3"));
+            Assert.assertEquals("insertCount is wrong", 3, insertCount);
+            Assert.assertEquals("insertCount is wrong", 3, insertCount2);
 
-        Assert.assertEquals("insertCount is wrong",3,insertCount);
-        Assert.assertEquals("insertCount is wrong",3,insertCount2);
+            // test for SPLICE-1850
+            ResultSet rs = methodWatcher.executeQuery("select * from \n" +
+                    "l --splice-properties useSpark=true\n" +
+                    ", r --splice-properties joinStrategy=broadcast\n" +
+                    "where l.col1=r.col1");
+            Assert.assertEquals("COL1 |COL1 |\n" +
+                    "------------\n" +
+                    "  1  |  1  |\n" +
+                    "  2  |  2  |\n" +
+                    "  3  |  3  |", TestUtils.FormattedResult.ResultFactory.toString(rs));
 
-        ResultSet rs = methodWatcher.executeQuery("select * from \n" +
-                "l --splice-properties useSpark=true\n" +
-                ", r --splice-properties joinStrategy=broadcast\n" +
-                "where l.col1=r.col1");
-        Assert.assertEquals("COL1 |COL1 |\n" +
-                "------------\n" +
-                "  1  |  1  |\n" +
-                "  2  |  2  |\n" +
-                "  3  |  3  |",TestUtils.FormattedResult.ResultFactory.toString(rs));
+            methodWatcher.executeUpdate(String.format("create external table joined (col1 int, col2 int)" +
+                    " STORED AS " + fileFormat + " LOCATION '%s'", tablePath + "joined"));
+
+            // test for DB-9770
+            // using cross join will go over NativeSparkDataSet instead of SparkDataSet
+            int insertCountJoin = methodWatcher.executeUpdate(String.format("insert into joined (select a.col1,b.col1 from l a, l b)"));
+            Assert.assertEquals("insertCount for cross join is wrong", 9, insertCountJoin);
+            methodWatcher.execute("DROP TABLE l");
+            methodWatcher.execute("DROP TABLE r");
+            methodWatcher.execute("DROP TABLE joined");
+        }
     }
 
     @Ignore

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSet.java
@@ -543,14 +543,7 @@ public class ControlDataSet<V> implements DataSet<V> {
     }
 
     /**
-     *
-     * Not Supported
-     *
-     * @param dsp
-     * @param partitionBy
-     * @param location
-     * @param context
-     * @return
+     * ControlDataSet.writeParquetFile is used in EXPORT_BINARY
      */
     @Override
     @SuppressFBWarnings(value="REC_CATCH_EXCEPTION", justification="DB-10231")


### PR DESCRIPTION
consisting of changes DB-9770 (fix) and DB-10267 (speed improvement)