### PR TITLE
DB-10385 Add JAVA_HOME check to standalone sqlshell

### DIFF
--- a/assembly/standalone/template/bin/sqlshell.sh
+++ b/assembly/standalone/template/bin/sqlshell.sh
@@ -9,6 +9,17 @@ if [[ -z ${SPID} || -z ${ZPID} ]] || [[ -z ${YPID} ]]; then
      echo "Splice Machine is not running.  Make sure the database is started."
      exit 1;
 fi
+if [ -z "$JAVA_HOME" ]; then
+    cat 1>&2 <<EOF
++======================================================================+
+|                    Error: JAVA_HOME is not set                       |
++----------------------------------------------------------------------+
+|                Please download and configure Java                    |
+|              sqlshell requires Java 1.8 or openjdk8                  |
++======================================================================
+EOF
+    exit 1
+fi
 
 
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"


### PR DESCRIPTION
Runs into an error with spark queries if JAVA_HOME is not set. We should check if it is correctly set before sqlshell starts in standalone.