### PR TITLE
DB-10544 fix missing serialization items in LastIndexKeyOperation / ScanOperation (3.0)

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/LastIndexKeyOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/LastIndexKeyOperation.java
@@ -18,6 +18,7 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.loader.GeneratedMethod;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
+import com.splicemachine.db.impl.sql.GenericColumnDescriptor;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperationContext;
 import com.splicemachine.derby.stream.function.SetCurrentLocatedRowAndRowKeyFunction;
@@ -97,6 +98,7 @@ public class LastIndexKeyOperation extends ScanOperation {
         tableName = in.readUTF();
         if (in.readBoolean())
             indexName = in.readUTF();
+        tableVersion = GenericColumnDescriptor.readNullableUTF(in);
     }
 
     @Override
@@ -106,6 +108,7 @@ public class LastIndexKeyOperation extends ScanOperation {
         out.writeBoolean(indexName != null);
         if (indexName != null)
             out.writeUTF(indexName);
+        GenericColumnDescriptor.writeNullableUTF(out, tableVersion);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScanOperation.java
@@ -170,6 +170,7 @@ public abstract class ScanOperation extends SpliceBaseOperation{
         location = in.readBoolean()?in.readUTF():null;
         partitionRefItem = in.readInt();
         splits = in.readInt();
+        pastTx = in.readLong();
     }
 
     @Override
@@ -199,6 +200,7 @@ public abstract class ScanOperation extends SpliceBaseOperation{
             out.writeUTF(location);
         out.writeInt(partitionRefItem);
         out.writeInt(splits);
+        out.writeLong(pastTx);
     }
 
     @Override


### PR DESCRIPTION
fixes a problems caused by DB-10328 -> DB-10253 -> REVERT DB-10328