### PR TITLE
DB-10534 fix VacuumIT / unclosed Transactions in Tests (3.0)

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/derby/utils/VacuumIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/utils/VacuumIT.java
@@ -100,18 +100,16 @@ public class VacuumIT extends SpliceUnitTest{
             .around(spliceTableIWatcher)
             .around(spliceTableJWatcher);
 
-    @Before
+    @BeforeClass
     public static void setUpClass() throws Exception {
-        SpliceWatcher methodWatcher = new SpliceWatcher(null);
-        // check other tests didn't leave transactions open, which is bad for Vacuum tests
-        String name = "A test before VacuumIT"; // ... failed to close transactions
-        SpliceUnitTest.waitForStaleTransactions(methodWatcher, name, 10 );
-
-        // vacuum leftovers from other tests
-        try (CallableStatement callableStatement = methodWatcher.prepareCall("call SYSCS_UTIL.VACUUM()")) {
-            callableStatement.execute();
+        try(SpliceWatcher methodWatcher = new SpliceWatcher(null)) {
+            LOG.info("check other tests didn't leave transactions open, which is bad for Vacuum tests.");
+            String name = "A test before VacuumIT"; // ... failed to close transactions
+            SpliceUnitTest.waitForStaleTransactions(methodWatcher, name, 10, true);
+            LOG.info("done. vacuum leftovers from other tests..");
+            methodWatcher.execute("call SYSCS_UTIL.VACUUM()");
+            LOG.info("done.");
         }
-        methodWatcher.closeAll();
     }
 
     @Test
@@ -532,7 +530,6 @@ public class VacuumIT extends SpliceUnitTest{
 
     @Test
     public void testVacuumDisabledTable() throws Exception {
-        setUpClass();
         Connection connection = spliceClassWatcher.getOrCreateConnection();
         long[] conglomerateNumber = SpliceAdmin.getConglomNumbers(connection, CLASS_NAME, TABLEA);
         String conglomerateString = Long.toString(conglomerateNumber[0]);

--- a/hbase_sql/src/test/java/com/splicemachine/derby/utils/VacuumIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/utils/VacuumIT.java
@@ -100,23 +100,18 @@ public class VacuumIT extends SpliceUnitTest{
             .around(spliceTableIWatcher)
             .around(spliceTableJWatcher);
 
-    // todo: investigate/fix this https://splicemachine.atlassian.net/browse/DB-10490
     @Before
-    public void waitForStaleTransactions() throws Exception
-    {
-        // wait at max 60s for other transactions to finish
-        // we have defined SerialTest.class, so no other test should run in parallel
-        for(int i=0; i<60; i++) {
-            try (ResultSet rs = methodWatcher.executeQuery(
-                    "call SYSCS_UTIL.SYSCS_GET_ACTIVE_TRANSACTION_IDS()")) {
-                String actual = TestUtils.FormattedResult.ResultFactory.toString(rs);
-                if( actual.equals("") ) return;
-                Thread.sleep(1000);
-                LOG.info("VacuumIT: Waiting for active transactions:\n" + actual);
-            }
+    public static void setUpClass() throws Exception {
+        SpliceWatcher methodWatcher = new SpliceWatcher(null);
+        // check other tests didn't leave transactions open, which is bad for Vacuum tests
+        String name = "A test before VacuumIT"; // ... failed to close transactions
+        SpliceUnitTest.waitForStaleTransactions(methodWatcher, name, 10 );
+
+        // vacuum leftovers from other tests
+        try (CallableStatement callableStatement = methodWatcher.prepareCall("call SYSCS_UTIL.VACUUM()")) {
+            callableStatement.execute();
         }
-        Assert.fail("VacuumIT can't run with active transactions still happening. This is a bug in other " +
-                "tests failing to close their transactions.");
+        methodWatcher.closeAll();
     }
 
     @Test
@@ -191,8 +186,18 @@ public class VacuumIT extends SpliceUnitTest{
         }
     }
 
+    void assertCleaned(Admin admin, long[] conglomerates) throws Exception {
+        for (long congId : conglomerates) {
+            // make sure the table has been dropped by VACUUM
+            assertFalse("Dropped table splice:" + congId + " not in use hasn't been vaccumed",
+                admin.tableExists(TableName.valueOf("splice:" + congId)));
+        }
+    }
+
     @Test
     public void testVacuumDoesNotDeleteTablePossiblyInUse() throws Exception {
+        int oldest = SpliceUnitTest.getOldestActiveTransaction(methodWatcher);
+        LOG.info("VacuumIT: oldest: " + oldest + "\n");
         Connection connection = spliceClassWatcher.getOrCreateConnection();
 
         boolean autoCommit = connection.getAutoCommit();
@@ -220,11 +225,9 @@ public class VacuumIT extends SpliceUnitTest{
                     try (CallableStatement callableStatement = connection2.prepareCall("call SYSCS_UTIL.VACUUM()")) {
                         callableStatement.execute();
                     }
-                    
-                    for (long congId : conglomerates) {
-                        // make sure the table has been dropped by VACUUM
-                        assertFalse("Dropped table not in use hasn't been vaccumed", admin.tableExists(TableName.valueOf("splice:" + congId)));
-                    }
+
+                    assertCleaned(admin, conglomerates);
+
                 }
             }
 
@@ -275,10 +278,7 @@ public class VacuumIT extends SpliceUnitTest{
                         callableStatement.execute();
                     }
 
-                    for (long congId : conglomerates) {
-                        // make sure the table has been dropped by VACUUM
-                        assertFalse("Dropped table not in use hasn't been vaccumed", admin.tableExists(TableName.valueOf("splice:" + congId)));
-                    }
+                    assertCleaned(admin, conglomerates);
                 }
             }
 
@@ -308,10 +308,7 @@ public class VacuumIT extends SpliceUnitTest{
                         callableStatement.execute();
                     }
 
-                    for (long congId : conglomerates) {
-                        // make sure the table has been dropped by VACUUM
-                        assertFalse("Dropped table not in use hasn't been vaccumed", admin.tableExists(TableName.valueOf("splice:" + congId)));
-                    }
+                    assertCleaned(admin, conglomerates);
                 }
             }
 
@@ -331,10 +328,7 @@ public class VacuumIT extends SpliceUnitTest{
                         callableStatement.execute();
                     }
 
-                    for (long congId : conglomerates) {
-                        // make sure the table has been dropped by VACUUM
-                        assertFalse("Dropped table not in use hasn't been vaccumed", admin.tableExists(TableName.valueOf("splice:" + congId)));
-                    }
+                    assertCleaned(admin, conglomerates);
                 }
             }
         } finally {
@@ -538,6 +532,7 @@ public class VacuumIT extends SpliceUnitTest{
 
     @Test
     public void testVacuumDisabledTable() throws Exception {
+        setUpClass();
         Connection connection = spliceClassWatcher.getOrCreateConnection();
         long[] conglomerateNumber = SpliceAdmin.getConglomNumbers(connection, CLASS_NAME, TABLEA);
         String conglomerateString = Long.toString(conglomerateNumber[0]);

--- a/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SMInputFormatIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/mrio/api/core/SMInputFormatIT.java
@@ -130,16 +130,17 @@ public class SMInputFormatIT extends BaseMRIOTest {
         config.set(MRConstants.SPLICE_TABLE_NAME, tableWatcherA.toString());
         config.set(MRConstants.SPLICE_INPUT_TABLE_NAME, tableWatcherA.toString());
         config.set(MRConstants.SPLICE_INPUT_CONGLOMERATE, String.valueOf(classWatcher.getConglomId(tableWatcherA.tableName, tableWatcherA.getSchema())));
-        Job job = Job.getInstance(config, "Test Scan");
-        JavaPairRDD<RowLocation, ExecRow> table = sparkWatcher.jsc.newAPIHadoopRDD(job.getConfiguration(), SMInputFormat.class, RowLocation.class, ExecRow.class);
-        List<Tuple2<RowLocation, ExecRow>> data = table.collect();
-        int i = 0;
-        for (Tuple2<RowLocation, ExecRow> tuple: data) {
-            i++;
-            Assert.assertNotNull(tuple._1());
-            Assert.assertNotNull(tuple._2());
+        try(Job job = Job.getInstance(config, "Test Scan")) {
+            JavaPairRDD<RowLocation, ExecRow> table = sparkWatcher.jsc.newAPIHadoopRDD(job.getConfiguration(), SMInputFormat.class, RowLocation.class, ExecRow.class);
+            List<Tuple2<RowLocation, ExecRow>> data = table.collect();
+            int i = 0;
+            for (Tuple2<RowLocation, ExecRow> tuple : data) {
+                i++;
+                Assert.assertNotNull(tuple._1());
+                Assert.assertNotNull(tuple._2());
+            }
+            Assert.assertEquals("Incorrect Results Returned", 2, i);
         }
-        Assert.assertEquals("Incorrect Results Returned", 2,i);
     }
 
     @Test
@@ -147,17 +148,17 @@ public class SMInputFormatIT extends BaseMRIOTest {
         config.set(MRConstants.SPLICE_TABLE_NAME, tableWatcherB.toString());
         config.set(MRConstants.SPLICE_INPUT_TABLE_NAME, tableWatcherB.toString());
         config.set(MRConstants.SPLICE_INPUT_CONGLOMERATE, String.valueOf(classWatcher.getConglomId(tableWatcherB.tableName, tableWatcherB.getSchema())));
-        Job job = Job.getInstance(config, "Test Scan");
-        JavaPairRDD<RowLocation, ExecRow> table = sparkWatcher.jsc.newAPIHadoopRDD(job.getConfiguration(), SMInputFormat.class, RowLocation.class, ExecRow.class);
-        List<Tuple2<RowLocation, ExecRow>> data = table.collect();
-        int i = 0;
-        for (Tuple2<RowLocation, ExecRow> tuple: data) {
-            i++;
-            Assert.assertNotNull(tuple._1());
-            Assert.assertNotNull(tuple._2());
+        try(Job job = Job.getInstance(config, "Test Scan")) {
+            JavaPairRDD<RowLocation, ExecRow> table = sparkWatcher.jsc.newAPIHadoopRDD(job.getConfiguration(), SMInputFormat.class, RowLocation.class, ExecRow.class);
+            List<Tuple2<RowLocation, ExecRow>> data = table.collect();
+            int i = 0;
+            for (Tuple2<RowLocation, ExecRow> tuple : data) {
+                i++;
+                Assert.assertNotNull(tuple._1());
+                Assert.assertNotNull(tuple._2());
+            }
+            Assert.assertEquals("Incorrect Results Returned", 10000, i);
         }
-        Assert.assertEquals("Incorrect Results Returned", 10000,i);
-
     }
 
     private void executeQueryAndAssert(String query, int expected) throws SQLException {
@@ -202,9 +203,10 @@ public class SMInputFormatIT extends BaseMRIOTest {
         config.set(MRConstants.SPLICE_TABLE_NAME, tableWatcherB.toString());
         config.set(MRConstants.SPLICE_INPUT_TABLE_NAME, tableWatcherB.toString());
         config.set(MRConstants.SPLICE_INPUT_CONGLOMERATE, String.valueOf(classWatcher.getConglomId(tableWatcherB.tableName, tableWatcherB.getSchema())));
-        Job job = Job.getInstance(config, "Test Scan");
-        JavaPairRDD<RowLocation, ExecRow> table = sparkWatcher.jsc.newAPIHadoopRDD(job.getConfiguration(), SMInputFormatFail.class, RowLocation.class, ExecRow.class);
-        List<Tuple2<RowLocation, ExecRow>> data = table.collect();
+        try(Job job = Job.getInstance(config, "Test Scan")) {
+            JavaPairRDD<RowLocation, ExecRow> table = sparkWatcher.jsc.newAPIHadoopRDD(job.getConfiguration(), SMInputFormatFail.class, RowLocation.class, ExecRow.class);
+            table.collect();
+        }
     }
 
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
@@ -799,8 +799,7 @@ public class SpliceAdmin extends BaseAdminProcedures{
             throw PublicAPI.wrapStandardException(e);
         }
     }
-
-    public static void VACUUM() throws SQLException{
+    public static long getOldestActiveTransaction() throws SQLException {
         long oldestActiveTransaction = Long.MAX_VALUE;
         try {
             PartitionAdmin pa = SIDriver.driver().getTableFactory().getAdmin();
@@ -827,7 +826,11 @@ public class SpliceAdmin extends BaseAdminProcedures{
                     "com.splicemachine.si.data.hbase.coprocessor.SpliceRSRpcServices",
                     "hbase.coprocessor.regionserver.classes"));
         }
+        return oldestActiveTransaction;
+    }
 
+    public static void VACUUM() throws SQLException{
+        long oldestActiveTransaction = getOldestActiveTransaction();
         Vacuum vacuum = new Vacuum(getDefaultConn());
         try{
             vacuum.vacuumDatabase(oldestActiveTransaction);
@@ -929,12 +932,12 @@ public class SpliceAdmin extends BaseAdminProcedures{
             // Describe the format of the input rows (ExecRow).
             //
             // Columns of "virtual" row:
-            //   STMTNAME				VARCHAR
-            //   TYPE					CHAR
-            //   VALID					BOOLEAN
-            //   LASTCOMPILED			TIMESTAMP
-            //   INITIALLY_COMPILABLE	BOOLEAN
-            //   CONSTANTSTATE			BLOB --> VARCHAR showing existence of plan
+            //   STMTNAME               VARCHAR
+            //   TYPE                   CHAR
+            //   VALID                  BOOLEAN
+            //   LASTCOMPILED           TIMESTAMP
+            //   INITIALLY_COMPILABLE   BOOLEAN
+            //   CONSTANTSTATE          BLOB --> VARCHAR showing existence of plan
             DataValueDescriptor[] dvds= {
                     new SQLVarchar(),
                     new SQLChar(),
@@ -1006,9 +1009,9 @@ public class SpliceAdmin extends BaseAdminProcedures{
             // Describe the format of the input rows (ExecRow).
             //
             // Columns of "virtual" row:
-            //   KEY			VARCHAR
-            //   VALUE			VARCHAR
-            //   TYPE			VARCHAR (JVM, SERVICE, DATABASE, APP)
+            //   KEY            VARCHAR
+            //   VALUE          VARCHAR
+            //   TYPE           VARCHAR (JVM, SERVICE, DATABASE, APP)
             DataValueDescriptor[] dvds= {
                     new SQLVarchar(),
                     new SQLVarchar(),
@@ -1193,9 +1196,9 @@ public class SpliceAdmin extends BaseAdminProcedures{
         }
                 /*
                  * An index conglomerate id can be returned by the query before the main table one is,
-				 * but it should ALWAYS have a higher conglomerate id, so if we sort the congloms,
-				 * we should return the main table before any of its indices.
-				 */
+                 * but it should ALWAYS have a higher conglomerate id, so if we sort the congloms,
+                 * we should return the main table before any of its indices.
+                 */
         Arrays.sort(congloms);
         return congloms;
     }
@@ -1790,14 +1793,14 @@ public class SpliceAdmin extends BaseAdminProcedures{
     }
 
     public static void SYSCS_GET_OLDEST_ACTIVE_TRANSACTION(ResultSet[] resultSet) throws SQLException{
-        Long id = SIDriver.driver().getTxnStore().oldestActiveTransaction();
+        long id = getOldestActiveTransaction();
 
         EmbedConnection conn = (EmbedConnection)getDefaultConn();
         Activation lastActivation = conn.getLanguageConnection().getLastActivation();
 
         List<ExecRow> rows = new ArrayList<>(1);
         ExecRow row = new ValueRow(1);
-        row.setColumn(1, id == null ? null : new SQLLongint(id));
+        row.setColumn(1, new SQLLongint(id));
         GenericColumnDescriptor[] descriptor = new GenericColumnDescriptor[]{
                 new GenericColumnDescriptor("transactionId", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BIGINT))
         };

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HBaseBulkLoadIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HBaseBulkLoadIT.java
@@ -89,17 +89,17 @@ public class HBaseBulkLoadIT extends SpliceUnitTest {
             BULKLOADDIR = SpliceUnitTest.createBulkLoadDirectory(SCHEMA_NAME).getCanonicalPath();
 
             TestUtils.executeSqlFile(spliceClassWatcher, "tcph/TPCHIT.sql", SCHEMA_NAME);
-            spliceClassWatcher.prepareStatement(format("call SYSCS_UTIL.BULK_IMPORT_HFILE('%s','%s',null,'%s','|','\"',null,null,null,0,null,true,null, '%s', false)", SCHEMA_NAME, LINEITEM, getResource("lineitem.tbl"), BULKLOADDIR)).execute();
-            spliceClassWatcher.prepareStatement(format("call SYSCS_UTIL.BULK_IMPORT_HFILE('%s','%s',null,'%s','|','\"',null,null,null,0,null,true,null, '%s', false)", SCHEMA_NAME, ORDERS, getResource("orders.tbl"), BULKLOADDIR)).execute();
-            spliceClassWatcher.prepareStatement(format("call SYSCS_UTIL.BULK_IMPORT_HFILE('%s','%s',null,'%s','|','\"',null,null,null,0,null,true,null, '%s', false)", SCHEMA_NAME, CUSTOMERS, getResource("customer.tbl"), BULKLOADDIR)).execute();
-            spliceClassWatcher.prepareStatement(format("call SYSCS_UTIL.BULK_IMPORT_HFILE('%s','%s',null,'%s','|','\"',null,null,null,0,null,true,null, '%s', false)", SCHEMA_NAME, PARTSUPP, getResource("partsupp.tbl"), BULKLOADDIR)).execute();
-            spliceClassWatcher.prepareStatement(format("call SYSCS_UTIL.BULK_IMPORT_HFILE('%s','%s',null,'%s','|','\"',null,null,null,0,null,true,null, '%s', false)", SCHEMA_NAME, SUPPLIER, getResource("supplier.tbl"), BULKLOADDIR)).execute();
-            spliceClassWatcher.prepareStatement(format("call SYSCS_UTIL.BULK_IMPORT_HFILE('%s','%s',null,'%s','|','\"',null,null,null,0,null,true,null, '%s', false)", SCHEMA_NAME, PART, getResource("part.tbl"), BULKLOADDIR)).execute();
-            spliceClassWatcher.prepareStatement(format("call SYSCS_UTIL.BULK_IMPORT_HFILE('%s','%s',null,'%s','|','\"',null,null,null,0,null,true,null, '%s', false)", SCHEMA_NAME, NATION, getResource("nation.tbl"), BULKLOADDIR)).execute();
-            spliceClassWatcher.prepareStatement(format("call SYSCS_UTIL.BULK_IMPORT_HFILE('%s','%s',null,'%s','|','\"',null,null,null,0,null,true,null, '%s', false)", SCHEMA_NAME, REGION, getResource("region.tbl"), BULKLOADDIR)).execute();
+            spliceClassWatcher.execute(format("call SYSCS_UTIL.BULK_IMPORT_HFILE('%s','%s',null,'%s','|','\"',null,null,null,0,null,true,null, '%s', false)", SCHEMA_NAME, LINEITEM, getResource("lineitem.tbl"), BULKLOADDIR));
+            spliceClassWatcher.execute(format("call SYSCS_UTIL.BULK_IMPORT_HFILE('%s','%s',null,'%s','|','\"',null,null,null,0,null,true,null, '%s', false)", SCHEMA_NAME, ORDERS, getResource("orders.tbl"), BULKLOADDIR));
+            spliceClassWatcher.execute(format("call SYSCS_UTIL.BULK_IMPORT_HFILE('%s','%s',null,'%s','|','\"',null,null,null,0,null,true,null, '%s', false)", SCHEMA_NAME, CUSTOMERS, getResource("customer.tbl"), BULKLOADDIR));
+            spliceClassWatcher.execute(format("call SYSCS_UTIL.BULK_IMPORT_HFILE('%s','%s',null,'%s','|','\"',null,null,null,0,null,true,null, '%s', false)", SCHEMA_NAME, PARTSUPP, getResource("partsupp.tbl"), BULKLOADDIR));
+            spliceClassWatcher.execute(format("call SYSCS_UTIL.BULK_IMPORT_HFILE('%s','%s',null,'%s','|','\"',null,null,null,0,null,true,null, '%s', false)", SCHEMA_NAME, SUPPLIER, getResource("supplier.tbl"), BULKLOADDIR));
+            spliceClassWatcher.execute(format("call SYSCS_UTIL.BULK_IMPORT_HFILE('%s','%s',null,'%s','|','\"',null,null,null,0,null,true,null, '%s', false)", SCHEMA_NAME, PART, getResource("part.tbl"), BULKLOADDIR));
+            spliceClassWatcher.execute(format("call SYSCS_UTIL.BULK_IMPORT_HFILE('%s','%s',null,'%s','|','\"',null,null,null,0,null,true,null, '%s', false)", SCHEMA_NAME, NATION, getResource("nation.tbl"), BULKLOADDIR));
+            spliceClassWatcher.execute(format("call SYSCS_UTIL.BULK_IMPORT_HFILE('%s','%s',null,'%s','|','\"',null,null,null,0,null,true,null, '%s', false)", SCHEMA_NAME, REGION, getResource("region.tbl"), BULKLOADDIR));
 
-            spliceClassWatcher.prepareStatement(format("call SYSCS_UTIL.COLLECT_SCHEMA_STATISTICS('%s', false)", SCHEMA_NAME)).execute();
-            spliceClassWatcher.prepareStatement(format("create table A(c varchar(200))"));
+            spliceClassWatcher.execute(format("call SYSCS_UTIL.COLLECT_SCHEMA_STATISTICS('%s', false)", SCHEMA_NAME));
+            spliceClassWatcher.execute(format("create table A(c varchar(200))"));
             // validate
             assertEquals(9958L, (long) spliceClassWatcher.query("select count(*) from " + LINEITEM));
             assertEquals(2500L, (long) spliceClassWatcher.query("select count(*) from " + ORDERS));
@@ -109,7 +109,7 @@ public class HBaseBulkLoadIT extends SpliceUnitTest {
             assertEquals(333L, (long) spliceClassWatcher.query("select count(*) from " + PART));
             assertEquals(25L, (long) spliceClassWatcher.query("select count(*) from " + NATION));
             assertEquals(5L, (long) spliceClassWatcher.query("select count(*) from " + REGION));
-            spliceClassWatcher.prepareStatement("CREATE TABLE LINEITEM4 (\n" +
+            spliceClassWatcher.execute("CREATE TABLE LINEITEM4 (\n" +
                     "  L_ORDERKEY      BIGINT NOT NULL,\n" +
                     "  L_PARTKEY       INTEGER NOT NULL,\n" +
                     "  L_SUPPKEY       INTEGER NOT NULL,\n" +
@@ -127,7 +127,7 @@ public class HBaseBulkLoadIT extends SpliceUnitTest {
                     "  L_SHIPMODE      CHAR(10),\n" +
                     "  L_COMMENT       VARCHAR(44),\n" +
                     "  PRIMARY KEY (L_ORDERKEY, L_LINENUMBER)\n" +
-                    ")").execute();
+                    ")");
         }
         catch (Exception e) {
             java.lang.Throwable ex = Throwables.getRootCause(e);
@@ -165,18 +165,20 @@ public class HBaseBulkLoadIT extends SpliceUnitTest {
         String sql = String.format("delete from %s --splice-properties bulkDeleteDirectory='%s',index=%s", tableName, BULKLOADDIR,
                 indexName!=null?indexName:"null");
         spliceClassWatcher.execute(sql);
-        ResultSet rs = spliceClassWatcher.executeQuery(String.format("select count(*) from %s", tableName));
-        rs.next();
-        int count = rs.getInt(1);
-        Assert.assertTrue(count==0);
+        try(ResultSet rs = spliceClassWatcher.executeQuery(String.format("select count(*) from %s", tableName))) {
+            rs.next();
+            int count = rs.getInt(1);
+            Assert.assertTrue(count == 0);
+        }
     }
 
     private static void countUsingIndex(String tableName, String indexName) throws Exception {
-        ResultSet rs = spliceClassWatcher.executeQuery(
-                String.format("select count(*) from %s --splice-properties index=%s", tableName, indexName));
-        rs.next();
-        int count = rs.getInt(1);
-        Assert.assertTrue(count==0);
+        try(ResultSet rs = spliceClassWatcher.executeQuery(
+                String.format("select count(*) from %s --splice-properties index=%s", tableName, indexName))) {
+            rs.next();
+            int count = rs.getInt(1);
+            Assert.assertTrue(count == 0);
+        }
     }
 
     @Test
@@ -334,7 +336,7 @@ public class HBaseBulkLoadIT extends SpliceUnitTest {
             return;
         String sql = getContent("13.sql");
         executeQuery(sql, getContent("13.expected.txt"), true);
-        assertSubqueryNodeCount(conn(), sql, ZERO_SUBQUERY_NODES);
+        assertSubqueryNodeCount(methodWatcher, sql, ZERO_SUBQUERY_NODES);
     }
 
     @Test
@@ -615,14 +617,14 @@ public class HBaseBulkLoadIT extends SpliceUnitTest {
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     private void executeQuery(String query, String expected, boolean isResultSetOrdered) throws Exception {
-        ResultSet resultSet = methodWatcher.executeQuery(query);
+        try(ResultSet resultSet = methodWatcher.executeQuery(query)) {
+            // If the ResultSet is NOT ordered (no order by clause in query) then sort it before comparing to expected result.
+            // When we don't sort we are assuming the order by clause gives the ResultSet a unique order-- seems to be
+            // the case for this data set (no duplicates in result set order by columns).
+            boolean sort = !isResultSetOrdered;
 
-        // If the ResultSet is NOT ordered (no order by clause in query) then sort it before comparing to expected result.
-        // When we don't sort we are assuming the order by clause gives the ResultSet a unique order-- seems to be
-        // the case for this data set (no duplicates in result set order by columns).
-        boolean sort = !isResultSetOrdered;
-
-        assertEquals(expected, TestUtils.FormattedResult.ResultFactory.convert("", resultSet, sort).toString().trim());
+            assertEquals(expected, TestUtils.FormattedResult.ResultFactory.convert("", resultSet, sort).toString().trim());
+        }
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/OrderByIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/OrderByIT.java
@@ -34,8 +34,8 @@ import static com.splicemachine.test_tools.Rows.rows;
  */
 public class OrderByIT extends SpliceUnitTest {
     public static final String CLASS_NAME = OrderByIT.class.getSimpleName().toUpperCase();
-    protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);
-    protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
+    protected final static SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);
+    protected final static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
 
     @ClassRule
     public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
@@ -386,19 +386,19 @@ public class OrderByIT extends SpliceUnitTest {
     public void testAliasInOrderComplex() throws Exception {
         String sqlText = "select sum(a1) as ALIAS from t2 order by -ALIAS";
         String expected = "ALIAS |\n" +
-                         "--------\n" +
-                         "  15   |" ;
-        SqlExpectToString( methodWatcher, sqlText, expected, false );
+                "--------\n" +
+                "  15   |" ;
+        sqlExpectToString( methodWatcher, sqlText, expected, false );
 
         sqlText = "select sqrt(a1*a1)*2 as ALIAS from t2 order by -2*ALIAS+a1";
         expected = "ALIAS |\n" +
-                  "--------\n" +
-                  " 10.0  |\n" +
-                  "  8.0  |\n" +
-                  "  6.0  |\n" +
-                  "  4.0  |\n" +
-                  "  2.0  |";
-        SqlExpectToString( methodWatcher, sqlText, expected, false );
+                "--------\n" +
+                " 10.0  |\n" +
+                "  8.0  |\n" +
+                "  6.0  |\n" +
+                "  4.0  |\n" +
+                "  2.0  |";
+        sqlExpectToString( methodWatcher, sqlText, expected, false );
     }
 
     @Test
@@ -406,7 +406,7 @@ public class OrderByIT extends SpliceUnitTest {
         // use these TWO order by to make sure ResultColumnList correctly calculates getFirstOrderByIndex.
         String sqlText = "select a1 as ALIAS from t2 order by -ALIAS, -2*ALIAS";
         String expected = "ALIAS |\n--------\n   5   |\n   4   |\n   3   |\n   2   |\n   1   |";
-        SqlExpectToString( methodWatcher, sqlText, expected, false );
+        sqlExpectToString( methodWatcher, sqlText, expected, false );
     }
 
     // make sure we disable access to alias for WHERE, HAVING and GROUP BY
@@ -416,15 +416,15 @@ public class OrderByIT extends SpliceUnitTest {
                 {       "select a1+1 as ALIAS from t2 WHERE ALIAS > 0 ORDER BY -ALIAS",
                         "select a1+1 as ALIAS from t2 GROUP BY ALIAS ORDER BY -ALIAS",
                         "select a1, sum(b1+1) as ALIAS from t1 GROUP BY a1 HAVING ALIAS > 0 ORDER BY -ALIAS"
-                        };
+                };
         for( String sqlText : sqlTexts ) {
-            SqlExpectException( methodWatcher, sqlText, "42X04" );
+            sqlExpectException( methodWatcher, sqlText, "42X04", false);
         }
     }
     // avoid that we refer an alias on the more left hand side inside the same select
     @Test
     public void testAliasNoLeftToRightReferal() throws Exception {
-        SqlExpectException( methodWatcher, "select a1*2 as ALIAS1, ALIAS1+1 as ALIAS2 from t2 order by -ALIAS2", "42X04" );
+        sqlExpectException( methodWatcher, "select a1*2 as ALIAS1, ALIAS1+1 as ALIAS2 from t2 order by -ALIAS2", "42X04", false);
     }
 
     @Test
@@ -435,7 +435,7 @@ public class OrderByIT extends SpliceUnitTest {
                         "select a1 from t2 ORDER BY 2"
                 };
         for( String sqlText : sqlTexts ) {
-            SqlExpectException( methodWatcher, sqlText, "42X77" );
+            sqlExpectException( methodWatcher, sqlText, "42X77", false);
         }
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceUDTIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceUDTIT.java
@@ -64,10 +64,6 @@ public class SpliceUDTIT extends SpliceUnitTest {
         createData(spliceClassWatcher);
     }
 
-    @Test
-    public void testNothing(){}
-
-
     private static void createData(SpliceWatcher w) throws Exception {
         try {
             w.execute(String.format(CALL_INSTALL_JAR_FORMAT_STRING, STORED_PROCS_JAR_FILE, JAR_FILE_SQL_NAME));
@@ -129,31 +125,34 @@ public class SpliceUDTIT extends SpliceUnitTest {
 
     @Test
     public void testAggregationReferencingUDF() throws Exception {
-        ResultSet rs;
-        rs =  methodWatcher.executeQuery("SELECT count(*) FROM\n" +
+        try(ResultSet rs =  methodWatcher.executeQuery("SELECT count(*) FROM\n" +
                                                 "(\n" +
                                                 "SELECT makePrice('USD', t1.rawPrice) AS ItemPrice\n" +
                                                 "FROM t1" +
-                                                ") x");
-        Assert.assertTrue(rs.next());
-        Assert.assertEquals(6, rs.getInt(1));
+                                                ") x")) {
+            Assert.assertTrue(rs.next());
+            Assert.assertEquals(6, rs.getInt(1));
+        }
 
-        rs =  methodWatcher.executeQuery("SELECT count(*) FROM\n" +
-        "(\n" +
-        "SELECT makePrice('USD', t1.rawPrice) AS ItemPrice\n" +
-        "FROM t1 JOIN t\n" +
-        "ON t.i = t1.rawPrice\n" +
-        ") x");
-        Assert.assertTrue(rs.next());
-        Assert.assertEquals(6, rs.getInt(1));
+        try(ResultSet rs =  methodWatcher.executeQuery("SELECT count(*) FROM\n" +
+            "(\n" +
+            "SELECT makePrice('USD', t1.rawPrice) AS ItemPrice\n" +
+            "FROM t1 JOIN t\n" +
+            "ON t.i = t1.rawPrice\n" +
+            ") x") ) {
+            Assert.assertTrue(rs.next());
+            Assert.assertEquals(6, rs.getInt(1));
+        }
 
-        rs =  methodWatcher.executeQuery("SELECT count(*) from t1 where testconnection() < 'a'");
-        Assert.assertTrue(rs.next());
-        Assert.assertEquals(6, rs.getInt(1));
+        try(ResultSet rs =  methodWatcher.executeQuery("SELECT count(*) from t1 where testconnection() < 'a'") ) {
+            Assert.assertTrue(rs.next());
+            Assert.assertEquals(6, rs.getInt(1));
+        }
 
-        rs =  methodWatcher.executeQuery("SELECT count(testconnection()) from t1");
-        Assert.assertTrue(rs.next());
-        Assert.assertEquals(6, rs.getInt(1));
+        try(ResultSet rs =  methodWatcher.executeQuery("SELECT count(testconnection()) from t1")) {
+            Assert.assertTrue(rs.next());
+            Assert.assertEquals(6, rs.getInt(1));
+        }
     }
 
     @Test
@@ -207,10 +206,11 @@ public class SpliceUDTIT extends SpliceUnitTest {
         methodWatcher.execute("insert into strings values 'a','b','c','d'");
 
         for (boolean useSpark : Arrays.asList(true, false)) {
-            ResultSet rs = methodWatcher.executeQuery("select string_concat(v) from strings --splice-properties useSpark="+useSpark);
-            Assert.assertTrue(rs.next());
-            String res = rs.getString(1);
-            assertThat(res, allOf(containsString("a"), containsString("b"), containsString("c"), containsString("d")));
+            try(ResultSet rs = methodWatcher.executeQuery("select string_concat(v) from strings --splice-properties useSpark="+useSpark)) {
+                Assert.assertTrue(rs.next());
+                String res = rs.getString(1);
+                assertThat(res, allOf(containsString("a"), containsString("b"), containsString("c"), containsString("d")));
+            }
         }
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceUDTIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceUDTIT.java
@@ -191,10 +191,11 @@ public class SpliceUDTIT extends SpliceUnitTest {
         try(SpliceWatcher watcher2 = new SpliceWatcher(CLASS_NAME))
         {
             watcher2.setConnection( watcher2.connectionBuilder().useOLAP(true).build() );
-            ResultSet rs = watcher2.executeQuery("select testConnection() from test");
-            String result = rs.next() ? rs.getString(1) : null;
-            Assert.assertNotNull(result);
-            Assert.assertTrue(result, result.compareTo("Got an internal connection") == 0);
+            try(ResultSet rs = watcher2.executeQuery("select testConnection() from test")) {
+                String result = rs.next() ? rs.getString(1) : null;
+                Assert.assertNotNull(result);
+                Assert.assertTrue(result, result.compareTo("Got an internal connection") == 0);
+            }
         }
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceUDTIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceUDTIT.java
@@ -42,8 +42,8 @@ import static org.junit.Assert.assertThat;
 @Category(SerialTest.class) //serial because it loads a jar
 public class SpliceUDTIT extends SpliceUnitTest {
     public static final String CLASS_NAME = SpliceUDTIT.class.getSimpleName().toUpperCase();
-    protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);
-    protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
+    protected static final SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);
+    protected static final SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
 
     private static final String CALL_INSTALL_JAR_FORMAT_STRING = "CALL SQLJ.INSTALL_JAR('%s', '%s', 0)";
     private static final String CALL_REMOVE_JAR_FORMAT_STRING = "CALL SQLJ.REMOVE_JAR('%s', 0)";
@@ -57,17 +57,11 @@ public class SpliceUDTIT extends SpliceUnitTest {
     public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
             .around(spliceSchemaWatcher);
     @ClassRule
-    public static SpliceWatcher methodWatcher = new SpliceWatcher(CLASS_NAME);
+    public static final SpliceWatcher methodWatcher = new SpliceWatcher(CLASS_NAME);
 
     @BeforeClass
     public static void setup() throws Exception {
         createData(spliceClassWatcher.getOrCreateConnection());
-    }
-
-    @AfterClass
-    public static void close()
-    {
-        methodWatcher.closeAll();
     }
 
     @Test
@@ -161,8 +155,6 @@ public class SpliceUDTIT extends SpliceUnitTest {
         rs =  methodWatcher.executeQuery("SELECT count(testconnection()) from t1");
         Assert.assertTrue(rs.next());
         Assert.assertEquals(6, rs.getInt(1));
-
-        methodWatcher.closeAll();
     }
 
     @Test
@@ -188,7 +180,7 @@ public class SpliceUDTIT extends SpliceUnitTest {
     }
 
     @Test
-    public void TestSelectStatistics() throws Exception {
+    public void testSelectStatistics() throws Exception {
         methodWatcher.execute("analyze schema " + CLASS_NAME);
         try(ResultSet rs = methodWatcher.executeQuery("select count(*) from sysvw.syscolumnstatistics") ) {
             Assert.assertTrue(rs.next());

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimestampIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimestampIT.java
@@ -47,9 +47,9 @@ public class TimestampIT extends SpliceUnitTest {
     private static final String SCHEMA = TimestampIT.class.getSimpleName().toUpperCase();
     private Boolean useSpark;
     private static boolean extendedTimestamps = true;
-    protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher(SCHEMA);
-    protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(SCHEMA);
-    protected static SpliceWatcher methodWatcher = new SpliceWatcher(SCHEMA);
+    protected static final SpliceWatcher spliceClassWatcher = new SpliceWatcher(SCHEMA);
+    protected static final SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(SCHEMA);
+    protected static final SpliceWatcher methodWatcher = new SpliceWatcher(SCHEMA);
 
     private static File BADDIR;
 
@@ -255,14 +255,12 @@ public class TimestampIT extends SpliceUnitTest {
         ps.setTimestamp(3, new Timestamp(3 - 1900/*year*/, 0 /*month-1*/, 1 /*day*/, 0 /*hour*/, 0/*minute*/, 0 /*second*/, 0 /*nano*/));
         ps.setTimestamp(4, new Timestamp(4 - 1900/*year*/, 0 /*month-1*/, 1 /*day*/, 0 /*hour*/, 0/*minute*/, 0 /*second*/, 0 /*nano*/));
 
-        try {
-            ResultSet rs = ps.executeQuery();
+        try (ResultSet rs = ps.executeQuery()) {
             int i = 0;
             while (rs.next()) {
                 i++;
             }
             Assert.assertEquals("Incorrect count returned!", 4, i);
-            rs.close();
         }
         catch (SQLException e) {
             if (extendedTimestamps)

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimestampIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimestampIT.java
@@ -72,10 +72,19 @@ public class TimestampIT extends SpliceUnitTest {
 
     @BeforeClass
     public static void createDataSet() throws Exception {
-        methodWatcher.setAutoCommit(false);
         spliceClassWatcher.setAutoCommit(false);
         createSharedTables(spliceClassWatcher.getOrCreateConnection());
         spliceClassWatcher.closeAll();
+    }
+
+    @After
+    public void after() throws Exception {
+        // reset autocommit to true if we failed within a non-autocommit test
+        if(!methodWatcher.getOrCreateConnection().getAutoCommit()) {
+            methodWatcher.rollback();
+            methodWatcher.setAutoCommit(true);
+        }
+        methodWatcher.closeAll();
     }
 
     public static void createSharedTables(Connection conn) throws Exception {
@@ -731,7 +740,7 @@ public class TimestampIT extends SpliceUnitTest {
         TestUtils.FormattedResult.ResultFactory.toString(rs));  */
 
         methodWatcher.rollback();
-        methodWatcher.setAutoCommit(false);
+        methodWatcher.setAutoCommit(true);
 
         String match = extendedTimestamps ?
         "COL1          |COL2 |\n" +

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WithStatementIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WithStatementIT.java
@@ -23,6 +23,7 @@ import org.junit.rules.TestRule;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 import static com.splicemachine.test_tools.Rows.row;
 import static com.splicemachine.test_tools.Rows.rows;
@@ -109,9 +110,8 @@ public class WithStatementIT extends SpliceUnitTest {
 
         @Override
         public void run() {
-            try {
-                connection.createStatement().executeQuery(
-                        format("with %s as (select * from t12) select * from %s", viewName, viewName));
+            try (Statement s = connection.createStatement()){
+                s.executeQuery(format("with %s as (select * from t12) select * from %s", viewName, viewName));
             } catch (SQLException e) {
                 throw new RuntimeException(e);
             }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WithStatementIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WithStatementIT.java
@@ -52,7 +52,7 @@ public class WithStatementIT extends SpliceUnitTest {
     protected static final String TEST_PASSWORD = "ajkglja233";
     protected static final String TEST_ROLE = "read_only";
 
-    protected static TestConnection testUserConn;
+    private static TestConnection testUserConn;
 
     @ClassRule
     public static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(SCHEMA);
@@ -96,7 +96,9 @@ public class WithStatementIT extends SpliceUnitTest {
 
         testUserConn = spliceClassWatcher.connectionBuilder().user(TEST_USER).password(TEST_PASSWORD).build();
 
-        connection.createStatement().execute(format("grant access,select on schema %s to %s", SCHEMA, TEST_USER));
+        try(Statement s = connection.createStatement()) {
+            s.execute(format("grant access,select on schema %s to %s", SCHEMA, TEST_USER));
+        }
     }
 
     private static class CreateDynamicViewTask implements Runnable {
@@ -111,7 +113,7 @@ public class WithStatementIT extends SpliceUnitTest {
         @Override
         public void run() {
             try (Statement s = connection.createStatement()){
-                s.executeQuery(format("with %s as (select * from t12) select * from %s", viewName, viewName));
+                s.executeQuery(format("with %s as (select * from t12) select * from %s", viewName, viewName)).close();
             } catch (SQLException e) {
                 throw new RuntimeException(e);
             }
@@ -266,7 +268,8 @@ public class WithStatementIT extends SpliceUnitTest {
             assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
         }
 
-        try (ResultSet rs = testUserConn.createStatement().executeQuery("values current schema")) {
+        try (Statement s = testUserConn.createStatement();
+             ResultSet rs = s.executeQuery("values current schema")) {
             String expectedSchema = "1        |\n" +
                     "-----------------\n" +
                     "WITHSTATEMENTIT |";
@@ -274,7 +277,8 @@ public class WithStatementIT extends SpliceUnitTest {
         }
 
         // user with no write privilege, dynamic view in SESSION schema
-        try (ResultSet rs = testUserConn.createStatement().executeQuery(format("with dt as (select * from t12) select * from dt"))) {
+        try (Statement s = testUserConn.createStatement();
+             ResultSet rs = s.executeQuery(format("with dt as (select * from t12) select * from dt"))) {
             assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
         }
         // user with no write privilege, dynamic view in current schema

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
@@ -1068,6 +1068,7 @@ public class SpliceUnitTest {
      *
      * Note that this is only correct if the test ends and nothing else is running anymore
      * (e.g. @Category({SerialTest.class}) ). Because of this, the default should be failOnError = false.
+     * @param failOnError if true, fail on error (don't do this on parallel tests). otherwise, just LOG.
      */
     public static void waitForStaleTransactions(SpliceWatcher methodWatcher, String name, int numSeconds,
                                                 boolean failOnError) throws Exception
@@ -1087,6 +1088,8 @@ public class SpliceUnitTest {
             Assert.fail(name + " failed to close all transactions.");
         }
         else {
+            // if you see this error, this is a hint that something might be left open, especially if you see
+            // multiple of these messages. turn failOnError=true and check tests one by one.
             LOG.info("WARNING: " + name + " failed to close all transactions. This might be due to multiple " +
                 "tests running in parallel.");
         }
@@ -1103,7 +1106,10 @@ public class SpliceUnitTest {
     @AfterClass
     public static void waitForStaleTransactions() throws Exception {
         SpliceWatcher methodWatcher = new SpliceWatcher(null);
-        waitForStaleTransactions(methodWatcher, "Test", 5, true);
+        // for parallel running tests waitForStaleTransactions might report false positives,
+        // but you can set this to true if you're checking the tests one by one manually.
+        boolean failOnError = false;
+        waitForStaleTransactions(methodWatcher, "Test", 5, failOnError);
         methodWatcher.closeAll();
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
@@ -1071,7 +1071,7 @@ public class SpliceUnitTest {
      * @param failOnError if true, fail on error (don't do this on parallel tests). otherwise, just LOG.
      */
     public static void waitForStaleTransactions(SpliceWatcher methodWatcher, String name, int numSeconds,
-                                                boolean failOnError) throws Exception
+                                                boolean failOnError)
     {
         Logger LOG = Logger.getLogger("SpliceUnitTest");
         try {
@@ -1098,7 +1098,12 @@ public class SpliceUnitTest {
                     "'java.lang.UnsupportedOperationException: Operation not supported in Mem profile: java.io.IOException'."))
                 return;
             else
-                LOG.info("WARNING: Couldn't execute SYSCS_GET_OLDEST_ACTIVE_TRANSACTION");
+                LOG.info("WARNING: Couldn't execute SYSCS_GET_OLDEST_ACTIVE_TRANSACTION: " + e.toString());
+        }
+        catch( Exception e)
+        {
+            // some tests might have closed the database (RestoreIT)
+            LOG.info("WARNING: Couldn't execute SYSCS_GET_OLDEST_ACTIVE_TRANSACTION: " + e.toString());
         }
     }
 
@@ -1111,7 +1116,7 @@ public class SpliceUnitTest {
     }
 
     @AfterClass
-    public static void waitForStaleTransactions() throws Exception {
+    public static void waitForStaleTransactions() {
         SpliceWatcher methodWatcher = new SpliceWatcher(null);
         // for parallel running tests waitForStaleTransactions might report false positives,
         // but you can set this to true if you're checking the tests one by one manually.

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
@@ -14,7 +14,6 @@
 
 package com.splicemachine.derby.test.framework;
 
-import com.splicemachine.db.iapi.types.SQLLongint;
 import com.splicemachine.homeless.TestUtils;
 import com.splicemachine.utils.Pair;
 import org.apache.commons.io.FileUtils;
@@ -27,6 +26,7 @@ import splice.com.google.common.base.Joiner;
 import java.io.*;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -122,10 +122,11 @@ public class SpliceUnitTest {
             Path us = Paths.get(userDir);
             nioPath = Paths.get(us.toString(),"splice_machine");
             if(!Files.exists(nioPath)){
-             /* Try to go up and to the left. If it's not
-             * there, then we are screwed anyway, so just go with it
-             */
+                /* Try to go up and to the left. If it's not
+                 * there, then we are screwed anyway, so just go with it
+                 */
                 Path parent=Paths.get(userDir).getParent();
+                if(parent == null) throw new RuntimeException("path " + userDir + " not found");
                 nioPath=Paths.get(parent.toString(),"splice_machine");
             }
         }
@@ -169,16 +170,17 @@ public class SpliceUnitTest {
             Path us = Paths.get(userDir);
             nioPath = Paths.get(us.toString(),"platform_it");
             if(!Files.exists(nioPath)){
-             /* Try to go up and to the left. If it's not
-             * there, then we are screwed anyway, so just go with it
-             */
+                /* Try to go up and to the left. If it's not
+                 * there, then we are screwed anyway, so just go with it
+                 */
                 Path parent=Paths.get(userDir).getParent();
+                if(parent == null) throw new RuntimeException("path " + userDir + " not found");
                 nioPath=Paths.get(parent.toString(),"platform_it");
             }
         }
         return nioPath.toString();
     }
-    
+
     public static String getHiveWarehouseDirectory() {
         return getHBaseDirectory()+"/user/hive/warehouse";
     }
@@ -219,7 +221,7 @@ public class SpliceUnitTest {
                 for(int level : levels){
                     if(level==i){
                         Assert.assertTrue("failed query at level ("+level+"): \n"+query+"\nExpected: "+contains[k]+"\nWas: "
-                                              +resultSet.getString(1),resultSet.getString(1).contains(contains[k]));
+                                +resultSet.getString(1),resultSet.getString(1).contains(contains[k]));
                         k++;
                     }
                 }
@@ -460,8 +462,8 @@ public class SpliceUnitTest {
     }
 
     protected void testQueryDoesNotContain(String sqlText, String containedString,
-                                     SpliceWatcher methodWatcher,
-                                     boolean caseInsensitive) throws Exception {
+                                           SpliceWatcher methodWatcher,
+                                           boolean caseInsensitive) throws Exception {
         ResultSet rs = null;
         try {
             rs = methodWatcher.executeQuery(sqlText);
@@ -580,21 +582,20 @@ public class SpliceUnitTest {
      * @throws SQLException Error accessing the database.
      */
     public void assertTableRowCount(String table, int rowCount, Statement s)
-       throws SQLException, AssertionError
+            throws SQLException, AssertionError
     {
-        ResultSet rs = s.executeQuery(
-                "SELECT COUNT(*) FROM " + table);
-        rs.next();
-        assertEquals(table + " row count:",
-            rowCount, rs.getInt(1));
-        rs.close();
+        try( ResultSet rs = s.executeQuery("SELECT COUNT(*) FROM " + table) ) {
+            rs.next();
+            assertEquals(table + " row count:",
+                    rowCount, rs.getInt(1));
+        }
     }
 
     public static void assertUpdateCount(Statement st,
-        int expectedRC, String sql) throws SQLException, AssertionError
+                                         int expectedRC, String sql) throws SQLException, AssertionError
     {
         assertEquals("Update count does not match:",
-            expectedRC, st.executeUpdate(sql));
+                expectedRC, st.executeUpdate(sql));
     }
 
     public static class Contains {
@@ -618,8 +619,8 @@ public class SpliceUnitTest {
 
     protected static void importData(SpliceWatcher methodWatcher, String schema,String tableName, String fileName) throws Exception {
         String file = SpliceUnitTest.getResourceDirectory()+ fileName;
-        PreparedStatement ps = methodWatcher.prepareStatement(String.format("call SYSCS_UTIL.IMPORT_DATA('%s','%s','%s','%s',',',null,null,null,null,1,null,true,'utf-8')", schema, tableName, null, file));
-        ps.executeQuery();
+        String sql = String.format("call SYSCS_UTIL.IMPORT_DATA('%s','%s','%s','%s',',',null,null,null,null,1,null,true,'utf-8')", schema, tableName, null, file);
+        methodWatcher.execute(sql);
     }
 
     protected static void validateImportResults(ResultSet resultSet, int good,int bad) throws SQLException {
@@ -710,8 +711,12 @@ public class SpliceUnitTest {
         File importFileDirectory = new File(getHBaseDirectory() + "/target/import_data/" + schemaName);
         if (importFileDirectory.exists()) {
             //noinspection ConstantConditions
-            for (File file : importFileDirectory.listFiles()) {
-                assertTrue("Couldn't create "+file,file.delete());
+            File[] files = importFileDirectory.listFiles();
+            if( files != null ) {
+                for (File file : files) {
+                    if (file != null)
+                        assertTrue("Couldn't create " + file, file.delete());
+                }
             }
             assertTrue("Couldn't create "+importFileDirectory,importFileDirectory.delete());
         }
@@ -783,7 +788,7 @@ public class SpliceUnitTest {
 
 
     public static SpliceUnitTest.TestFileGenerator generatePartialRow(File directory, String fileName, int size,
-                                                                       List<int[]> fileData) throws IOException {
+                                                                      List<int[]> fileData) throws IOException {
         SpliceUnitTest.TestFileGenerator generator = new SpliceUnitTest.TestFileGenerator(directory, fileName);
         try {
             for (int i = 0; i < size; i++) {
@@ -798,8 +803,8 @@ public class SpliceUnitTest {
     }
 
     public static SpliceUnitTest.TestFileGenerator generateFullRow(File directory, String fileName, int size,
-                                                                        List<int[]> fileData,
-                                                                        boolean duplicateLast) throws IOException {
+                                                                   List<int[]> fileData,
+                                                                   boolean duplicateLast) throws IOException {
         return generateFullRow(directory,fileName,size,fileData,duplicateLast,false);
     }
 
@@ -829,6 +834,7 @@ public class SpliceUnitTest {
 
     public static boolean existsBadFile(File badDir, String prefix) {
         String[] files = badDir.list();
+        if( files == null ) return false;
         for (String file : files) {
             if (file.startsWith(prefix)) {
                 return true;
@@ -839,6 +845,7 @@ public class SpliceUnitTest {
 
     public static String getBadFile(File badDir, String prefix) {
         String[] files = badDir.list();
+        if( files == null ) return null;
         for (String file : files) {
             if (file.startsWith(prefix)) {
                 return file;
@@ -850,6 +857,7 @@ public class SpliceUnitTest {
     public static List<String> getAllBadFiles(File badDir, String prefix) {
         List<String> badFiles = new ArrayList<>();
         String[] files = badDir.list();
+        if( files == null ) return badFiles;
         for (String file : files) {
             if (file.startsWith(prefix)) {
                 badFiles.add(file);
@@ -874,7 +882,7 @@ public class SpliceUnitTest {
         public TestFileGenerator(File directory, String fileName) throws IOException {
             this.fileName = fileName+".csv";
             this.file = new File(directory, this.fileName);
-            this.writer =  new BufferedWriter(new FileWriter(file));
+            this.writer =  new BufferedWriter( (new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)));
             this.joiner = Joiner.on(",");
         }
 
@@ -959,8 +967,9 @@ public class SpliceUnitTest {
     }
 
     public static void assertFailed(Connection connection, String sql, String errorState) {
-        try {
-            connection.createStatement().execute(sql);
+        try(Statement s = connection.createStatement())
+        {
+            s.execute(sql);
             fail("Did not fail");
         } catch (Exception e) {
             assertTrue("Incorrect error type: " + e.getClass().getName(), e instanceof SQLException);
@@ -973,7 +982,8 @@ public class SpliceUnitTest {
     {
         File path = new File(getHBaseDirectory(), "/target/tmp/" + subpath);
         FileUtils.deleteDirectory(path); // clean directory
-        path.mkdirs();
+        if( !path.mkdirs() )
+            throw new RuntimeException("couldn't create " + path.toString());
         return path;
     }
 
@@ -1021,29 +1031,35 @@ public class SpliceUnitTest {
     }
 
     /// execute sql query 'sqlText' and expect an exception of certain state being thrown
-    public static void SqlExpectException( SpliceWatcher methodWatcher, String sqlText, String expectedState )
+    public static void sqlExpectException(SpliceWatcher methodWatcher, String sqlText, String expectedState, boolean update)
     {
         try {
-            ResultSet rs = methodWatcher.executeQuery(sqlText);
-            rs.close();
+            if( update )
+                methodWatcher.executeUpdate(sqlText);
+            else {
+                ResultSet rs = methodWatcher.executeQuery(sqlText);
+                rs.close();
+            }
             Assert.fail("Exception not thrown for " + sqlText);
 
         } catch (SQLException e) {
-            System.out.println( e );
             Assert.assertEquals("Wrong Exception for " + sqlText, expectedState, e.getSQLState());
+        } catch (Exception e) {
+            Assert.assertEquals("Wrong Exception for " + sqlText, expectedState, e.getClass().getName());
         }
     }
 
     /// execute sql query 'sqlText' and expect a certain formatted result
-    public static void SqlExpectToString( SpliceWatcher methodWatcher, String sqlText, String expected, boolean sort ) throws Exception
+    public static void sqlExpectToString(SpliceWatcher methodWatcher, String sqlText, String expected, boolean sort ) throws Exception
     {
         try( ResultSet rs = methodWatcher.executeQuery(sqlText) ) {
             String val = sort
                     ? TestUtils.FormattedResult.ResultFactory.toString(rs)
                     : TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
-            Assert.assertEquals(expected, val);
+            Assert.assertEquals(sqlText, expected, val);
         }
     }
+
 
     /**
      * check if there's any transactions still open
@@ -1072,7 +1088,7 @@ public class SpliceUnitTest {
         }
         else {
             LOG.info("WARNING: " + name + " failed to close all transactions. This might be due to multiple " +
-                    "tests running in parallel.");
+                "tests running in parallel.");
         }
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
@@ -18,6 +18,7 @@ import com.splicemachine.db.iapi.types.SQLLongint;
 import com.splicemachine.homeless.TestUtils;
 import com.splicemachine.utils.Pair;
 import org.apache.commons.io.FileUtils;
+import org.apache.log4j.Logger;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.runner.Description;
@@ -1044,11 +1045,20 @@ public class SpliceUnitTest {
         }
     }
 
-    public static void waitForStaleTransactions(SpliceWatcher methodWatcher, String name, int numSeconds) throws Exception
+    /**
+     * check if there's any transactions still open
+     * if getOldestActiveTransaction is two times the same in a row, there's a stale transaction
+     * otherwise, we will get every time different ids since also the CALL SYSUTIL_... will open a mini-transaction
+     *
+     * Note that this is only correct if the test ends and nothing else is running anymore
+     * (e.g. @Category({SerialTest.class}) ). Because of this, the default should be failOnError = false.
+     */
+    public static void waitForStaleTransactions(SpliceWatcher methodWatcher, String name, int numSeconds,
+                                                boolean failOnError) throws Exception
     {
-        // wait for other transactions to finish
-        // if getOldestActiveTransaction is two times the same in a row, there's a stale transaction
-        // otherwise, we will get every time different ids since also the CALL SYSUTIL_... will open a mini-transaction
+        Logger LOG = Logger.getLogger("SpliceUnitTest");
+        LOG.info("checking for stale transactions");
+
         int oldest1 = getOldestActiveTransaction(methodWatcher);
         for(int i=0; i < numSeconds; i++) {
             int oldest2 = getOldestActiveTransaction(methodWatcher);
@@ -1057,7 +1067,13 @@ public class SpliceUnitTest {
             Thread.sleep(1000);
             oldest1 = oldest2;
         }
-        Assert.fail(name + " failed to close all transactions.");
+        if( failOnError ) {
+            Assert.fail(name + " failed to close all transactions.");
+        }
+        else {
+            LOG.info("WARNING: " + name + " failed to close all transactions. This might be due to multiple " +
+                    "tests running in parallel.");
+        }
     }
 
     public static int getOldestActiveTransaction(SpliceWatcher methodWatcher) throws SQLException {
@@ -1071,7 +1087,7 @@ public class SpliceUnitTest {
     @AfterClass
     public static void waitForStaleTransactions() throws Exception {
         SpliceWatcher methodWatcher = new SpliceWatcher(null);
-        waitForStaleTransactions(methodWatcher, "Test", 5);
+        waitForStaleTransactions(methodWatcher, "Test", 5, true);
         methodWatcher.closeAll();
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
@@ -14,9 +14,11 @@
 
 package com.splicemachine.derby.test.framework;
 
+import com.splicemachine.db.iapi.types.SQLLongint;
 import com.splicemachine.homeless.TestUtils;
 import com.splicemachine.utils.Pair;
 import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.runner.Description;
 import splice.com.google.common.base.Joiner;
@@ -44,13 +46,13 @@ public class SpliceUnitTest {
     /// set the following boolean to true to prevent deletion of temporary files (e.g. for debugging)
     static private final boolean debug_no_delete = false;
 
-	public String getSchemaName() {
-		Class<?> enclosingClass = getClass().getEnclosingClass();
-		if (enclosingClass != null)
-		    return enclosingClass.getSimpleName().toUpperCase();
-		else
-		    return getClass().getSimpleName().toUpperCase();
-	}
+    public String getSchemaName() {
+        Class<?> enclosingClass = getClass().getEnclosingClass();
+        if (enclosingClass != null)
+            return enclosingClass.getSimpleName().toUpperCase();
+        else
+            return getClass().getSimpleName().toUpperCase();
+    }
 
     /**
      * Load a table with given values
@@ -67,31 +69,31 @@ public class SpliceUnitTest {
     }
 
     public String getTableReference(String tableName) {
-		return getSchemaName() + "." + tableName;
-	}
+        return getSchemaName() + "." + tableName;
+    }
 
-	public String getPaddedTableReference(String tableName) {
-		return " " + getSchemaName() + "." + tableName.toUpperCase()+ " ";
-	}
+    public String getPaddedTableReference(String tableName) {
+        return " " + getSchemaName() + "." + tableName.toUpperCase()+ " ";
+    }
 
-	
-	public static int resultSetSize(ResultSet rs) throws Exception {
-		int i = 0;
-		while (rs.next()) {
-			i++;
-		}
-		return i;
-	}
+
+    public static int resultSetSize(ResultSet rs) throws Exception {
+        int i = 0;
+        while (rs.next()) {
+            i++;
+        }
+        return i;
+    }
 
     public static int columnWidth(ResultSet rs ) throws SQLException {
         return rs.getMetaData().getColumnCount();
     }
 
-	public static String format(String format, Object...args) {
-		return String.format(format, args);
-	}
-	public static String getBaseDirectory() {
-		String userDir = System.getProperty("user.dir");
+    public static String format(String format, Object...args) {
+        return String.format(format, args);
+    }
+    public static String getBaseDirectory() {
+        String userDir = System.getProperty("user.dir");
         /*
          * The ITs can run in multiple different locations based on the different architectures
          * that are available, but the actual test data files are located in the splice_machine directory; thus,
@@ -127,11 +129,11 @@ public class SpliceUnitTest {
             }
         }
         return nioPath.toString();
-	}
+    }
 
     public static String getResourceDirectory() {
-		return getBaseDirectory()+"/src/test/test-data/";
-	}
+        return getBaseDirectory()+"/src/test/test-data/";
+    }
 
     public static String getHbaseRootDirectory() {
         return getHBaseDirectory()+"/target/hbase";
@@ -177,8 +179,8 @@ public class SpliceUnitTest {
     }
     
     public static String getHiveWarehouseDirectory() {
-		return getHBaseDirectory()+"/user/hive/warehouse";
-	}
+        return getHBaseDirectory()+"/user/hive/warehouse";
+    }
 
     public static class MyWatcher extends SpliceTableWatcher {
 
@@ -1040,5 +1042,36 @@ public class SpliceUnitTest {
                     : TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
             Assert.assertEquals(expected, val);
         }
+    }
+
+    public static void waitForStaleTransactions(SpliceWatcher methodWatcher, String name, int numSeconds) throws Exception
+    {
+        // wait for other transactions to finish
+        // if getOldestActiveTransaction is two times the same in a row, there's a stale transaction
+        // otherwise, we will get every time different ids since also the CALL SYSUTIL_... will open a mini-transaction
+        int oldest1 = getOldestActiveTransaction(methodWatcher);
+        for(int i=0; i < numSeconds; i++) {
+            int oldest2 = getOldestActiveTransaction(methodWatcher);
+            if( oldest1 != oldest2 )
+                return;
+            Thread.sleep(1000);
+            oldest1 = oldest2;
+        }
+        Assert.fail(name + " failed to close all transactions.");
+    }
+
+    public static int getOldestActiveTransaction(SpliceWatcher methodWatcher) throws SQLException {
+        try (ResultSet rs = methodWatcher.executeQuery("call SYSCS_UTIL.SYSCS_GET_OLDEST_ACTIVE_TRANSACTION()"))
+        {
+            Assert.assertEquals(true, rs.next());
+            return rs.getInt(1);
+        }
+    }
+
+    @AfterClass
+    public static void waitForStaleTransactions() throws Exception {
+        SpliceWatcher methodWatcher = new SpliceWatcher(null);
+        waitForStaleTransactions(methodWatcher, "Test", 5);
+        methodWatcher.closeAll();
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
@@ -281,13 +281,15 @@ public class SpliceWatcher extends TestWatcher implements AutoCloseable {
     }
 
     public int executeUpdate(String sql) throws Exception {
-        Statement s = getStatement();
-        return s.executeUpdate(sql);
+        try(Statement s = getOrCreateConnection().createStatement()) {
+            return s.executeUpdate(sql);
+        }
     }
     
     public boolean execute(String sql) throws Exception {
-    	Statement s = getStatement();
-    	return s.execute(sql);
+        try(Statement s = getOrCreateConnection().createStatement()) {
+            return s.execute(sql);
+        }
     }
 
     public int executeUpdate(String sql, String userName, String password) throws Exception {

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
@@ -272,11 +272,12 @@ public class SpliceWatcher extends TestWatcher implements AutoCloseable {
      */
     public <T> T query(String sql) throws Exception {
         T result;
-        ResultSet rs = executeQuery(sql);
-        assertTrue("does not have next",rs.next());
-        result = (T) rs.getObject(1);
-        assertFalse(rs.next());
-        return result;
+        try(ResultSet rs = executeQuery(sql)) {
+            assertTrue("does not have next", rs.next());
+            result = (T) rs.getObject(1);
+            assertFalse(rs.next());
+            return result;
+        }
     }
 
     public int executeUpdate(String sql) throws Exception {
@@ -343,20 +344,19 @@ public class SpliceWatcher extends TestWatcher implements AutoCloseable {
     }
 
     public void splitTable(String tableName, String schemaName) throws Exception {
-        long conglom = getConglomId(tableName,schemaName);
-//        ConglomerateUtils.splitConglomerate(getConglomId(tableName,schemaName));
+        getConglomId(tableName,schemaName);
     }
 
     public long getConglomId(String tableName, String schemaName) throws Exception {
-           /*
-            * This is a needlessly-complicated and annoying way of doing this,
-	        * because *when it was written*, the metadata information was kind of all messed up
-	        * and doing a join between systables and sysconglomerates resulted in an error. When you are
-	        * looking at this code and going WTF?!? feel free to try cleaning up the SQL. If you get a bunch of
-	        * wonky errors, then we haven't fixed the underlying issue yet. If you don't, then you just cleaned up
-	        * some ugly-ass code. Good luck to you.
-	        *
-	        */
+        /*
+         * This is a needlessly-complicated and annoying way of doing this,
+         * because *when it was written*, the metadata information was kind of all messed up
+         * and doing a join between systables and sysconglomerates resulted in an error. When you are
+         * looking at this code and going WTF?!? feel free to try cleaning up the SQL. If you get a bunch of
+         * wonky errors, then we haven't fixed the underlying issue yet. If you don't, then you just cleaned up
+         * some ugly-ass code. Good luck to you.
+         *
+         */
         PreparedStatement ps = prepareStatement("select c.conglomeratenumber from " +
                 "sys.systables t, sys.sysconglomerates c,sys.sysschemas s " +
                 "where t.tableid = c.tableid " +
@@ -366,11 +366,12 @@ public class SpliceWatcher extends TestWatcher implements AutoCloseable {
                 "and s.schemaname = ?");
         ps.setString(1, tableName);
         ps.setString(2, schemaName);
-        ResultSet rs = ps.executeQuery();
-        if (rs.next()) {
-            return rs.getLong(1);
-        } else {
-            LOG.warn("Unable to find the conglom id for table  " + tableName);
+        try (ResultSet rs = ps.executeQuery()) {
+            if (rs.next()) {
+                return rs.getLong(1);
+            } else {
+                LOG.warn("Unable to find the conglom id for table  " + tableName);
+            }
         }
         return -1l;
     }

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
@@ -34,7 +34,7 @@ import static splice.com.google.common.base.Strings.isNullOrEmpty;
  *
  * Not thread-safe, synchronize externally if using in a multi-threaded test case.
  */
-public class SpliceWatcher extends TestWatcher {
+public class SpliceWatcher extends TestWatcher implements AutoCloseable {
 
     private static final Logger LOG = Logger.getLogger(SpliceWatcher.class);
 
@@ -55,6 +55,11 @@ public class SpliceWatcher extends TestWatcher {
 
     public SpliceWatcher(String defaultSchema) {
         this.defaultSchema = defaultSchema == null ? null : defaultSchema.toUpperCase();
+    }
+
+    @Override
+    public void close() throws Exception {
+        closeAll();
     }
 
     public class ConnectionBuilder {

--- a/splice_machine/src/test/java/com/splicemachine/homeless/TestUtils.java
+++ b/splice_machine/src/test/java/com/splicemachine/homeless/TestUtils.java
@@ -18,6 +18,7 @@ import com.splicemachine.derby.test.framework.SpliceDataWatcher;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
 import com.splicemachine.utils.Pair;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.dbutils.BasicRowProcessor;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
@@ -27,11 +28,13 @@ import splice.com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.Serializable;
 import java.sql.*;
 import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 
+@SuppressFBWarnings("SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE") // intentional
 public class TestUtils {
     private static final Logger LOG = Logger.getLogger(TestUtils.class);
 
@@ -301,8 +304,10 @@ public class TestUtils {
                                               "and t2.schemaid=t3.schemaid and t3.schemaname = '%s' and t2" +
                                               ".tablename = '%s' order by t1.conglomeratenumber desc",
                                           schemaName, tableName);
-        ResultSet rs = connection.createStatement().executeQuery(indexQuery);
-        return FormattedResult.ResultFactory.convert(indexQuery, rs);
+        try(Statement s = connection.createStatement();
+            ResultSet rs= s.executeQuery(indexQuery)) {
+            return FormattedResult.ResultFactory.convert(indexQuery, rs);
+        }
     }
 
     public static void killRunningOperations(SpliceWatcher spliceClassWatcher) throws Exception {
@@ -522,7 +527,7 @@ public class TestUtils {
 
     }
 
-    private static class ListComparator implements Comparator<List<String>> {
+    private static class ListComparator implements Comparator<List<String>>, Serializable {
         @Override
         public int compare(List<String> list1, List<String> list2) {
             for (int i = 0; i < list1.size(); i++) {

--- a/splice_machine/src/test/java/com/splicemachine/homeless/TestUtils.java
+++ b/splice_machine/src/test/java/com/splicemachine/homeless/TestUtils.java
@@ -77,9 +77,10 @@ public class TestUtils {
             for (String s : str.split(";")) {
                 String trimmed = s.trim();
                 if (!trimmed.equals("")) {
-                    Statement stmt = connection.createStatement();
-                    stmt.execute(s);
-                    connection.commit();
+                    try(Statement stmt = connection.createStatement()) {
+                        stmt.execute(s);
+                        connection.commit();
+                    }
                 }
             }
         } catch (Exception e) {

--- a/splice_machine/src/test/java/com/splicemachine/subquery/SubqueryITUtil.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/SubqueryITUtil.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.subquery;
 
+import com.splicemachine.derby.test.framework.SpliceWatcher;
 import com.splicemachine.homeless.TestUtils;
 
 import java.sql.Connection;
@@ -74,11 +75,23 @@ public class SubqueryITUtil {
     public static void assertSubqueryNodeCount(Connection connection,
                                                String query,
                                                int expectedSubqueryCountInPlan) throws Exception {
-        ResultSet rs2 = connection.createStatement().executeQuery("explain " + query);
-        String explainPlanText = TestUtils.FormattedResult.ResultFactory.toString(rs2);
-        assertEquals(expectedSubqueryCountInPlan, countSubqueriesInPlan(explainPlanText));
+        try(ResultSet rs2 = connection.createStatement().executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toString(rs2);
+            assertEquals(expectedSubqueryCountInPlan, countSubqueriesInPlan(explainPlanText));
+        }
     }
 
+    /**
+     * Assert that the plan for the specified query has the expected number of Subquery nodes.
+     */
+    public static void assertSubqueryNodeCount(SpliceWatcher watcher,
+                                               String query,
+                                               int expectedSubqueryCountInPlan) throws Exception {
+        try(ResultSet rs2 = watcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toString(rs2);
+            assertEquals(expectedSubqueryCountInPlan, countSubqueriesInPlan(explainPlanText));
+        }
+    }
     /**
      * Counts the number of Subquery nodes that appear in the explain plan text for a given query.
      */

--- a/splice_machine/src/test/java/com/splicemachine/subquery/SubqueryITUtil.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/SubqueryITUtil.java
@@ -19,6 +19,7 @@ import com.splicemachine.homeless.TestUtils;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.Statement;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -63,10 +64,11 @@ public class SubqueryITUtil {
                                              String query,
                                              int expectedSubqueryCountInPlan,
                                              String expectedResult) throws Exception {
-        ResultSet rs = connection.createStatement().executeQuery(query);
-        assertEquals(expectedResult, TestUtils.FormattedResult.ResultFactory.toString(rs));
-
-        assertSubqueryNodeCount(connection, query, expectedSubqueryCountInPlan);
+        try(Statement s = connection.createStatement();
+            ResultSet rs = s.executeQuery(query)) {
+            assertEquals(expectedResult, TestUtils.FormattedResult.ResultFactory.toString(rs));
+            assertSubqueryNodeCount(connection, query, expectedSubqueryCountInPlan);
+        }
     }
 
     /**
@@ -75,8 +77,9 @@ public class SubqueryITUtil {
     public static void assertSubqueryNodeCount(Connection connection,
                                                String query,
                                                int expectedSubqueryCountInPlan) throws Exception {
-        try(ResultSet rs2 = connection.createStatement().executeQuery("explain " + query)) {
-            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toString(rs2);
+        try(Statement s = connection.createStatement();
+            ResultSet rs = s.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toString(rs);
             assertEquals(expectedSubqueryCountInPlan, countSubqueriesInPlan(explainPlanText));
         }
     }


### PR DESCRIPTION
This fixes the issues because of un-closed Transactions which are preventing VacuumIT from running correctly.
It also introduces a @AfterClass function for each tests that logs messages of the following form:
`WARNING: Test failed to close all transactions. This might be due to multiple tests running in parallel.`
in case it finds left open transactions.
However, this message might be also caused by multiple tests running in parallel (that's why it's not Assert.fail).

To check if these Warnings are actually issues (especially if you see multiple of these messages), you can turn `failOnError=true` in SpliceUnitTest.waitForStaleTransactions() and check the tests that reported issues one by one (forcing Serial mode).

Also, SYSCS_GET_OLDEST_ACTIVE_TRANSACTION will now return same oldest Transaction as VACUUM, that is, the oldest active transaction over all region servers