### PR TITLE
DB-10558 Improve getTxnAt performance (3.1)

### DIFF
--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/SkeletonTxnNetworkLayer.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/SkeletonTxnNetworkLayer.java
@@ -134,8 +134,7 @@ public abstract class SkeletonTxnNetworkLayer implements TxnNetworkLayer{
     public TxnMessage.TxnAtResponse getTxnAt(final TxnMessage.TxnAtRequest request) throws IOException {
         Map<byte[], TxnMessage.TxnAtResponse> data=coprocessorService(TxnMessage.TxnLifecycleService.class,
                 HConstants.EMPTY_START_ROW,HConstants.EMPTY_END_ROW, instance -> {
-                    SpliceRpcController controller=new SpliceRpcController();
-                    controller.setPriority(HBaseTableDescriptor.HIGH_TABLE_PRIORITY);
+                    ServerRpcController controller=new ServerRpcController();
                     BlockingRpcCallback<TxnMessage.TxnAtResponse> response=new BlockingRpcCallback<>();
 
                     instance.getTxnAt(controller,request,response);

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/SkeletonTxnNetworkLayer.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/SkeletonTxnNetworkLayer.java
@@ -134,7 +134,8 @@ public abstract class SkeletonTxnNetworkLayer implements TxnNetworkLayer{
     public TxnMessage.TxnAtResponse getTxnAt(final TxnMessage.TxnAtRequest request) throws IOException {
         Map<byte[], TxnMessage.TxnAtResponse> data=coprocessorService(TxnMessage.TxnLifecycleService.class,
                 HConstants.EMPTY_START_ROW,HConstants.EMPTY_END_ROW, instance -> {
-                    ServerRpcController controller=new ServerRpcController();
+                    SpliceRpcController controller=new SpliceRpcController();
+                    controller.setPriority(HBaseTableDescriptor.HIGH_TABLE_PRIORITY);
                     BlockingRpcCallback<TxnMessage.TxnAtResponse> response=new BlockingRpcCallback<>();
 
                     instance.getTxnAt(controller,request,response);

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/server/PurgeConfigBuilder.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/server/PurgeConfigBuilder.java
@@ -14,8 +14,6 @@
 
 package com.splicemachine.si.impl.server;
 
-import java.io.IOException;
-
 public class PurgeConfigBuilder {
     private PurgeConfig.PurgeLatestTombstone purgeLatestTombstone = null;
     private Boolean respectActiveTransactions = null;
@@ -102,7 +100,7 @@ public class PurgeConfigBuilder {
         return this;
     }
 
-    public PurgeConfig build() throws IOException {
+    public PurgeConfig build() {
         assert purgeDeletes != null;
         assert purgeUpdates != null;
         assert purgeLatestTombstone != null;


### PR DESCRIPTION
This PR addresses TPC-C performance regressions reported recently, the root cause was [DB-10084](https://github.com/splicemachine/spliceengine/pull/4163) PR, in that PR we made our purge-during-flush logic play nicely with time travel's minimum retention period (MRP) such that if we want to flush we check whether the involved transaction is within MRP, if so, we skip the purging preserving as a result the validity of past transactions within MRP.

The new check leverages the `getTxnAt` RPC which we introduced a while ago with time travel. This method performs HBase scans in a very inefficient way potentially causing a full scan of Splice txn table. That is maybe OK if the system is not under heavy load.

The TPC-C benchmark is intentionally putting the system under a heavy transnational workload to [benchmark](http://www.tpc.org/tpcc/detail5.asp) its OLTP performance, as a result the Splice txn table could grow to a much larger size causing HBase scans on it to take considerable amount of time and exposing as a result the inefficiency in `getTxnAt` RPC implementation since now flushes are taking a considerable amount of time causing the overall performance to drop heavily.

The proposed fix includes making HBase scans needed by `getTxnAt` algorithm much more efficient by setting proper start/stop rows for the scan and return a single row instead of (unnecessary) many rows.