### PR TITLE
DB-10514-2.8 Reject adding foreign key with delete actions via ALTER statement

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/AlterTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/AlterTableConstantOperation.java
@@ -260,6 +260,7 @@ public class AlterTableConstantOperation extends IndexConstantOperation {
                     case DataDictionary.FOREIGNKEY_CONSTRAINT:
                         if (td.getTableType() == TableDescriptor.EXTERNAL_TYPE)
                             throw StandardException.newException(SQLState.EXTERNAL_TABLES_NO_REFERENCE_CONSTRAINTS,td.getName());
+                        cca.validateSupported();
                         // Do everything but FK constraints first, then FK constraints on 2nd pass.
                         fkConstraints.add(cca);
                         break;

--- a/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKey_AlterDropTable_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKey_AlterDropTable_IT.java
@@ -231,6 +231,34 @@ public class ForeignKey_AlterDropTable_IT {
         }
     }
 
+    @Test
+    public void testAlterAddFKOnDeleteCascadeNotSupported() throws Exception {
+        try(Statement s = conn.createStatement()) {
+            s.execute("create table P(a1 int, b1 int, c1 int, primary key(a1))");
+            s.execute("create table C(a2 int, b2 int, c2 int)");
+            try {
+                s.execute("alter table C add constraint fk foreign key (a2) references P(a1) on delete cascade");
+                fail("Expected Feature not implemented: ON DELETE CASCADE exception");
+            } catch(Exception e) {
+                Assert.assertEquals("Feature not implemented: ON DELETE CASCADE.", e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void testAlterAddFKOnDeleteSetNullNotSupported() throws Exception {
+        try(Statement s = conn.createStatement()) {
+            s.execute("create table P(a1 int, b1 int, c1 int, primary key(a1))");
+            s.execute("create table C(a2 int, b2 int, c2 int)");
+            try {
+                s.execute("alter table C add constraint fk foreign key (a2) references P(a1) on delete set null");
+                fail("Expected Feature not implemented: ON DELETE SET NULL exception");
+            } catch(Exception e) {
+                Assert.assertEquals("Feature not implemented: ON DELETE SET NULL.", e.getMessage());
+            }
+        }
+    }
+
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     //
     // helper methods


### PR DESCRIPTION
We do not allow tables to be created with a foreign key that has a delete action (`on delete cascade` and `on delete set null`) since they these actions are not supported. However we still incorrectly allow the user to add such foreign keys via the `alter` statement.

In this PR we fix this behavior disallowing the user to add a foreign key with delete action via `alter` statement.