### PR TITLE
DB-9656 better error output for nonmatching parameters in CALL

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/RoutineAliasInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/RoutineAliasInfo.java
@@ -41,12 +41,14 @@ import java.io.ObjectOutput;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.util.IdUtil;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Describe a routine (procedure or function) alias.
  *
  * @see com.splicemachine.db.catalog.AliasInfo
  */
+@SuppressFBWarnings("EI_EXPOSE_REP")
 public class RoutineAliasInfo extends MethodAliasInfo
 {
 
@@ -442,18 +444,19 @@ public class RoutineAliasInfo extends MethodAliasInfo
 	 */
 	public String toString() {
 
-		StringBuilder sb = new StringBuilder(100);
-		toStringParameters(sb);
+        StringBuilder sb = new StringBuilder(100);
+        toStringParameters(sb);
 
-		sb.append(" LANGUAGE ");
-		sb.append(this.language);	// Language can now be Python
-		sb.append(" PARAMETER STYLE " );
+        sb.append(" LANGUAGE ");
+        sb.append(this.language);	// Language can now be Python
+        sb.append(" PARAMETER STYLE " );
 
-		switch( parameterStyle )
-		{
-		    case PS_JAVA:    sb.append( "JAVA " ); break;
-		    case PS_SPLICE_JDBC_RESULT_SET:    sb.append( "SPLICE_JDBC_RESULT_SET " ); break;
-		}
+        switch( parameterStyle )
+        {
+            case PS_JAVA:                   sb.append( "JAVA " ); break;
+            case PS_SPLICE_JDBC_RESULT_SET: sb.append( "SPLICE_JDBC_RESULT_SET " ); break;
+            default: break;
+        }
         
         if ( isDeterministic() )
         { sb.append( " DETERMINISTIC " ); }
@@ -461,24 +464,24 @@ public class RoutineAliasInfo extends MethodAliasInfo
         if ( hasDefinersRights())
         { sb.append( " EXTERNAL SECURITY DEFINER " ); }
 
-		sb.append(RoutineAliasInfo.SQL_CONTROL[getSQLAllowed()]);
-		if ((returnType == null) &&
-			(dynamicResultSets != 0))
-		{ // Only print dynamic result sets if this is a PROCEDURE
-		  // because it's not valid syntax for FUNCTIONs.
-			sb.append(" DYNAMIC RESULT SETS ");
-			sb.append(dynamicResultSets);
-		}
+        sb.append(RoutineAliasInfo.SQL_CONTROL[getSQLAllowed()]);
+        if ((returnType == null) &&
+            (dynamicResultSets != 0))
+        { // Only print dynamic result sets if this is a PROCEDURE
+          // because it's not valid syntax for FUNCTIONs.
+            sb.append(" DYNAMIC RESULT SETS ");
+            sb.append(dynamicResultSets);
+        }
 
-		if (returnType != null) {
-		// this a FUNCTION, so append the syntax telling what to
-		// do with a null parameter.
-			sb.append(calledOnNullInput ? " CALLED " : " RETURNS NULL ");
-			sb.append("ON NULL INPUT");
-		}
-		
-		return sb.toString();
-	}
+        if (returnType != null) {
+        // this a FUNCTION, so append the syntax telling what to
+        // do with a null parameter.
+            sb.append(calledOnNullInput ? " CALLED " : " RETURNS NULL ");
+            sb.append("ON NULL INPUT");
+        }
+
+        return sb.toString();
+    }
 
 	public static String parameterMode(int parameterMode) {
 		switch (parameterMode) {

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/RoutineAliasInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/RoutineAliasInfo.java
@@ -403,6 +403,34 @@ public class RoutineAliasInfo extends MethodAliasInfo
 	 */
 	public	int	getTypeFormatId()	{ return StoredFormatIds.ROUTINE_INFO_V01_ID; }
 
+	public void toStringParameters(StringBuilder sb)
+	{
+		sb.append(getMethodName());
+		sb.append('(');
+		for (int i = 0; i < parameterCount; i++) {
+			if (i != 0)
+				sb.append(", ");
+
+			if (returnType == null) {
+				// This is a PROCEDURE.  We only want to print the
+				// parameter mode (ex. "IN", "OUT", "INOUT") for procedures--
+				// we don't do it for functions since use of the "IN" keyword
+				// is not part of the FUNCTION syntax.
+				sb.append(RoutineAliasInfo.parameterMode(parameterModes[i]));
+				sb.append(' ');
+			}
+			sb.append(IdUtil.normalToDelimited(parameterNames[i]));
+			sb.append(' ');
+			sb.append(parameterTypes[i].getSQLstring());
+		}
+		sb.append(')');
+
+		if (returnType != null) {
+			// this a FUNCTION, so syntax requires us to append the return type.
+			sb.append(" RETURNS ").append(returnType.getSQLstring());
+		}
+	}
+
 	/**
 	 * Get this alias info as a string.  NOTE: The "ALIASINFO" column
 	 * in the SYSALIASES table will return the result of this method
@@ -415,30 +443,7 @@ public class RoutineAliasInfo extends MethodAliasInfo
 	public String toString() {
 
 		StringBuilder sb = new StringBuilder(100);
-		sb.append(getMethodName());
-		sb.append('(');
-		for (int i = 0; i < parameterCount; i++) {
-			if (i != 0)
-				sb.append(',');
-
-			if (returnType == null) {
-			// This is a PROCEDURE.  We only want to print the
-			// parameter mode (ex. "IN", "OUT", "INOUT") for procedures--
-			// we don't do it for functions since use of the "IN" keyword
-			// is not part of the FUNCTION syntax.
-				sb.append(RoutineAliasInfo.parameterMode(parameterModes[i]));
-				sb.append(' ');
-			}
-			sb.append(IdUtil.normalToDelimited(parameterNames[i]));
-			sb.append(' ');
-			sb.append(parameterTypes[i].getSQLstring());
-		}
-		sb.append(')');
-
-		if (returnType != null) {
-		// this a FUNCTION, so syntax requires us to append the return type.
-			sb.append(" RETURNS ").append(returnType.getSQLstring());
-		}
+		toStringParameters(sb);
 
 		sb.append(" LANGUAGE ");
 		sb.append(this.language);	// Language can now be Python

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -2101,6 +2101,8 @@ public interface SQLState {
 
     String HBASE_OPERATION_ERROR = "HO001";
 
+    String ERROR_CALL_PARAMETER_COUNT_WRONG = "44004";
+    String ERROR_CALL_PARAMETER_CAST_ERROR = "44005";
 
 }
 

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -983,6 +983,7 @@ public interface SQLState {
     String LANG_NO_SUCH_METHOD_ALIAS                                       = "42Y03.S.0";
     String LANG_NO_SUCH_PROCEDURE                                          = "42Y03.S.1";
     String LANG_NO_SUCH_FUNCTION                                           = "42Y03.S.2";
+    String LANG_NO_SUCH_PROCEDURE2                                         = "42Y03.S.3";
     String LANG_INVALID_FULL_STATIC_METHOD_NAME                            = "42Y04";
     String LANG_NO_SUCH_FOREIGN_KEY                                        = "42Y05";
     String LANG_CURRENT_FUNCTION_PATH_SCHEMA_DOES_NOT_EXIST                = "42Y06";

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -3436,6 +3436,27 @@ Guide.
                 <text>Timestamp '{0}' is out of range (~ from 21 Sep 1677 00:12:44 GMT to 11 Apr 2262 23:47:16 GMT).</text>
                 <arg>dateOrTimestamp</arg>
             </msg>
+
+            <msg>
+                <name>44004</name>
+                <text>- Parameter count is wrong (provided {0}, but needs {1})
+  for {2}
+</text>
+                <arg>providedParameterCount</arg>
+                <arg>needsParameterCount</arg>
+                <arg>routineInfo</arg>
+            </msg>
+
+            <msg>
+                <name>44005</name>
+                <text>- ERROR for parameter {0}: {1}:
+  for {2}
+</text>
+                <arg>parameterNumber</arg>
+                <arg>errorMsg</arg>
+                <arg>routineInfo</arg>
+            </msg>
+
         </family>
 
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -2455,6 +2455,13 @@ Guide.
             </msg>
 
             <msg>
+                <name>42Y03.S.3</name>
+                <text>Could not resolve function or procedure call '{0}':{1}</text>
+                <arg>procedureName</arg>
+                <arg>statement</arg>
+            </msg>
+
+            <msg>
                 <name>42Y04</name>
                 <text>Cannot create a procedure or function with EXTERNAL NAME '{0}' because it is not a list separated by periods. The expected format is &lt;full java path&gt;.&lt;method name&gt;.</text>
                 <arg>name</arg>

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceAdminIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceAdminIT.java
@@ -386,6 +386,36 @@ public class SpliceAdminIT extends SpliceUnitTest {
     }
 
     @Test
+    public void testCallWithWrongParameters() throws Exception {
+        // wrong parameter count
+        try {
+            methodWatcher.execute("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY('hello')");
+        }
+        catch(SQLException e )
+        {
+            Assert.assertEquals(
+                    "java.sql.SQLSyntaxErrorException: Could not resolve function or procedure call 'SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY':\n" +
+                    "- Parameter count is wrong (provided 1, but needs 2)\n" +
+                    "  for SYSCS_SET_GLOBAL_DATABASE_PROPERTY(IN \"KEY\" VARCHAR(128), IN \"VALUE\" VARCHAR(32672))\n",
+                    e.toString());
+        }
+
+        // wrong parameter type
+        try {
+            methodWatcher.execute("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 123, 123 )");
+        }
+        catch(SQLException e )
+        {
+            Assert.assertEquals(
+                    "java.sql.SQLSyntaxErrorException: Could not resolve function or procedure call 'SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY':\n" +
+                    "- ERROR for parameter 0: Cannot convert types 'INTEGER' to 'VARCHAR'.:\n" +
+                    "  for SYSCS_SET_GLOBAL_DATABASE_PROPERTY(IN \"KEY\" VARCHAR(128), IN \"VALUE\" VARCHAR(32672))\n",
+                    e.toString());
+        }
+    }
+
+
+    @Test
     public void testUpdateSchemaOwner() throws Exception {
         String schemaName = "SPLICEADMINITSCHEMAFOO";
         String userName = "SPLICEADMINITUSERFRED";


### PR DESCRIPTION
# Description
Adding better error output for when users try to call functions with wrong parameters.

# Motivation

Users can make various mistakes when calling a function, and the error message should help solving those.
Examples of current behavior:

## parameter count wrong (old behavior)
```
splice> call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'a', 'b', 'c');
ERROR 42Y03: 'SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY' is not recognized as a function or procedure.
```

This is misleading, as there IS a function, however the parameter count is wrong.

## wrong parameter type (old behavior)

```
splice> call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 123, 123 );
ERROR 42846: Cannot convert types 'INTEGER' to 'VARCHAR'.
```

This is better than the behavior when having wrong parameter count. However, when calling a function with multiple parameters, it might not be clear which one of the integers is wrong.

In both cases, error output should list the parameters of the function that was found.

# How to test

New error output looks like this:

## parameter count wrong (NEW behavior)
```
splice> call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'a', 'b', 'c');
ERROR 42Y03: Could not resolve function or procedure call 'SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY':
- Parameter count is wrong (provided 3, but needs 2)
  for SYSCS_SET_GLOBAL_DATABASE_PROPERTY(IN "KEY" VARCHAR(128), IN "VALUE" VARCHAR(32672))
```

## wrong parameter type (NEW behavior)
```
splice> call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 123, 123 );
ERROR 42Y03: Could not resolve function or procedure call 'SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY':
- ERROR for parameter 0: Cannot convert types 'INTEGER' to 'VARCHAR'.:
  for SYSCS_SET_GLOBAL_DATABASE_PROPERTY(IN "KEY" VARCHAR(128), IN "VALUE" VARCHAR(32672))
```