### PR TITLE
DB-10597 Support DB2 style varchar comparison.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/StoredFormatIds.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/StoredFormatIds.java
@@ -1370,6 +1370,11 @@ public interface StoredFormatIds {
     int SQL_VARCHAR_ID =
             (MIN_ID_2 + 85);
 
+    // A special internal format id, only to be
+    // used for spark ValueRow serialization.
+    int SQL_VARCHAR_DB2_COMPATIBLE_ID =
+            (MIN_ID_2 + 86);
+
     int LIST_ID =
         (MIN_ID_2 + 478);
     

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
@@ -82,7 +82,7 @@ public interface CompilerContext extends Context
         ON,     // Process the operation using UnSafeRows if the source operation produces them.
         OFF,    // Process the operation using Derby rows.
         FORCED  // Convert the source operation's rows into UnSafeRows,
-            // then process the current operation using UnSafeRows, if possible.
+                // then process the current operation using UnSafeRows, if possible.
     }
 
     enum NewMergeJoinExecutionType {
@@ -187,6 +187,7 @@ public interface CompilerContext extends Context
     boolean DEFAULT_SSQ_FLATTENING_FOR_UPDATE_DISABLED = false;
     NewMergeJoinExecutionType DEFAULT_SPLICE_NEW_MERGE_JOIN = NewMergeJoinExecutionType.SYSTEM;
     boolean DEFAULT_DISABLE_PARALLEL_TASKS_JOIN_COSTING = false;
+    boolean DEFAULT_SPLICE_DB2_VARCHAR_COMPATIBLE = false;
 
     /////////////////////////////////////////////////////////////////////////////////////
     //
@@ -738,4 +739,8 @@ public interface CompilerContext extends Context
     void setDisablePerParallelTaskJoinCosting(boolean newValue);
 
     boolean getDisablePerParallelTaskJoinCosting();
+
+    void setVarcharDB2CompatibilityMode(boolean newValue);
+
+    boolean getVarcharDB2CompatibilityMode();
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLVarchar.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLVarchar.java
@@ -56,7 +56,7 @@ class CollatorSQLVarchar extends SQLVarchar implements CollationElementsInterfac
 	/*
 	 * constructors
 	 */
-    CollatorSQLVarchar()
+    public CollatorSQLVarchar()
     {
 
     }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLVarchar.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLVarchar.java
@@ -56,6 +56,10 @@ class CollatorSQLVarchar extends SQLVarchar implements CollationElementsInterfac
 	/*
 	 * constructors
 	 */
+    CollatorSQLVarchar()
+    {
+
+    }
 
     /**
      * Create SQL VARCHAR value initially set to NULL that

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLVarcharDB2Compatible.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLVarcharDB2Compatible.java
@@ -36,32 +36,20 @@ import com.splicemachine.db.iapi.services.sanity.SanityManager;
 
 import java.text.RuleBasedCollator;
 
-/**
- * CollatorSQLVarchar class differs from SQLVarchar based on how the 2 classes  
- * use different collations to collate their data. SQLVarchar uses Derby's 
- * default collation which is UCS_BASIC. Whereas, this class uses the 
- * RuleBasedCollator object that was passed to it in it's constructor and that 
- * RuleBasedCollator object decides the collation.
- * 
- * In Derby 10.3, this class will be passed a RuleBasedCollator which is based 
- * on the database's territory. In future releases of Derby, this class can be 
- * used to do other kinds of collations like case-insensitive collation etc by  
- * just passing an appropriate RuleBasedCollator object for that kind of 
- * collation.
- */
-class CollatorSQLVarchar extends SQLVarchar implements CollationElementsInterface
+
+class CollatorSQLVarcharDB2Compatible extends SQLVarcharDB2Compatible implements CollationElementsInterface
 {
 	private WorkHorseForCollatorDatatypes holderForCollationSensitiveInfo = null;
 
 	/*
 	 * constructors
 	 */
-
+    
     /**
      * Create SQL VARCHAR value initially set to NULL that
      * performs collation according to collatorForCharacterDatatypes 
      */
-    CollatorSQLVarchar(RuleBasedCollator collatorForCharacterDatatypes)
+    CollatorSQLVarcharDB2Compatible(RuleBasedCollator collatorForCharacterDatatypes)
     {
         setCollator(collatorForCharacterDatatypes);
     }
@@ -70,12 +58,11 @@ class CollatorSQLVarchar extends SQLVarchar implements CollationElementsInterfac
      * Create SQL VARCHAR value initially set to value that
      * performs collation according to collatorForCharacterDatatypes 
      */
-	CollatorSQLVarchar(String val, RuleBasedCollator collatorForCharacterDatatypes)
+	CollatorSQLVarcharDB2Compatible(String val, RuleBasedCollator collatorForCharacterDatatypes)
 	{
 		super(val);
         setCollator(collatorForCharacterDatatypes);
 	}
-
 
 	/*
 	 * DataValueDescriptor interface
@@ -88,7 +75,7 @@ class CollatorSQLVarchar extends SQLVarchar implements CollationElementsInterfac
 	{
 		try
 		{
-			return new CollatorSQLVarchar(getString(), 
+			return new CollatorSQLVarcharDB2Compatible(getString(),
 					holderForCollationSensitiveInfo.getCollatorForCollation());
 		}
 		catch (StandardException se)
@@ -104,13 +91,13 @@ class CollatorSQLVarchar extends SQLVarchar implements CollationElementsInterfac
 	 */
 	public DataValueDescriptor getNewNull()
 	{
-		return new CollatorSQLVarchar(
+		return new CollatorSQLVarcharDB2Compatible(
 				holderForCollationSensitiveInfo.getCollatorForCollation());
 	}
 
 	protected StringDataValue getNewVarchar() throws StandardException
 	{
-		return new CollatorSQLVarchar(
+		return new CollatorSQLVarcharDB2Compatible(
 				holderForCollationSensitiveInfo.getCollatorForCollation());
 	}
 
@@ -133,12 +120,13 @@ class CollatorSQLVarchar extends SQLVarchar implements CollationElementsInterfac
 		} else {
 			//null collatorForComparison means use UCS_BASIC for collation.
 			//For that, we need to use the base class SQLVarchar
-			SQLVarchar s = new SQLVarchar();
+			SQLVarcharDB2Compatible s = new SQLVarcharDB2Compatible();
 			s.copyState(this);
 			return s;
 		}
 	}
 
+	/** @see SQLChar#stringCompare(SQLChar, SQLChar) */
 	 protected int stringCompare(SQLChar char1, SQLChar char2)
 	 throws StandardException
 	 {
@@ -154,6 +142,7 @@ class CollatorSQLVarchar extends SQLVarchar implements CollationElementsInterfac
      public int hashCode() {
          return hashCodeForCollation();
      }
+
 
 	/**
 	 * Set the RuleBasedCollator for this instance of CollatorSQLVarchar. It will

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLVarcharDB2Compatible.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLVarcharDB2Compatible.java
@@ -45,7 +45,7 @@ class CollatorSQLVarcharDB2Compatible extends SQLVarcharDB2Compatible implements
 	 * constructors
 	 */
 
-    CollatorSQLVarcharDB2Compatible()
+    public CollatorSQLVarcharDB2Compatible()
     {
 
     }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLVarcharDB2Compatible.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/CollatorSQLVarcharDB2Compatible.java
@@ -44,7 +44,12 @@ class CollatorSQLVarcharDB2Compatible extends SQLVarcharDB2Compatible implements
 	/*
 	 * constructors
 	 */
-    
+
+    CollatorSQLVarcharDB2Compatible()
+    {
+
+    }
+
     /**
      * Create SQL VARCHAR value initially set to NULL that
      * performs collation according to collatorForCharacterDatatypes 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueFactory.java
@@ -188,6 +188,13 @@ public interface DataValueFactory
          */
         StringDataValue getVarcharDataValue(String value, StringDataValue previous,
                 int collationType) throws StandardException;
+
+        StringDataValue getVarcharDB2CompatibleDataValue(String value);
+        StringDataValue getVarcharDB2CompatibleDataValue(String value, StringDataValue previous)
+            throws StandardException;
+        StringDataValue getVarcharDB2CompatibleDataValue(String value, StringDataValue previous,
+                int collationType) throws StandardException;
+
         /**
          * Get a SQL long varchar with the given value.  A null argument means
          * get a SQL null value.
@@ -677,19 +684,28 @@ public interface DataValueFactory
          * that value.
          *
          */
-        StringDataValue         getNullVarchar(StringDataValue dataValue);
+        StringDataValue getNullVarchar(StringDataValue dataValue);
 
         /**
          * Get a SQL VARCHAR set to NULL with collation set to collationType.
          * If the supplied value is null then get a new value,
          * otherwise set it to null and return that value.
          */
-        StringDataValue         getNullVarchar(StringDataValue dataValue,
-                int collationType)
-        throws StandardException;
+        StringDataValue getNullVarchar(StringDataValue dataValue,
+                                       int collationType)
+                        throws StandardException;
 
         StringDataValue getNullVarchar(StringDataValue previous, int collationType, int maxSize)
-        throws StandardException;
+                        throws StandardException;
+
+        StringDataValue getNullVarcharDB2Compatible(StringDataValue dataValue);
+
+        StringDataValue getNullVarcharDB2Compatible(StringDataValue dataValue,
+                                                    int collationType)
+                        throws StandardException;
+
+        StringDataValue getNullVarcharDB2Compatible(StringDataValue previous, int collationType, int maxSize)
+                        throws StandardException;
 
         /**
          * Get a SQL LONG VARCHAR (UCS_BASIC) with a SQL null value. If the supplied value

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueFactoryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueFactoryImpl.java
@@ -1290,6 +1290,7 @@ public abstract class DataValueFactoryImpl implements DataValueFactory, ModuleCo
             case StoredFormatIds.SQL_TIMESTAMP_ID: return new SQLTimestamp();
             case StoredFormatIds.SQL_TINYINT_ID: return new SQLTinyint();
             case StoredFormatIds.SQL_VARCHAR_ID: return new SQLVarchar();
+            case StoredFormatIds.SQL_VARCHAR_DB2_COMPATIBLE_ID: return new SQLVarcharDB2Compatible();
             case StoredFormatIds.SQL_LONGVARCHAR_ID: return new SQLLongvarchar();
             case StoredFormatIds.SQL_VARBIT_ID: return new SQLVarbit();
             case StoredFormatIds.SQL_LONGVARBIT_ID: return new SQLLongVarbit();

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueFactoryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueFactoryImpl.java
@@ -409,12 +409,25 @@ public abstract class DataValueFactoryImpl implements DataValueFactory, ModuleCo
                 return new SQLVarchar(value);
         }
 
-        public StringDataValue getVarcharDataValue(String value,
-                                                                                                StringDataValue previous)
-                                                                                                        throws StandardException
+        public StringDataValue getVarcharDB2CompatibleDataValue(String value)
+        {
+                return new SQLVarcharDB2Compatible(value);
+        }
+
+        public StringDataValue getVarcharDataValue(String value, StringDataValue previous)
+                               throws StandardException
         {
                 if (previous == null)
                         return new SQLVarchar(value);
+                previous.setValue(value);
+                return previous;
+        }
+
+        public StringDataValue getVarcharDB2CompatibleDataValue(String value, StringDataValue previous)
+                               throws StandardException
+        {
+                if (previous == null)
+                        return new SQLVarcharDB2Compatible(value);
                 previous.setValue(value);
                 return previous;
         }
@@ -432,6 +445,21 @@ public abstract class DataValueFactoryImpl implements DataValueFactory, ModuleCo
 
             if (previous == null)
                 return new CollatorSQLVarchar(value,
+                        getCharacterCollator(collationType));
+
+            previous.setValue(value);
+            return previous;
+        }
+
+        public StringDataValue getVarcharDB2CompatibleDataValue(String value,
+                StringDataValue previous, int collationType)
+            throws StandardException
+        {
+            if (collationType == StringDataValue.COLLATION_TYPE_UCS_BASIC)
+                return getVarcharDB2CompatibleDataValue(value, previous);
+
+            if (previous == null)
+                return new CollatorSQLVarcharDB2Compatible(value,
                         getCharacterCollator(collationType));
 
             previous.setValue(value);
@@ -864,6 +892,53 @@ public abstract class DataValueFactoryImpl implements DataValueFactory, ModuleCo
                     ret = (SQLVarchar) getVarcharDataValue((String) null);
             } else {
                     ret = new CollatorSQLVarchar(getCharacterCollator(collationType));
+            }
+            ret.setSqlCharSize(maxSize);
+
+            return ret;
+        }
+
+        public StringDataValue getNullVarcharDB2Compatible(StringDataValue dataValue)
+        {
+                if (dataValue == null)
+                {
+                        return getVarcharDB2CompatibleDataValue((String) null);
+                }
+                else
+                {
+                        dataValue.setToNull();
+                        return dataValue;
+                }
+        }
+
+        public StringDataValue getNullVarcharDB2Compatible(StringDataValue previous,
+                int collationType)
+        throws StandardException
+        {
+            if (collationType == StringDataValue.COLLATION_TYPE_UCS_BASIC)
+                return getNullChar(previous);
+
+            if (previous == null)
+                return new CollatorSQLVarcharDB2Compatible(getCharacterCollator(collationType));
+
+            previous.setToNull();
+            return previous;
+        }
+
+        public StringDataValue getNullVarcharDB2Compatible(StringDataValue previous, int collationType, int maxSize)
+        throws StandardException
+        {
+            if (previous != null) {
+                previous.setToNull();
+                return previous;
+            }
+
+            SQLVarcharDB2Compatible ret = null;
+
+            if (collationType == StringDataValue.COLLATION_TYPE_UCS_BASIC) {
+                    ret = (SQLVarcharDB2Compatible) getVarcharDB2CompatibleDataValue((String) null);
+            } else {
+                    ret = new CollatorSQLVarcharDB2Compatible(getCharacterCollator(collationType));
             }
             ret.setSqlCharSize(maxSize);
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLVarchar.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLVarchar.java
@@ -35,6 +35,7 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.types.DataValueFactoryImpl.Format;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.sql.Clob;
 import java.text.RuleBasedCollator;
@@ -272,6 +273,7 @@ public class SQLVarchar
     /**
      @exception StandardException thrown on error
      */
+    @SuppressFBWarnings(value = "RV_NEGATING_RESULT_OF_COMPARETO", justification = "Intentional negation of return value.")
     public int compare(DataValueDescriptor other) throws StandardException {
         /* Use compare method from dominant type, negating result
          * to reflect flipping of sides.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -629,6 +629,19 @@ public class GenericStatement implements Statement{
             }
             cc.setSSQFlatteningForUpdateDisabled(ssqFlatteningForUpdateDisabled);
 
+            String varcharDB2CompatibilityModeString =
+                    PropertyUtil.getCachedDatabaseProperty(lcc, Property.SPLICE_DB2_VARCHAR_COMPATIBLE);
+            boolean varcharDB2CompatibilityMode = CompilerContext.DEFAULT_SPLICE_DB2_VARCHAR_COMPATIBLE;
+            try {
+                if (varcharDB2CompatibilityModeString != null)
+                    varcharDB2CompatibilityMode =
+                            Boolean.parseBoolean(varcharDB2CompatibilityModeString);
+            } catch (Exception e) {
+                // If the property value failed to convert to a boolean, don't throw an error,
+                // just use the default setting.
+            }
+            cc.setVarcharDB2CompatibilityMode(varcharDB2CompatibilityMode);
+
             fourPhasePrepare(lcc,paramDefaults,timestamps,beginTimestamp,foundInCache,cc);
         }catch(StandardException se){
             if(foundInCache)

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
@@ -290,6 +290,12 @@ public class CompilerContextImpl extends ContextImpl
 
     public boolean getDisablePerParallelTaskJoinCosting() { return disablePerParallelTaskJoinCosting; }
 
+    public void setVarcharDB2CompatibilityMode(boolean newValue) {
+        varcharDB2CompatibilityMode = newValue;
+    }
+
+    public boolean getVarcharDB2CompatibilityMode() { return varcharDB2CompatibilityMode; }
+
     public void setCurrentTimestampPrecision(int newValue) {
         currentTimestampPrecision = newValue;
     }
@@ -1175,6 +1181,7 @@ public class CompilerContextImpl extends ContextImpl
     private boolean             ssqFlatteningForUpdateDisabled;
     private NewMergeJoinExecutionType newMergeJoin = DEFAULT_SPLICE_NEW_MERGE_JOIN;
     private boolean disablePerParallelTaskJoinCosting = DEFAULT_DISABLE_PARALLEL_TASKS_JOIN_COSTING;
+    private boolean varcharDB2CompatibilityMode = DEFAULT_SPLICE_DB2_VARCHAR_COMPATIBLE;
     /**
      * Saved execution time default schema, if we need to change it
      * temporarily.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
@@ -42,10 +42,7 @@ import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.sql.compile.NodeFactory;
 import com.splicemachine.db.iapi.sql.compile.Optimizable;
-import com.splicemachine.db.iapi.types.DataTypeDescriptor;
-import com.splicemachine.db.iapi.types.DataValueDescriptor;
-import com.splicemachine.db.iapi.types.ListDataType;
-import com.splicemachine.db.iapi.types.TypeId;
+import com.splicemachine.db.iapi.types.*;
 
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -172,6 +169,8 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 		else if (allLeftOperandsColumnReferences() &&
 			     rightOperandList.containsOnlyConstantAndParamNodes())
 		{
+			boolean DB2CompatibilityMode = getCompilerContext().getVarcharDB2CompatibilityMode();
+
 			/* At this point we have an IN-list made up of constant and/or
 			 * parameter values.  Ex.:
 			 *
@@ -293,11 +292,22 @@ public final class InListOperatorNode extends BinaryListOperatorNode
                 
                 if (singleLeftOperand) {
                     judgeODV = ((DataTypeDescriptor) targetTypes.get(0)).getNull();
+                    if ((judgeODV instanceof SQLVarchar) && DB2CompatibilityMode) {
+                    	SQLVarcharDB2Compatible newDVD = new SQLVarcharDB2Compatible();
+                    	newDVD.setSqlCharSize(((SQLVarchar)judgeODV).getSqlCharSize());
+						judgeODV = newDVD;
+					}
                 }
                 else {
                     ListDataType ldt = new ListDataType(leftOperandList.size());
                     for (int j = 0; j < leftOperandList.size(); j++) {
-                        ldt.setFrom(((DataTypeDescriptor) targetTypes.get(j)).getNull(), j);
+                    	judgeODV = ((DataTypeDescriptor) targetTypes.get(j)).getNull();
+						if ((judgeODV instanceof SQLVarchar) && DB2CompatibilityMode) {
+							SQLVarcharDB2Compatible newDVD = new SQLVarcharDB2Compatible();
+							newDVD.setSqlCharSize(((SQLVarchar)judgeODV).getSqlCharSize());
+							judgeODV = newDVD;
+						}
+                        ldt.setFrom(judgeODV, j);
                     }
                     judgeODV = ldt;
                 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
@@ -52,6 +52,8 @@ import org.apache.spark.sql.types.StructField;
 import java.util.Collections;
 import java.util.List;
 
+import static com.splicemachine.db.impl.sql.compile.CharTypeCompiler.getDB2CompatibilityMode;
+
 /**
  * A ResultColumn represents a result column in a SELECT, INSERT, or UPDATE
  * statement.  In a SELECT statement, the result column just represents an
@@ -1818,7 +1820,8 @@ public class ResultColumn extends ValueNode
                 String sourceValue = constantValue.getString();
                 int sourceWidth = sourceValue.length();
                 int posn;
-
+                boolean DB2CompatibilityMode =
+                        getCompilerContext().getVarcharDB2CompatibilityMode();
                 /*
                 ** If the input is already the right length, no normalization is
                 ** necessary - just return the source.
@@ -1827,8 +1830,12 @@ public class ResultColumn extends ValueNode
 
                 if (sourceWidth <= maxWidth)
                 {
-                    if(formatId == StoredFormatIds.VARCHAR_TYPE_ID)
-                        return dvf.getVarcharDataValue(sourceValue);
+                    if(formatId == StoredFormatIds.VARCHAR_TYPE_ID) {
+                        if (DB2CompatibilityMode)
+                            return dvf.getVarcharDB2CompatibleDataValue(sourceValue);
+                        else
+                            return dvf.getVarcharDataValue(sourceValue);
+                    }
                 }
 
                 /*
@@ -1848,8 +1855,12 @@ public class ResultColumn extends ValueNode
                     }
                 }
 
-                if (formatId == StoredFormatIds.VARCHAR_TYPE_ID)
-                    return dvf.getVarcharDataValue(sourceValue.substring(0, maxWidth));
+                if (formatId == StoredFormatIds.VARCHAR_TYPE_ID) {
+                    if (DB2CompatibilityMode)
+                        return dvf.getVarcharDB2CompatibleDataValue(sourceValue.substring(0, maxWidth));
+                    else
+                        return dvf.getVarcharDataValue(sourceValue.substring(0, maxWidth));
+                }
 
             case StoredFormatIds.LONGVARCHAR_TYPE_ID:
                 //No need to check widths here (unlike varchar), since no max width

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNodeList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNodeList.java
@@ -782,6 +782,7 @@ public class ValueNodeList extends QueryTreeNodeVector
 		int numNodes = dtdList.size();
 		int [] maxSize = new int[numNodes];
 		String [] typeid = new String[numNodes];
+		boolean DB2CompatibilityMode = getCompilerContext().getVarcharDB2CompatibilityMode();
 
 		
 		for (int i = 0; i < numNodes; i++) {
@@ -797,7 +798,7 @@ public class ValueNodeList extends QueryTreeNodeVector
 
 					CharConstantNode charConstantNode = (CharConstantNode)valueNode;
 
-					if (!(charConstantNode.getValue() instanceof SQLVarchar)) {
+					if (!DB2CompatibilityMode && !(charConstantNode.getValue() instanceof SQLVarchar)) {
 						charConstantNode.setValue(new SQLVarchar(charConstantNode.getString()));
 					}
 				}

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1514,6 +1514,8 @@ public interface Property {
 
     String SPLICE_DB2_IMPORT_EMPTY_STRING_COMPATIBLE = "splice.db2.import.empty_string_compatible";
 
+    String SPLICE_DB2_VARCHAR_COMPATIBLE = "splice.db2.varchar.compatible";
+
     String SPLICE_NEW_MERGE_JOIN =
             "splice.execution.newMergeJoin";
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
@@ -220,6 +220,16 @@ public class SpliceSparkKryoRegistrator implements KryoRegistrator, KryoPool.Kry
                 dvd.setValue(input.readString());
             }
         });
+        instance.register(SQLVarcharDB2Compatible.class,new DataValueDescriptorSerializer<SQLVarcharDB2Compatible>() {
+            @Override
+            protected void writeValue(Kryo kryo, Output output, SQLVarcharDB2Compatible object) throws StandardException {
+                output.writeString(object.getString());
+            }
+            @Override
+            protected void readValue(Kryo kryo, Input input, SQLVarcharDB2Compatible dvd) {
+                dvd.setValue(input.readString());
+            }
+        });
         instance.register(SQLLongvarchar.class,new DataValueDescriptorSerializer<SQLLongvarchar>() {
             @Override
             protected void writeValue(Kryo kryo, Output output, SQLLongvarchar object) throws StandardException {

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSetProcessor.java
@@ -1036,4 +1036,11 @@ public class SparkDataSetProcessor implements DistributedDataSetProcessor, Seria
         SparkDataSet rdd = new SparkDataSet(SpliceSpark.getContext().parallelize(partitions, partitions.size()));
         return rdd.flatMap(new KafkaReadFunction(context, topicName, bootstrapServers));
     }
+
+    @Override
+    public boolean isSparkDB2CompatibilityMode() {
+        if (broadcastedActivation == null)
+            return false;
+        return broadcastedActivation.isDB2VarcharCompatibilityMode();
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
+++ b/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
@@ -492,6 +492,17 @@ public class SpliceKryoRegistry implements KryoPool.KryoRegistry{
                 object.setValue(input.readDouble());
             }
         }, 45);
+        instance.register(SQLVarcharDB2Compatible.class,new DataValueDescriptorSerializer<SQLVarcharDB2Compatible>(){
+            @Override
+            protected void writeValue(Kryo kryo,Output output,SQLVarcharDB2Compatible object) throws StandardException{
+                output.writeString(object.getString());
+            }
+
+            @Override
+            protected void readValue(Kryo kryo,Input input,SQLVarcharDB2Compatible dvd){
+                dvd.setValue(input.readString());
+            }
+        },46);
         /*instance.register(SQLRef.class, new DataValueDescriptorSerializer<SQLRef>() {
             @Override
             protected void writeValue(Kryo kryo, Output output, SQLRef object) throws StandardException {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
@@ -34,8 +34,6 @@ public class MergeSortJoinStrategy extends HashableJoinStrategy {
                             Optimizer optimizer,
                             CostEstimate outerCost,boolean wasHinted,
                             boolean skipKeyCheck) throws StandardException {
-        if (predList != null && ((PredicateList)predList).getCompilerContext().getVarcharDB2CompatibilityMode())
-            return false;
 		return super.feasible(innerTable, predList, optimizer,outerCost,wasHinted,skipKeyCheck);
 	}
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
@@ -20,6 +20,7 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.compile.*;
 import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.impl.sql.compile.HashableJoinStrategy;
+import com.splicemachine.db.impl.sql.compile.PredicateList;
 import com.splicemachine.db.impl.sql.compile.SelectivityUtil;
 
 public class MergeSortJoinStrategy extends HashableJoinStrategy {
@@ -33,6 +34,8 @@ public class MergeSortJoinStrategy extends HashableJoinStrategy {
                             Optimizer optimizer,
                             CostEstimate outerCost,boolean wasHinted,
                             boolean skipKeyCheck) throws StandardException {
+        if (predList != null && ((PredicateList)predList).getCompilerContext().getVarcharDB2CompatibilityMode())
+            return false;
 		return super.feasible(innerTable, predList, optimizer,outerCost,wasHinted,skipKeyCheck);
 	}
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastFullOuterJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastFullOuterJoinOperation.java
@@ -119,6 +119,7 @@ public class BroadcastFullOuterJoinOperation extends BroadcastJoinOperation {
 
         DataSet<ExecRow> result;
         boolean usesNativeSparkDataSet =
+                !dsp.isSparkDB2CompatibilityMode() &&
                 (dsp.getType().equals(DataSetProcessor.Type.SPARK) &&
                         (restriction == null || hasSparkJoinPredicate()) &&
                         !containsUnsafeSQLRealComparison());

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
@@ -183,6 +183,7 @@ public class BroadcastJoinOperation extends JoinOperation{
 
         DataSet<ExecRow> result;
         boolean usesNativeSparkDataSet =
+           !dsp.isSparkDB2CompatibilityMode() &&
            (useDataset && dsp.getType().equals(DataSetProcessor.Type.SPARK) &&
              ((restriction == null || hasSparkJoinPredicate()) || (!isOuterJoin() && !isAntiJoin() && !isOneRowRightSide())) &&
               !containsUnsafeSQLRealComparison());

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/CrossJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/CrossJoinOperation.java
@@ -104,7 +104,8 @@ public class CrossJoinOperation extends JoinOperation{
 
         OperationContext operationContext = dsp.createOperationContext(this);
         dsp.incrementOpDepth();
-        boolean usesNativeSparkDataSet = 
+        boolean usesNativeSparkDataSet =
+           !dsp.isSparkDB2CompatibilityMode() &&
            dsp.getType().equals(DataSetProcessor.Type.SPARK) &&
                 (this.leftHashKeys.length == 0 || !containsUnsafeSQLRealComparison());
         if (usesNativeSparkDataSet)

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctScalarAggregateOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctScalarAggregateOperation.java
@@ -114,13 +114,13 @@ public class DistinctScalarAggregateOperation extends GenericAggregateOperation 
         dsp.decrementOpDepth();
         DataSet<ExecRow> dataSetWithNativeSparkAggregation = null;
 
-        if (nativeSparkForced())
+        if (nativeSparkForced(dsp))
             dataSet = dataSet.upgradeToSparkNativeDataSet(operationContext);
 
         // If the aggregation can be applied using native Spark UnsafeRow, then do so
         // and return immediately.  Otherwise, use traditional Splice lower-level
         // functional APIs.
-        if (nativeSparkEnabled())
+        if (nativeSparkEnabled(dsp))
             dataSetWithNativeSparkAggregation =
                 dataSet.applyNativeSparkAggregation(null, aggregates,
                                                     false, operationContext);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/GenericAggregateOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/GenericAggregateOperation.java
@@ -27,6 +27,7 @@ import com.splicemachine.derby.iapi.sql.execute.SpliceOperationContext;
 import com.splicemachine.derby.impl.sql.execute.operations.framework.DerbyAggregateContext;
 import com.splicemachine.derby.impl.sql.execute.operations.framework.SpliceGenericAggregator;
 import com.splicemachine.derby.impl.sql.execute.operations.iapi.AggregateContext;
+import com.splicemachine.derby.stream.iapi.DataSetProcessor;
 import com.splicemachine.utils.SpliceLogUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.log4j.Logger;
@@ -76,12 +77,14 @@ public abstract class GenericAggregateOperation extends SpliceBaseOperation {
 					this.nativeSparkMode = nativeSparkMode;
 		}
 
-		public boolean nativeSparkForced() {
-			return nativeSparkMode == CompilerContext.NativeSparkModeType.FORCED;
+		public boolean nativeSparkForced(DataSetProcessor dsp) {
+			return nativeSparkMode == CompilerContext.NativeSparkModeType.FORCED &&
+			       !dsp.isSparkDB2CompatibilityMode();
 		}
-		public boolean nativeSparkEnabled() {
-			return nativeSparkMode == CompilerContext.NativeSparkModeType.ON ||
-			       nativeSparkMode == CompilerContext.NativeSparkModeType.FORCED;
+		public boolean nativeSparkEnabled(DataSetProcessor dsp) {
+			return (nativeSparkMode == CompilerContext.NativeSparkModeType.ON ||
+			        nativeSparkMode == CompilerContext.NativeSparkModeType.FORCED) &&
+				   !dsp.isSparkDB2CompatibilityMode();
 		}
 		public boolean nativeSparkUsed() { return nativeSparkUsed; }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/GroupedAggregateOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/GroupedAggregateOperation.java
@@ -151,7 +151,7 @@ public class GroupedAggregateOperation extends GenericAggregateOperation {
         dsp.decrementOpDepth();
         DataSet dataSetWithNativeSparkAggregation = null;
 
-        if (nativeSparkForced() && (isRollup || aggregates.length > 0))
+        if (nativeSparkForced(dsp) && (isRollup || aggregates.length > 0))
             set = set.upgradeToSparkNativeDataSet(operationContext);
 
         operationContext.pushScope();
@@ -166,7 +166,7 @@ public class GroupedAggregateOperation extends GenericAggregateOperation {
         // If the aggregation can be applied using native Spark UnsafeRow, then do so
         // and return immediately.  Otherwise, use traditional Splice lower-level
         // functional APIs.
-        if (nativeSparkEnabled())
+        if (nativeSparkEnabled(dsp))
             dataSetWithNativeSparkAggregation =
                 set.applyNativeSparkAggregation(extendedGroupBy, aggregates,
                                                 isRollup, operationContext);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeSortJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeSortJoinOperation.java
@@ -165,6 +165,7 @@ public class MergeSortJoinOperation extends JoinOperation {
         OperationContext<JoinOperation> operationContext = dsp.<JoinOperation>createOperationContext(this);
         dsp.incrementOpDepth();
         boolean useNativeSparkJoin = (dsp.getType().equals(DataSetProcessor.Type.SPARK)   &&
+                                      !dsp.isSparkDB2CompatibilityMode()               &&
                                       (restriction == null || hasSparkJoinPredicate()) &&
                                       !rightFromSSQ && !containsUnsafeSQLRealComparison());
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScalarAggregateOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScalarAggregateOperation.java
@@ -113,13 +113,13 @@ public class ScalarAggregateOperation extends GenericAggregateOperation {
         dsp.decrementOpDepth();
         DataSet<ExecRow> dataSetWithNativeSparkAggregation = null;
 
-        if (nativeSparkForced())
+        if (nativeSparkForced(dsp))
             dsSource = dsSource.upgradeToSparkNativeDataSet(operationContext);
 
         // If the aggregation can be applied using native Spark UnsafeRow, then do so
         // and return immediately.  Otherwise, use traditional Splice lower-level
         // functional APIs.
-        if (nativeSparkEnabled())
+        if (nativeSparkEnabled(dsp))
             dataSetWithNativeSparkAggregation =
                 dsSource.applyNativeSparkAggregation(null, aggregates,
                                                      false, operationContext);

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlDataSetProcessor.java
@@ -426,4 +426,7 @@ public class ControlDataSetProcessor implements DataSetProcessor{
     public <V> DataSet<ExecRow> readKafkaTopic(String topicName, OperationContext context) throws StandardException {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public boolean isSparkDB2CompatibilityMode() { return false; }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSetProcessor.java
@@ -284,4 +284,6 @@ public interface DataSetProcessor {
     // <- End operations related to spark explain.
 
     <V> DataSet<ExecRow> readKafkaTopic(String topicName, OperationContext op) throws StandardException;
+
+    boolean isSparkDB2CompatibilityMode();
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ForwardingDataSetProcessor.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/utils/ForwardingDataSetProcessor.java
@@ -239,4 +239,7 @@ public abstract class ForwardingDataSetProcessor implements DataSetProcessor{
     public <V> DataSet<ExecRow> readKafkaTopic(String topicName, OperationContext context) throws StandardException {
         return delegate.readKafkaTopic(topicName, context);
     }
+
+    @Override
+    public boolean isSparkDB2CompatibilityMode() { return delegate.isSparkDB2CompatibilityMode(); }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/EngineUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/EngineUtils.java
@@ -24,6 +24,7 @@ import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.db.iapi.types.SQLVarcharDB2Compatible;
 import com.splicemachine.db.impl.jdbc.EmbedConnection;
 import com.splicemachine.db.impl.jdbc.EmbedDatabaseMetaData;
 import com.splicemachine.pipeline.ErrorState;
@@ -32,6 +33,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
+import static com.splicemachine.db.iapi.services.io.StoredFormatIds.SQL_VARCHAR_DB2_COMPATIBLE_ID;
 
 /**
  * @author Scott Fines
@@ -52,7 +55,10 @@ public class EngineUtils{
     public static int[] getFormatIds(DataValueDescriptor[] dvds) {
         int[] ids = new int [dvds.length];
         for (int i = 0; i < dvds.length; ++i) {
-            ids[i] = dvds[i].getTypeFormatId();
+            if (dvds[i] instanceof SQLVarcharDB2Compatible)
+                ids[i] = SQL_VARCHAR_DB2_COMPATIBLE_ID;
+            else
+                ids[i] = dvds[i].getTypeFormatId();
         }
         return ids;
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/Scans.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/Scans.java
@@ -276,7 +276,7 @@ public class Scans extends SpliceUtils {
                     if (!isEmpty(keyDecodingMap) && keyDecodingMap[i] >= 0 && !isEmpty(keyTablePositionMap)) {
                         DataValueDescriptor targetDesc = scannedRow.getColumn(keyTablePositionMap[keyDecodingMap[i]] + 1); // the maps are 0-based, get Column is 1-based
                         if (!rowIdKey) {
-                            startKeyValue[i] = QualifierUtils.adjustDataValueDescriptor(startDesc, targetDesc, dataValueFactory);
+                            startKeyValue[i] = QualifierUtils.adjustDataValueDescriptor(startDesc, targetDesc, dataValueFactory, true);
                         }
                     }
                 }
@@ -297,7 +297,7 @@ public class Scans extends SpliceUtils {
                     if (!isEmpty(keyDecodingMap) && !isEmpty(keyTablePositionMap)) {
                         DataValueDescriptor targetDesc = scannedRow.getColumn(keyTablePositionMap[keyDecodingMap[i]] + 1);
                         if (!rowIdKey) {
-                            stop[i] = QualifierUtils.adjustDataValueDescriptor(stopDesc, targetDesc, dataValueFactory);
+                            stop[i] = QualifierUtils.adjustDataValueDescriptor(stopDesc, targetDesc, dataValueFactory, false);
                         }
                     }
                 }
@@ -427,7 +427,7 @@ public class Scans extends SpliceUtils {
                         int targetColFormatId = columnTypes[keyTablePositionMap[keyDecodingMap[i]]];
                         DataValueDescriptor targetDesc = templateRow.getColumn(keyTablePositionMap[keyDecodingMap[i]] + 1); // the maps are 0-based, get Column is 1-based
                         if (startDesc.getTypeFormatId() != targetColFormatId && !rowIdKey) {
-                            startKeyValue[i] = QualifierUtils.adjustDataValueDescriptor(startDesc, targetDesc, dataValueFactory);
+                            startKeyValue[i] = QualifierUtils.adjustDataValueDescriptor(startDesc, targetDesc, dataValueFactory, true);
                         }
                     }
                 }
@@ -449,7 +449,7 @@ public class Scans extends SpliceUtils {
                         int targetColFormatId = columnTypes[keyTablePositionMap[keyDecodingMap[i]]];
                         DataValueDescriptor targetDesc = templateRow.getColumn(keyTablePositionMap[keyDecodingMap[i]] + 1); // the maps are 0-based, get Column is 1-based
                         if (stopDesc.getTypeFormatId() != targetColFormatId && !rowIdKey) {
-                            stop[i] = QualifierUtils.adjustDataValueDescriptor(stopDesc, targetDesc, dataValueFactory);
+                            stop[i] = QualifierUtils.adjustDataValueDescriptor(stopDesc, targetDesc, dataValueFactory, false);
                         }
                     }
                 }

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
@@ -17,7 +17,6 @@ package com.splicemachine.db.impl.sql.compile;
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
-import com.splicemachine.test.LongerThanTwoMinutes;
 import com.splicemachine.test.SerialTest;
 import com.splicemachine.test_tools.TableCreator;
 import org.junit.*;
@@ -28,11 +27,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import splice.com.google.common.collect.Lists;
 
-import java.math.BigDecimal;
 import java.sql.Connection;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 
 import static com.splicemachine.test_tools.Rows.row;
 import static com.splicemachine.test_tools.Rows.rows;
@@ -137,6 +133,8 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
         testQuery(sqlText, expected, methodWatcher);
         sqlText = format(sqlTemplate, "MERGE");
         testQuery(sqlText, expected, methodWatcher);
+        sqlText = format(sqlTemplate, "SORTMERGE");
+        testQuery(sqlText, expected, methodWatcher);
         sqlText = format(sqlTemplate2, "NESTEDLOOP", "NESTEDLOOP");
         testQuery(sqlText, expected, methodWatcher);
     }
@@ -216,6 +214,8 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
 
         testQuery(sqlText, expected, methodWatcher);
         sqlText = format(sqlTemplate, "MERGE");
+        testQuery(sqlText, expected, methodWatcher);
+        sqlText = format(sqlTemplate, "SORTMERGE");
         testQuery(sqlText, expected, methodWatcher);
         sqlText = format(sqlTemplate2, "NESTEDLOOP", "NESTEDLOOP");
         testQuery(sqlText, expected, methodWatcher);

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
@@ -18,6 +18,7 @@ import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
 import com.splicemachine.test.LongerThanTwoMinutes;
+import com.splicemachine.test.SerialTest;
 import com.splicemachine.test_tools.TableCreator;
 import org.junit.*;
 import org.junit.experimental.categories.Category;
@@ -39,6 +40,7 @@ import static com.splicemachine.test_tools.Rows.rows;
 /**
  * Test DB2 Varchar compatibility mode (ignore trailing spaces in comparisons).
  */
+@Category({SerialTest.class})
 @RunWith(Parameterized.class)
 public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
     

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.test.LongerThanTwoMinutes;
+import com.splicemachine.test_tools.TableCreator;
+import org.junit.*;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import splice.com.google.common.collect.Lists;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static com.splicemachine.test_tools.Rows.row;
+import static com.splicemachine.test_tools.Rows.rows;
+
+/**
+ * Test DB2 Varchar compatibility mode (ignore trailing spaces in comparisons).
+ */
+@RunWith(Parameterized.class)
+public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
+    
+    private Boolean useSpark;
+    
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        Collection<Object[]> params = Lists.newArrayListWithCapacity(2);
+        params.add(new Object[]{true});
+        params.add(new Object[]{false});
+        return params;
+    }
+    public static final String CLASS_NAME = DB2VarcharCompatibilityIT.class.getSimpleName().toUpperCase();
+    protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);
+    protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
+
+    @ClassRule
+    public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
+            .around(spliceSchemaWatcher);
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher(CLASS_NAME);
+    
+    public DB2VarcharCompatibilityIT(Boolean useSpark) {
+        this.useSpark = useSpark;
+    }
+    
+    public static void createData(Connection conn, String schemaName) throws Exception {
+
+        new TableCreator(conn)
+                .withCreate("create table t1 (a int, b varchar(10), primary key(b))")
+                .withInsert("insert into t1 values(?, ?)")
+                .withRows(rows(
+                        row(1, "a"),
+                        row(1, "a "),
+                        row(1, "a  "),
+                        row(1, "a   "),
+                        row(1, "ab"),
+                        row(1, "abc"),
+                        row(1, "a b"),
+                        row(1, "abcd")))
+                .create();
+
+        new TableCreator(conn)
+                .withCreate("create table t11 (a int, b varchar(10))")
+                .create();
+
+        String sqlText = "insert into t11 select * from t1";
+		spliceClassWatcher.executeUpdate(sqlText);
+    }
+
+    @BeforeClass
+    public static void createDataSet() throws Exception {
+        createData(spliceClassWatcher.getOrCreateConnection(), spliceSchemaWatcher.toString());
+        spliceClassWatcher.executeUpdate("call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', true)");
+    }
+
+    @AfterClass
+    public static void exitDB2CompatibilityMode() throws Exception {
+        spliceClassWatcher.executeUpdate("call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', null)");
+    }
+
+    @Test
+    public void testInnerJoin() throws Exception {
+        String sqlTemplate = "select * from t1 a --splice-properties useSpark=" + useSpark.toString() +
+                             ", joinStrategy=%s\n, t1 b where a.b = b.b";
+        String sqlTemplate2 = "select * from t11 a --splice-properties useSpark=" + useSpark.toString() +
+                             ", joinStrategy=%s\n, t11 b --splice-properties joinStrategy=%s\n where a.b = b.b";
+        String sqlText = format(sqlTemplate, "BROADCAST");
+
+        String expected =
+            "A |  B  | A |  B  |\n" +
+            "--------------------\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 | a b | 1 | a b |\n" +
+            " 1 | ab  | 1 | ab  |\n" +
+            " 1 | abc | 1 | abc |\n" +
+            " 1 |abcd | 1 |abcd |";
+
+        testQuery(sqlText, expected, methodWatcher);
+        sqlText = format(sqlTemplate, "MERGE");
+        testQuery(sqlText, expected, methodWatcher);
+        sqlText = format(sqlTemplate2, "NESTEDLOOP", "NESTEDLOOP");
+        testQuery(sqlText, expected, methodWatcher);
+    }
+
+    @Test
+    public void testInequalityJoin() throws Exception {
+        String sqlTemplate = "select * from t1 a --splice-properties useSpark=" + useSpark.toString() +
+                             ", joinStrategy=%s\n, t1 b where a.b > b.b";
+        String sqlTemplate2 = "select * from t11 a --splice-properties useSpark=" + useSpark.toString() +
+                             ", joinStrategy=%s\n, t11 b --splice-properties joinStrategy=%s\n where a.b > b.b";
+        String sqlText = format(sqlTemplate, "BROADCAST");
+
+        String expected =
+            "A |  B  | A | B  |\n" +
+            "-------------------\n" +
+            " 1 | a b | 1 | a  |\n" +
+            " 1 | a b | 1 | a  |\n" +
+            " 1 | a b | 1 | a  |\n" +
+            " 1 | a b | 1 | a  |\n" +
+            " 1 | ab  | 1 | a  |\n" +
+            " 1 | ab  | 1 | a  |\n" +
+            " 1 | ab  | 1 | a  |\n" +
+            " 1 | ab  | 1 | a  |\n" +
+            " 1 | ab  | 1 |a b |\n" +
+            " 1 | abc | 1 | a  |\n" +
+            " 1 | abc | 1 | a  |\n" +
+            " 1 | abc | 1 | a  |\n" +
+            " 1 | abc | 1 | a  |\n" +
+            " 1 | abc | 1 |a b |\n" +
+            " 1 | abc | 1 |ab  |\n" +
+            " 1 |abcd | 1 | a  |\n" +
+            " 1 |abcd | 1 | a  |\n" +
+            " 1 |abcd | 1 | a  |\n" +
+            " 1 |abcd | 1 | a  |\n" +
+            " 1 |abcd | 1 |a b |\n" +
+            " 1 |abcd | 1 |ab  |\n" +
+            " 1 |abcd | 1 |abc |";
+
+        testQuery(sqlText, expected, methodWatcher);
+        sqlText = format(sqlTemplate, "CROSS");
+        testQuery(sqlText, expected, methodWatcher);
+        sqlText = format(sqlTemplate2, "NESTEDLOOP", "NESTEDLOOP");
+        testQuery(sqlText, expected, methodWatcher);
+    }
+
+    @Test
+    public void testOuterJoin() throws Exception {
+        String sqlTemplate = "select * from t1 a --splice-properties useSpark=" + useSpark.toString() +
+                             "\n left outer join t1 b --splice-properties joinStrategy=%s\n on a.b = b.b";
+        String sqlTemplate2 = "select * from t11 a --splice-properties useSpark=" + useSpark.toString() +
+                             ", joinStrategy=%s\n left outer join t1 b --splice-properties joinStrategy=%s\n on a.b = b.b";
+        String sqlText = format(sqlTemplate, "BROADCAST");
+
+        String expected =
+            "A |  B  | A |  B  |\n" +
+            "--------------------\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 |  a  | 1 |  a  |\n" +
+            " 1 | a b | 1 | a b |\n" +
+            " 1 | ab  | 1 | ab  |\n" +
+            " 1 | abc | 1 | abc |\n" +
+            " 1 |abcd | 1 |abcd |";
+
+        testQuery(sqlText, expected, methodWatcher);
+        sqlText = format(sqlTemplate, "MERGE");
+        testQuery(sqlText, expected, methodWatcher);
+        sqlText = format(sqlTemplate2, "NESTEDLOOP", "NESTEDLOOP");
+        testQuery(sqlText, expected, methodWatcher);
+    }
+
+    @Test
+    public void testAggregationAndPK() throws Exception {
+        String sql = "select * from t1 --splice-properties useSpark=" + useSpark.toString() +
+                             "\n where b = 'a '";
+        String sql2 = "select * from t1 --splice-properties useSpark=" + useSpark.toString() +
+                             "\n where b in ('a', 'a ', 'a  ')";
+        String sql3 = "select b, count(*) from t1 --splice-properties useSpark=" + useSpark.toString() +
+                             "\n group by b";
+        String sql4 = "select b from t1 --splice-properties useSpark=" + useSpark.toString() +
+                             "\n order by b";
+        String sql5 = "select b from t11 --splice-properties useSpark=" + useSpark.toString() +
+                             "\n order by b";
+        String expected =
+            "A | B |\n" +
+            "--------\n" +
+            " 1 | a |\n" +
+            " 1 | a |\n" +
+            " 1 | a |\n" +
+            " 1 | a |";
+
+        testQuery(sql, expected, methodWatcher);
+        testQuery(sql2, expected, methodWatcher);
+
+        expected =
+            "B  | 2 |\n" +
+            "----------\n" +
+            "  a  | 4 |\n" +
+            " a b | 1 |\n" +
+            " ab  | 1 |\n" +
+            " abc | 1 |\n" +
+            "abcd | 1 |";
+
+        testQuery(sql3, expected, methodWatcher);
+
+        expected =
+            "B  |\n" +
+            "------\n" +
+            "  a  |\n" +
+            "  a  |\n" +
+            "  a  |\n" +
+            "  a  |\n" +
+            " a b |\n" +
+            " ab  |\n" +
+            " abc |\n" +
+            "abcd |";
+        
+        testQuery(sql4, expected, methodWatcher);
+        testQuery(sql5, expected, methodWatcher);
+
+    }
+
+}


### PR DESCRIPTION
Comparison of trailing spaces in VARCHAR is ignored with the following database property enabled:
    call syscs_util.syscs_set_global_database_property('**splice.db2.varchar.compatible**', true);