### PR TITLE
DB-10578 Use proper DataSet type for trigger rows.

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/catalog/TriggerNewTransitionRows.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/catalog/TriggerNewTransitionRows.java
@@ -181,7 +181,8 @@ public class TriggerNewTransitionRows
             else {
                 DataSet<ExecRow> cachedRowsSet = null;
                 boolean isSpark = triggerRowsHolder == null || triggerRowsHolder.isSpark();
-                cachedRowsSet = dsp.createDataSet(triggerRowsHolder.getCachedRowsIterator());
+                if (triggerRowsHolder != null)
+                    cachedRowsSet = dsp.createDataSet(triggerRowsHolder.getCachedRowsIterator());
 
                 if (conglomID != 0) {
                     String tableName = Long.toString(conglomID);

--- a/splice_machine/src/main/java/com/splicemachine/derby/catalog/TriggerNewTransitionRows.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/catalog/TriggerNewTransitionRows.java
@@ -181,8 +181,8 @@ public class TriggerNewTransitionRows
             else {
                 DataSet<ExecRow> cachedRowsSet = null;
                 boolean isSpark = triggerRowsHolder == null || triggerRowsHolder.isSpark();
-                if (!isSpark)
-                    cachedRowsSet = new ControlDataSet<>(triggerRowsHolder.getCachedRowsIterator());
+                cachedRowsSet = dsp.createDataSet(triggerRowsHolder.getCachedRowsIterator());
+
                 if (conglomID != 0) {
                     String tableName = Long.toString(conglomID);
                     TransactionController transactionExecute = activation.getLanguageConnectionContext().getTransactionExecute();

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Statement_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Statement_IT.java
@@ -363,6 +363,22 @@ public class Trigger_Statement_IT {
 
     }
 
+@Test
+    public void sparkHint() throws Exception {
+        methodWatcher.executeUpdate("create trigger trig22\n" +
+                                    "after insert on t1\n" +
+                                    "referencing new_table as NT\n" +
+                                    "for each statement\n" +
+                                    "insert into t3 --splice-properties useSpark=true\n" +
+                                    "select * from NT\n");
+
+        // The following should not throw a ClassCastException.
+        methodWatcher.executeUpdate("insert into t1 values (1, 'abcdefg', 'dummy')");
+        Assert.assertEquals(1, (int)methodWatcher.query("select a3 from t3"));
+        methodWatcher.executeUpdate("drop trigger trig22");
+        methodWatcher.executeUpdate("delete from t3");
+    }
+
     private void assertQueryFails(String query, String expectedError) {
         try {
             methodWatcher.executeUpdate(query);


### PR DESCRIPTION
This fixes a ClassCastException Ben was seeing when a DML statement runs in control but a trigger it fires runs in Spark.
Test case:

> create table t1 (a int, b int);
> create table t2 (a int, b int);
> 
> create trigger trig2
> after insert on t1
> referencing new_table as NT
> for each statement
> insert into t2 --splice-properties useSpark=true
> select * from NT;
> 
> insert into t1 values(1,2);
> ERROR SE001: Splice Engine exception: unexpected exception
> ERROR XJ001: Java exception: 'java.lang.ClassCastException: com.splicemachine.derby.stream.control.ControlDataSet cannot be cast to com.splicemachine.derby.stream.spark.SparkDataSet: java.io.IOException'.
> ERROR XJ001: Java exception: 'com.splicemachine.derby.stream.control.ControlDataSet cannot be cast to com.splicemachine.derby.stream.spark.SparkDataSet: java.lang.ClassCastException'.
> 