### PR TITLE
DB-10662 Fix DB-10597 Performance regression.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -55,6 +55,7 @@ import com.splicemachine.db.iapi.sql.execute.ExecPreparedStatement;
 import com.splicemachine.db.iapi.sql.execute.ExecutionStmtValidator;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.types.DataValueFactory;
+import com.splicemachine.db.impl.sql.compile.CharTypeCompiler;
 import com.splicemachine.db.impl.sql.execute.TriggerExecutionContext;
 import com.splicemachine.db.impl.sql.execute.TriggerExecutionStack;
 import com.splicemachine.db.impl.sql.misc.CommentStripper;
@@ -1481,5 +1482,10 @@ public interface LanguageConnectionContext extends Context {
 	String getReplicationRole();
 
     boolean isNLJPredicatePushDownDisabled();
+
+    void setDB2VarcharCompatibilityModeNeedsReset(boolean newValue,
+                                                  CharTypeCompiler charTypeCompiler);
+
+    void resetDB2VarcharCompatibilityMode();
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -46,9 +46,11 @@ import com.splicemachine.db.iapi.sql.depend.Dependency;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
 import com.splicemachine.db.iapi.sql.execute.ExecutionContext;
+import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.util.ByteArray;
 import com.splicemachine.db.iapi.util.InterruptStatus;
 import com.splicemachine.db.impl.ast.JsonTreeBuilderVisitor;
+import com.splicemachine.db.impl.sql.compile.CharTypeCompiler;
 import com.splicemachine.db.impl.sql.compile.ExplainNode;
 import com.splicemachine.db.impl.sql.compile.StatementNode;
 import com.splicemachine.db.impl.sql.conn.GenericLanguageConnectionContext;
@@ -62,12 +64,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Timestamp;
+import java.sql.Types;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.splicemachine.db.iapi.reference.Property.SPLICE_SPARK_COMPILE_VERSION;
 import static com.splicemachine.db.iapi.reference.Property.SPLICE_SPARK_VERSION;
 import static com.splicemachine.db.iapi.sql.compile.CompilerContext.MAX_MULTICOLUMN_PROBE_VALUES_MAX_VALUE;
+import static com.splicemachine.db.impl.sql.compile.CharTypeCompiler.getCurrentCharTypeCompiler;
 
 @SuppressWarnings("SynchronizeOnNonFinalField")
 @SuppressFBWarnings(value = {"IS2_INCONSISTENT_SYNC", "ML_SYNC_ON_FIELD_TO_GUARD_CHANGING_THAT_FIELD"}, justification = "FIXME: DB-10223")
@@ -636,6 +640,14 @@ public class GenericStatement implements Statement{
                 if (varcharDB2CompatibilityModeString != null)
                     varcharDB2CompatibilityMode =
                             Boolean.parseBoolean(varcharDB2CompatibilityModeString);
+                if (varcharDB2CompatibilityMode) {
+                    CharTypeCompiler charTC = getCurrentCharTypeCompiler(lcc);
+                    if (charTC != null) {
+                        charTC.setDB2VarcharCompatibilityMode(varcharDB2CompatibilityMode);
+                        lcc.setDB2VarcharCompatibilityModeNeedsReset(true, charTC);
+                    }
+                }
+
             } catch (Exception e) {
                 // If the property value failed to convert to a boolean, don't throw an error,
                 // just use the default setting.
@@ -712,6 +724,7 @@ public class GenericStatement implements Statement{
             lcc.logErrorCompiling(getSource(), e, System.nanoTime() - startTime);
             throw e;
         }  finally{ // for block introduced by pushCompilerContext()
+            lcc.resetDB2VarcharCompatibilityMode();
             lcc.popCompilerContext(cc);
         }
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
@@ -52,8 +52,6 @@ import org.apache.spark.sql.types.StructField;
 import java.util.Collections;
 import java.util.List;
 
-import static com.splicemachine.db.impl.sql.compile.CharTypeCompiler.getDB2CompatibilityMode;
-
 /**
  * A ResultColumn represents a result column in a SELECT, INSERT, or UPDATE
  * statement.  In a SELECT statement, the result column just represents an
@@ -1820,8 +1818,7 @@ public class ResultColumn extends ValueNode
                 String sourceValue = constantValue.getString();
                 int sourceWidth = sourceValue.length();
                 int posn;
-                boolean DB2CompatibilityMode =
-                        getCompilerContext().getVarcharDB2CompatibilityMode();
+
                 /*
                 ** If the input is already the right length, no normalization is
                 ** necessary - just return the source.
@@ -1830,13 +1827,9 @@ public class ResultColumn extends ValueNode
 
                 if (sourceWidth <= maxWidth)
                 {
-                    if(formatId == StoredFormatIds.VARCHAR_TYPE_ID) {
-                        if (DB2CompatibilityMode)
-                            return dvf.getVarcharDB2CompatibleDataValue(sourceValue);
-                        else
+                    if(formatId == StoredFormatIds.VARCHAR_TYPE_ID)
                             return dvf.getVarcharDataValue(sourceValue);
                     }
-                }
 
                 /*
                 ** Check whether any non-blank characters will be truncated.
@@ -1855,12 +1848,8 @@ public class ResultColumn extends ValueNode
                     }
                 }
 
-                if (formatId == StoredFormatIds.VARCHAR_TYPE_ID) {
-                    if (DB2CompatibilityMode)
-                        return dvf.getVarcharDB2CompatibleDataValue(sourceValue.substring(0, maxWidth));
-                    else
+                if (formatId == StoredFormatIds.VARCHAR_TYPE_ID)
                         return dvf.getVarcharDataValue(sourceValue.substring(0, maxWidth));
-                }
 
             case StoredFormatIds.LONGVARCHAR_TYPE_ID:
                 //No need to check widths here (unlike varchar), since no max width

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -64,6 +64,7 @@ import com.splicemachine.db.iapi.util.InterruptStatus;
 import com.splicemachine.db.iapi.util.StringUtil;
 import com.splicemachine.db.impl.sql.GenericStatement;
 import com.splicemachine.db.impl.sql.GenericStorablePreparedStatement;
+import com.splicemachine.db.impl.sql.compile.CharTypeCompiler;
 import com.splicemachine.db.impl.sql.compile.CompilerContextImpl;
 import com.splicemachine.db.impl.sql.execute.*;
 import com.splicemachine.db.impl.sql.misc.CommentStripper;
@@ -78,6 +79,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
 import static com.splicemachine.db.iapi.reference.Property.MATCHING_STATEMENT_CACHE_IGNORING_COMMENT_OPTIMIZATION_ENABLED;
+import static com.splicemachine.db.impl.sql.compile.CharTypeCompiler.getCurrentCharTypeCompiler;
 
 /**
  * LanguageConnectionContext keeps the pool of prepared statements,
@@ -347,6 +349,8 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     private boolean nljPredicatePushDownDisabled = false;
 
     private String replicationRole = "NONE";
+    private boolean db2VarcharCompatibilityModeNeedsReset = false;
+    private CharTypeCompiler charTypeCompiler = null;
 
     /* constructor */
     public GenericLanguageConnectionContext(
@@ -4004,5 +4008,21 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         }
 
         return nljPredicatePushDownDisabled;
+    }
+
+    @Override
+    public void setDB2VarcharCompatibilityModeNeedsReset(boolean newValue,
+                                                         CharTypeCompiler charTypeCompiler) {
+        db2VarcharCompatibilityModeNeedsReset = newValue;
+        this.charTypeCompiler = charTypeCompiler;
+    }
+
+    @Override
+    public void resetDB2VarcharCompatibilityMode() {
+        db2VarcharCompatibilityModeNeedsReset = false;
+        if (charTypeCompiler != null) {
+            charTypeCompiler.setDB2VarcharCompatibilityMode(false);
+            charTypeCompiler = null;
+        }
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/QualifierUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/QualifierUtils.java
@@ -19,16 +19,13 @@ import com.splicemachine.db.iapi.reference.Limits;
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 import com.splicemachine.db.iapi.sql.execute.ScanQualifier;
 import com.splicemachine.db.iapi.store.access.Qualifier;
-import com.splicemachine.db.iapi.types.DataValueDescriptor;
-import com.splicemachine.db.iapi.types.DataValueFactory;
-import com.splicemachine.db.iapi.types.SQLChar;
-import com.splicemachine.db.iapi.types.SQLVarchar;
+import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.db.iapi.util.StringUtil;
 import com.splicemachine.db.impl.sql.execute.GenericScanQualifier;
 import java.math.BigDecimal;
 import java.util.GregorianCalendar;
 
-import static com.splicemachine.db.impl.sql.compile.CharTypeCompiler.getDB2CompatibilityMode;
+import static com.splicemachine.db.impl.sql.compile.CharTypeCompiler.getDB2CompatibilityModeStatic;
 
 /**
  * @author Scott Fines
@@ -96,7 +93,8 @@ public class QualifierUtils {
 
                 return convertChar((SQLChar) sourceDvd, sourceLength, targetLength);
             } else {
-                boolean DB2CompatibilityMode = getDB2CompatibilityMode();
+                boolean DB2CompatibilityMode = targetDvd instanceof SQLVarcharDB2Compatible ||
+                                               getDB2CompatibilityModeStatic();
                 if (DB2CompatibilityMode && isVarChar(targetType)) {
                     int targetLength =
                       forStartKey ? 0 : ((SQLVarchar) targetDvd).getSqlCharSize();
@@ -115,7 +113,8 @@ public class QualifierUtils {
             return convertDate(sourceDvd, targetType, dataValueFactory);
         } else if (isTime(targetType)) {
             return convertTime(sourceDvd, targetType, dataValueFactory);
-        } else if (isVarChar(targetType) && isFixedChar(sourceType) && getDB2CompatibilityMode()) {
+        } else if (isVarChar(targetType) && isFixedChar(sourceType) &&
+                   (targetDvd instanceof SQLVarcharDB2Compatible || getDB2CompatibilityModeStatic())) {
             int targetLength =
               forStartKey ? 0 : ((SQLVarchar) targetDvd).getSqlCharSize();
             return convertChar((SQLChar)sourceDvd, sourceDvd.getLength(), targetLength);


### PR DESCRIPTION
ITs on the mem platform are taking twice as long after DB-10597 merged.

Fix:
Introduced a thread local variable to avoid doing many costly cached database property lookups.