### PR TITLE
DB-10685 Fix SYSCS_INVALIDATE_STORED_STATEMENTS

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/catalog/SystemProcedures.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/SystemProcedures.java
@@ -48,17 +48,22 @@ import com.splicemachine.db.iapi.util.StringUtil;
 import com.splicemachine.db.impl.jdbc.EmbedDatabaseMetaData;
 import com.splicemachine.db.impl.jdbc.Util;
 import com.splicemachine.db.impl.load.Import;
+import com.splicemachine.db.impl.sql.catalog.DataDictionaryCache;
 import com.splicemachine.db.impl.sql.execute.JarUtil;
 import com.splicemachine.db.jdbc.InternalDriver;
 import com.splicemachine.db.shared.common.reference.AuditEventType;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.log4j.Logger;
 import com.splicemachine.utils.StringUtils;
+import splice.com.google.common.collect.Lists;
+import splice.com.google.common.net.HostAndPort;
 
+import java.io.IOException;
 import java.security.AccessController;
 import java.security.Policy;
 import java.security.PrivilegedAction;
 import java.sql.*;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.StringTokenizer;
@@ -1537,13 +1542,29 @@ public class SystemProcedures{
      * Invalidate all the stored statements so they will get recompiled when
      * executed next time around.
      */
-    public static void SYSCS_INVALIDATE_STORED_STATEMENTS()
+    public static void SYSCS_INVALIDATE_PERSISTED_STORED_STATEMENTS()
             throws SQLException{
         try{
             LanguageConnectionContext lcc=ConnectionUtil.getCurrentLCC();
             DataDictionary dd=lcc.getDataDictionary();
 
             dd.invalidateAllSPSPlans(lcc);
+        }catch(StandardException se){
+            throw PublicAPI.wrapStandardException(se);
+        }
+    }
+
+    public static void SYSCS_EMPTY_STORED_STATEMENT_CACHE()
+            throws SQLException{
+        try{
+            LanguageConnectionContext lcc=ConnectionUtil.getCurrentLCC();
+            DataDictionary dd=lcc.getDataDictionary();
+
+            DataDictionaryCache dc = dd.getDataDictionaryCache();
+            dc.clearAliasCache();
+            dc.clearSpsNameCache();
+            dc.clearStoredPreparedStatementCache();
+
         }catch(StandardException se){
             throw PublicAPI.wrapStandardException(se);
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DefaultSystemProcedureGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DefaultSystemProcedureGenerator.java
@@ -55,7 +55,7 @@ import java.util.*;
  *         Created on: 2/22/13
  */
 public class DefaultSystemProcedureGenerator implements SystemProcedureGenerator,ModuleControl {
-    private static final String SYSTEM_PROCEDURES = "com.splicemachine.db.catalog.SystemProcedures";
+    public static final String SYSTEM_PROCEDURES = "com.splicemachine.db.catalog.SystemProcedures";
     private static final String LOB_STORED_PROCEDURE = "com.splicemachine.db.impl.jdbc.LOBStoredProcedure";
 
     private static final DataTypeDescriptor TYPE_SYSTEM_IDENTIFIER =
@@ -435,7 +435,13 @@ public class DefaultSystemProcedureGenerator implements SystemProcedureGenerator
                     .ownerClass(SYSTEM_PROCEDURES)
                     .build()
             ,
-            Procedure.newBuilder().name("SYSCS_INVALIDATE_STORED_STATEMENTS")
+            Procedure.newBuilder().name("SYSCS_INVALIDATE_PERSISTED_STORED_STATEMENTS")
+                    .numOutputParams(0).numResultSets(0).modifiesSql()
+                    .returnType(null).isDeterministic(false)
+                    .ownerClass(SYSTEM_PROCEDURES)
+                    .build()
+            ,
+            Procedure.newBuilder().name("SYSCS_EMPTY_STORED_STATEMENT_CACHE")
                     .numOutputParams(0).numResultSets(0).modifiesSql()
                     .returnType(null).isDeterministic(false)
                     .ownerClass(SYSTEM_PROCEDURES)

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -1059,6 +1059,20 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                             .sqlControl(RoutineAliasInfo.NO_SQL).returnType(null).isDeterministic(false)
                             .build());
 
+                    procedures.add(Procedure.newBuilder().name("SYSCS_EMPTY_GLOBAL_STORED_STATEMENT_CACHE")
+                            .numOutputParams(0)
+                            .numResultSets(0)
+                            .ownerClass(SpliceAdmin.class.getCanonicalName())
+                            .sqlControl(RoutineAliasInfo.NO_SQL).returnType(null).isDeterministic(false)
+                            .build());
+
+                    procedures.add(Procedure.newBuilder().name("SYSCS_INVALIDATE_STORED_STATEMENTS")
+                            .numOutputParams(0)
+                            .numResultSets(0)
+                            .ownerClass(SpliceAdmin.class.getCanonicalName())
+                            .sqlControl(RoutineAliasInfo.NO_SQL).returnType(null).isDeterministic(false)
+                            .build());
+
                     procedures.add(Procedure.newBuilder().name("GET_ACTIVATION")
                             .numOutputParams(0)
                             .numResultSets(1)

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
@@ -1320,6 +1320,28 @@ public class SpliceAdmin extends BaseAdminProcedures{
         }
     }
 
+    public static void SYSCS_INVALIDATE_STORED_STATEMENTS() throws SQLException{
+        SystemProcedures.SYSCS_INVALIDATE_PERSISTED_STORED_STATEMENTS();
+        SYSCS_EMPTY_GLOBAL_STORED_STATEMENT_CACHE();
+    }
+
+    public static void SYSCS_EMPTY_GLOBAL_STORED_STATEMENT_CACHE() throws SQLException{
+        List<HostAndPort> servers;
+        try {
+            servers = EngineDriver.driver().getServiceDiscovery().listServers();
+        } catch (IOException e) {
+            throw PublicAPI.wrapStandardException(Exceptions.parseException(e));
+        }
+
+        for (HostAndPort server : servers) {
+            try (Connection connection = RemoteUser.getConnection(server.toString())) {
+                try (PreparedStatement ps = connection.prepareStatement("call SYSCS_UTIL.SYSCS_EMPTY_STORED_STATEMENT_CACHE()")) {
+                    ps.execute();
+                }
+            }
+        }
+    }
+
     private static Collection<PartitionServer> getLoad() throws SQLException{
         try(PartitionAdmin admin=SIDriver.driver().getTableFactory().getAdmin()){
             return admin.allServers();


### PR DESCRIPTION
The SYSCS_INVALIDATE_STORED_STATEMENTS procedure should clear stored statements from the dictionary cache so that they will be recompiled the next time they are executed.  Currently it does not, it only invalidates stored statements on disk.