### PR TITLE
DB-10703 HBaseTxnFinder.find() does not close RegionScanner

### DIFF
--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/region/HBaseTxnFinder.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/region/HBaseTxnFinder.java
@@ -178,11 +178,12 @@ public class HBaseTxnFinder implements TxnFinder {
             else
                 hbaseScan.withStartRow(new byte[]{bucket});
         }
-        HBaseTxnFinder.ScanTimestampIterator si = new ScanTimestampIterator(region.getScanner(hbaseScan));
-        if (si.hasNext()) {
-            return si.next;
-        } else {
-            return null;
+        try (HBaseTxnFinder.ScanTimestampIterator si = new ScanTimestampIterator(region.getScanner(hbaseScan))) {
+            if (si.hasNext()) {
+                return si.next;
+            } else {
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
Ensure the iterator is closed, which also closes the underlying scanner.  