### PR TITLE
DB-10708 SpliceCK interactive mode and other improvements

### DIFF
--- a/splice_ck/src/main/java/com/splicemachine/ck/ConnectionCache.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/ConnectionCache.java
@@ -1,0 +1,26 @@
+package com.splicemachine.ck;
+
+import com.splicemachine.ck.hwrap.ConnectionWrapper;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+
+public class ConnectionCache {
+
+    static ConnectionWrapper c;
+    public static ConnectionWrapper getConnection(final Configuration config) throws IOException {
+        if( c == null ) {
+            System.out.print("Trying to connect... ");
+            c = new ConnectionWrapper().withConfiguration(config).connect();
+            System.out.println("connected!");
+        }
+        return c;
+    }
+
+    public static void close() throws Exception {
+        if( c != null ) {
+            c.close();
+            c = null;
+        }
+    }
+}

--- a/splice_ck/src/main/java/com/splicemachine/ck/ConnectionSingleton.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/ConnectionSingleton.java
@@ -5,7 +5,7 @@ import org.apache.hadoop.conf.Configuration;
 
 import java.io.IOException;
 
-public class ConnectionCache {
+public class ConnectionSingleton {
 
     static ConnectionWrapper c;
     public static ConnectionWrapper getConnection(final Configuration config) throws IOException {

--- a/splice_ck/src/main/java/com/splicemachine/ck/HBaseInspector.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/HBaseInspector.java
@@ -152,7 +152,8 @@ public class HBaseInspector {
         TxnTableRowPrinter rowVisitor = new TxnTableRowPrinter();
 
         // scan for one more than the limit so the we know if we truncated
-        int scanLimit = limit == 0 ? 0 : limit+1, count = 0;
+        int scanLimit = limit == 0 ? 0 : limit+1;
+        int count = 0;
         ConnectionWrapper c = getCachedConnection().withRegion(region);
         try(final ResultScanner rs = c.scanVersions(scanLimit, 0 /*all*/ ) ) {
             for (Result row : rs) {

--- a/splice_ck/src/main/java/com/splicemachine/ck/HBaseInspector.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/HBaseInspector.java
@@ -31,6 +31,7 @@ import com.splicemachine.si.constants.SIConstants;
 import com.splicemachine.storage.HPut;
 import com.splicemachine.utils.IntArrays;
 import com.splicemachine.utils.Pair;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.TableNotFoundException;
@@ -43,6 +44,8 @@ import org.apache.hadoop.hbase.util.Bytes;
 import java.io.IOException;
 import java.util.BitSet;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.function.Predicate;
 
 import static com.splicemachine.ck.Constants.*;
 import static com.splicemachine.ck.Utils.checkNull;
@@ -55,17 +58,31 @@ public class HBaseInspector {
         this.config = config;
     }
 
-    public String scanRow(final String region, final String rowKey, final Utils.SQLType[] cols) throws Exception {
+    public String scanRow(final String region, final String rowKey, final Utils.SQLType[] cols,
+                          int limit, int versions, boolean hbase) throws Exception {
+
         StringBuilder result = new StringBuilder();
+        UserDataDecoder decoder = cols == null ? null : new UserDefinedDataDecoder(cols, 4);
+
+        int count = 0;
         ConnectionWrapper c = getCachedConnection().withRegion(region);
-        try(final ResultScanner rs = rowKey == null ? c.scanAllVersions() : c.scanSingleRowAllVersions(rowKey)) {
-            TableRowPrinter rowVisitor = new TableRowPrinter(cols == null ? null : new UserDefinedDataDecoder(cols, 4));
+        try(final ResultScanner rs = rowKey == null ?
+                c.scanAllVersions(limit+1, versions) :
+                c.scanSingleRowAllVersions(rowKey, versions)) {
             for(Result row : rs) {
+                if( count++ == limit ) {
+                    result.append(Utils.Colored.red("\n--- Result list was limited to " + limit + " entries, result was cut off ---"));
+                    break;
+                }
+                TableRowPrinter rowVisitor = new TableRowPrinter(decoder, hbase);
+                String hbaseStr = !hbase ? "" : " / " + com.splicemachine.primitives.Bytes.toStringBinary(row.getRow());
+                result.append(Utils.Colored.red("[ Row " + Hex.encodeHexString(row.getRow()) + hbaseStr + "]\n"));
                 for(String s : rowVisitor.processRow(row)) {
                     result.append(s);
                 }
             }
         }
+
         return result.toString();
     }
 
@@ -73,13 +90,14 @@ public class HBaseInspector {
         return ConnectionCache.getConnection(config);
     }
 
-    private Utils.Tabular getListTables() throws Exception {
+
+    private Utils.Tabular getListTables(Predicate<Utils.Tabular.Row> filter) throws Exception {
         Utils.Tabular tabular = new Utils.Tabular(Utils.Tabular.SortHint.AsString, TBL_TABLES_COL0, TBL_TABLES_COL1,
                                                   TBL_TABLES_COL2, TBL_TABLES_COL3, TBL_TABLES_COL4);
 
         final List<TableDescriptor> descriptors = getCachedConnection().descriptorsOfPattern(Constants.SPLICE_PATTERN);
         for (TableDescriptor td : descriptors) {
-            tabular.addRow(checkNull(td.getTableName().toString()),
+            tabular.addRow(filter, checkNull(td.getTableName().toString()),
                     checkNull(td.getValue(SIConstants.SCHEMA_DISPLAY_NAME_ATTR)),
                     checkNull(td.getValue(SIConstants.TABLE_DISPLAY_NAME_ATTR)),
                     checkNull(td.getValue(SIConstants.INDEX_DISPLAY_NAME_ATTR)),
@@ -142,8 +160,16 @@ public class HBaseInspector {
         return tabular;
     }
 
-    public String listTables() throws Exception {
-        return Utils.printTabularResults(getListTables());
+    public String listTables(String filter) throws Exception {
+        Predicate<Utils.Tabular.Row> predicate = null;
+        if( filter.length() > 0 ) {
+            predicate = row -> {
+                            String schema = checkNull( row.cols.get(TBL_TABLES_SCHEMA_IDX) );
+                            String table = checkNull( row.cols.get(TBL_TABLES_NAME_IDX) );
+                            return (schema + "." + table).matches(filter);
+                        };
+        }
+        return Utils.printTabularResults( getListTables( predicate ) );
     }
 
     public String listSchemas() throws Exception {
@@ -208,19 +234,25 @@ public class HBaseInspector {
     }
 
     public String regionOf(String schemaName, String tableName) throws Exception {
-        Utils.Tabular results = getListTables();
-        Utils.Tabular.Row row = results.rows.stream().filter(result -> result.cols.get(TBL_TABLES_NAME_IDX).equals(tableName)
-                && (schemaName == null ? result.cols.get(TBL_TABLES_SCHEMA_IDX).equals(NULL) : schemaName.equals(result.cols.get(TBL_TABLES_SCHEMA_IDX)))
-                && result.cols.get(TBL_TABLES_INDEX_IDX).equals(NULL)).min((l, r) -> Long.compare(Long.parseLong(r.cols.get(TBL_TABLES_CREATE_TXN_IDX)),
-                Long.parseLong(l.cols.get(TBL_TABLES_CREATE_TXN_IDX)))).orElseThrow(TableNotFoundException::new);
+        Utils.Tabular results = getListTables(result ->
+                result.cols.get(TBL_TABLES_NAME_IDX).equals(tableName)
+                        && (schemaName == null ? result.cols.get(TBL_TABLES_SCHEMA_IDX).equals(NULL) :
+                                                 schemaName.equals(result.cols.get(TBL_TABLES_SCHEMA_IDX)))
+                        && result.cols.get(TBL_TABLES_INDEX_IDX).equals(NULL));
+
+        Utils.Tabular.Row row = results.rows.stream()
+                .min((l, r) -> Long.compare(Long.parseLong(r.cols.get(TBL_TABLES_CREATE_TXN_IDX)),
+                                            Long.parseLong(l.cols.get(TBL_TABLES_CREATE_TXN_IDX))))
+                .orElseThrow(TableNotFoundException::new);
         assert row.cols.size() > 0;
         return row.cols.get(TBL_TABLES_HBASE_NAME_IDX);
     }
 
     public Pair<String, String> tableOf(String regionName) throws Exception {
-        Utils.Tabular tables = getListTables();
-        Utils.Tabular.Row r = tables.rows.stream().filter(result -> result.cols.get(TBL_TABLES_HBASE_NAME_IDX).equals(regionName)
-                && result.cols.get(TBL_TABLES_INDEX_IDX).equals(NULL)).findAny().orElseThrow(TableNotFoundException::new);
+        Utils.Tabular tables = getListTables(result ->
+                result.cols.get(TBL_TABLES_HBASE_NAME_IDX).equals(regionName) &&
+                result.cols.get(TBL_TABLES_INDEX_IDX).equals(NULL));
+        Utils.Tabular.Row r = tables.rows.stream().findAny().orElseThrow(TableNotFoundException::new);
         return new Pair<>(r.cols.get(TBL_TABLES_SCHEMA_IDX), r.cols.get(TBL_TABLES_NAME_IDX));
     }
 

--- a/splice_ck/src/main/java/com/splicemachine/ck/Utils.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/Utils.java
@@ -25,9 +25,11 @@ import com.splicemachine.encoding.Encoding;
 import com.splicemachine.encoding.MultiFieldEncoder;
 import com.splicemachine.si.api.txn.Txn;
 import com.splicemachine.utils.Pair;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.TableNotFoundException;
+import org.apache.hadoop.hbase.client.Result;
 
 import java.io.UncheckedIOException;
 import java.util.*;
@@ -43,6 +45,25 @@ public class Utils {
         conf.set(Constants.HBASE_CONFIGURATION_ZOOKEEPER_QUORUM, zkq);
         conf.set(Constants.HBASE_CONFIGURATION_ZOOKEEPER_CLIENTPORT, Integer.toString(port));
         return conf;
+    }
+
+    /**
+     * helper method to print when results are truncated
+     */
+    public static String limitString(int limit)
+    {
+        return "   .\n   .\n   .\n" + Colored.red(
+                "--- Result list was limited to " + limit + " entries, " + "result was cut off ---");
+    }
+
+    /**
+     * get the string representation of the row id
+     * @param hbaseStyle if true, add hbase Style binary printing (e.g. b2b75d580918e001 / \xB2\xB7]X\x09\x18\xE0\x01 )
+     */
+    public static String getRowId(Result row, boolean hbaseStyle)
+    {
+        String hbaseStr = !hbaseStyle ? "" : " / " + com.splicemachine.primitives.Bytes.toStringBinary(row.getRow());
+        return "Row " + Hex.encodeHexString(row.getRow()) + hbaseStr;
     }
 
     public static class Tabular {

--- a/splice_ck/src/main/java/com/splicemachine/ck/Utils.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/Utils.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hbase.TableNotFoundException;
 
 import java.io.UncheckedIOException;
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import static com.splicemachine.ck.Constants.NULL;
@@ -101,9 +102,15 @@ public class Utils {
             rows = new TreeSet<>();
         }
 
-        public void addRow(String... cols) {
+        public void addRow(Predicate<Row> filter, String... cols) {
             assert cols.length == headers.size();
-            rows.add(new Row(sortHint, cols));
+            Row r = new Row(sortHint, cols);
+            if( filter == null || filter.test(r) )
+                rows.add(r);
+        }
+
+        public void addRow(String... cols) {
+            addRow(null, cols);
         }
 
         public List<String> getCol(int index) {

--- a/splice_ck/src/main/java/com/splicemachine/ck/command/RGetCommand.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/command/RGetCommand.java
@@ -39,7 +39,7 @@ public class RGetCommand extends CommonOptions implements Callable<Integer>
     TableNameGroup tableNameGroup;
 
     @CommandLine.Option(names = {"-L", "--limit"}, required = false, description =
-            "maximum number of rows to print (default is 100)", defaultValue = "100") Long limit;
+            "maximum number of rows to print (default is 100)", defaultValue = "100") Integer limit;
 
     @CommandLine.Option(names = {"-V", "--versions"}, required = false, description =
             "versions to display (default 0 = all)", defaultValue = "0") Long versions;

--- a/splice_ck/src/main/java/com/splicemachine/ck/command/RGetCommand.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/command/RGetCommand.java
@@ -62,12 +62,13 @@ public class RGetCommand extends CommonOptions implements Callable<Integer>
                     region = tableNameGroup.region;
                 }
             }
+            String rowKey = id.equals("all") ? null : id;
             if(rowParsingGroup.auto != null) {
                 Utils.Tabular cols = hbaseInspector.columnsOf(region);
                 Utils.SQLType[] sqlTypes = Utils.toSQLTypeArray(cols.getCol(2));
-                System.out.println(hbaseInspector.scanRow(region, id, sqlTypes));
+                System.out.println(hbaseInspector.scanRow(region, rowKey, sqlTypes));
             } else {
-                System.out.println(hbaseInspector.scanRow(region, id, rowParsingGroup.colsSchema /* ok if null */));
+                System.out.println(hbaseInspector.scanRow(region, rowKey, rowParsingGroup.colsSchema /* ok if null */));
             }
             return 0;
         } catch (Exception e) {

--- a/splice_ck/src/main/java/com/splicemachine/ck/command/RGetCommand.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/command/RGetCommand.java
@@ -18,10 +18,10 @@ import com.splicemachine.ck.HBaseInspector;
 import com.splicemachine.ck.Utils;
 import com.splicemachine.ck.command.common.CommonOptions;
 import com.splicemachine.ck.command.common.TableNameGroup;
-import com.splicemachine.derby.utils.EngineUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hbase.TableNotFoundException;
 import picocli.CommandLine;
 
+import java.io.UncheckedIOException;
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(name = "rget",
@@ -31,16 +31,30 @@ import java.util.concurrent.Callable;
         optionListHeading = "Options:%n" )
 public class RGetCommand extends CommonOptions implements Callable<Integer>
 {
-    @CommandLine.Parameters(index = "0", description = "row id") String id;
+    @CommandLine.Parameters(index = "0", description = "row id or 'all' to display all rows (limited by -L)") String id;
+
     @CommandLine.ArgGroup(exclusive = true, multiplicity = "1", heading = "row values parsing options%n")
     ExclusiveRowParsing rowParsingGroup;
     @CommandLine.ArgGroup(exclusive = true, multiplicity = "1", heading = "table identifier options%n")
     TableNameGroup tableNameGroup;
 
+    @CommandLine.Option(names = {"-L", "--limit"}, required = false, description =
+            "maximum number of rows to print (default is 100)", defaultValue = "100") Long limit;
+
+    @CommandLine.Option(names = {"-V", "--versions"}, required = false, description =
+            "versions to display (default 0 = all)", defaultValue = "0") Long versions;
+
+    @CommandLine.Option(names = {"--hbase"}, required = false,
+            description = "output data like hbase") Boolean hbaseOption;
+
     public static class ExclusiveRowParsing {
-        @CommandLine.Option(names = {"-c", "--columns"}, required = true, split =",", description = "user-defined table columns, possible values: ${COMPLETION-CANDIDATES}") Utils.SQLType[] colsSchema;
-        @CommandLine.Option(names = {"-a", "--auto"}, required = true, description = "retrieve table columns automatically") Boolean auto;
-        @CommandLine.Option(names = {"-n", "--none"}, required = true, description = "print the row in hex") Boolean none;
+        @CommandLine.Option(names = {"-c", "--columns"}, required = true, split =",",
+                description = "user-defined table columns, possible values: ${COMPLETION-CANDIDATES}")
+            Utils.SQLType[] colsSchema;
+        @CommandLine.Option(names = {"-a", "--auto"}, required = true,
+                description = "retrieve table columns automatically") Boolean auto;
+        @CommandLine.Option(names = {"-n", "--none"}, required = true,
+                description = "print the row in hex") Boolean none;
     }
 
     public RGetCommand() {
@@ -50,25 +64,34 @@ public class RGetCommand extends CommonOptions implements Callable<Integer>
     public Integer call() throws Exception {
         HBaseInspector hbaseInspector = new HBaseInspector(Utils.constructConfig(zkq, port));
         try {
-            String region;
-            if(tableNameGroup.qualifiedTableName != null) {
-                tableNameGroup.qualifiedTableName.table = EngineUtils.validateTable(tableNameGroup.qualifiedTableName.table);
-                tableNameGroup.qualifiedTableName.schema = EngineUtils.validateSchema(tableNameGroup.qualifiedTableName.schema);
-                region = hbaseInspector.regionOf(tableNameGroup.qualifiedTableName.schema, tableNameGroup.qualifiedTableName.table);
-            } else {
-                if(StringUtils.isNumeric(tableNameGroup.region)) {
-                    region = "splice:" + tableNameGroup.region;
-                } else {
-                    region = tableNameGroup.region;
-                }
-            }
+            String region = tableNameGroup.getRegion(hbaseInspector);
+            boolean hbase = hbaseOption != null;
+
             String rowKey = id.equals("all") ? null : id;
             if(rowParsingGroup.auto != null) {
-                Utils.Tabular cols = hbaseInspector.columnsOf(region);
-                Utils.SQLType[] sqlTypes = Utils.toSQLTypeArray(cols.getCol(2));
-                System.out.println(hbaseInspector.scanRow(region, rowKey, sqlTypes));
-            } else {
-                System.out.println(hbaseInspector.scanRow(region, rowKey, rowParsingGroup.colsSchema /* ok if null */));
+                Utils.Tabular cols = null;
+                try {
+                    cols = hbaseInspector.columnsOf(region);
+                }
+                catch(Exception e)
+                {
+                    if (e instanceof TableNotFoundException ||
+                            (e instanceof UncheckedIOException && e.getCause() instanceof TableNotFoundException)) {
+                        rowParsingGroup.auto = null;
+                        cols = null;
+                        System.out.println("WARNING: couldn't find schema of " + region + ", will print rows as hex");
+                    }
+                }
+                if( cols != null ) {
+                    Utils.SQLType[] sqlTypes = Utils.toSQLTypeArray(cols.getCol(2));
+                    System.out.println(hbaseInspector.scanRow(region, rowKey, sqlTypes,
+                            limit.intValue(), versions.intValue(), hbase ));
+                }
+            }
+
+            if(rowParsingGroup.auto == null) {
+                System.out.println(hbaseInspector.scanRow(region, rowKey, rowParsingGroup.colsSchema /* ok if null */,
+                        limit.intValue(), versions.intValue(), hbase));
             }
             return 0;
         } catch (Exception e) {

--- a/splice_ck/src/main/java/com/splicemachine/ck/command/RPutCommand.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/command/RPutCommand.java
@@ -58,19 +58,8 @@ public class RPutCommand extends CommonOptions implements Callable<Integer>
     public Integer call() throws Exception {
         HBaseInspector hbaseInspector = new HBaseInspector(Utils.constructConfig(zkq, port));
         try {
-            String region;
-            if(tableNameGroup.qualifiedTableName != null) {
-                tableNameGroup.qualifiedTableName.table = EngineUtils.validateTable(tableNameGroup.qualifiedTableName.table);
-                tableNameGroup.qualifiedTableName.schema = EngineUtils.validateSchema(tableNameGroup.qualifiedTableName.schema);
-                String table = tableNameGroup.qualifiedTableName.table;
-                region = hbaseInspector.regionOf(tableNameGroup.qualifiedTableName.schema, table);
-            } else {
-                if(StringUtils.isNumeric(tableNameGroup.region)) {
-                    region = "splice:" + tableNameGroup.region;
-                } else {
-                    region = tableNameGroup.region;
-                }
-            }
+            String region = tableNameGroup.getRegion(hbaseInspector);
+
             RPutConfigBuilder configBuilder = new RPutConfigBuilder();
             configBuilder.withCommitTS(txn);
             if(rowOptions.tombstone != null) {

--- a/splice_ck/src/main/java/com/splicemachine/ck/command/RootCommand.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/command/RootCommand.java
@@ -16,6 +16,7 @@ package com.splicemachine.ck.command;
 
 import com.splicemachine.ck.ConnectionSingleton;
 import com.splicemachine.ck.Utils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import picocli.CommandLine;
@@ -29,6 +30,7 @@ import java.util.Scanner;
         TColsCommand.class, RegionOfCommand.class, TableOfCommand.class, RGetCommand.class, RPutCommand.class,
         TxListCommand.class, SListCommand.class})
 class RootCommand {
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING") // intentional
     public static void main(String... args) {
         Logger.getRootLogger().setLevel(Level.OFF);
         ConnectionSingleton c = new ConnectionSingleton();

--- a/splice_ck/src/main/java/com/splicemachine/ck/command/RootCommand.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/command/RootCommand.java
@@ -14,14 +14,13 @@
 
 package com.splicemachine.ck.command;
 
-import com.splicemachine.ck.ConnectionCache;
+import com.splicemachine.ck.ConnectionSingleton;
 import com.splicemachine.ck.Utils;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-import java.util.Arrays;
 import java.util.Scanner;
 
 @Command(mixinStandardHelpOptions = true, name = "spliceck", description = "SpliceMachine check command suite",
@@ -32,7 +31,7 @@ import java.util.Scanner;
 class RootCommand {
     public static void main(String... args) {
         Logger.getRootLogger().setLevel(Level.OFF);
-        ConnectionCache c = new ConnectionCache();
+        ConnectionSingleton c = new ConnectionSingleton();
 
         int exitCode = 0;
         if(!args[0].equals("interactive")) {
@@ -43,16 +42,13 @@ class RootCommand {
             CommandLine cl = new CommandLine(new RootCommand()).setExecutionStrategy(new CommandLine.RunLast());
             while (true) {
                 System.out.print("spliceck> ");
-                String s = command.nextLine();
-                if (s.equals("exit")) break;
-                if (s.trim().length() == 0) continue;
+                String s = command.nextLine().trim();
+
+                if (s.equals("exit") || s.equals("quit") || s.equals("q") ) break;
+                if (s.length() == 0) continue;
+
                 String[] args2 = s.split(" ");
                 exitCode = cl.execute(args2);
-                if( exitCode == 0 )
-                    System.out.println(Utils.Colored.green( "return code " + exitCode + "\n") );
-                else
-                    System.out.println(Utils.Colored.red( "return code " + exitCode + "\n") );
-
             }
             command.close();
         }

--- a/splice_ck/src/main/java/com/splicemachine/ck/command/RootCommand.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/command/RootCommand.java
@@ -15,6 +15,7 @@
 package com.splicemachine.ck.command;
 
 import com.splicemachine.ck.ConnectionCache;
+import com.splicemachine.ck.Utils;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import picocli.CommandLine;
@@ -44,9 +45,14 @@ class RootCommand {
                 System.out.print("spliceck> ");
                 String s = command.nextLine();
                 if (s.equals("exit")) break;
+                if (s.trim().length() == 0) continue;
                 String[] args2 = s.split(" ");
                 exitCode = cl.execute(args2);
-                System.out.println("returned " + exitCode);
+                if( exitCode == 0 )
+                    System.out.println(Utils.Colored.green( "return code " + exitCode + "\n") );
+                else
+                    System.out.println(Utils.Colored.red( "return code " + exitCode + "\n") );
+
             }
             command.close();
         }

--- a/splice_ck/src/main/java/com/splicemachine/ck/command/TListCommand.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/command/TListCommand.java
@@ -24,10 +24,27 @@ import java.util.concurrent.Callable;
 @CommandLine.Command(name = "tlist", description = "list SpliceMachine tables (similar to systables)" )
 public class TListCommand extends CommonOptions implements Callable<Integer>
 {
+    @CommandLine.Parameters(index = "0", description = "a filter applied on schemaname.tablename. supported is * or ?, e.g. *SYS????S",
+            defaultValue = "") String filter;
+
+    public static String getJavaRegexpFilterFromAsterixFilter(String asterixFilter)
+    {
+        String filter = asterixFilter;
+        String toEscape[] = {"<", "(", "[", "{", "\\", "^", "-", "=", "$", "!", "|", "]", "}", ")", "+", ".", ">"};
+            for(String s : toEscape) {
+                filter = filter.replaceAll("\\" + s, "\\" + s);
+            }
+
+        filter = filter.replaceAll("\\*", ".*");
+        return filter.replaceAll("\\?", ".");
+    }
+
     @Override
     public Integer call() throws Exception {
         HBaseInspector hbaseInspector = new HBaseInspector(Utils.constructConfig(zkq, port));
-        System.out.println(hbaseInspector.listTables());
+
+        String javaFilter = getJavaRegexpFilterFromAsterixFilter(filter);
+        System.out.println(hbaseInspector.listTables(javaFilter.toUpperCase()));
         return 0;
     }
 }

--- a/splice_ck/src/main/java/com/splicemachine/ck/command/TxListCommand.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/command/TxListCommand.java
@@ -24,10 +24,12 @@ import java.util.concurrent.Callable;
 @CommandLine.Command(name = "txlist", description = "list SpliceMachine transactions" )
 public class TxListCommand extends CommonOptions implements Callable<Integer>
 {
+    @CommandLine.Option(names = {"-L", "--limit"}, required = false, description =
+            "maximum number of entries to print (default is 250)", defaultValue = "250") Integer limit;
     @Override
     public Integer call() throws Exception {
         HBaseInspector hbaseInspector = new HBaseInspector(Utils.constructConfig(zkq, port));
-        System.out.println(hbaseInspector.listTransactions());
+        System.out.println(hbaseInspector.getListTransactions(limit.intValue()));
         return 0;
     }
 }

--- a/splice_ck/src/main/java/com/splicemachine/ck/command/common/TableNameGroup.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/command/common/TableNameGroup.java
@@ -1,6 +1,11 @@
 package com.splicemachine.ck.command.common;
 
+import com.splicemachine.ck.HBaseInspector;
+import com.splicemachine.derby.utils.EngineUtils;
+import org.apache.commons.lang3.StringUtils;
 import picocli.CommandLine;
+
+import java.sql.SQLException;
 
 public class TableNameGroup {
     @CommandLine.ArgGroup(exclusive = false, multiplicity = "1")
@@ -8,4 +13,18 @@ public class TableNameGroup {
 
     @CommandLine.Option(names = {"-r", "--region"}, required = true, description = "HBase region name (with of without 'splice:' prefix)")
     public String region;
+
+    public String getRegion(HBaseInspector hbaseInspector) throws Exception {
+        if(qualifiedTableName != null) {
+            qualifiedTableName.table = EngineUtils.validateTable(qualifiedTableName.table);
+            qualifiedTableName.schema = EngineUtils.validateSchema(qualifiedTableName.schema);
+            return hbaseInspector.regionOf(qualifiedTableName.schema, qualifiedTableName.table);
+        } else {
+            if(StringUtils.isNumeric(region)) {
+                return "splice:" + region;
+            } else {
+                return region;
+            }
+        }
+    }
 }

--- a/splice_ck/src/main/java/com/splicemachine/ck/hwrap/ConnectionWrapper.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/hwrap/ConnectionWrapper.java
@@ -50,16 +50,24 @@ public class ConnectionWrapper implements AutoCloseable {
         return this;
     }
 
-    public ResultScanner scanSingleRowAllVersions(String key, int versions) throws IOException {
+    /**
+     * @param rowKey the row key to scan for
+     * @param versions number of versions. if 0, all versions
+     */
+    public ResultScanner scanSingleRow(String rowKey, int versions) throws IOException {
         assert table != null;
         Scan scan = new Scan();
         tell("hbase scan table", table.getName().toString(), "with all versions");
         if(versions == 0) versions = Integer.MAX_VALUE;
-        scan.withStartRow(Bytes.fromHex(key)).setLimit(1).readVersions(versions);
+        scan.withStartRow(Bytes.fromHex(rowKey)).setLimit(1).readVersions(versions);
         return table.getScanner(scan);
     }
 
-    public ResultScanner scanAllVersions(int limit, int versions) throws IOException {
+    /**
+     * @param limit maximum number of elements to return
+     * @param versions  number of versions. if 0, all versions
+     */
+    public ResultScanner scanVersions(int limit, int versions) throws IOException {
         assert table != null;
         Scan scan = new Scan();
         if(limit != 0 ) scan.setLimit(limit);

--- a/splice_ck/src/main/java/com/splicemachine/ck/hwrap/ConnectionWrapper.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/hwrap/ConnectionWrapper.java
@@ -50,19 +50,21 @@ public class ConnectionWrapper implements AutoCloseable {
         return this;
     }
 
-    public ResultScanner scanSingleRowAllVersions(String key) throws IOException {
+    public ResultScanner scanSingleRowAllVersions(String key, int versions) throws IOException {
         assert table != null;
         Scan scan = new Scan();
         tell("hbase scan table", table.getName().toString(), "with all versions");
-        scan.withStartRow(Bytes.fromHex(key)).setLimit(1).readAllVersions();
+        if(versions == 0) versions = Integer.MAX_VALUE;
+        scan.withStartRow(Bytes.fromHex(key)).setLimit(1).readVersions(versions);
         return table.getScanner(scan);
     }
 
-    public ResultScanner scanAllVersions() throws IOException {
+    public ResultScanner scanAllVersions(int limit, int versions) throws IOException {
         assert table != null;
         Scan scan = new Scan();
-        scan.readAllVersions();
-        return table.getScanner(scan);
+        if(limit != 0 ) scan.setLimit(limit);
+        if(versions == 0) versions = Integer.MAX_VALUE;
+        return table.getScanner( scan.readVersions(versions) );
     }
 
 

--- a/splice_ck/src/main/java/com/splicemachine/ck/hwrap/ConnectionWrapper.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/hwrap/ConnectionWrapper.java
@@ -58,6 +58,14 @@ public class ConnectionWrapper implements AutoCloseable {
         return table.getScanner(scan);
     }
 
+    public ResultScanner scanAllVersions() throws IOException {
+        assert table != null;
+        Scan scan = new Scan();
+        scan.readAllVersions();
+        return table.getScanner(scan);
+    }
+
+
     public ResultScanner scanColumn(byte[] col) throws IOException {
         assert table != null;
         tell("hbase scan table", table.getName().toString(), "with projection");

--- a/splice_ck/src/main/java/com/splicemachine/ck/visitor/TableCellPrinter.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/visitor/TableCellPrinter.java
@@ -22,6 +22,7 @@ import com.splicemachine.hbase.CellUtils;
 import com.splicemachine.primitives.Bytes;
 import com.splicemachine.storage.CellType;
 import com.splicemachine.utils.Pair;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.hadoop.hbase.Cell;
 
 import java.util.*;
@@ -94,6 +95,7 @@ class TableCellPrinter {
     }
 
     public void visitCommitTimestamp(Cell cell) {
+
         stringBuilder.append(Utils.Colored.green("commit timestamp "));
         stringBuilder.append(Utils.Colored.green(Long.toString(CellUtils.getCommitTimestamp(cell))));
     }
@@ -127,7 +129,7 @@ class TableCellPrinter {
     }
 
     public void visitDeleteRightAfterFirstWrite() {
-        stringBuilder.append(Utils.Colored.purple("delete right after first right set"));
+        stringBuilder.append(Utils.Colored.purple("delete right after first write set"));
     }
 
     public void visitForeignKeyCounter() {

--- a/splice_ck/src/main/java/com/splicemachine/ck/visitor/TableCellPrinter.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/visitor/TableCellPrinter.java
@@ -66,11 +66,13 @@ class TableCellPrinter {
     private final UserDataDecoder decoder;
     StringBuilder stringBuilder;
     SortedMap<Long, List<String>> events;
+    boolean hbase;
 
-    public TableCellPrinter(UserDataDecoder decoder) {
+    public TableCellPrinter(UserDataDecoder decoder, boolean hbase) {
         this.decoder = decoder;
         this.stringBuilder = new StringBuilder();
         events = new TreeMap<>();
+        this.hbase = hbase;
     }
 
     public String getOutput() {
@@ -87,11 +89,33 @@ class TableCellPrinter {
     protected void preVisit(Cell cell) {
         stringBuilder.setLength(0);
     }
+    public static byte[] getSliceOfArray(byte[] arr,
+                                        int start, int len)
+    {
+
+        // Get the slice of the Array
+        byte[] slice = new byte[len];
+
+        // Copy elements of arr to slice
+        for (int i = 0; i < slice.length; i++) {
+            slice[i] = arr[start + i];
+        }
+
+        // return the slice
+        return slice;
+    }
 
     protected void postVisit(Cell cell) {
         Long key = cell.getTimestamp();
         events.computeIfAbsent(key, k -> new ArrayList<>());
+        byte[] b = cell.getRowArray();
         events.get(key).add(stringBuilder.toString());
+        if(hbase) {
+            events.get(key).add("  column=" + com.splicemachine.primitives.Bytes.toStringBinary(getSliceOfArray(b, cell.getFamilyOffset(), cell.getFamilyLength()))
+                    + ":" + com.splicemachine.primitives.Bytes.toStringBinary(getSliceOfArray(b, cell.getQualifierOffset(), cell.getQualifierLength()))
+                    + ", value = " + com.splicemachine.primitives.Bytes.toStringBinary(getSliceOfArray(b, cell.getValueOffset(), cell.getValueLength())));
+        }
+
     }
 
     public void visitCommitTimestamp(Cell cell) {

--- a/splice_ck/src/main/java/com/splicemachine/ck/visitor/TableRowPrinter.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/visitor/TableRowPrinter.java
@@ -15,6 +15,7 @@
 package com.splicemachine.ck.visitor;
 
 import com.splicemachine.ck.decoder.UserDataDecoder;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.Result;
 
@@ -25,8 +26,8 @@ public class TableRowPrinter implements IRowPrinter {
 
     private final TableCellPrinter tableCellPrinter;
 
-    public TableRowPrinter(UserDataDecoder decoder) {
-        this.tableCellPrinter = new TableCellPrinter(decoder);
+    public TableRowPrinter(UserDataDecoder decoder, boolean hbase) {
+        this.tableCellPrinter = new TableCellPrinter(decoder, hbase);
     }
 
     @Override

--- a/splice_ck/src/main/java/com/splicemachine/ck/visitor/TableRowPrinter.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/visitor/TableRowPrinter.java
@@ -33,7 +33,7 @@ public class TableRowPrinter implements IRowPrinter {
     @Override
     public List<String> processRow(Result row) throws Exception {
         List<String> result = new ArrayList<>();
-        result.add( Utils.Colored.red("[ " + Utils.getRowId(row, this.tableCellPrinter.hbase) + " ]") );
+        result.add( Utils.Colored.red("[ " + Utils.getRowId(row, this.tableCellPrinter.hbase) + " ]\n") );
 
         for(Cell cell : row.listCells()) {
             tableCellPrinter.visit(cell);

--- a/splice_ck/src/main/java/com/splicemachine/ck/visitor/TableRowPrinter.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/visitor/TableRowPrinter.java
@@ -14,8 +14,8 @@
 
 package com.splicemachine.ck.visitor;
 
+import com.splicemachine.ck.Utils;
 import com.splicemachine.ck.decoder.UserDataDecoder;
-import org.apache.commons.codec.binary.Hex;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.Result;
 
@@ -33,6 +33,8 @@ public class TableRowPrinter implements IRowPrinter {
     @Override
     public List<String> processRow(Result row) throws Exception {
         List<String> result = new ArrayList<>();
+        result.add( Utils.Colored.red("[ " + Utils.getRowId(row, this.tableCellPrinter.hbase) + " ]") );
+
         for(Cell cell : row.listCells()) {
             tableCellPrinter.visit(cell);
         }

--- a/spliceck.sh
+++ b/spliceck.sh
@@ -5,7 +5,14 @@ platform=cdh6.3.0
 function help() {
   echo "spliceck.sh [--platform <platform>] command"
   echo "<platform> The cluster platform, default is cdh6.3.0"
+  echo "to run in interactive mode use spliceck.sh [--platform <platform>] 'interactive'"
 }
+
+if hash rlwrap 2>/dev/null; then
+    RLWRAP=rlwrap
+else
+    RLWRAP=
+fi
 
 if [ $# -eq 0 ]
 then
@@ -22,7 +29,7 @@ else
       i="${i//\\/\\\\}"
       C="$C '${i//\'/\\\"}'"
   done
-  mvn -q -Pcore,${platform} -f ./splice_ck/pom.xml exec:java -Dexec.args="${C}"
+  RLWRAP mvn -q -Pcore,${platform} -f ./splice_ck/pom.xml exec:java -Dexec.args="${C}"
 fi
 
 


### PR DESCRIPTION
- `./spliceck.sh interactive` starts spliceck in "interactive shell" `spliceck>` mode. Commands stay the same, however since -we're caching the hbase connection, it's much faster. exit with `exit`
- rget can now also get all rows (use `all` instead of rowid)
- since this can be quite a lot, `--limit X` limits the number of rows to X. Default is 100.
- rget can limit the version it prints with e.g. `-V 1` (like default for hbase shell)
- rget can print additional cells like hbase (`--hbase`)
- tlist can accept filters e.g. `tlist *DUMMY` list all schema.table that end with DUMMY
- txlist also limits output by default to 100 (change with --limit)
- both rget and txlist notify when they cut off results due to --limit.