### PR TITLE
DB-10236 Take expression-based indexes as covering indexes properly (3.0)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/IndexDescriptorImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/IndexDescriptorImpl.java
@@ -391,7 +391,7 @@ public class IndexDescriptorImpl implements IndexDescriptor, Formatable {
                 indexColumnTypes[i].readExternal(in);
             }
         }
-        synchronized(this) {
+        synchronized (this) {
             executableExprs = new BaseExecutableIndexExpression[numIndexExpr];
         }
     }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizable.java
@@ -31,11 +31,12 @@
 
 package com.splicemachine.db.iapi.sql.compile;
 
-import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
-import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
-import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
+import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
+import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.util.JBitSet;
+
 import java.util.Properties;
 
 /**

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizablePredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizablePredicateList.java
@@ -31,14 +31,12 @@
 
 package com.splicemachine.db.iapi.sql.compile;
 
-import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
-
-import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
-
 import com.splicemachine.db.iapi.error.StandardException;
-
+import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.util.JBitSet;
+import com.splicemachine.db.impl.sql.compile.ValueNode;
 
 /**
  * OptimizablePredicateList provides services for optimizing a table in a query.
@@ -177,6 +175,18 @@ public interface OptimizablePredicateList {
 	 * @exception StandardException		Thrown on error
 	 */
 	boolean hasOptimizableEquijoin(Optimizable optTable, int columnNumber) throws StandardException;
+
+	/**
+	 * Is there an optimizable equijoin on the specified expression?
+	 *
+	 * @param optTable		The optimizable the expression refers to.
+	 * @param expr			The expression itself.
+	 *
+	 * @return Whether or not there is an optimizable equijoin on the specified expression.
+	 *
+	 * @exception StandardException		Thrown on error
+	 */
+	boolean hasOptimizableEquijoin(Optimizable optTable, ValueNode expr) throws StandardException;
 									
 
 	/**
@@ -190,6 +200,18 @@ public interface OptimizablePredicateList {
 	 * @exception StandardException		Thrown on error
 	 */
 	void putOptimizableEqualityPredicateFirst(Optimizable optTable, int columnNumber) throws StandardException;
+
+	/**
+	 * Find the optimizable equality predicate on the specified expression and make
+	 * it the first predicate in this list.  This is useful for hash joins where
+	 * Qualifier[0] is assumed to be on the hash key.
+	 *
+	 * @param optTable		The optimizable the expression refers to.
+	 * @param expr			The expression itself.
+	 *
+	 * @exception StandardException		Thrown on error
+	 */
+	void putOptimizableEqualityPredicateFirst(Optimizable optTable, ValueNode expr) throws StandardException;
 
 	/**
 	 * Transfer the predicates whose referenced set is contained by the

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AggregateNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AggregateNode.java
@@ -45,10 +45,11 @@ import com.splicemachine.db.iapi.sql.dictionary.AliasDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
-import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.splicemachine.db.iapi.sql.compile.AggregateDefinition.FunctionType;
 import static com.splicemachine.db.iapi.sql.compile.AggregateDefinition.fromString;
@@ -723,5 +724,21 @@ public class AggregateNode extends UnaryOperatorNode {
 
     public FunctionType getType() {
         return this.type;
+    }
+
+    @Override
+    public ValueNode replaceIndexExpression(ResultColumnList childRCL) throws StandardException {
+        if (operand != null) {
+            operand = operand.replaceIndexExpression(childRCL);
+        }
+        return this;
+    }
+
+    @Override
+    public boolean collectExpressions(Map<Integer, Set<ValueNode>> exprMap) {
+        if (operand != null) {
+            return operand.collectExpressions(exprMap);
+        }
+        return true;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayConstantNode.java
@@ -25,18 +25,17 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.ClassName;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.classfile.VMOpcode;
-import com.splicemachine.db.iapi.services.sanity.SanityManager;
-import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.compiler.LocalField;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.compile.Visitor;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.util.JBitSet;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.lang.reflect.Modifier;
 import java.sql.Types;
@@ -49,7 +48,6 @@ import java.util.List;
  *
  */
 
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class ArrayConstantNode extends ValueNode {
     ValueNodeList    argumentsList; //this is the list of arguments to the function. We are interested in the first not-null argument
 
@@ -310,7 +308,8 @@ public class ArrayConstantNode extends ValueNode {
         }
 
         ArrayConstantNode other = (ArrayConstantNode)o;
-        return argumentsList.isEquivalent(other.argumentsList);
+        return (argumentsList == null && other.argumentsList == null) ||
+                (argumentsList != null && argumentsList.isEquivalent(other.argumentsList));
     }
 
     /**
@@ -323,7 +322,13 @@ public class ArrayConstantNode extends ValueNode {
         }
 
         ArrayConstantNode other = (ArrayConstantNode)o;
-        return argumentsList.isSemanticallyEquivalent(other.argumentsList);
+        return (argumentsList == null && other.argumentsList == null) ||
+                (argumentsList != null && argumentsList.isSemanticallyEquivalent(other.argumentsList));
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * getBaseHashCode() + (argumentsList == null ? 0 : argumentsList.hashCode());
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayOperatorNode.java
@@ -37,7 +37,6 @@ import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.util.JBitSet;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.lang.reflect.Modifier;
 import java.util.Collections;
@@ -50,7 +49,6 @@ import java.util.List;
  *
  */
 
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class ArrayOperatorNode extends ValueNode {
     public int extractField = -1;
     public ValueNode operand;
@@ -170,7 +168,11 @@ public class ArrayOperatorNode extends ValueNode {
         ArrayOperatorNode other = (ArrayOperatorNode) o;
 
         return operand.isEquivalent(other.operand);
+    }
 
+    @Override
+    public int hashCode() {
+        return 31 * getBaseHashCode() + operand.hashCode();
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseColumnNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseColumnNode.java
@@ -31,16 +31,16 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
-import java.util.Collections;
-import java.util.List;
-
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
-import com.splicemachine.db.iapi.types.DataTypeDescriptor;
-import com.splicemachine.db.iapi.store.access.Qualifier;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import com.splicemachine.db.iapi.store.access.Qualifier;
+import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * A BaseColumnNode represents a column in a base table.  The parser generates a
@@ -52,7 +52,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  *
  */
 
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class BaseColumnNode extends ValueNode
 {
     private String    columnName;
@@ -191,6 +190,10 @@ public class BaseColumnNode extends ValueNode
             && other.columnName.equals(columnName);
         }
         return false;
+    }
+
+    public int hashCode() {
+        return Objects.hash(getBaseHashCode(), tableName, columnName);
     }
 
     public List<? extends QueryTreeNode> getChildren() {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BetweenOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BetweenOperatorNode.java
@@ -327,10 +327,4 @@ public class BetweenOperatorNode extends BinaryListOperatorNode
 		newAnd.postBindFixup();
 		newAnd.generateExpression(acb, mb);
 	}
-	
-	public int hashCode(){
-		int result = getLeftOperand()==null? 0: getLeftOperand().hashCode();
-		result = 31*result+(rightOperandList==null?0:rightOperandList.hashCode());
-		return result;
-	}
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryListOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryListOperatorNode.java
@@ -42,6 +42,8 @@ import com.splicemachine.db.iapi.util.JBitSet;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.splicemachine.db.shared.common.sanity.SanityManager.THROWASSERT;
 
@@ -441,6 +443,14 @@ public abstract class BinaryListOperatorNode extends ValueNode{
                 rightOperandList.isSemanticallyEquivalent(other.rightOperandList);
     }
 
+    public int hashCode() {
+        int result = getBaseHashCode();
+        result = 31 * result + operator.hashCode();
+        result = 31 * result + (leftOperandList == null ? 0 : leftOperandList.hashCode());
+        result = 31 * result + (rightOperandList == null ? 0 : rightOperandList.hashCode());
+        return result;
+    }
+
     @Override
     public List<? extends QueryTreeNode> getChildren(){
         return new LinkedList<QueryTreeNode>(){{
@@ -483,5 +493,28 @@ public abstract class BinaryListOperatorNode extends ValueNode{
 
     public void setOuterJoinLevel(int level) {
         outerJoinLevel = level;
+    }
+
+    @Override
+    public ValueNode replaceIndexExpression(ResultColumnList childRCL) throws StandardException {
+        if (leftOperandList != null) {
+            leftOperandList = leftOperandList.replaceIndexExpression(childRCL);
+        }
+        if (rightOperandList != null) {
+            rightOperandList = rightOperandList.replaceIndexExpression(childRCL);
+        }
+        return this;
+    }
+
+    @Override
+    public boolean collectExpressions(Map<Integer, Set<ValueNode>> exprMap) {
+        boolean result = true;
+        if (leftOperandList != null) {
+            result = leftOperandList.collectExpressions(exprMap);
+        }
+        if (rightOperandList != null) {
+            result = result && rightOperandList.collectExpressions(exprMap);
+        }
+        return result;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryLogicalOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryLogicalOperatorNode.java
@@ -32,16 +32,16 @@
 package com.splicemachine.db.impl.sql.compile;
 
 import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
-
-import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.reference.ClassName;
 import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.services.classfile.VMOpcode;
+import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 
-import com.splicemachine.db.iapi.services.classfile.VMOpcode;
-
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 abstract class BinaryLogicalOperatorNode extends BinaryOperatorNode
 {
@@ -227,5 +227,31 @@ abstract class BinaryLogicalOperatorNode extends BinaryOperatorNode
 
 		return leftType.getNullabilityType(
 					leftType.isNullable() || rightType.isNullable());
+	}
+
+	@Override
+	public ValueNode replaceIndexExpression(ResultColumnList childRCL) throws StandardException {
+		if (childRCL == null) {
+			return this;
+		}
+		if (leftOperand != null) {
+			leftOperand = leftOperand.replaceIndexExpression(childRCL);
+		}
+		if (rightOperand != null) {
+			rightOperand = rightOperand.replaceIndexExpression(childRCL);
+		}
+		return this;
+	}
+
+	@Override
+	public boolean collectExpressions(Map<Integer, Set<ValueNode>> exprMap) {
+		boolean result = true;
+		if (leftOperand != null) {
+			result = leftOperand.collectExpressions(exprMap);
+		}
+		if (rightOperand != null) {
+			result = result && rightOperand.collectExpressions(exprMap);
+		}
+		return result;
 	}
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryOperatorNode.java
@@ -40,6 +40,7 @@ import com.splicemachine.db.iapi.services.compiler.LocalField;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.compile.Visitor;
+import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.util.JBitSet;
@@ -90,11 +91,26 @@ public class BinaryOperatorNode extends OperatorNode
     String        resultInterfaceType;
     int            operatorType;
 
-    // If an operand matches an index expression.
-    // -1  : no match
-    // >=0 : table number
+    /* If an operand matches an index expression. Once set,
+     * values should be valid through the whole optimization
+     * process of the current query.
+     * -1  : no match
+     * >=0 : table number
+     */
     protected int leftMatchIndexExpr  = -1;
     protected int rightMatchIndexExpr = -1;
+
+    /* The following four fields record operand matches for
+     * which conglomerate and which column. These values
+     * are reset and valid only for the current access path.
+     * They should not be used beyond cost estimation.
+     */
+    protected ConglomerateDescriptor leftMatchIndexExprConglomDesc = null;
+    protected ConglomerateDescriptor rightMatchIndexExprConglomDesc = null;
+
+    // 0-based index column position
+    protected int leftMatchIndexExprColumnPosition  = -1;
+    protected int rightMatchIndexExprColumnPosition = -1;
 
     // At the time of adding XML support, it was decided that
     // we should avoid creating new OperatorNodes where possible.
@@ -1039,9 +1055,10 @@ public class BinaryOperatorNode extends OperatorNode
     }
 
     public int hashCode() {
-        int hashCode = methodName.hashCode();
-        hashCode = 31*hashCode+leftOperand.hashCode();
-        hashCode = 31*hashCode + rightOperand.hashCode();
+        int hashCode = getBaseHashCode();
+        hashCode = 31 * hashCode + methodName.hashCode();
+        hashCode = 31 * hashCode + leftOperand.hashCode();
+        hashCode = 31 * hashCode + rightOperand.hashCode();
         return hashCode;
     }
 
@@ -1105,12 +1122,19 @@ public class BinaryOperatorNode extends OperatorNode
 
     public int getOperatorType() { return operatorType; }
 
-    public void setMatchIndexExpr(int tableNumber, boolean isLeft) {
+    public void setMatchIndexExpr(int tableNumber, int columnPosition, ConglomerateDescriptor conglomDesc, boolean isLeft) {
         if (isLeft) {
             this.leftMatchIndexExpr = tableNumber;
+            this.leftMatchIndexExprColumnPosition = columnPosition;
+            this.leftMatchIndexExprConglomDesc = conglomDesc;
         } else {
             this.rightMatchIndexExpr = tableNumber;
+            this.rightMatchIndexExprColumnPosition = columnPosition;
+            this.rightMatchIndexExprConglomDesc = conglomDesc;
         }
     }
+
+    public int getLeftMatchIndexExprTableNumber() { return this.leftMatchIndexExpr; }
+    public int getRightMatchIndexExprTableNumber() { return this.rightMatchIndexExpr; }
 }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CastNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CastNode.java
@@ -47,7 +47,6 @@ import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.iapi.util.ReuseFactory;
 import com.splicemachine.db.iapi.util.StringUtil;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.lang.reflect.Modifier;
 import java.sql.Types;
@@ -59,7 +58,6 @@ import java.util.List;
  *
  */
 
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class CastNode extends ValueNode
 {
     ValueNode   castOperand;
@@ -1160,11 +1158,18 @@ public class CastNode extends ValueNode
     @Override
     protected boolean isSemanticallyEquivalent(ValueNode o) throws StandardException {
         if (isSameNodeType(o)) {
-            CastNode other = (CastNode)o;
+            CastNode other = (CastNode) o;
             return getTypeServices().equals(other.getTypeServices())
                     && castOperand.isSemanticallyEquivalent(other.castOperand);
         }
         return false;
+    }
+
+    public int hashCode() {
+        int result = getBaseHashCode();
+        result = 31 * result + getTypeServices().hashCode();
+        result = 31 * result + castOperand.hashCode();
+        return result;
     }
 
     public List<? extends QueryTreeNode> getChildren() {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CoalesceFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CoalesceFunctionNode.java
@@ -73,7 +73,7 @@ public class CoalesceFunctionNode extends MultiaryFunctionNode
         }
 
         // don't compare function name because it could be coalesce or value
-        MultiaryFunctionNode other = (MultiaryFunctionNode)o;
+        CoalesceFunctionNode other = (CoalesceFunctionNode)o;
         return argumentsList.isEquivalent(other.argumentsList);
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnReference.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnReference.java
@@ -1356,8 +1356,12 @@ public class ColumnReference extends ValueNode {
 
     @Override
     public int hashCode(){
-        int hc = tableNumber;
-        hc = hc*31+columnName.hashCode();
+        int hc = 31 * getBaseHashCode() + tableNumber;
+        if (columnName.length() == 0) {
+            hc = hc * 31 + getSource().hashCode();
+        } else {
+            hc = hc * 31 + columnName.hashCode();
+        }
         return hc;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConditionalNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConditionalNode.java
@@ -44,7 +44,6 @@ import com.splicemachine.db.iapi.sql.compile.Visitor;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.util.JBitSet;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -56,7 +55,6 @@ import java.util.List;
  *
  */
 
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class ConditionalNode extends ValueNode
 {
     ValueNode        testCondition;
@@ -737,14 +735,20 @@ public class ConditionalNode extends ValueNode
     /**
      * {@inheritDoc}
      */
-    protected boolean isSemanticallyEquivalent(ValueNode o) throws StandardException
-    {
+    protected boolean isSemanticallyEquivalent(ValueNode o) throws StandardException {
         if (isSameNodeType(o)) {
-            ConditionalNode other = (ConditionalNode)o;
+            ConditionalNode other = (ConditionalNode) o;
             return testCondition.isSemanticallyEquivalent(other.testCondition) &&
                     thenElseList.isSemanticallyEquivalent(other.thenElseList);
         }
         return false;
+    }
+
+    public int hashCode() {
+        int result = getBaseHashCode();
+        result = 31 * result + testCondition.hashCode();
+        result = 31 * result + thenElseList.hashCode();
+        return result;
     }
 
     public List<? extends QueryTreeNode> getChildren() {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstantNode.java
@@ -313,7 +313,7 @@ public abstract class ConstantNode extends ValueNode
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return 31 * getBaseHashCode() + (value == null ? 0 : value.hashCode());
     }
 
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CurrentDatetimeOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CurrentDatetimeOperatorNode.java
@@ -31,29 +31,27 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.services.compiler.LocalField;
+import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
-import com.splicemachine.db.iapi.sql.compile.CompilerContext;
-import com.splicemachine.db.iapi.types.DataTypeDescriptor;
-import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
-import com.splicemachine.db.iapi.services.compiler.LocalField;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.store.access.Qualifier;
-
-import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.TypeId;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.sql.Types;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * The CurrentDatetimeOperator operator is for the builtin CURRENT_DATE,
  * CURRENT_TIME, and CURRENT_TIMESTAMP operations.
  *
  */
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class CurrentDatetimeOperatorNode extends ValueNode {
 
     public static final int CURRENT_DATE = 0;
@@ -216,6 +214,10 @@ public class CurrentDatetimeOperatorNode extends ValueNode {
             return other.whichType == whichType;
         }
         return false;
+    }
+
+    public int hashCode() {
+        return Objects.hash(getBaseHashCode(), whichType);
     }
 
     public List<? extends QueryTreeNode> getChildren() {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CurrentRowLocationNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CurrentRowLocationNode.java
@@ -31,19 +31,16 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
-import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
-import com.splicemachine.db.iapi.types.TypeId;
-import com.splicemachine.db.iapi.types.DataTypeDescriptor;
-import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
-import com.splicemachine.db.iapi.services.compiler.LocalField;
-
-import java.lang.reflect.Modifier;
-
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.ClassName;
 import com.splicemachine.db.iapi.services.classfile.VMOpcode;
-import com.splicemachine.db.iapi.error.StandardException;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import com.splicemachine.db.iapi.services.compiler.LocalField;
+import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
+import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+import com.splicemachine.db.iapi.types.TypeId;
 
+import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.List;
 
@@ -54,7 +51,6 @@ import java.util.List;
  * that represents the ResultSet to be deleted or updated.
  */
 
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class CurrentRowLocationNode extends ValueNode
 {
     /**
@@ -168,6 +164,11 @@ public class CurrentRowLocationNode extends ValueNode
     protected boolean isEquivalent(ValueNode o)
     {
         return this == o;
+    }
+
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(this);
     }
 
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLStatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLStatementNode.java
@@ -41,12 +41,13 @@ import com.splicemachine.db.iapi.sql.compile.DataSetProcessorType;
 import com.splicemachine.db.iapi.sql.compile.Visitor;
 import com.splicemachine.db.iapi.sql.conn.Authorizer;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
+import com.splicemachine.db.impl.ast.CollectingVisitor;
 import com.splicemachine.db.impl.ast.LimitOffsetVisitor;
 import com.splicemachine.db.impl.ast.SpliceDerbyVisitorAdapter;
 import com.splicemachine.db.impl.sql.compile.subquery.SubqueryFlattening;
+import splice.com.google.common.base.Predicates;
 
-import java.util.Collection;
-import java.util.Vector;
+import java.util.*;
 
 /**
  * A DMLStatementNode represents any type of DML statement: a cursor declaration, an INSERT statement, and UPDATE
@@ -170,7 +171,47 @@ public abstract class DMLStatementNode extends StatementNode {
         // prune tree based on unsat condition
         accept(new TreePruningVisitor());
 
-
+        // At this point, the query tree should be stable. Collect all expressions
+        // in the query and set them to base tables accordingly. This step is
+        // necessary for deciding if an index on expressions is a covering index.
+        Map<Integer, Set<ValueNode>> exprMap = new HashMap<>();
+        CollectingVisitor<QueryTreeNode> cv = new CollectingVisitor<>(
+                Predicates.or(
+                        Predicates.instanceOf(SelectNode.class),
+                        Predicates.instanceOf(SubqueryNode.class)
+                ));
+        accept(cv);
+        List<QueryTreeNode> nodeList = cv.getCollected();
+        for (QueryTreeNode node : nodeList) {
+            if (node instanceof SelectNode) {
+                ((SelectNode) node).collectExpressions().forEach((k, v) -> {
+                    if (exprMap.containsKey(k)) {
+                        exprMap.get(k).addAll(v);
+                    } else {
+                        exprMap.put(k, v);
+                    }
+                });
+            } else if (node instanceof SubqueryNode) {
+                SubqueryNode subq = (SubqueryNode) node;
+                if (subq.leftOperand != null) {
+                    subq.leftOperand.collectExpressions(exprMap);
+                }
+                if (subq.resultSet instanceof ProjectRestrictNode) {
+                    // don't call ProjectRestrictNode.collectExpressions() because it will
+                    // collect child SelectNode again
+                    PredicateList predList = ((ProjectRestrictNode) subq.resultSet).restrictionList;
+                    if (predList != null) {
+                        predList.collectExpressions(exprMap);
+                    }
+                }
+            }
+        }
+        CollectNodesVisitor cnv = new CollectNodesVisitor(FromBaseTable.class);
+        accept(cnv);
+        List<FromBaseTable> fbtList = cnv.getList();
+        for (FromBaseTable fbt : fbtList) {
+            fbt.setReferencingExpressions(exprMap);
+        }
 
         // We should try to cost control first, and fallback to spark if necessary
         DataSetProcessorType connectionType = getLanguageConnectionContext().getDataSetProcessorType();
@@ -190,7 +231,7 @@ public abstract class DMLStatementNode extends StatementNode {
         }
 
         if (shouldRunSpark(resultSet)) {
-            CollectNodesVisitor cnv = new CollectNodesVisitor(FromTable.class);
+            cnv = new CollectNodesVisitor(FromTable.class);
             resultSet.accept(cnv);
             for (Object obj : cnv.getList()) {
                 FromTable ft = (FromTable) obj;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DefaultNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DefaultNode.java
@@ -31,19 +31,18 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
+import com.splicemachine.db.catalog.types.DefaultInfoImpl;
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.sql.compile.Parser;
-import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.sql.compile.Visitable;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.dictionary.ColumnDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.DefaultDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
-import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.catalog.types.DefaultInfoImpl;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Collections;
 import java.util.List;
@@ -51,7 +50,6 @@ import java.util.List;
 /**
  * DefaultNode represents a column/parameter default.
  */
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public  class DefaultNode extends ValueNode
 {
     private String        columnName;
@@ -303,6 +301,11 @@ public  class DefaultNode extends ValueNode
     protected boolean isEquivalent(ValueNode other)
     {
         return this == other;
+    }
+
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(this);
     }
 
     public List<? extends QueryTreeNode> getChildren() {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GenerationClauseNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GenerationClauseNode.java
@@ -31,13 +31,11 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
-import com.splicemachine.db.iapi.sql.depend.ProviderList;
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
-
-import com.splicemachine.db.iapi.error.StandardException;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import com.splicemachine.db.iapi.sql.depend.ProviderList;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -47,7 +45,6 @@ import java.util.Vector;
  * This node describes a Generation Clause in a column definition.
  *
  */
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class GenerationClauseNode extends ValueNode
 {
     ///////////////////////////////////////////////////////////////////////////////////
@@ -144,11 +141,16 @@ public class GenerationClauseNode extends ValueNode
     protected boolean isSemanticallyEquivalent(ValueNode other)
             throws StandardException
     {
-        if ( !( other instanceof GenerationClauseNode) ) { return false; }
+        if (!(other instanceof GenerationClauseNode)) {
+            return false;
+        }
 
-        GenerationClauseNode    that = (GenerationClauseNode) other;
+        GenerationClauseNode that = (GenerationClauseNode) other;
+        return this._generationExpression.isSemanticallyEquivalent(that._generationExpression);
+    }
 
-        return this._generationExpression.isSemanticallyEquivalent( that._generationExpression );
+    public int hashCode() {
+        return 31 * getBaseHashCode() + _generationExpression.hashCode();
     }
     
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GroupByList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GroupByList.java
@@ -38,6 +38,8 @@ import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * A GroupByList represents the list of expressions in a GROUP BY clause in
@@ -336,5 +338,21 @@ public class GroupByList extends OrderedColumnList{
             groupingCol.setColumnExpression(
                     groupingCol.getColumnExpression().preprocess(numTables,fromList,whereSubquerys,wherePredicates));
         }
+    }
+
+    public void replaceIndexExpressions(ResultColumnList childRCL) throws StandardException {
+        for (int i = 0; i < size(); i++) {
+            GroupByColumn gbc = (GroupByColumn) elementAt(i);
+            gbc.setColumnExpression(gbc.getColumnExpression().replaceIndexExpression(childRCL));
+        }
+    }
+
+    public boolean collectExpressions(Map<Integer, Set<ValueNode>> exprMap) {
+        boolean result = true;
+        for (int i = 0; i < size(); i++) {
+            GroupByColumn gbc = (GroupByColumn) elementAt(i);
+            result = result && gbc.getColumnExpression().collectSingleExpression(exprMap);
+        }
+        return result;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GroupByNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GroupByNode.java
@@ -672,6 +672,7 @@ public class GroupByNode extends SingleChildResultSetNode{
         /*
         ** Get the new PR, put above the GroupBy.
         */
+        boolean isFromExprIndex = resultColumns.isFromExprIndex();
         ResultColumnList rclNew=(ResultColumnList)getNodeFactory().getNode(C_NodeTypes.RESULT_COLUMN_LIST,
                 getContextManager());
         int sz=resultColumns.size();
@@ -681,6 +682,7 @@ public class GroupByNode extends SingleChildResultSetNode{
                 rclNew.addElement(rc);
             }
         }
+        rclNew.setFromExprIndex(isFromExprIndex);
 
         // if any columns in the source RCL were generated for an order by
         // remember it in the new RCL as well. After the sort is done it will
@@ -704,12 +706,13 @@ public class GroupByNode extends SingleChildResultSetNode{
         */
         childResult.setResultColumns((ResultColumnList)
                 getNodeFactory().getNode(C_NodeTypes.RESULT_COLUMN_LIST,getContextManager()));
+        childResult.getResultColumns().setFromExprIndex(isFromExprIndex);
 
         /*
         ** Set the group by RCL to be empty
         */
         resultColumns=(ResultColumnList)getNodeFactory().getNode(C_NodeTypes.RESULT_COLUMN_LIST,getContextManager());
-
+        resultColumns.setFromExprIndex(isFromExprIndex);
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
@@ -39,6 +39,7 @@ import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.compile.*;
 import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
+import com.splicemachine.db.iapi.sql.dictionary.IndexRowGenerator;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.util.JBitSet;
 
@@ -512,12 +513,14 @@ public abstract class HashableJoinStrategy extends BaseJoinStrategy {
         int[] conglomColumn = new int[hashKeyColumns.length];
         if (cd != null && cd.isIndex()) {
 			/*
-			** If the conglomerate is an index, get the column numbers of the
+			** If the conglomerate is a normal index, get the column numbers of the
 			** hash keys in the base heap.
 			*/
-            for (int index = 0; index < hashKeyColumns.length; index++) {
-                conglomColumn[index] =
-                        cd.getIndexDescriptor().baseColumnPositions()[hashKeyColumns[index]];
+            if (!cd.getIndexDescriptor().isOnExpression()) {
+                for (int index = 0; index < hashKeyColumns.length; index++) {
+                    conglomColumn[index] =
+                            cd.getIndexDescriptor().baseColumnPositions()[hashKeyColumns[index]];
+                }
             }
         }
         else {
@@ -533,10 +536,20 @@ public abstract class HashableJoinStrategy extends BaseJoinStrategy {
             }
         }
 		/* Put the equality predicates on the key columns for the hash first.
-		 * (Column # is columns[colCtr] from above.)
 		 */
-        for (int index = hashKeyColumns.length - 1; index >= 0; index--) {
-            nonStoreRestrictionList.putOptimizableEqualityPredicateFirst(innerTable, conglomColumn[index]);
+        if (cd != null && cd.isIndex() && cd.getIndexDescriptor().isOnExpression()) {
+            IndexRowGenerator irg = cd.getIndexDescriptor();
+            assert innerTable instanceof QueryTreeNode;
+            QueryTreeNode inner = (QueryTreeNode) innerTable;
+
+            ValueNode[] exprAsts = irg.getParsedIndexExpressions(inner.getLanguageConnectionContext(), innerTable);
+            for (int index = hashKeyColumns.length - 1; index >= 0; index--) {
+                nonStoreRestrictionList.putOptimizableEqualityPredicateFirst(innerTable, exprAsts[hashKeyColumns[index]]);
+            }
+        } else {
+            for (int index = hashKeyColumns.length - 1; index >= 0; index--) {
+                nonStoreRestrictionList.putOptimizableEqualityPredicateFirst(innerTable, conglomColumn[index]);
+            }
         }
     }
 
@@ -585,7 +598,9 @@ public abstract class HashableJoinStrategy extends BaseJoinStrategy {
             }
         }
         else if (cd.isIndex()) {
-            columns = cd.getIndexDescriptor().baseColumnPositions();
+            if (!cd.getIndexDescriptor().isOnExpression()) {
+                columns = cd.getIndexDescriptor().baseColumnPositions();
+            }
         }
         else {
             columns = new int[innerTable.getTableDescriptor().getNumberOfColumns()];
@@ -595,12 +610,24 @@ public abstract class HashableJoinStrategy extends BaseJoinStrategy {
         }
 
         // Build a Vector of all the hash key columns
-        int colCtr;
         Vector hashKeyVector = new Vector();
-        for (colCtr = 0; colCtr < columns.length; colCtr++) {
-            // Is there an equijoin condition on this column?
-            if (predList.hasOptimizableEquijoin(innerTable, columns[colCtr])) {
-                hashKeyVector.add(colCtr);
+        if (cd != null && cd.isIndex() && cd.getIndexDescriptor().isOnExpression()) {
+            IndexRowGenerator irg = cd.getIndexDescriptor();
+            assert innerTable instanceof QueryTreeNode;
+            QueryTreeNode inner = (QueryTreeNode) innerTable;
+
+            ValueNode[] exprAsts = irg.getParsedIndexExpressions(inner.getLanguageConnectionContext(), innerTable);
+            for (int colIdx = 0; colIdx < exprAsts.length; colIdx++) {
+                if (predList.hasOptimizableEquijoin(innerTable, exprAsts[colIdx])) {
+                    hashKeyVector.add(colIdx);
+                }
+            }
+        } else {
+            for (int colCtr = 0; colCtr < columns.length; colCtr++) {
+                // Is there an equijoin condition on this column?
+                if (predList.hasOptimizableEquijoin(innerTable, columns[colCtr])) {
+                    hashKeyVector.add(colCtr);
+                }
             }
         }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
@@ -46,6 +46,7 @@ import com.splicemachine.db.iapi.types.*;
 
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Objects;
 
 /**
  * An InListOperatorNode represents an IN list.
@@ -983,10 +984,7 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 	
 	@Override
 	public int hashCode(){
-		int result=(isOrdered?1:0);
-		result=31*result+(sortDescending?1:0);
-		result = 31*result + leftOperandList.hashCode();
-		result = 31*result + rightOperandList.hashCode();
-		return result;
+		int result = super.hashCode();
+		return Objects.hash(result, isOrdered, sortDescending);
 	}
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IndexToBaseRowNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IndexToBaseRowNode.java
@@ -409,4 +409,11 @@ public class IndexToBaseRowNode extends FromTable{
                 attrDelim + getFinalCostEstimate(false).prettyIndexLookupString(attrDelim) +
                 ")";
     }
+
+    @Override
+    public void replaceIndexExpressions(ResultColumnList childRCL) throws StandardException {
+        if (restrictionList != null) {
+            restrictionList.replaceIndexExpression(childRCL);
+        }
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IsNullNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IsNullNode.java
@@ -46,6 +46,8 @@ import com.splicemachine.db.iapi.types.TypeId;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.sql.Types;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * This node represents either a unary 
@@ -254,6 +256,16 @@ public final class IsNullNode extends UnaryComparisonOperatorNode  {
 		return cr!=null;
 	}
 
+	@Override
+	public boolean optimizableEqualityNode(Optimizable optTable,
+										   ValueNode indexExpr,
+										   boolean isNullOkay) {
+		if (!isNullNode() || !isNullOkay)
+			return false;
+
+		return indexExpr.semanticallyEquals(operand);
+	}
+
     /**
      *
      * The cardinality of a isNull UnaryOperator.  Always 2.
@@ -265,5 +277,19 @@ public final class IsNullNode extends UnaryComparisonOperatorNode  {
         return Math.min(2L, numberOfRows);
     }
 
+    @Override
+	public ValueNode replaceIndexExpression(ResultColumnList childRCL) throws StandardException {
+		if (operand != null) {
+			operand = operand.replaceIndexExpression(childRCL);
+		}
+		return this;
+	}
 
+	@Override
+	public boolean collectExpressions(Map<Integer, Set<ValueNode>> exprMap) {
+		if (operand != null) {
+			return operand.collectExpressions(exprMap);
+		}
+		return true;
+	}
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JavaToSQLValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JavaToSQLValueNode.java
@@ -43,7 +43,6 @@ import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.StringDataValue;
 import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.util.JBitSet;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.lang.reflect.Modifier;
 import java.util.Collections;
@@ -53,7 +52,6 @@ import java.util.List;
  * This node type converts a value from the Java domain to the SQL domain.
  */
 
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class JavaToSQLValueNode extends ValueNode
 {
     JavaValueNode    javaNode;
@@ -376,6 +374,10 @@ public class JavaToSQLValueNode extends ValueNode
             return javaNode.isSemanticallyEquivalent(other.javaNode);
         }
         return false;
+    }
+
+    public int hashCode() {
+        return 31 * getBaseHashCode() + (javaNode == null ? 0 : javaNode.hashCode());
     }
 
     public List<? extends QueryTreeNode> getChildren() {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JavaValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JavaValueNode.java
@@ -477,4 +477,8 @@ abstract class JavaValueNode extends QueryTreeNode implements ParentNode
     public boolean isSemanticallyEquivalent(QueryTreeNode o) throws StandardException {
         return false;
     }
+
+    public int hashCode() {
+        return getBaseHashCode();
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
@@ -51,7 +51,6 @@ import com.splicemachine.db.impl.ast.PredicateUtils;
 import com.splicemachine.db.impl.ast.RSUtils;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.SerializationUtils;
-import org.apache.spark.sql.catalyst.optimizer.Cost;
 import splice.com.google.common.base.Joiner;
 import splice.com.google.common.base.Predicates;
 import splice.com.google.common.collect.Lists;
@@ -370,6 +369,31 @@ public class JoinNode extends TableOperatorNode{
         return true;
     }
 
+    private static void getNewResultColumns(ResultColumnList oldRCL, ResultColumnList newRCL, ResultSetNode child)
+            throws StandardException
+    {
+        ResultColumnList childRCL = child.getResultColumns();
+        if (childRCL.isFromExprIndex()) {
+            ResultColumnList childCopy = childRCL.copyListAndObjects();
+            childCopy.genVirtualColumnNodes(child, childRCL);
+            for (ResultColumn childRC : childCopy) {
+                newRCL.addResultColumn(childRC);
+            }
+            newRCL.setFromExprIndex(true);
+        } else {
+            Set<ResultColumn> childRCSet = new HashSet<>();
+            for (ResultColumn childRC : childRCL) {
+                childRCSet.add(childRC);
+            }
+            for (ResultColumn oldRC : oldRCL) {
+                ResultColumn source = oldRC.getChildResultColumn();
+                if (childRCSet.contains(source)) {
+                    newRCL.addResultColumn(oldRC);
+                }
+            }
+        }
+    }
+
     @Override
     public Optimizable modifyAccessPath(JBitSet outerTables) throws StandardException{
         // modify access path for On clause subqueries
@@ -377,6 +401,33 @@ public class JoinNode extends TableOperatorNode{
             subqueryList.modifyAccessPaths();
 
         super.modifyAccessPath(outerTables);
+
+        /* If any of the two children has chosen an index on expression, result
+         * columns have to be rebuilt because the number may change. Column
+         * mapping between parent node and this node is broken after reassigning
+         * resultColumns. For this reason, resultColumns of (grand-)parent nodes
+         * must be rebuilt until the top select node in the current query block.
+         *
+         * This logic handles nested JoinNode. If parent node is a PRN, its
+         * result columns are rebuilt in its modifyAccessPath() method. If
+         * parent is SelectNode, there is no need to rebuild its result columns
+         * but only replace their expressions.
+         */
+        if (leftResultSet.getResultColumns().isFromExprIndex() || rightResultSet.getResultColumns().isFromExprIndex()) {
+            ResultColumnList newResultColumns = (ResultColumnList) getNodeFactory()
+                    .getNode(C_NodeTypes.RESULT_COLUMN_LIST, getContextManager());
+            newResultColumns.copyOrderBySelect(resultColumns);
+
+            getNewResultColumns(resultColumns, newResultColumns, leftResultSet);
+            getNewResultColumns(resultColumns, newResultColumns, rightResultSet);
+            resultColumns = newResultColumns;
+            assert resultColumns.size() == leftResultSet.getResultColumns().size() + rightResultSet.getResultColumns().size();
+        }
+
+        // replace join predicates pushed down to right
+        if (leftResultSet.getResultColumns().isFromExprIndex()) {
+            rightResultSet.replaceIndexExpressions(leftResultSet.getResultColumns());
+        }
 
         /* By the time we're done here, both the left and right
          * predicate lists should be empty because we pushed everything
@@ -685,7 +736,7 @@ public class JoinNode extends TableOperatorNode{
      * @throws StandardException Thrown on error
      */
     @Override
-    public ResultSetNode preprocess(int numTables,GroupByList gbl,FromList fromList) throws StandardException{
+    public ResultSetNode preprocess(int numTables, GroupByList gbl, FromList fromList) throws StandardException{
         ResultSetNode newTreeTop;
 
         newTreeTop=super.preprocess(numTables,gbl,fromList);
@@ -2308,5 +2359,25 @@ public class JoinNode extends TableOperatorNode{
 
     public void resetOptimized() {
         optimized = false;
+    }
+
+    public ValueNode getJoinClause() { return joinClause; }
+
+    @Override
+    public boolean collectExpressions(Map<Integer, Set<ValueNode>> exprMap) {
+        boolean result = true;
+        if (joinClause != null) {
+            result = joinClause.collectExpressions(exprMap);
+        }
+        if (joinPredicates != null) {
+            result = result && joinPredicates.collectExpressions(exprMap);
+        }
+        if (leftPredicateList != null) {
+            result = result && leftPredicateList.collectExpressions(exprMap);
+        }
+        if (rightPredicateList != null) {
+            result = result && rightPredicateList.collectExpressions(exprMap);
+        }
+        return result && super.collectExpressions(exprMap);
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ListValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ListValueNode.java
@@ -190,9 +190,12 @@ public final class ListValueNode extends ValueNode {
     public int hashCode() {
         final int prime = 37;
         int result = 17;
-        
-        for (int i = 0; i < numValues(); i++) {
-            result = result * prime + valuesList.elementAt(i).hashCode();
+
+        result = prime * result + getBaseHashCode();
+        if (valuesList != null) {
+            for (int i = 0; i < numValues(); i++) {
+                result = result * prime + valuesList.elementAt(i).hashCode();
+            }
         }
         return result;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MethodCallNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MethodCallNode.java
@@ -1392,4 +1392,15 @@ abstract class MethodCallNode extends JavaValueNode
         }
         return false;
     }
+
+    @Override
+    public int hashCode() {
+        int result = getBaseHashCode();
+        result = 31 * result + javaClassName.hashCode();
+        result = 31 * result + methodName.hashCode();
+        for (JavaValueNode methodParm : methodParms) {
+            result = 31 * result + methodParm.hashCode();
+        }
+        return Objects.hash(result, deterministicBuiltInFunctions.contains(methodName.toLowerCase()));
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MultiaryFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MultiaryFunctionNode.java
@@ -43,7 +43,6 @@ import com.splicemachine.db.iapi.util.JBitSet;
 
 import java.lang.reflect.Modifier;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * SQL Reference Guide for DB2 has section titled "Rules for result data types" at the following url
@@ -371,7 +370,10 @@ public abstract class MultiaryFunctionNode extends ValueNode
 
     @Override
     public int hashCode() {
-        return Objects.hash(functionName, argumentsList);
+        int result = getBaseHashCode();
+        result = 31 * result + functionName.hashCode();
+        result = 31 * result + argumentsList.hashCode();
+        return result;
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NextSequenceNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NextSequenceNode.java
@@ -31,24 +31,22 @@
 package com.splicemachine.db.impl.sql.compile;
 
 import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.reference.ClassName;
-import com.splicemachine.db.iapi.services.sanity.SanityManager;
-import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
-import com.splicemachine.db.iapi.sql.compile.CompilerContext;
+import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.classfile.VMOpcode;
-import com.splicemachine.db.iapi.sql.dictionary.SequenceDescriptor;
+import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import com.splicemachine.db.iapi.sql.dictionary.SequenceDescriptor;
 
+import java.sql.Types;
 import java.util.Collections;
 import java.util.List;
-import java.sql.Types;
 
 /**
  * A class that represents a value obtained from a Sequence using 'NEXT VALUE'
  */
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class NextSequenceNode extends ValueNode {
 
     private TableName sequenceName;
@@ -199,6 +197,10 @@ public class NextSequenceNode extends ValueNode {
 
     protected boolean isEquivalent(ValueNode other) throws StandardException {
         return this == other;
+    }
+
+    public int hashCode() {
+        return System.identityHashCode(this);
     }
 
     public List<? extends QueryTreeNode> getChildren() {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderByColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrderByColumn.java
@@ -31,8 +31,6 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
-import java.util.Iterator;
-
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OverClause.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OverClause.java
@@ -39,6 +39,8 @@ import com.splicemachine.db.iapi.services.sanity.SanityManager;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * This class aggregates objects that make up a Window Over() clause.<br/>
@@ -337,5 +339,26 @@ public class OverClause extends QueryTreeNode {
             }
             return this;
         }
+    }
+
+    public OverClause replaceIndexExpression(ResultSetNode child) throws StandardException {
+        if (partition != null) {
+            partition.replaceIndexExpressions(child.getResultColumns());
+        }
+        if (orderByClause != null) {
+            orderByClause.replaceIndexExpressions(child);
+        }
+        return this;
+    }
+
+    public boolean collectExpressions(Map<Integer, Set<ValueNode>> exprMap) {
+        boolean result = true;
+        if (partition != null) {
+            result = partition.collectExpressions(exprMap);
+        }
+        if (orderByClause != null) {
+            result = result && orderByClause.collectExpressions(exprMap);
+        }
+        return result;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParameterNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParameterNode.java
@@ -42,7 +42,6 @@ import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.types.JSQLType;
 import com.splicemachine.db.iapi.types.TypeId;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.sql.Types;
 import java.util.LinkedList;
@@ -54,7 +53,6 @@ import java.util.Vector;
  *
  */
 
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class ParameterNode extends ValueNode
 {
 
@@ -524,6 +522,10 @@ public class ParameterNode extends ValueNode
     protected boolean isEquivalent(ValueNode o)
     {
         return this == o;
+    }
+
+    public int hashCode() {
+        return System.identityHashCode(this);
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
@@ -740,6 +740,7 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
                      */
                     resultColumns.doProjection(false);
                 }
+
                 /* We consider materialization into a temp table as a last step.
                  * Currently, we only materialize VTIs that are inner tables
                  * and can't be instantiated multiple times.  In the future we
@@ -808,6 +809,31 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
             childResult=childResult.changeAccessPath(outerTables);
         }
         accessPathModified=true;
+
+        if (childResult.getResultColumns().isFromExprIndex()) {
+            /* We get a shallow copy of the ResultColumnList and its
+             * ResultColumns.  (Copy maintains ResultColumn.expression for now.)
+             *
+             * The following assignment to resultColumns is destructive because
+             * the column mapping from parent node to this PRN is broken. However,
+             * it has to be done because if childResult's access path is an index
+             * on expressions, the number of result columns may change here. As
+             * long as this code path is executed, resultColumns of (grand-)parent
+             * nodes must be rebuilt until the top select node in the current query
+             * block. There, we can replace RC's expressions but keep RC instances.
+             *
+             * If parent is also a PRN, its result columns would be rebuilt here,
+             * too. If parent is any type of join, then its result columns would be
+             * rebuilt in modifyAccessPath() in JoinNode. If parent is SelectNode,
+             * there is no need to rebuild its result columns but only replace
+             * their expressions.
+             */
+            resultColumns = childResult.getResultColumns().copyListAndObjects();
+            resultColumns.genVirtualColumnNodes(childResult, childResult.getResultColumns());
+            if (restrictionList != null) {
+                restrictionList.replaceIndexExpression(childResult.getResultColumns());
+            }
+        }
 
         /*
         ** Replace this PRN with a HTN if a hash join
@@ -2066,5 +2092,22 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
             return ((FromTable)childResult).hasJoinPredicatePushedDownFromOuter();
 
         return hasJoinPredicatePushedDownFromOuter;
+    }
+
+    @Override
+    public void replaceIndexExpressions(ResultColumnList childRCL) throws StandardException {
+        if (restrictionList != null) {
+            restrictionList.replaceIndexExpression(childRCL);
+        }
+        childResult.replaceIndexExpressions(childRCL);
+    }
+
+    @Override
+    public boolean collectExpressions(Map<Integer, Set<ValueNode>> exprMap) {
+        boolean result = true;
+        if (restrictionList != null) {
+            result = restrictionList.collectExpressions(exprMap);
+        }
+        return result && childResult.collectExpressions(exprMap);
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QueryTreeNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QueryTreeNode.java
@@ -2076,4 +2076,9 @@ public abstract class QueryTreeNode implements Node, Visitable{
         accept(visitor);
         return visitor.getNodes();
     }
+
+    protected int getBaseHashCode() {
+        int nodeType = getNodeType();
+        return nodeType ^ (nodeType >>> 16);
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RelationalOperator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RelationalOperator.java
@@ -143,6 +143,15 @@ public interface RelationalOperator
 						throws StandardException;
 
 	/**
+	 * Get the index column position if there is one operand matches an index
+	 * expression defined on optTable.
+	 * @param tableNumber Table number of the base table on which the index
+	 *                    expression is defined.
+	 * @return The matching index column position if there is a match, otherwise -1.
+	 */
+	int getMatchingExprIndexColumnPosition(int tableNumber);
+
+	/**
 	 * Check whether this RelationalOperator compares the given ColumnReference
 	 * to any columns in the same table as the ColumnReference.
 	 *

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
@@ -137,6 +137,9 @@ public class ResultColumn extends ValueNode
     /* virtualColumnId is the ResultColumn's position (1-based) within the ResultSet */
     private int        virtualColumnId;
 
+    /* whether this result column comes from an expression-based index column */
+    private ValueNode indexExpression = null;
+
     /**
      * Different types of initializer parameters indicate different
      * types of initialization. Parameters may be:
@@ -1639,6 +1642,7 @@ public class ResultColumn extends ValueNode
         }
 
         newResultColumn.fromLeftChild = this.fromLeftChild;
+        newResultColumn.indexExpression = this.indexExpression;
         return newResultColumn;
     }
 
@@ -1912,7 +1916,14 @@ public class ResultColumn extends ValueNode
     public int getTableNumber() {
         ResultColumn other = this;
         while (true) {
-            if (other.expression instanceof ColumnReference)
+            if (other.indexExpression != null) {
+                // an index expression has at least one column reference and all column
+                // references must refer to the same table
+                List<ColumnReference> crList = other.getHashableJoinColumnReference();
+                assert(!crList.isEmpty());
+                return crList.get(0).getTableNumber();
+            }
+            else if (other.expression instanceof ColumnReference)
                 return ((ColumnReference) other.expression).getTableNumber();
             else if (other.expression instanceof VirtualColumnNode) {
                 VirtualColumnNode vcn = (VirtualColumnNode) other.expression;
@@ -1965,6 +1976,11 @@ public class ResultColumn extends ValueNode
 
     public boolean equals(Object o){
         return this == o;
+    }
+
+    public int hashCode() {
+        int result = getBaseHashCode();
+        return 31 * result + (expression == null ? 0 : expression.hashCode());
     }
 
 
@@ -2099,6 +2115,21 @@ public class ResultColumn extends ValueNode
         return -1L;
     }
 
+    public ResultColumn getChildResultColumn() {
+        ValueNode expression = getExpression();
+        while (expression != null) {
+            if (expression instanceof VirtualColumnNode) {
+                return ((VirtualColumnNode) expression).getSourceColumn();
+            } else if (expression instanceof ColumnReference) {
+                return ((ColumnReference) expression).getSource();
+            } else if (expression instanceof CastNode) {
+                expression = ((CastNode) expression).getCastOperand();
+            } else {
+                expression = null;
+            }
+        }
+        return null;
+    }
 
     public void setFromLeftChild(boolean fromLeftChild) {
         this.fromLeftChild = fromLeftChild;
@@ -2106,6 +2137,60 @@ public class ResultColumn extends ValueNode
 
     public boolean isFromLeftChild() {
         return fromLeftChild;
+    }
+
+    public ValueNode getIndexExpression() {
+        return indexExpression;
+    }
+
+    public void setIndexExpression(ValueNode indexExpression) {
+        this.indexExpression = indexExpression;
+    }
+
+    /**
+     * Get a ColumnReference node referring to this ResultColumn. This method should be used only in
+     * case of replacing an index expression.
+     * @param originalExpr Original expression to be replaced.
+     *                     originalExpr.semanticallyEquals(getIndexExpression()) should always be true.
+     * @return A column reference referring to this ResultColumn.
+     */
+    public ColumnReference getColumnReference(ValueNode originalExpr) throws StandardException {
+        List<ColumnReference> origCRs = originalExpr.getHashableJoinColumnReference();
+        assert !origCRs.isEmpty();
+        ColumnReference origCR = origCRs.get(0);
+
+        ColumnReference cr = (ColumnReference) getNodeFactory().getNode(
+                C_NodeTypes.COLUMN_REFERENCE,
+                getColumnName(),
+                getTableNameObject(),
+                getContextManager()
+        );
+        cr.setSource(this);
+        cr.setTableNumber(getTableNumber());
+        cr.setColumnNumber(getColumnPosition());
+        cr.columnName = this.name;
+        cr.setType(getTypeServices());
+        cr.setOuterJoinLevel(origCR.getOuterJoinLevel());
+        cr.setNestingLevel(origCR.getNestingLevel());
+        cr.setSourceLevel(origCR.getSourceLevel());
+
+        return cr;
+    }
+
+    @Override
+    public ValueNode replaceIndexExpression(ResultColumnList childRCL) throws StandardException {
+        // For ResultColumn, never construct a new instance. Only replace expression
+        // and set indexExpression properly.
+        if (childRCL != null) {
+            for (ResultColumn childRC : childRCL) {
+                if (expression.semanticallyEquals(childRC.getIndexExpression())) {
+                    expression = childRC.getColumnReference(expression);
+                    indexExpression = childRC.getIndexExpression();
+                    break;
+                }
+            }
+        }
+        return this;
     }
 }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumnList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumnList.java
@@ -76,6 +76,7 @@ public class ResultColumnList extends QueryTreeNodeVector<ResultColumn>{
     /* Is this the ResultColumnList for an index row? */
     protected boolean indexRow;
     protected long conglomerateId;
+    protected boolean fromExprIndex=false;
 
     int orderBySelect=0; // the number of result columns pulled up
     // from ORDERBY list
@@ -1616,6 +1617,7 @@ public class ResultColumnList extends QueryTreeNodeVector<ResultColumn>{
             newList.addResultColumn(newResultColumn);
         }
         newList.copyOrderBySelect(this);
+        newList.setFromExprIndex(this.isFromExprIndex());
         return newList;
     }
 
@@ -3158,6 +3160,7 @@ public class ResultColumnList extends QueryTreeNodeVector<ResultColumn>{
         ResultColumnList newCols=(ResultColumnList)getNodeFactory().getNode(
                 C_NodeTypes.RESULT_COLUMN_LIST,
                 getContextManager());
+        newCols.setFromExprIndex(fromExprIndex);
 
         int size=size();
         for(index=0;index<size;index++){
@@ -3966,6 +3969,12 @@ public class ResultColumnList extends QueryTreeNodeVector<ResultColumn>{
         return isExpressableInSparkSQL;
     }
 
+    public boolean isFromExprIndex() {
+        return fromExprIndex;
+    }
 
+    public void setFromExprIndex(boolean fromExprIndex) {
+        this.fromExprIndex = fromExprIndex;
+    }
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultSetNode.java
@@ -50,10 +50,7 @@ import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.util.JBitSet;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 
 /**
  * A ResultSetNode represents a result set, that is, a set of rows.  It is
@@ -541,7 +538,7 @@ public abstract class ResultSetNode extends QueryTreeNode{
      * @throws StandardException Thrown on error
      */
 
-    public ResultSetNode preprocess(int numTables,GroupByList gbl,FromList fromList) throws StandardException{
+    public ResultSetNode preprocess(int numTables, GroupByList gbl, FromList fromList) throws StandardException{
         if(SanityManager.DEBUG)
             SanityManager.THROWASSERT(
                     "preprocess() not expected to be called for "+getClass().toString());
@@ -1763,5 +1760,12 @@ public abstract class ResultSetNode extends QueryTreeNode{
 
     public boolean getContainsSelfReference() {
         return containsSelfReference;
+    }
+
+    public void replaceIndexExpressions(ResultColumnList childRCL) throws StandardException {
+    }
+
+    public boolean collectExpressions(Map<Integer, Set<ValueNode>> exprMap) {
+        return true;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLToJavaValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLToJavaValueNode.java
@@ -538,4 +538,9 @@ public class SQLToJavaValueNode extends JavaValueNode {
         }
         return false;
     }
+
+    @Override
+    public int hashCode() {
+        return 31 * getBaseHashCode() + value.hashCode();
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
@@ -850,7 +850,7 @@ public class SelectNode extends ResultSetNode{
      * @throws StandardException Thrown on error
      */
     @Override
-    public ResultSetNode preprocess(int numTables,GroupByList gbl,FromList fl) throws StandardException{
+    public ResultSetNode preprocess(int numTables, GroupByList gbl, FromList fl) throws StandardException{
         ResultSetNode newTop=this;
 
         /* Put the expression trees in conjunctive normal form.
@@ -1220,6 +1220,23 @@ public class SelectNode extends ResultSetNode{
         boolean eliminateSort=false;
         ResultSetNode prnRSN;
 
+        // replace index expressions in select list with column references referencing child result set
+        // only happen when best access path is an expression-based covering index
+        ResultColumnList childResultColumns = ((ResultSetNode)fromList.elementAt(0)).getResultColumns();
+        if (childResultColumns.isFromExprIndex()) {
+            for (ResultColumn rc : resultColumns) {
+                rc.replaceIndexExpression(childResultColumns);
+            }
+            // Do not set fromIndexExpr for select node's result columns since they are used as
+            // anchors for outer level column references. An outer column references refers to an
+            // inner level index expression points to these anchors. If the flag is propagated to
+            // outer level, it doesn't help replacing index expressions but break column mapping.
+
+            if (wherePredicates != null) {
+                wherePredicates.replaceIndexExpression(childResultColumns);
+            }
+        }
+
         prnRSN=(ResultSetNode)getNodeFactory().getNode(
                 C_NodeTypes.PROJECT_RESTRICT_NODE,
                 fromList.elementAt(0),    /* Child ResultSet */
@@ -1244,6 +1261,20 @@ public class SelectNode extends ResultSetNode{
             }
         }
 
+        if(hasWindows()) {
+            for (WindowNode windowDefinition : windowDefinitionList) {
+                if (childResultColumns.isFromExprIndex()) {
+                    windowDefinition.replaceIndexExpression((ResultSetNode) fromList.elementAt(0));
+                }
+            }
+        }
+
+        if(orderByList!=null) {
+            if (childResultColumns.isFromExprIndex()) {
+                orderByList.replaceIndexExpressions((ResultSetNode) fromList.elementAt(0));
+            }
+        }
+
         /*
         ** If we have aggregates OR a select list we want
         ** to generate a GroupByNode.  In the case of a
@@ -1253,6 +1284,28 @@ public class SelectNode extends ResultSetNode{
         ** block.
         */
         if(((selectAggregates!=null) && (!selectAggregates.isEmpty())) || (groupByList!=null)){
+            if (childResultColumns.isFromExprIndex()) {
+                if (groupByList != null) {
+                    groupByList.replaceIndexExpressions(childResultColumns);
+                }
+                if (havingClause != null) {
+                    for (ResultColumn childRC : childResultColumns) {
+                        IndexExpressionReplacementVisitor ierv =
+                                new IndexExpressionReplacementVisitor(childRC, null);
+                        havingClause.accept(ierv);
+                    }
+                }
+                if (havingAggregates != null) {
+                    for (AggregateNode havingAggr : havingAggregates) {
+                        havingAggr.replaceIndexExpression(childResultColumns);
+                    }
+                }
+                if (selectAggregates != null) {
+                    for (AggregateNode selectAggr : selectAggregates) {
+                        selectAggr.replaceIndexExpression(childResultColumns);
+                    }
+                }
+            }
 
             List<AggregateNode> aggs=selectAggregates;
             if(havingAggregates!=null && !havingAggregates.isEmpty()){
@@ -1895,6 +1948,19 @@ public class SelectNode extends ResultSetNode{
             rightRCList.genVirtualColumnNodes(rightResultSet,rightResultSet.resultColumns);
             rightRCList.adjustVirtualColumnIds(leftRCList.size());
 
+            /* At this point, the right side may still have join predicates pushed down to it but refer
+             * to outer index expressions. If the outer result set chose a covering expression-based
+             * index access path, all outer index expressions used in inner result set should be replaced
+             * here because the outer result columns are updated during modifyAccessPath(). If we don't
+             * replace these index expressions, they refer to the outdated result columns which will not
+             * get any result set number assigned later.
+             * Index expressions refer to the inner table are already replaced during modifying inner
+             * table's access path.
+             */
+            if (leftRCList.isFromExprIndex()) {
+                rightResultSet.replaceIndexExpressions(leftResultSet.getResultColumns());
+            }
+
 //            if(leftBaseTable != null && rightBaseTable != null){
 //                int size = rightBaseTable.restrictionList.size();
 //
@@ -1911,6 +1977,9 @@ public class SelectNode extends ResultSetNode{
 
             /* Concatenate the 2 ResultColumnLists */
             leftRCList.nondestructiveAppend(rightRCList);
+            if (rightRCList.isFromExprIndex()) {
+                leftRCList.setFromExprIndex(true);
+            }
 
             /* Now we're finally ready to generate the JoinNode and have it
              * replace the 1st 2 entries in the FromList.
@@ -1956,6 +2025,10 @@ public class SelectNode extends ResultSetNode{
                         newPRNode.addNewPredicate(pred);
                     }
                     ((FromTable)rightResultSet).setPostJoinPredicates(null);
+                    if (postJoinPredicates.size() > 0) {
+                        ((ProjectRestrictNode) newPRNode).getRestrictionList()
+                                .replaceIndexExpression(joinNode.getResultColumns());
+                    }
                 }
             }
 
@@ -2385,29 +2458,6 @@ public class SelectNode extends ResultSetNode{
         }
 
         return wl;
-    }
-
-
-    /*
-        From where clause, this method returns a collection of all predicates that are eligible as a hash join predicate.
-        That is, the operator is an equal operator, both operands are column references.
-     */
-    private void collectJoinPredicates(ValueNode n,List<BinaryRelationalOperatorNode> l){
-
-        if(n instanceof BinaryRelationalOperatorNode){
-            BinaryRelationalOperatorNode cNode=(BinaryRelationalOperatorNode)n;
-            if(cNode.operator.compareTo("=")==0
-                    && cNode.leftOperand instanceof ColumnReference
-                    && cNode.rightOperand instanceof ColumnReference){
-
-                l.add((BinaryRelationalOperatorNode)n);
-            }
-        }else if(n instanceof BinaryOperatorNode){
-            collectJoinPredicates(((BinaryOperatorNode)n).leftOperand,l);
-            collectJoinPredicates(((BinaryOperatorNode)n).rightOperand,l);
-        }else if(n instanceof UnaryOperatorNode){
-            collectJoinPredicates(((UnaryOperatorNode)n).operand,l);
-        }
     }
 
     /**
@@ -2876,4 +2926,60 @@ public class SelectNode extends ResultSetNode{
         }
         return collected;
     }
+
+    public Map<Integer, Set<ValueNode>> collectExpressions() {
+        HashMap<Integer, Set<ValueNode>> result = new HashMap<>();
+
+        if (groupByList != null) {
+            groupByList.collectExpressions(result);
+        }
+
+        if (orderByList != null) {
+            orderByList.collectExpressions(result);
+        }
+
+        if (whereClause != null) {
+            whereClause.collectExpressions(result);
+        }
+        if (wherePredicates != null) {
+            wherePredicates.collectExpressions(result);
+        }
+
+        if (havingClause != null) {
+            havingClause.collectExpressions(result);
+        }
+
+        if (selectAggregates != null) {
+            for (AggregateNode selectAggregate : selectAggregates) {
+                selectAggregate.collectExpressions(result);
+            }
+        }
+
+        if (havingAggregates != null) {
+            for (AggregateNode havingAggregate : havingAggregates) {
+                havingAggregate.collectExpressions(result);
+            }
+        }
+        // no need to check whereAggregates, should be empty
+
+        if (windowDefinitionList != null) {
+            for (WindowNode wn : windowDefinitionList) {
+                wn.collectExpressions(result);
+            }
+        }
+
+        for (QueryTreeNode fromItem : fromList) {
+            if (fromItem instanceof ResultSetNode) {  // this is probably always true?
+                ((ResultSetNode) fromItem).collectExpressions(result);
+            }
+        }
+
+        for (ResultColumn rc : resultColumns) {
+            rc.getExpression().collectSingleExpression(result);
+        }
+
+        return result;
+    }
+
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelfReferenceNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelfReferenceNode.java
@@ -43,9 +43,7 @@ import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.iapi.util.StringUtil;
 
 import java.lang.reflect.Modifier;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * Created by yxia on 3/20/19.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SpecialFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SpecialFunctionNode.java
@@ -42,7 +42,6 @@ import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.store.access.Qualifier;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.lang.reflect.Modifier;
 import java.sql.Types;
@@ -85,7 +84,6 @@ import java.util.List;
 
 
 */
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class SpecialFunctionNode extends ValueNode
 {
     /**
@@ -313,6 +311,10 @@ public class SpecialFunctionNode extends ValueNode
             return methodName.equals(other.methodName);
         }
         return false;
+    }
+
+    public int hashCode() {
+        return 31 * getBaseHashCode() + methodName.hashCode();
     }
 
     public List<? extends QueryTreeNode> getChildren() {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StaticClassFieldReferenceNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StaticClassFieldReferenceNode.java
@@ -31,22 +31,18 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
-import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
-
-import com.splicemachine.db.iapi.services.sanity.SanityManager;
-
 import com.splicemachine.db.iapi.error.StandardException;
-
+import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.loader.ClassInspector;
-
+import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.store.access.Qualifier;
-
 import com.splicemachine.db.iapi.util.JBitSet;
 
 import java.lang.reflect.Member;
 import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A StaticClassFieldReferenceNode represents a Java static field reference from 
@@ -265,5 +261,13 @@ public final class StaticClassFieldReferenceNode extends JavaValueNode {
                     Modifier.isFinal(field.getModifiers());
         }
         return false;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getBaseHashCode();
+        result = 31 * result + javaClassName.hashCode();
+        result = 31 * result + fieldName.hashCode();
+        return Objects.hash(result, field.getModifiers());
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
@@ -39,10 +39,7 @@ import com.splicemachine.db.iapi.services.compiler.LocalField;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.context.ContextService;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
-import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
-import com.splicemachine.db.iapi.sql.compile.CompilerContext;
-import com.splicemachine.db.iapi.sql.compile.CostEstimate;
-import com.splicemachine.db.iapi.sql.compile.Visitor;
+import com.splicemachine.db.iapi.sql.compile.*;
 import com.splicemachine.db.iapi.sql.conn.Authorizer;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.store.access.Qualifier;
@@ -50,7 +47,6 @@ import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.iapi.util.StringUtil;
 import com.splicemachine.db.impl.sql.execute.OnceResultSet;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.lang.reflect.Modifier;
 import java.util.*;
@@ -84,7 +80,6 @@ import java.util.*;
  * <UL> where x = (SELECT true FROM (SELECT MAX(x) FROM z) WHERE SQLCOL1 = y) </UL>
  */
 
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class SubqueryNode extends ValueNode{
     /* Subquery types.
      * NOTE: FROM_SUBQUERY only exists for a brief second in the parser.  It
@@ -1716,6 +1711,10 @@ public class SubqueryNode extends ValueNode{
         return this==o;
     }
 
+    public int hashCode() {
+        return System.identityHashCode(this);
+    }
+
     /**
      * Get whether or not this SubqueryNode has already been
      * preprocessed.
@@ -2894,5 +2893,11 @@ public class SubqueryNode extends ValueNode{
         } else {
             return OnceResultSet.DO_CARDINALITY_CHECK;
         }
+    }
+
+    @Override
+    public ValueNode replaceIndexExpression(ResultColumnList childRCL) throws StandardException {
+        resultSet.replaceIndexExpressions(childRCL);
+        return this;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableOperatorNode.java
@@ -40,6 +40,8 @@ import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.util.JBitSet;
 
 import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * A TableOperatorNode represents a relational operator like UNION, INTERSECT,
@@ -144,6 +146,7 @@ public abstract class TableOperatorNode extends FromTable{
         if(callModifyAccessPaths){
             return (Optimizable)modifyAccessPaths();
         }
+
         return this;
     }
 
@@ -843,4 +846,25 @@ public abstract class TableOperatorNode extends FromTable{
         leftResultSet.buildTree(tree,depth+1);
     }
 
+    @Override
+    public void replaceIndexExpressions(ResultColumnList childRCL) throws StandardException {
+        if (leftResultSet != null) {
+            leftResultSet.replaceIndexExpressions(childRCL);
+        }
+        if (rightResultSet != null) {
+            rightResultSet.replaceIndexExpressions(childRCL);
+        }
+    }
+
+    @Override
+    public boolean collectExpressions(Map<Integer, Set<ValueNode>> exprMap) {
+        boolean result = true;
+        if (leftResultSet != null) {
+            result = leftResultSet.collectExpressions(exprMap);
+        }
+        if (rightResultSet != null) {
+            result = result && rightResultSet.collectExpressions(exprMap);
+        }
+        return result;
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
@@ -48,12 +48,13 @@ import com.splicemachine.db.iapi.types.StringDataValue;
 import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.iapi.util.ReuseFactory;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.lang.reflect.Modifier;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * A TernaryOperatorNode represents a built-in ternary operators.
@@ -63,7 +64,6 @@ import java.util.List;
  *
  */
 
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class TernaryOperatorNode extends OperatorNode
 {
     String        operator;
@@ -1424,6 +1424,15 @@ public class TernaryOperatorNode extends OperatorNode
         return false;
     }
 
+    public int hashCode() {
+        int result = getBaseHashCode();
+        result = 31 * result + methodName.hashCode();
+        result = 31 * result + (receiver == null ? 0 : receiver.hashCode());
+        result = 31 * result + (leftOperand == null ? 0 : leftOperand.hashCode());
+        result = 31 * result + (rightOperand == null ? 0 : rightOperand.hashCode());
+        return result;
+    }
+
     public List<? extends QueryTreeNode> getChildren() {
         return new ArrayList<QueryTreeNode>(){{
             add(receiver);
@@ -1481,4 +1490,46 @@ public class TernaryOperatorNode extends OperatorNode
     public boolean isLeading()  {return trimType == StringDataValue.LEADING;}
     public boolean isTrailing() {return trimType == StringDataValue.TRAILING;}
     public boolean isBoth()     {return trimType == StringDataValue.BOTH;}
+
+    @Override
+    public ValueNode replaceIndexExpression(ResultColumnList childRCL) throws StandardException {
+        if (childRCL == null) {
+            return this;
+        }
+        // this special handling for like predicate is fine because like cannot appear in index expressions
+        if (operatorType == LIKE) {
+            if (receiver != null) {
+                receiver = receiver.replaceIndexExpression(childRCL);
+            }
+            if (leftOperand != null) {
+                leftOperand = leftOperand.replaceIndexExpression(childRCL);
+            }
+            if (rightOperand != null) {
+                rightOperand = rightOperand.replaceIndexExpression(childRCL);
+            }
+            return this;
+        } else {
+            return super.replaceIndexExpression(childRCL);
+        }
+    }
+
+    @Override
+    public boolean collectExpressions(Map<Integer, Set<ValueNode>> exprMap) {
+        // this special handling for like predicate is fine because like cannot appear in index expressions
+        if (operatorType == LIKE) {
+            boolean result = true;
+            if (receiver != null) {
+                result = receiver.collectExpressions(exprMap);
+            }
+            if (leftOperand != null) {
+                result = result && leftOperand.collectExpressions(exprMap);
+            }
+            if (rightOperand != null) {
+                result = result && rightOperand.collectExpressions(exprMap);
+            }
+            return result;
+        } else {
+            return this.collectSingleExpression(exprMap);
+        }
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TimeSpanNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TimeSpanNode.java
@@ -35,10 +35,10 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.DateTimeDataValue;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A TimeSpanNode is a node used to represent an added time interval
@@ -46,7 +46,6 @@ import java.util.List;
  * to be replaced by a function call to ADD_{DAYS,MONTHS,YEARS}
  */
 
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class TimeSpanNode extends ValueNode
 {
     private int unit;
@@ -81,6 +80,11 @@ public class TimeSpanNode extends ValueNode
             return this.unit == other.unit && value.isEquivalent(other.value);
         }
         return false;
+    }
+
+    public int hashCode() {
+        int result = Objects.hash(getBaseHashCode(), unit);
+        return 31 * result + value.hashCode();
     }
 
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryComparisonOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryComparisonOperatorNode.java
@@ -247,6 +247,15 @@ public abstract class UnaryComparisonOperatorNode extends UnaryOperatorNode impl
 		acb.generateNull(mb, operand.getTypeCompiler(),  operand.getTypeServices());
 	}
 
+	@Override
+	public int getMatchingExprIndexColumnPosition(int tableNumber) {
+		if (operandMatchIndexExpr >= 0 && operandMatchIndexExpr == tableNumber) {
+			assert operandMatchIndexExprColumnPosition >= 0;
+			return operandMatchIndexExprColumnPosition;
+		}
+		return -1;
+	}
+
 	/** @see RelationalOperator#getStartOperator */
 	@Override
 	public int getStartOperator(Optimizable optTable) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryOperatorNode.java
@@ -41,6 +41,7 @@ import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.sql.compile.Visitor;
+import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.store.access.Qualifier;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.DataTypeUtilities;
@@ -61,7 +62,6 @@ import java.util.List;
  *
  */
 
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class UnaryOperatorNode extends OperatorNode
 {
     String	operator;
@@ -128,6 +128,24 @@ public class UnaryOperatorNode extends OperatorNode
     // Array to hold Objects that contain primitive
     // args required by the operator method call.
     private Object [] additionalArgs;
+
+    /* If operand matches an index expression. Once set,
+     * values should be valid through the whole optimization
+     * process of the current query.
+     * -1  : no match
+     * >=0 : table number
+     */
+    protected int operandMatchIndexExpr = -1;
+
+    /* The following four fields record operand matches for
+     * which conglomerate and which column. These values
+     * are reset and valid only for the current access path.
+     * They should not be used beyond cost estimation.
+     */
+    protected ConglomerateDescriptor operandMatchIndexExprConglomDesc = null;
+
+    // 0-based index column position
+    protected int operandMatchIndexExprColumnPosition = -1;
 
     /**
      * Initializer for a UnaryOperatorNode.
@@ -886,15 +904,21 @@ public class UnaryOperatorNode extends OperatorNode
      * {@inheritDoc}
      */
     @Override
-    protected boolean isSemanticallyEquivalent(ValueNode o) throws StandardException
-    {
+    protected boolean isSemanticallyEquivalent(ValueNode o) throws StandardException {
         if (isSameNodeType(o)) {
-            UnaryOperatorNode other = (UnaryOperatorNode)o;
+            UnaryOperatorNode other = (UnaryOperatorNode) o;
             return ((operator == null && other.operator == null) || (operator != null && operator.equals(other.operator)) &&
                     // the first condition in the || covers the case when both operands are null.
                     ((operand == other.operand) || ((operand != null) && operand.isSemanticallyEquivalent(other.operand))));
         }
         return false;
+    }
+
+    public int hashCode() {
+        int result = getBaseHashCode();
+        result = 31 * result + (operator == null ? 0 : operator.hashCode());
+        result = 31 * result + (operand == null ? 0 : operand.hashCode());
+        return result;
     }
 
     public List<? extends QueryTreeNode> getChildren() {
@@ -928,6 +952,13 @@ public class UnaryOperatorNode extends OperatorNode
 
     @Override
     public boolean isConstantOrParameterTreeNode() {
-        return operand.isConstantOrParameterTreeNode();
+        // for count(*), operand is null
+        return operand != null && operand.isConstantOrParameterTreeNode();
+    }
+
+    public void setMatchIndexExpr(int tableNumber, int columnPosition, ConglomerateDescriptor conglomDesc) {
+        this.operandMatchIndexExpr = tableNumber;
+        this.operandMatchIndexExprColumnPosition = columnPosition;
+        this.operandMatchIndexExprConglomDesc = conglomDesc;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNodeList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNodeList.java
@@ -34,16 +34,14 @@ package com.splicemachine.db.impl.sql.compile;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.sql.compile.TypeCompiler;
 import com.splicemachine.db.iapi.store.access.Qualifier;
 import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.iapi.util.StringUtil;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 /**
  * A ValueNodeList represents a list of ValueNodes within a specific predicate 
@@ -852,5 +850,21 @@ public class ValueNodeList extends QueryTreeNodeVector
 		constantNode.setValue(new SQLChar(StringUtil.padRight(stringConstant, SQLChar.PAD, maxSize)));
 	}
 
+	public ValueNodeList replaceIndexExpression(ResultColumnList childRCL) throws StandardException {
+		ValueNodeList newList = (ValueNodeList) getNodeFactory().getNode(
+				C_NodeTypes.VALUE_NODE_LIST,
+				getContextManager());
+		for (int i = 0; i < size(); i++) {
+			newList.addValueNode(((ValueNode) elementAt(i)).replaceIndexExpression(childRCL));
+		}
+		return newList;
+	}
 
+	public boolean collectExpressions(Map<Integer, Set<ValueNode>> exprMap) {
+		boolean result = true;
+		for (int i = 0; i <size(); i++) {
+			result = result && ((ValueNode) elementAt(i)).collectExpressions(exprMap);
+		}
+		return result;
+	}
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueTupleNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueTupleNode.java
@@ -2,7 +2,6 @@ package com.splicemachine.db.impl.sql.compile;
 
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.util.JBitSet;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,7 +11,6 @@ import java.util.List;
  * select * from t where (a,b) = (0,0)
  *
  */
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class ValueTupleNode extends ValueNode {
     private List<ValueNode> tuple = new ArrayList<>();
 
@@ -50,6 +48,14 @@ public class ValueTupleNode extends ValueNode {
             }
         }
         return true;
+    }
+
+    public int hashCode() {
+        int result = getBaseHashCode();
+        for (ValueNode vn : tuple) {
+            result = 31 * result + vn.hashCode();
+        }
+        return result;
     }
 
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/VirtualColumnNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/VirtualColumnNode.java
@@ -35,7 +35,6 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Collections;
 import java.util.List;
@@ -50,7 +49,6 @@ import java.util.List;
  *
  */
 
-@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class VirtualColumnNode extends ValueNode
 {
     /* A VirtualColumnNode contains a pointer to the immediate child result
@@ -312,13 +310,16 @@ public class VirtualColumnNode extends ValueNode
     }
 
     @Override
-    protected boolean isSemanticallyEquivalent(ValueNode o) throws StandardException
-    {
+    protected boolean isSemanticallyEquivalent(ValueNode o) throws StandardException {
         if (isSameNodeType(o)) {
-            VirtualColumnNode other = (VirtualColumnNode)o;
+            VirtualColumnNode other = (VirtualColumnNode) o;
             return sourceColumn.isSemanticallyEquivalent(other.sourceColumn);
         }
         return false;
+    }
+
+    public int hashCode() {
+        return 31 * getBaseHashCode() + sourceColumn.hashCode();
     }
 
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowDefinitionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowDefinitionNode.java
@@ -36,6 +36,8 @@ import com.splicemachine.db.iapi.services.sanity.SanityManager;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * This class represents an OLAP window definition.
@@ -267,5 +269,33 @@ public final class WindowDefinitionNode extends WindowNode
     @Override
     public void setOverClause(OverClause overClause) {
         this.overClause = overClause;
+    }
+
+    @Override
+    public WindowNode replaceIndexExpression(ResultSetNode child) throws StandardException {
+        if (overClause != null) {
+            overClause = overClause.replaceIndexExpression(child);
+        }
+        if (functionNodes != null) {
+            ResultColumnList childRCL = child.getResultColumns();
+            for (WindowFunctionNode wfn : functionNodes) {
+                wfn.replaceIndexExpression(childRCL);
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public boolean collectExpressions(Map<Integer, Set<ValueNode>> exprMap) {
+        boolean result = true;
+        if (overClause != null) {
+            result = overClause.collectExpressions(exprMap);
+        }
+        if (functionNodes != null) {
+            for (WindowFunctionNode wfn : functionNodes) {
+                result = result && wfn.collectExpressions(exprMap);
+            }
+        }
+        return result;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WindowNode.java
@@ -34,6 +34,8 @@ package com.splicemachine.db.impl.sql.compile;
 import com.splicemachine.db.iapi.error.StandardException;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Superclass of window definition and window reference.
@@ -88,5 +90,9 @@ public abstract class WindowNode extends QueryTreeNode
     public abstract OverClause getOverClause();
 
     public abstract void setOverClause(OverClause overClause);
+
+    public abstract WindowNode replaceIndexExpression(ResultSetNode child) throws StandardException;
+
+    public abstract boolean collectExpressions(Map<Integer, Set<ValueNode>> exprMap);
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WrappedAggregateFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/WrappedAggregateFunctionNode.java
@@ -31,10 +31,6 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.io.FormatableHashtable;
@@ -45,6 +41,8 @@ import com.splicemachine.db.iapi.sql.compile.Visitor;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import splice.com.google.common.collect.Lists;
+
+import java.util.*;
 
 import static com.splicemachine.db.iapi.sql.compile.AggregateDefinition.fromString;
 
@@ -257,5 +255,21 @@ public class WrappedAggregateFunctionNode extends WindowFunctionNode {
         if (aggregateFunction instanceof StringAggregateNode)
             ht.put("param", ((StringAggregateNode)aggregateFunction).getParameter());
         return ht;
+    }
+
+    @Override
+    public ValueNode replaceIndexExpression(ResultColumnList childRCL) throws StandardException {
+        if (aggregateFunction != null) {
+            aggregateFunction.replaceIndexExpression(childRCL);
+        }
+        return this;
+    }
+
+    @Override
+    public boolean collectExpressions(Map<Integer, Set<ValueNode>> exprMap) {
+        if (aggregateFunction != null) {
+            return aggregateFunction.collectExpressions(exprMap);
+        }
+        return true;
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/IndexIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/IndexIT.java
@@ -602,7 +602,7 @@ public class IndexIT extends SpliceUnitTest{
         ResultSet resultSet=methodWatcher.executeQuery(""+
                 "select pa.pid\n"+
                 "from PERSON_ADDRESS pa --SPLICE-PROPERTIES index=pa_idx\n"+
-                "join ADDRESS a         --SPLICE-PROPERTIES index=a_idx\n"+
+                "join ADDRESS a         --SPLICE-PROPERTIES index=a_idx, joinStrategy=broadcast\n"+
                 "  on pa.addr_id=a.addr_id\n"+
                 "where a.std_state_provence in ('IA', 'FL', 'NY')");
 
@@ -1477,6 +1477,22 @@ public class IndexIT extends SpliceUnitTest{
     }
 
     @Test
+    public void testIndexExpressionTernaryOperatorRewriting() throws Exception {
+        String tableName = "TEST_TERNARY_OP_EXPR";
+        methodWatcher.executeUpdate(format("create table %s (vc varchar(32), ts timestamp)", tableName));
+        methodWatcher.executeUpdate(
+                format("insert into %s values " +
+                                "('abc  ', '2014-01-01 22:00:05')," +
+                                "('def  ', '2016-05-01 12:04:30')"
+                        , tableName));
+        methodWatcher.executeUpdate(format("CREATE INDEX %s_IDX ON %s (timestampadd(SQL_TSI_DAY, 2, ts), rtrim(vc))", tableName, tableName));
+
+        rowContainsQuery(new int[]{1}, format("select rtrim(vc) from %s --splice-properties index=%s_IDX\n" +
+                        " where timestampadd(SQL_TSI_DAY, 2, ts) = '2014-01-03 22:00:05' and rtrim(vc) like 'ab_%%'", tableName, tableName), methodWatcher,
+                "abc");
+    }
+
+    @Test
     public void testIndexExpressionOnMultipleColumns() throws Exception {
         String tableName = "TEST_INDEX_EXPR_MULTIPLE_COLUMNS";
         methodWatcher.executeUpdate(format("create table %s (c char(4), i int, d double)", tableName));
@@ -1513,7 +1529,7 @@ public class IndexIT extends SpliceUnitTest{
                 "IndexScan",
                 " > 3.2"            // should be on the same line as IndexScan
         };
-        rowContainsQuery(new int[]{4,5,5}, "explain " + query, methodWatcher, expectedOps);
+        rowContainsQuery(new int[]{4, 5, 5}, "explain " + query, methodWatcher, expectedOps);
 
         String expected = "C  |\n" +
                 "-----\n" +
@@ -1527,7 +1543,62 @@ public class IndexIT extends SpliceUnitTest{
         // an index expression containing method calls (also, note operands' order of plus)
         query = format("select c from %s --splice-properties index=%s_IDX\n where sqrt(d) + log10(i) > 3.2", tableName, tableName);
 
-        rowContainsQuery(new int[]{4,5,5}, "explain " + query, methodWatcher, expectedOps);
+        rowContainsQuery(new int[]{4, 5, 5}, "explain " + query, methodWatcher, expectedOps);
+
+        try (ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+    }
+
+    @Test
+    public void testIndexExpressionInListRightHandSide() throws Exception {
+        methodWatcher.executeUpdate("create table TEST_IN_LIST_RHS(a1 int, a2 int)");
+        methodWatcher.executeUpdate("insert into TEST_IN_LIST_RHS values(0,0),(1,10),(2,20),(3,30),(4,40),(5,50)");
+        methodWatcher.executeUpdate("create index TEST_IN_LIST_RHS_IDX on TEST_IN_LIST_RHS(a1 * 3, a2)");
+
+        methodWatcher.executeUpdate("create table TEST_IN_LIST_RHS_2(b1 int, b2 int)");
+        methodWatcher.executeUpdate("insert into TEST_IN_LIST_RHS_2 values(0,0),(3,30),(5,50)");
+
+        String query = "select b1, a2 from TEST_IN_LIST_RHS --splice-properties index=TEST_IN_LIST_RHS_IDX\n, " +
+                "TEST_IN_LIST_RHS_2 where b1 in (1, a1 * 3)";
+
+        String[] expectedOps = new String[]{
+                "ProjectRestrict",
+                "[(B1[2:1] IN (1,TEST_IN_LIST_RHS_IDX_col1[1:1]))]",
+                "TableScan[TEST_IN_LIST_RHS_2",
+                "IndexScan[TEST_IN_LIST_RHS_IDX"
+        };
+        rowContainsQuery(new int[]{5,5,6,7}, "explain " + query, methodWatcher, expectedOps);
+
+        String expected = "B1 |A2 |\n" +
+                "--------\n" +
+                " 0 | 0 |\n" +
+                " 3 |10 |";
+
+        try (ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+    }
+
+    @Test
+    public void testIndexOnExpressionCountAsterisk() throws Exception {
+        methodWatcher.executeUpdate("create table TEST_COUNT_STAR(a1 int, a2 int)");
+        methodWatcher.executeUpdate("insert into TEST_COUNT_STAR values(0,0),(1,10),(2,20),(3,30),(4,40),(5,50)");
+        methodWatcher.executeUpdate("create index TEST_COUNT_STAR_IDX on TEST_COUNT_STAR(mod(a1, 2))");
+
+        String query = "select count(*) from TEST_COUNT_STAR --splice-properties index=TEST_COUNT_STAR_IDX";
+
+        /* check plan */
+        try(ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan[TEST_COUNT_STAR_IDX"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup"));
+        }
+
+        /* check result */
+        String expected = "1 |\n" +
+                "----\n" +
+                " 6 |";
 
         try (ResultSet rs = methodWatcher.executeQuery(query)) {
             Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
@@ -1559,6 +1630,711 @@ public class IndexIT extends SpliceUnitTest{
                 "foo |foo |";
 
         try (ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+    }
+
+    @Test
+    public void testCoveringExpressionBasedIndex() throws Exception {
+        String tableName = "TEST_COVERING_EXPR_INDEX";
+        methodWatcher.executeUpdate(format("create table %s (c char(4), i int, d double)", tableName));
+        methodWatcher.executeUpdate(format("insert into %s values ('foo', 0, 2.0), ('bar', 1, 0.5)", tableName));
+
+        methodWatcher.executeUpdate(format("CREATE INDEX %s_IDX ON %s (UPPER(C), mod(i, 2) + 1, d + i)", tableName, tableName));
+        methodWatcher.executeUpdate(format("insert into %s values ('abc', 2, 1.0)", tableName));
+
+        ///////////////////////////////////////
+        // test select list and where clause //
+        ///////////////////////////////////////
+
+        String query = format("select upper(c), mod(i,2)+1 from %s --splice-properties index=%s_IDX\n where upper(c) = 'BAR'", tableName, tableName);
+
+        /* check plan */
+        try(ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toString(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup"));     // no base row retrieving
+            Assert.assertFalse(explainPlanText.contains("ProjectRestrict")); // no final upper(c) computation
+        }
+
+        /* check result */
+        String expected = "1  | 2 |\n" +
+                "---------\n" +
+                "BAR | 2 |";
+
+        try (ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+
+        ///////////////////////////////////////
+        // test group by and having clause   //
+        ///////////////////////////////////////
+
+        query = format("select upper(c) from %s --splice-properties index=%s_IDX\n group by upper(c) having upper(c) > 'BAN'", tableName, tableName);
+
+        /* check plan */
+        try(ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toString(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup"));  // no base row retrieving
+            Assert.assertTrue(explainPlanText.contains("GroupBy"));
+            Assert.assertFalse(explainPlanText.contains("upper"));        // ProjectRestrict is needed because of having, but no need to compute upper()
+        }
+
+        /* check result */
+        expected = "1  |\n" +
+                "-----\n" +
+                "BAR |\n" +
+                "FOO |";
+
+        try (ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+
+        ///////////////////////////////////////
+        // test order by clause              //
+        ///////////////////////////////////////
+
+        query = format("select upper(c) from %s --splice-properties index=%s_IDX\n group by upper(c) having upper(c) > 'BAN' order by upper(c)", tableName, tableName);
+
+        /* check plan */
+        try(ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toString(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup"));  // no base row retrieving
+            Assert.assertTrue(explainPlanText.contains("GroupBy"));
+            Assert.assertTrue(explainPlanText.contains("OrderBy"));
+            Assert.assertFalse(explainPlanText.contains("upper"));
+        }
+
+        /* check result */
+        expected = "1  |\n" +
+                "-----\n" +
+                "BAR |\n" +
+                "FOO |";
+
+        try (ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        }
+
+        query = format("select upper(c) from %s --splice-properties index=%s_IDX\n order by i + d", tableName, tableName);
+
+        /* check plan */
+        try(ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toString(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup"));  // no base row retrieving
+            Assert.assertTrue(explainPlanText.contains("OrderBy"));
+        }
+
+        /* check result */
+        expected = "1  |\n" +
+                "-----\n" +
+                "BAR |\n" +
+                "FOO |\n" +
+                "ABC |";
+
+        try (ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        }
+    }
+
+    @Test
+    public void testCoveringExpressionBasedIndexWithAggregates() throws Exception {
+        String tableName = "TEST_COVERING_EXPR_INDEX_AGGR";
+        methodWatcher.executeUpdate(format("create table %s (c char(4), i int, d double)", tableName));
+        methodWatcher.executeUpdate(format("insert into %s values ('abc', 11, 1.1), ('def', 20, 2.2), ('jkl', 21, 2.2), ('ghi', 30, 3.3), ('xyz', 40, 3.3)", tableName));
+
+        methodWatcher.executeUpdate(format("CREATE INDEX %s_IDX ON %s (UPPER(C), mod(i, 2), d)", tableName, tableName));
+
+        ///////////////////////////////////////
+        // test aggregates with group by     //
+        ///////////////////////////////////////
+
+        String query = format("select d, sum(mod(i,2)) from %s --splice-properties index=%s_IDX\n group by d having sum(mod(i,2)) > 0", tableName, tableName);
+
+        /* check plan */
+        try (ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toString(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup")); // no base row retrieving
+            Assert.assertFalse(explainPlanText.contains("mod"));
+        }
+
+        /* check result */
+        String expected = "D  | 2 |\n" +
+                "---------\n" +
+                "1.1 | 1 |\n" +
+                "2.2 | 1 |";
+
+        try (ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+
+        ///////////////////////////////////////
+        // test scalar aggregates            //
+        ///////////////////////////////////////
+
+        query = format("select max(d), sum(mod(i,2)) from %s --splice-properties index=%s_IDX\n", tableName, tableName);
+
+        /* check plan */
+        try (ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toString(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup")); // no base row retrieving
+            Assert.assertFalse(explainPlanText.contains("mod"));
+        }
+
+        /* check result */
+        expected = "1  | 2 |\n" +
+                "---------\n" +
+                "3.3 | 2 |";
+
+        try (ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+    }
+
+    @Test
+    public void testCoveringIndexOnExpressionsWindowFunction() throws Exception {
+        String tableName = "TEST_COVERING_EXPR_INDEX_WINDOW";
+        methodWatcher.executeUpdate(format("create table %s (c char(4), i int, d double)", tableName));
+        methodWatcher.executeUpdate(format("insert into %s values ('abc', 1, 1.0), ('def', 1, 2.0), ('jkl', 1, 3.0), ('ghi', 2, 3.3), ('xyz', 2, 4.3)", tableName));
+
+        methodWatcher.executeUpdate(format("CREATE INDEX %s_IDX ON %s (i + 1, d)", tableName, tableName));
+
+        String query = format("select i + 1, rank() over (partition by i + 1 order by d) " +
+                "from %s --splice-properties index=%s_IDX", tableName, tableName);
+
+        /* check plan */
+        try (ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup")); // no base row retrieving
+        }
+
+        /* check result */
+        String expected = "1 | 2 |\n" +
+                "--------\n" +
+                " 2 | 1 |\n" +
+                " 2 | 2 |\n" +
+                " 2 | 3 |\n" +
+                " 3 | 1 |\n" +
+                " 3 | 2 |";
+
+        try (ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+
+        query = format("select i + 1, sum(d) over (partition by i + 1), avg(d) over (partition by i + 1) " +
+                "from %s --splice-properties index=%s_IDX", tableName, tableName);
+
+        /* check plan */
+        try (ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup")); // no base row retrieving
+        }
+
+        /* check result */
+        expected = "1 | 2  | 3  |\n" +
+                "--------------\n" +
+                " 2 |6.0 |2.0 |\n" +
+                " 2 |6.0 |2.0 |\n" +
+                " 2 |6.0 |2.0 |\n" +
+                " 3 |7.6 |3.5 |\n" +
+                " 3 |7.6 |3.5 |";
+
+        try (ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+
+        query = format("select i + 1, sum(d) over (partition by i + 1), avg(d) over (partition by i + 1) " +
+                "from %s --splice-properties index=%s_IDX\n group by i + 1, d having d > 1.0", tableName, tableName);
+
+        /* check plan */
+        try (ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            Assert.assertTrue(explainPlanText.contains("GroupBy"));
+            Assert.assertTrue(explainPlanText.contains("IndexScan"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup")); // no base row retrieving
+        }
+
+        /* check result */
+        expected = "1 | 2  | 3  |\n" +
+                "--------------\n" +
+                " 2 |5.0 |2.5 |\n" +
+                " 2 |5.0 |2.5 |\n" +
+                " 3 |7.6 |3.5 |\n" +
+                " 3 |7.6 |3.5 |";
+
+        try (ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+    }
+
+    @Test
+    public void testJoinOverTwoCompoundExpressionBasedIndexes() throws Exception {
+        methodWatcher.executeUpdate("CREATE TABLE PERSON_ADDRESS_1 (PID INTEGER, ADDR_ID INTEGER)");
+        methodWatcher.executeUpdate("CREATE TABLE ADDRESS_1 (ADDR_ID INTEGER, STD_STATE_PROVENCE VARCHAR(30))");
+        methodWatcher.executeUpdate("CREATE INDEX pa_idx_1 ON PERSON_ADDRESS_1 (pid, max(addr_id, 300))");
+        methodWatcher.executeUpdate("CREATE INDEX a_idx_1 ON ADDRESS_1 (lower(std_state_provence), abs(addr_id))");
+        methodWatcher.executeUpdate("INSERT INTO PERSON_ADDRESS_1 VALUES (10, 100),(20, 200),(30,300),(40, 400),(50,500)");
+        methodWatcher.executeUpdate("INSERT INTO ADDRESS_1 VALUES (100, 'MO'),(200, 'IA'),(300,'NY'),(400,'FL'),(500,'AL')");
+
+        ///////////////////
+        // both covering //
+        ///////////////////
+
+        String query = "select pa.pid, lower(a.std_state_provence)\n"+
+                " from PERSON_ADDRESS_1 pa --SPLICE-PROPERTIES index=pa_idx_1\n"+
+                " join ADDRESS_1 a         --SPLICE-PROPERTIES index=a_idx_1 %s\n"+
+                "  on max(pa.addr_id, 300) = abs(a.addr_id)\n"+
+                " where lower(a.std_state_provence) in ('ia', 'fl', 'al')";
+
+        /* check plan */
+        try (ResultSet rs = methodWatcher.executeQuery("explain " + format(query, ""))) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            Assert.assertTrue(explainPlanText.contains("MultiProbeIndexScan[A_IDX_1")); // in-list for ADDRESS_1
+            Assert.assertTrue(explainPlanText.contains("IndexScan[PA_IDX_1"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup")); // no base row retrieving
+        }
+
+        /* check result */
+        String expected = "PID | 2 |\n" +
+                "----------\n" +
+                " 40  |fl |\n" +
+                " 50  |al |";
+
+        testJoinStrategy(query, "", expected);  // optimizer's choice
+        testJoinStrategy(query, "nestedloop", expected);
+        testJoinStrategy(query, "broadcast", expected);
+        testJoinStrategy(query, "cross, useSpark=true", expected);  // on spark
+        // merge and sortmerge are not feasible
+
+        ///////////////////////////////
+        // only pa_idx_1 is covering //
+        ///////////////////////////////
+
+        query = "select pa.pid, a.std_state_provence\n"+
+                " from PERSON_ADDRESS_1 pa --SPLICE-PROPERTIES index=pa_idx_1\n"+
+                " join ADDRESS_1 a         --SPLICE-PROPERTIES index=a_idx_1 %s\n"+
+                "  on max(pa.addr_id, 300) = abs(a.addr_id)\n"+
+                " where lower(a.std_state_provence) in ('ia', 'fl', 'al')";
+
+        /* check plan */
+        String[] expectedOps = new String[] {
+                "IndexScan[PA_IDX_1",
+                "IndexLookup",                 // base row retrieving for ADDRESS_1
+                "MultiProbeIndexScan[A_IDX_1", // in-list for ADDRESS_1
+        };
+        rowContainsQuery(new int[]{6,8,9}, "explain " + format(query, ""), methodWatcher, expectedOps);
+
+        /* check result */
+        expected = "PID |STD_STATE_PROVENCE |\n" +
+                "--------------------------\n" +
+                " 40  |        FL         |\n" +
+                " 50  |        AL         |";
+        testJoinStrategy(query, "", expected);  // optimizer's choice
+
+        ///////////////////////////////
+        // only a_idx_1 is covering  //
+        ///////////////////////////////
+
+        query = "select pa.pid + 1, abs(a.addr_id)\n"+
+                " from PERSON_ADDRESS_1 pa --SPLICE-PROPERTIES index=pa_idx_1\n"+
+                " join ADDRESS_1 a         --SPLICE-PROPERTIES index=a_idx_1 %s\n"+
+                "  on max(pa.addr_id, 300) = abs(a.addr_id)\n"+
+                " where lower(a.std_state_provence) in ('ia', 'fl', 'al')";
+
+        /* check plan */
+        expectedOps = new String[] {
+                "IndexLookup",                 // base row retrieving for ADDRESS_1
+                "IndexScan[PA_IDX_1",
+                "MultiProbeIndexScan[A_IDX_1", // in-list for ADDRESS_1
+        };
+        rowContainsQuery(new int[]{5,6,7}, "explain " + format(query, ""), methodWatcher, expectedOps);
+
+        /* check result */
+        expected = "1 | 2  |\n" +
+                "---------\n" +
+                "41 |400 |\n" +
+                "51 |500 |";
+        testJoinStrategy(query, "", expected);  // optimizer's choice
+
+        //////////////////////////
+        // neither is covering  //
+        //////////////////////////
+
+        query = "select *\n"+
+                " from PERSON_ADDRESS_1 pa --SPLICE-PROPERTIES index=pa_idx_1\n"+
+                " join ADDRESS_1 a         --SPLICE-PROPERTIES index=a_idx_1 %s\n"+
+                "  on max(pa.addr_id, 300) = abs(a.addr_id)\n"+
+                " where lower(a.std_state_provence) in ('ia', 'fl', 'al')";
+
+        /* check plan */
+        expectedOps = new String[] {
+                "IndexLookup",                 // base row retrieving for ADDRESS_1
+                "IndexScan[PA_IDX_1",
+                "IndexLookup",                 // base row retrieving for PERSON_ADDRESS_1
+                "MultiProbeIndexScan[A_IDX_1", // in-list for ADDRESS_1
+        };
+        rowContainsQuery(new int[]{5,6,7,8}, "explain " + format(query, ""), methodWatcher, expectedOps);
+
+        /* check result */
+        expected = "PID | ADDR_ID | ADDR_ID |STD_STATE_PROVENCE |\n" +
+                "----------------------------------------------\n" +
+                " 40  |   400   |   400   |        FL         |\n" +
+                " 50  |   500   |   500   |        AL         |";
+        testJoinStrategy(query, "", expected);  // optimizer's choice
+    }
+
+    private void testJoinStrategy(String queryFormat, String joinStrategy, String expected) throws Exception {
+        String query = format(queryFormat, joinStrategy.isEmpty() ? "" : ", joinStrategy=" + joinStrategy);
+
+        try(ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+    }
+
+    @Test
+    public void testCoveringIndexOnExpressionsOuterJoin() throws Exception {
+        methodWatcher.executeUpdate("create table TEST_INDEX_EXPR_FOJ_1 (a1 int, b1 int, c1 int, d1 int)");
+        methodWatcher.executeUpdate("create index TEST_INDEX_EXPR_FOJ_1_IDX on TEST_INDEX_EXPR_FOJ_1(a1+1, b1+1)");
+        methodWatcher.executeUpdate("create table TEST_INDEX_EXPR_FOJ_2 (a2 int, b2 int, c2 int)");
+
+        methodWatcher.executeUpdate("insert into TEST_INDEX_EXPR_FOJ_1 values (1,2,2,2), (2,3,3,3), (3,4,4,4)");
+        methodWatcher.executeUpdate("insert into TEST_INDEX_EXPR_FOJ_2 values (1,1,1), (2,2,2), (3,3,3), (4,4,4), (5,5,5)");
+
+        // full outer join, two tables
+        String query = "select a1+1 as X, b2 from TEST_INDEX_EXPR_FOJ_1 --splice-properties index=TEST_INDEX_EXPR_FOJ_1_IDX\n " +
+                "full join TEST_INDEX_EXPR_FOJ_2 on b1+1=b2";
+
+        /* check plan */
+        try (ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan[TEST_INDEX_EXPR_FOJ_1_IDX"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup")); // no base row retrieving
+        }
+
+        /* check result */
+        String expected = "X  |B2 |\n" +
+                "----------\n" +
+                "  2  | 3 |\n" +
+                "  3  | 4 |\n" +
+                "  4  | 5 |\n" +
+                "NULL | 1 |\n" +
+                "NULL | 2 |";
+        try(ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+
+        // full outer join, three tables
+        query = "select t11.b1+1 as X, t12.a1+1 as Y, b2 from " +
+                "TEST_INDEX_EXPR_FOJ_1 t11 --splice-properties index=TEST_INDEX_EXPR_FOJ_1_IDX\n " +
+                "full join TEST_INDEX_EXPR_FOJ_2 on t11.b1+1=b2 " +
+                "full join TEST_INDEX_EXPR_FOJ_1 t12 --splice-properties index=TEST_INDEX_EXPR_FOJ_1_IDX\n " +
+                " on t12.a1+1=b2";
+
+        /* check plan */
+        try (ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan[TEST_INDEX_EXPR_FOJ_1_IDX"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup")); // no base row retrieving
+        }
+
+        /* check result */
+        expected = "X  |  Y  |B2 |\n" +
+                "----------------\n" +
+                "  3  |  3  | 3 |\n" +
+                "  4  |  4  | 4 |\n" +
+                "  5  |NULL | 5 |\n" +
+                "NULL |  2  | 2 |\n" +
+                "NULL |NULL | 1 |";
+        try(ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+
+        // left outer join with post join conditions
+        query = "select a1+1, b2 from TEST_INDEX_EXPR_FOJ_2 left join TEST_INDEX_EXPR_FOJ_1 --splice-properties index=TEST_INDEX_EXPR_FOJ_1_IDX\n " +
+                "on a1+1=a2 where a1+1 is null";
+
+        /* check plan */
+        try (ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan[TEST_INDEX_EXPR_FOJ_1_IDX"));
+            Assert.assertTrue(explainPlanText.contains("[is null(TEST_INDEX_EXPR_FOJ_1_IDX_col1["));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup")); // no base row retrieving
+        }
+
+        /* check result */
+        expected = "1  |B2 |\n" +
+                "----------\n" +
+                "NULL | 1 |\n" +
+                "NULL | 5 |";
+        try(ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+    }
+
+    @Test
+    public void testCoveringIndexOnExpressionsDerivedTable() throws Exception {
+        methodWatcher.executeUpdate("create table TEST_DERIVED_TABLE(a1 int, a2 int)");
+        methodWatcher.executeUpdate("insert into TEST_DERIVED_TABLE values(0,0),(1,10),(2,20),(3,30),(4,40),(5,50)");
+        methodWatcher.executeUpdate("create index TEST_DERIVED_TABLE_IDX on TEST_DERIVED_TABLE(a1 * 3, a2)");
+
+        methodWatcher.executeUpdate("create table TEST_DERIVED_TABLE_2(b1 int, b2 int)");
+        methodWatcher.executeUpdate("insert into TEST_DERIVED_TABLE_2 values(1,10),(3,30),(5,50)");
+
+        // index is not covering for derived table, but query should be flattened to
+        // "select a1*3 from TEST_DERIVED_TABLE where a1*3 < 8;"
+        String query = "select a1*3 from " +
+                "(select a1 from TEST_DERIVED_TABLE --splice-properties index=TEST_DERIVED_TABLE_IDX\n) dt" +
+                " where a1 * 3 < 8";
+
+        /* check plan */
+        try (ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan[TEST_DERIVED_TABLE_IDX"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup")); // no base row retrieving
+        }
+
+        /* check result */
+        String expected = "1 |\n" +
+                "----\n" +
+                " 0 |\n" +
+                " 3 |\n" +
+                " 6 |";
+        testJoinStrategy(query, "", expected);  // optimizer's choice
+
+        // index is covering for derived table, outer level references aliases, y + 1 can use
+        // a1 * 3 column from index directly, so still no IndexLookup
+        // Note that this derived table cannot be flattened because not all select items are
+        // cloneable (an expression other than plain column reference is mostly not cloneable).
+        query = "select y + 1 from " +
+                "(select a2 as x, a1 * 3 as y from TEST_DERIVED_TABLE --splice-properties index=TEST_DERIVED_TABLE_IDX\n) dt" +
+                " where x < 25";
+
+        /* check plan */
+        try (ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan[TEST_DERIVED_TABLE_IDX"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup")); // no base row retrieving
+        }
+
+        /* check result */
+        expected = "1 |\n" +
+                "----\n" +
+                " 1 |\n" +
+                " 4 |\n" +
+                " 7 |";
+        testJoinStrategy(query, "", expected);  // optimizer's choice
+
+        // join inside derived table, then join
+        // derived table is not flattenable because fromList.size() > 1
+        query = "select x, t2.b2 from (select 3*a1 as x, b2 from TEST_DERIVED_TABLE --splice-properties index=TEST_DERIVED_TABLE_IDX\n" +
+                ", TEST_DERIVED_TABLE_2 where a1*3 = b1) dt, TEST_DERIVED_TABLE_2 t2\n" +
+                "where X=3";
+
+        /* check plan */
+        try (ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan[TEST_DERIVED_TABLE_IDX"));
+            Assert.assertTrue(explainPlanText.contains("TableScan[TEST_DERIVED_TABLE_2"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup")); // no base row retrieving
+        }
+
+        /* check result */
+        expected = "X |B2 |\n" +
+                "--------\n" +
+                " 3 |10 |\n" +
+                " 3 |30 |\n" +
+                " 3 |50 |";
+        testJoinStrategy(query, "", expected);  // optimizer's choice
+
+        // outer join inside derived table, then outer join
+        // derived table is not flattenable because fromList.size() > 1
+        query = "select dt.x, dt.b2, t1.a2 from " +
+                "  (select 3*a1 as x, b2 from TEST_DERIVED_TABLE --splice-properties index=TEST_DERIVED_TABLE_IDX\n " +
+                "                             right join TEST_DERIVED_TABLE_2 on a1*3 = b1) as dt " +
+                "  full join TEST_DERIVED_TABLE t1 --splice-properties index=TEST_DERIVED_TABLE_IDX\n on dt.b2 = t1.a2 " +
+                "where dt.x is null";
+
+        /* check plan */
+        try (ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan[TEST_DERIVED_TABLE_IDX"));
+            Assert.assertTrue(explainPlanText.contains("TableScan[TEST_DERIVED_TABLE_2"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup")); // no base row retrieving
+        }
+
+        /* check result */
+        expected = "X  | B2  |A2 |\n" +
+                "----------------\n" +
+                "NULL | 10  |10 |\n" +
+                "NULL | 50  |50 |\n" +
+                "NULL |NULL | 0 |\n" +
+                "NULL |NULL |20 |\n" +
+                "NULL |NULL |40 |";
+        testJoinStrategy(query, "", expected);  // optimizer's choice
+
+        // corner case: no inner base table column is referenced, not flattenable because of aggregation
+        query = "select x, t2.b1 from (select count(*) as x from TEST_DERIVED_TABLE --splice-properties index=TEST_DERIVED_TABLE_IDX\n) t1, " +
+                "TEST_DERIVED_TABLE_2 t2";
+
+        /* check plan */
+        try (ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan[TEST_DERIVED_TABLE_IDX"));
+            Assert.assertTrue(explainPlanText.contains("TableScan[TEST_DERIVED_TABLE_2"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup")); // no base row retrieving
+        }
+
+        /* check result */
+        expected = "X |B1 |\n" +
+                "--------\n" +
+                " 6 | 1 |\n" +
+                " 6 | 3 |\n" +
+                " 6 | 5 |";
+        testJoinStrategy(query, "", expected);  // optimizer's choice
+    }
+
+    @Test
+    public void testCoveringIndexOnExpressionsUnionAll() throws Exception {
+        methodWatcher.executeUpdate("create table TEST_INDEX_EXPR_UNION_1 (a1 int, b1 int, c1 int, d1 int)");
+        methodWatcher.executeUpdate("create index TEST_INDEX_EXPR_UNION_1_IDX on TEST_INDEX_EXPR_UNION_1(a1+1, b1+1)");
+        methodWatcher.executeUpdate("create table TEST_INDEX_EXPR_UNION_2 (a2 int, b2 int, c2 int)");
+
+        methodWatcher.executeUpdate("insert into TEST_INDEX_EXPR_UNION_1 values (1,2,2,2), (2,3,3,3), (3,4,4,4)");
+        methodWatcher.executeUpdate("insert into TEST_INDEX_EXPR_UNION_2 values (1,1,1), (2,2,2), (3,3,3), (4,4,4), (5,5,5)");
+
+        String query = "select b1+1 from TEST_INDEX_EXPR_UNION_1 --splice-properties index=TEST_INDEX_EXPR_UNION_1_IDX\n where a1 + 1 = 2 " +
+                "union all " +
+                "select a2 from TEST_INDEX_EXPR_UNION_2 where b2 = 4";
+
+        /* check plan */
+        try (ResultSet rs = methodWatcher.executeQuery("explain " + query)) {
+            String explainPlanText = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            Assert.assertTrue(explainPlanText.contains("IndexScan[TEST_INDEX_EXPR_UNION_1_IDX"));
+            Assert.assertFalse(explainPlanText.contains("IndexLookup")); // no base row retrieving
+        }
+
+        /* check result */
+        String expected = "1 |\n" +
+                "----\n" +
+                " 3 |\n" +
+                " 4 |";
+        try (ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+    }
+
+    @Test
+    public void testCoveringExpressionBasedIndexSubquery() throws Exception {
+        methodWatcher.executeUpdate("create table TEST_SUBQ_A(a1 int, a2 int)");
+        methodWatcher.executeUpdate("create table TEST_SUBQ_B(b1 int, b2 int)");
+        methodWatcher.executeUpdate("insert into TEST_SUBQ_A values(0,0),(1,10),(2,20),(3,30),(4,40),(5,50)");
+        methodWatcher.executeUpdate("insert into TEST_SUBQ_B values(0,0),(0,0),(1,10),(1,10),(2,20),(2,20),(3,30),(3,30),(4,40),(4,40),(5,50),(5,50)");
+        methodWatcher.executeUpdate("create index TEST_SUBQ_A_IDX on TEST_SUBQ_A(a1 * 3, a2)");
+        methodWatcher.executeUpdate("create index TEST_SUBQ_B_IDX on TEST_SUBQ_B(b1 * 3, ln(b2+1))");
+
+        ///////////////////////////////////////
+        // subquery can be flattened to join //
+        ///////////////////////////////////////
+
+        // uncorrelated
+        String query = "select a1 * 3, a2 from " +
+                " TEST_SUBQ_A --SPLICE-PROPERTIES index=TEST_SUBQ_A_IDX\n" +
+                " where a1 * 3 in " +
+                "  (select b1 * 3 from TEST_SUBQ_B --SPLICE-PROPERTIES index=TEST_SUBQ_B_IDX\n" +
+                "   where ln(b2 + 1) > 3.2)";
+
+        // Don't really care about result order, let it be how ResultFactory.toString() sorts.
+        String expected = "1 |A2 |\n" +
+                "--------\n" +
+                "12 |40 |\n" +
+                "15 |50 |\n" +
+                " 9 |30 |";
+
+        try(ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+
+        // correlated
+        query = "select a2 from TEST_SUBQ_A --SPLICE-PROPERTIES index=TEST_SUBQ_A_IDX\n" +
+                " where a2 > (select sum(b1*3) from TEST_SUBQ_B --SPLICE-PROPERTIES index=TEST_SUBQ_B_IDX\n" +
+                "              where ln(b2+1) < a1 * 3)";
+
+        expected = "A2 |\n" +
+                "----\n" +
+                "10 |";
+
+        try(ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+
+        // SSQ
+        query = "select b1 * 3, (select distinct a2 from TEST_SUBQ_A --SPLICE-PROPERTIES index=TEST_SUBQ_A_IDX\n" +
+                " where a1*3 > ln(b2+1) and a1 * 3 < 6) from TEST_SUBQ_B --SPLICE-PROPERTIES index=TEST_SUBQ_B_IDX\n" +
+                " where b1 * 3 between 3 and 6";
+
+        expected = "1 |  2  |\n" +
+                "----------\n" +
+                " 3 | 10  |\n" +
+                " 3 | 10  |\n" +
+                " 6 |NULL |\n" +
+                " 6 |NULL |";
+
+        try(ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+
+        //////////////////////////////////
+        // subquery cannot be flattened //
+        //////////////////////////////////
+
+        query = "select a1 * 3, a2 from " +
+                " TEST_SUBQ_A --SPLICE-PROPERTIES index=TEST_SUBQ_A_IDX\n" +
+                " where a1 * 3 between 0 and 3 or a1 * 3 in " +
+                "  (select b1 * 3 from TEST_SUBQ_B --SPLICE-PROPERTIES index=TEST_SUBQ_B_IDX\n" +
+                "   where ln(b2 + 1) > 3.2)";
+
+        // Don't really care about result order, let it be how ResultFactory.toString() sorts.
+        expected = "1 |A2 |\n" +
+                "--------\n" +
+                " 0 | 0 |\n" +
+                "12 |40 |\n" +
+                "15 |50 |\n" +
+                " 3 |10 |\n" +
+                " 9 |30 |";
+
+        try(ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+
+        query = "select a2 from " +
+                " TEST_SUBQ_A --SPLICE-PROPERTIES index=TEST_SUBQ_A_IDX\n" +
+                " where a1 * 3 not in " +
+                "  (select b1 * 3 from TEST_SUBQ_B --SPLICE-PROPERTIES index=TEST_SUBQ_B_IDX\n" +
+                "   where ln(b2 + 1) > 3.2)";
+
+        /* check plan */
+        String[] expectedOps = new String[] {
+                "or ((TEST_SUBQ_A_IDX_col1[1:1] = SQLCol1[4:1]) or false",
+                "ProjectRestrict",
+                "IndexScan[TEST_SUBQ_B_IDX",
+                "ProjectRestrict",
+                "IndexScan[TEST_SUBQ_A_IDX",
+        };
+        rowContainsQuery(new int[]{5,7,8,9,10}, "explain " + query, methodWatcher, expectedOps);
+
+        expected = "A2 |\n" +
+                "----\n" +
+                " 0 |\n" +
+                "10 |\n" +
+                "20 |";
+
+        try(ResultSet rs = methodWatcher.executeQuery(query)) {
             Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
         }
     }


### PR DESCRIPTION
…#4162)

* DB-10175 Expression-based index scan with relational operator preds

* DB-10175 Expression-based index scan with in-list predicates

* DB-10175 Fix SpotBugs

* DB-10175 Address comments

* DB-10236 Rewrite query for a covering expression-based index

In this change, rewriting happens in:

- where clause
- group by clause
- order by clause
- having clause, including aggregates
- select list, including aggregates

* DB-10236 Make joins work correctly for covering expr index

* DB-10236 Fix SpotBugs

* DB-10236 Fix TernaryOperator handling in index expression rewriting

* DB-10175 Address comments

* DB-10175 Address comments / add semanticallyEquals()

DB-10312 Cache index expression ASTs is partially applied here so that
the code binding index expressions is not duplicated everywhere.

* DB-10175 Address comments / fix potential concurrent issue

Index expression ASTs should not be cached in IndexDescriptor because
it is in turns cached in data dictionary cache, which is global to all
queries. For now, always return a copy of ASTs.

* DB-10236 Adapt to the latest changes made in DB-10175

Note: IndexIT.testCoveringExpressionBasedIndexSubquery fails in
current state because we cannot bind expressions after resultColumns
are changed to index columns after changeAccessPath(). As a result,
index expressions containing JavaToSQLValueNode do not work.

* DB-10236 Fix IndexIT.testCoveringExpressionBasedIndexSubquery

The fix is done by allowing binding base table columns even after
table's access path has been changed to index columns. This ability is
limited to index on expressions only.

* DB-10312 Add hashCode() to ValueNode class hierarchy

* DB-10236 Address comments / fix expr collecting and derived tables

* DB-10236 Address comments / fix index expr in RHS of in-list

* WIP: DB-10236 Address comments / fix count(*) and index expr in window

* Resolved missed conflicts

* DB-10236 Column mapping manipulation for index on expressions

* DB-10236 Fix outer join without correcting column references

* DB-10236 Address comments / fix collecting expressions

* DB-10236 Address comment / fix post join condition replacing