### PR TITLE
DB-10752 Move TriggerDescriptorV4 to the end of SpliceSparkKryoRegistrator.

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
@@ -868,10 +868,10 @@ public class SpliceSparkKryoRegistrator implements KryoRegistrator, KryoPool.Kry
         instance.register(TriggerDescriptor.class,EXTERNALIZABLE_SERIALIZER);
         instance.register(TriggerDescriptorV2.class,EXTERNALIZABLE_SERIALIZER);
         instance.register(TriggerDescriptorV3.class,EXTERNALIZABLE_SERIALIZER);
-        instance.register(TriggerDescriptorV4.class,EXTERNALIZABLE_SERIALIZER);
         instance.register(StringAggregator.class,EXTERNALIZABLE_SERIALIZER);
         instance.register(StringBuilder.class);
         instance.register(Vector.class);
         instance.register(KafkaReadFunction.Message.class,EXTERNALIZABLE_SERIALIZER);
+        instance.register(TriggerDescriptorV4.class,EXTERNALIZABLE_SERIALIZER);
     }
 }


### PR DESCRIPTION
Kryo increments a class registration id for each new class added.  TriggerDescriptorV4 should have been added at the end to avoid messing up the registration ids.