### PR TITLE
DB-10746 Fix UPDATE statement index corruption.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLModStatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLModStatementNode.java
@@ -1519,11 +1519,17 @@ abstract class DMLModStatementNode extends DMLStatementNode
             ** If this index doesn't contain any updated
             ** columns, then we can skip it.
             */
-            if ((updatedColumns != null) &&
-                    (!updatedColumns.updateOverlaps(
-                            cd.getIndexDescriptor().baseColumnPositions()))) {
-                continue;
-            }
+            // We must include all indexes in the update for now,
+            // because the logic to determine which indexes need to
+            // be updated is broken and needs a lot of rework.
+            // TODO: Re-enable this code once UpdateOperation is
+            //       properly trained to detect which indexes
+            //       can skip the update.
+//            if ((updatedColumns != null) &&
+//                    (!updatedColumns.updateOverlaps(
+//                            cd.getIndexDescriptor().baseColumnPositions()))) {
+//                continue;
+//            }
 
             if (conglomVector != null) {
                 int i;

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateOperationIT.java
@@ -105,6 +105,19 @@ public class UpdateOperationIT {
                 .withRows(rows(row(8, 1000, "GGG"), row(10, 1000, "III")))
                 .create();
 
+        new TableCreator(connection)
+                .withCreate("CREATE TABLE T (" +
+                            "ID CHAR(36) NOT NULL " +
+                            ",TABLE_PK1 CHAR(36) NOT NULL " +
+                            ",TS_COL TIMESTAMP NOT NULL default " +
+                            ",COL4 CHAR(1) NOT NULL DEFAULT '', " +
+                            "a int, primary key(a))")
+                .withIndex("create index t_idx on T(COL4, TABLE_PK1)")
+                .withIndex("create index uni_idx on T(TABLE_PK1,TS_COL)")
+                .withInsert("INSERT INTO T VALUES(?,?,?,?,?)")
+                .withRows(rows(row("id", "pk", new Timestamp(82376296), "0", 1)))
+                .create();
+
         try(CallableStatement cs = connection.prepareCall("call SYSCS_UTIL.COLLECT_SCHEMA_STATISTICS(?,false)")){
             cs.setString(1,SCHEMA);
             cs.execute();
@@ -721,4 +734,44 @@ public class UpdateOperationIT {
                 SpliceUnitTest.getExplainMessage(1,"explain update updateoperationit.alias1 set (a1) = (select a2 from updateoperationit.alias2 y)",methodWatcher).contains("Update"));
     }
 
+    @Test
+    public void testUpdateDoesntCorruptIndex() throws Exception {
+        TestConnection conn = methodWatcher.getOrCreateConnection();
+        boolean oldAutoCommit = conn.getAutoCommit();
+        conn.setAutoCommit(false);
+
+        try (Statement s = conn.createStatement()) {
+            /* update Q1 -- simple update*/
+            String sql = "UPDATE T SET COL4 = 'X'";
+            int n = s.executeUpdate(sql);
+            Assert.assertEquals("Incorrect number of rows updated", 1, n);
+
+            String expected =
+            "TS_COL          |\n" +
+            "-------------------------\n" +
+            "1970-01-01 14:52:56.296 |";
+
+            try (ResultSet rs = methodWatcher.executeQuery("select TS_COL from T --splice-properties index=uni_idx")) {
+                assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+            }
+
+            sql = "DELETE FROM T";
+            s.executeUpdate(sql);
+
+            expected =  "1 |\n" +
+                        "----\n" +
+                        " 0 |";
+            try (ResultSet rs = methodWatcher.executeQuery("select count(*) from T --splice-properties index=uni_idx")) {
+                assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+            }
+            try (ResultSet rs = methodWatcher.executeQuery("select count(*) from T --splice-properties index=t_idx")) {
+                assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+            }
+
+        } finally {
+            // roll back the update
+            conn.rollback();
+            conn.setAutoCommit(oldAutoCommit);
+        }
+    }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateOperationIT.java
@@ -114,8 +114,6 @@ public class UpdateOperationIT {
                             "a int, primary key(a))")
                 .withIndex("create index t_idx on T(COL4, TABLE_PK1)")
                 .withIndex("create index uni_idx on T(TABLE_PK1,TS_COL)")
-                .withInsert("INSERT INTO T VALUES(?,?,?,?,?)")
-                .withRows(rows(row("id", "pk", new Timestamp(82376296), "0", 1)))
                 .create();
 
         try(CallableStatement cs = connection.prepareCall("call SYSCS_UTIL.COLLECT_SCHEMA_STATISTICS(?,false)")){
@@ -741,8 +739,11 @@ public class UpdateOperationIT {
         conn.setAutoCommit(false);
 
         try (Statement s = conn.createStatement()) {
+            String sql = "INSERT INTO T VALUES ('id', 'pk', '1970-01-01 14:52:56.296', '0', 1)";
+            s.executeUpdate(sql);
+
             /* update Q1 -- simple update*/
-            String sql = "UPDATE T SET COL4 = 'X'";
+            sql = "UPDATE T SET COL4 = 'X'";
             int n = s.executeUpdate(sql);
             Assert.assertEquals("Incorrect number of rows updated", 1, n);
 


### PR DESCRIPTION
The logic in IndexTransformer and elsewhere to avoid updating an index on an UPDATE statement which doesn't modify any index columns is broken.  If an index shares any columns with some other index that is getting updated, then it will also be updated.  UpdateNode.getXAffectedIndexes() detects which indexes shouldn't get updates, and skips adding their columns to the update, meaning they will be inaccessible.  Any attempt to rebuild an index row with missing columns will corrupt the index (produce columns with bad data, possibly a base rowid which cannot be properly read).   Attempting to read the bad index row will return incorrect results or throw an error.  Deleted the corresponding base table row may fail to delete the index row.

The fix is to add all indexes to the update for now, so that all possible index columns are accessible during the update.  A follow-on Jira will fix the logic to properly detect which indexes to skip.