### PR TITLE
DB-10734 expose entire row history to foreign key child interceptor

### DIFF
--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/SIObserver.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/SIObserver.java
@@ -346,8 +346,14 @@ public class SIObserver implements RegionObserver, Coprocessor, RegionCoprocesso
     }
 
     protected boolean shouldUseSI(OperationWithAttributes op){
+        if(op.getAttributesMap().isEmpty()) return false;
         if(op.getAttribute(SIConstants.SI_NEEDED)==null) return false;
         else return op.getAttribute(SIConstants.SUPPRESS_INDEXING_ATTRIBUTE_NAME)==null;
+    }
+
+    protected boolean shouldReadAllVersions(OperationWithAttributes op) {
+        if(op.getAttributesMap().isEmpty()) return false;
+        return op.getAttribute(SIConstants.ALL_VERSIONS) != null;
     }
 
     @SuppressWarnings("RedundantIfStatement") //we keep it this way for clarity
@@ -403,6 +409,10 @@ public class SIObserver implements RegionObserver, Coprocessor, RegionCoprocesso
                 get.setTimeRange(0L,Long.MAX_VALUE);
                 assert (get.getMaxVersions()==Integer.MAX_VALUE);
                 addSIFilterToGet(get);
+            }
+            if(tableEnvMatch && shouldReadAllVersions(get)) {
+                get.setMaxVersions();
+                get.setTimeRange(0L,Long.MAX_VALUE);
             }
             SpliceLogUtils.trace(LOG,"preGet after %s",get);
 

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyChildInterceptWriteHandler.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyChildInterceptWriteHandler.java
@@ -28,15 +28,13 @@ import com.splicemachine.pipeline.client.WriteResult;
 import com.splicemachine.pipeline.constraint.ConstraintContext;
 import com.splicemachine.pipeline.context.WriteContext;
 import com.splicemachine.pipeline.writehandler.WriteHandler;
+import com.splicemachine.si.constants.SIConstants;
 import com.splicemachine.si.impl.SimpleTxnFilter;
 import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.si.impl.readresolve.NoOpReadResolver;
 import com.splicemachine.si.impl.txn.ActiveWriteTxn;
 import com.splicemachine.si.impl.txn.WritableTxn;
-import com.splicemachine.storage.DataCell;
-import com.splicemachine.storage.DataFilter;
-import com.splicemachine.storage.DataResult;
-import com.splicemachine.storage.Partition;
+import com.splicemachine.storage.*;
 import com.splicemachine.storage.util.MapAttributes;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
@@ -118,7 +116,9 @@ public class ForeignKeyChildInterceptWriteHandler implements WriteHandler{
             }else
                 throw new IOException("invalidTxn");
 
-            Iterator<DataResult> iterator = table.batchGet(new MapAttributes(),rowKeysToFetch);
+            Attributable attributes = new MapAttributes();
+            attributes.addAttribute(SIConstants.ALL_VERSIONS, SIConstants.ALL_VERSIONS_VALUE);
+            Iterator<DataResult> iterator = table.batchGet(attributes,rowKeysToFetch);
             BitSet misses = new BitSet(rowKeysToFetch.size());
 
             int i = 0;

--- a/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKeyCheckIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKeyCheckIT.java
@@ -22,6 +22,7 @@ import com.splicemachine.test_tools.TableCreator;
 import org.junit.*;
 import org.junit.experimental.categories.Category;
 
+import java.sql.Connection;
 import java.sql.Statement;
 import java.util.regex.Pattern;
 
@@ -706,6 +707,36 @@ public class ForeignKeyCheckIT {
     }
 
 
+    @Test
+    public void rowHistoryIsReadyCorrectly() throws Exception {
+            new TableCreator(conn)
+                    .withCreate("create table P(col1 int, col2 varchar(2), col3 int, col4 int, primary key (col2, col4))")
+                    .withInsert("insert into P values(?,?,?,?)")
+                    .withRows(rows(row(1, "a", 1, 1)))
+                    .create();
+            new TableCreator(conn)
+                    .withCreate("create table C (col1 int primary key, col2 varchar(2), col3 int, col4 int, constraint CHILD_FKEY foreign key(col2, col3) references P(col2, col4) )")
+                    .create();
+            conn.commit();
+
+        try(Connection c = newNoAutoCommitConnection()) {
+            c.setAutoCommit(false);
+
+            try (Statement statement = c.createStatement()) {
+                statement.executeUpdate("update P set col1 = 42");
+            }
+            Thread.sleep(30 * 1000);
+            c.rollback();
+        }
+
+        try(Connection conn = newNoAutoCommitConnection()) {
+            try(Statement s = conn.createStatement()) {
+                s.executeUpdate("insert into C values (400, 'a', 1, 42)"); // should not fail
+            }
+            conn.commit();
+        }
+    }
+
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     //
     // FK is UNIQUE in child table -- this is a very distinct case because we will reuse the unique index in the
@@ -760,6 +791,12 @@ public class ForeignKeyCheckIT {
             assertTrue(String.format("exception '%s' did not match expected pattern '%s'", e.getMessage(), expectedExceptionMessagePattern),
                     Pattern.compile(expectedExceptionMessagePattern).matcher(e.getMessage()).matches());
         }
+    }
+
+    private Connection newNoAutoCommitConnection() throws Exception {
+        Connection connection = methodWatcher.createConnection();
+        connection.setAutoCommit(false);
+        return connection;
     }
 
 }

--- a/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKeyCheckIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKeyCheckIT.java
@@ -725,7 +725,6 @@ public class ForeignKeyCheckIT {
             try (Statement statement = c.createStatement()) {
                 statement.executeUpdate("update P set col1 = 42");
             }
-            Thread.sleep(30 * 1000);
             c.rollback();
         }
 

--- a/splice_si_api/src/main/java/com/splicemachine/si/constants/SIConstants.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/constants/SIConstants.java
@@ -103,6 +103,10 @@ public class SIConstants {
 
     public static final String ENTRY_PREDICATE_LABEL= "p";
 
+    // flag to indicate the scan should get all the versions.
+    public static final String ALL_VERSIONS = "sav";
+    public static final byte[] ALL_VERSIONS_VALUE = {};
+
     public static final int DEFAULT_CACHE_SIZE=1<<10;
 
     // Name of property to use for caching full display name of table and index.


### PR DESCRIPTION
When adding a row in the child table, the child-interceptor logic was making decisions about the existence of the foreign key in the parent table using latest rows' latest versions from HBase which could lead to true negatives. This behavior is corrected by letting the child-interceptor examine the entire row history of the parent keys.