### PR TITLE
DB-10719 add unit tests for foreign key dependency checker.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/foreignkey/Graph.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/foreignkey/Graph.java
@@ -208,6 +208,7 @@ public class Graph {
                     edgeNode.next = null; // bye, GC.
                     return;
                 }
+                previous = edgeNode;
                 edgeNode = edgeNode.next;
             }
         }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/foreignkey/GraphAnnotator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/foreignkey/GraphAnnotator.java
@@ -35,10 +35,10 @@ public class GraphAnnotator {
 
         public String toString(Graph g) {
             StringBuilder sb = new StringBuilder();
-            sb.append("PATH action: ").append(action).append(" ");
-            for(int v : vertices) {
+            for(int v : removeSurrogates(vertices)) {
                 sb.append(g.getName(v)).append(" ");
             }
+            sb.append("(delete action: ").append(action).append(")");
             return sb.toString();
         }
 

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/sql/dictionary/foreignkey/GraphTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/sql/dictionary/foreignkey/GraphTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.db.iapi.sql.dictionary.foreignkey;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import splice.com.google.common.collect.Lists;
+
+import java.util.*;
+import java.util.stream.IntStream;
+
+@RunWith(Enclosed.class)
+public class GraphTest {
+
+    interface PermuteClosure {
+        void call(List<String> permutation) throws StandardException;
+    }
+
+    static void Permute(List<String> input, int k, PermuteClosure action) throws StandardException {
+        if (k == 1) {
+            action.call(input);
+        }
+        for (int i = 0; i < k; ++i) {
+            Permute(input, k - 1, action);
+            if (i < k - 1) {
+                if (k % 2 == 0) {
+                    Collections.swap(input, i, k - 1);
+                } else {
+                    Collections.swap(input, 0, input.size() - 1);
+                }
+            }
+        }
+    }
+
+    static List<String> permute(String graphviz) throws StandardException {
+        final List<String> edges = Lists.newArrayList(graphviz.split("\n"));
+        final String header = edges.remove(0);
+        final String footer = edges.remove(edges.size() - 1);
+        final List<String> result = new ArrayList<>(IntStream.rangeClosed(1, edges.size()).reduce(1, (int x, int y) -> x * y));
+        result.add(graphviz);
+        Permute(edges, edges.size(), permutation -> {
+            StringBuilder permutedGraph = new StringBuilder(header);
+            for (String edge : permutation) {
+                permutedGraph.append(edge);
+            }
+            permutedGraph.append(footer);
+            result.add(permutedGraph.toString());
+        });
+        return result;
+    }
+
+    static class NegativeTestCase {
+        final String graph;
+        final String pathA;
+        final String pathB;
+        final String deleteActionA;
+        final String deleteActionB;
+        final String table;
+
+        NegativeTestCase(String graph, String table, String pathA, String deleteActionA, String pathB, String deleteActionB) {
+            this.graph = graph;
+            this.pathA = pathA;
+            this.pathB = pathB;
+            this.deleteActionA = deleteActionA;
+            this.deleteActionB = deleteActionB;
+            this.table = table;
+        }
+
+        @Override
+        public String toString() {
+            return graph;
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class NegativeTests {
+
+        private static Collection<Object[]> parameters = Lists.newArrayListWithCapacity(100);
+
+        private static void addCase(String graph, String table, String pathA, String deleteActionA, String pathB, String deleteActionB) throws StandardException {
+            parameters.add(new Object[]{new NegativeTestCase(graph, table, pathA, deleteActionA, pathB, deleteActionB)});
+            List<String> invalidGraph1Permutations = permute(graph);
+            for (String permutedGraph : invalidGraph1Permutations) {
+                parameters.add(new Object[]{new NegativeTestCase(permutedGraph, table, pathA, deleteActionA, pathB, deleteActionB)});
+            }
+        }
+
+        @Parameterized.Parameters(name = "negative case --- {0}")
+        public static Collection<Object[]> data() throws StandardException {
+            addCase("digraph {\n" +
+                            "A -> B[label=\"Cascade\"];\n" +
+                            "B -> C[label=\"Cascade\"];\n" +
+                            "C -> A[label=\"SetNull\"];\n" +
+                            "C -> A[label=\"Restrict\"];\n" +
+                            "}", "C", "A", "SetNull", "A", "Restrict");
+            addCase("digraph {\n" +
+                            "T2 -> T1[label=\"Cascade\"];\n" +
+                            "T3 -> T1[label=\"Cascade\"];\n" +
+                            "T6 -> T2[label=\"Cascade\"];\n" +
+                            "T7 -> T6[label=\"Cascade\"];\n" +
+                            "T7 -> T4[label=\"SetNull\"];\n" +
+                            "T4 -> T3[label=\"Cascade\"];\n" +
+                            "}", "T7", "T1 T2 T6", "Cascade", "T1 T3 T4", "SetNull");
+            addCase("digraph {\n" +
+                            "B -> A[label=\"Cascade\"];\n" +
+                            "C -> A[label=\"Cascade\"];\n" +
+                            "D -> B[label=\"Cascade\"];\n" +
+                            "D -> C[label=\"SetNull\"];\n" +
+                            "}", "D", "A C", "SetNull", "A B", "Cascade");
+            addCase("digraph {\n" +
+                            "A -> B[label=\"Cascade\"];\n" +
+                            "A -> B[label=\"SetNull\"];\n" +
+                            "}", "A", "B", "SetNull", "B", "Cascade");
+            addCase("digraph {\n" +
+                            "B -> A[label=\"Cascade\"];\n" +
+                            "C -> A[label=\"Cascade\"];\n" +
+                            "D -> B[label=\"Cascade\"];\n" +
+                            "D -> C[label=\"SetNull\"];\n" +
+                            "}", "D", "A C", "SetNull", "A B", "Cascade");
+            return parameters;
+        }
+
+        public NegativeTests(NegativeTestCase negativeTestCase) {
+            this.negativeTestCase = negativeTestCase;
+        }
+
+        NegativeTestCase negativeTestCase;
+
+        @Test
+        public void testcase() throws Exception {
+            Graph graph = new GraphvizParser
+                    (negativeTestCase.graph).generateGraph("something");
+
+            GraphAnnotator annotater = new GraphAnnotator("something", graph);
+            annotater.annotate();
+            try {
+                annotater.analyzeAnnotations();
+                Assert.fail("the annotator should have failed with error containing: adding this foreign key leads to the conflicting delete actions on the table ...");
+            } catch (Exception e) {
+                Assert.assertTrue(e instanceof StandardException);
+                StandardException sqlException = (StandardException) e;
+                Assert.assertEquals("42915", sqlException.getSQLState());
+                Assert.assertTrue(sqlException.getMessage().contains("adding this foreign key leads to the conflicting delete actions on the table '" + negativeTestCase.table + "'"));
+                Assert.assertTrue(sqlException.getMessage().contains(negativeTestCase.pathA + " (delete action: " + negativeTestCase.deleteActionA + ")"));
+                Assert.assertTrue(sqlException.getMessage().contains(negativeTestCase.pathB + " (delete action: " + negativeTestCase.deleteActionB + ")"));
+            }
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class PositiveTests {
+
+        private static Collection<Object[]> parameters = Lists.newArrayListWithCapacity(100);
+
+        private static void addCase(String graph) throws StandardException {
+            parameters.add(new Object[]{graph});
+            List<String> validGraphPermutations = permute(graph);
+            for (String permutedGraph : validGraphPermutations) {
+                parameters.add(new Object[]{permutedGraph});
+            }
+        }
+
+        @Parameterized.Parameters(name = "positive case --- {0}")
+        public static Collection<Object[]> data() throws StandardException {
+            addCase("digraph {\n" +
+                            "A -> B[label=\"Cascade\"];\n" +
+                            "A -> B[label=\"Cascade\"];\n" +
+                            "}");
+            addCase("digraph {\n" +
+                            "B -> A[label=\"Cascade\"];\n" +
+                            "C -> A[label=\"Cascade\"];\n" +
+                            "D -> B[label=\"Cascade\"];\n" +
+                            "D -> C[label=\"Cascade\"];\n" +
+                            "}");
+            addCase("digraph {\n" +
+                            "A -> B[label=\"SetNull\"];\n" +
+                            "C -> A[label=\"Cascade\"];\n" +
+                            "B -> C[label=\"NoAction\"];\n" +
+                            "}");
+            addCase("digraph {\n" +
+                            "D -> A[label=\"SetNull\"];\n" +
+                            "D -> C[label=\"Cascade\"];\n" +
+                            "C -> B[label=\"Restrict\"];\n" +
+                            "B -> A[label=\"Cascade\"];\n" +
+                            "}");
+            return parameters;
+        }
+
+        public PositiveTests(String graph) {
+            this.graph = graph;
+        }
+
+        String graph;
+
+        @Test
+        public void testcase() throws Exception {
+            Graph g = new GraphvizParser(graph).generateGraph("something");
+            GraphAnnotator annotator = new GraphAnnotator("something", g);
+            annotator.annotate();
+            annotator.analyzeAnnotations();
+        }
+    }
+
+    public static class NonParameterizedTest {
+        @Test
+        public void invalidGraphIsDetectedProperlyCase5() { // invalid cascade cycle
+            try {
+                new GraphvizParser
+                        ("digraph {\n" +
+                                 "A -> B[label=\"Cascade\"];\n" +
+                                 "B -> C[label=\"Cascade\"];\n" +
+                                 "C -> A[label=\"Cascade\"];\n" +
+                                 "}").generateGraph("something");
+                Assert.fail("expected graph creation to fail with error message: adding the constraint between A and C would cause the following " +
+                                    "illegal delete action cascade cycle A B C");
+            } catch (Exception e) {
+                Assert.assertTrue(e instanceof StandardException);
+                StandardException sqlException = (StandardException) e;
+                Assert.assertEquals("42915", sqlException.getSQLState());
+                Assert.assertTrue(sqlException.getMessage().contains("adding the constraint between A and C would cause the following illegal delete action cascade cycle A B C"));
+            }
+        }
+    }
+}

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/sql/dictionary/foreignkey/GraphTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/sql/dictionary/foreignkey/GraphTest.java
@@ -31,12 +31,12 @@ public class GraphTest {
         void call(List<String> permutation) throws StandardException;
     }
 
-    static void Permute(List<String> input, int k, PermuteClosure action) throws StandardException {
+    static void permute(List<String> input, int k, PermuteClosure action) throws StandardException {
         if (k == 1) {
             action.call(input);
         }
         for (int i = 0; i < k; ++i) {
-            Permute(input, k - 1, action);
+            permute(input, k - 1, action);
             if (i < k - 1) {
                 if (k % 2 == 0) {
                     Collections.swap(input, i, k - 1);
@@ -53,7 +53,7 @@ public class GraphTest {
         final String footer = edges.remove(edges.size() - 1);
         final List<String> result = new ArrayList<>(IntStream.rangeClosed(1, edges.size()).reduce(1, (int x, int y) -> x * y));
         result.add(graphviz);
-        Permute(edges, edges.size(), permutation -> {
+        permute(edges, edges.size(), permutation -> {
             StringBuilder permutedGraph = new StringBuilder(header);
             for (String edge : permutation) {
                 permutedGraph.append(edge);
@@ -216,7 +216,7 @@ public class GraphTest {
         }
     }
 
-    public static class NonParameterizedTest {
+    public static class NonParameterizedTests {
         @Test
         public void invalidGraphIsDetectedProperlyCase5() { // invalid cascade cycle
             try {

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/sql/dictionary/foreignkey/GraphvizParser.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/sql/dictionary/foreignkey/GraphvizParser.java
@@ -1,0 +1,119 @@
+package com.splicemachine.db.iapi.sql.dictionary.foreignkey;
+
+import com.splicemachine.db.iapi.error.StandardException;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class GraphvizParser {
+
+    private static class Ast {
+        private static class Node {
+            final String from;
+            final String to;
+            final EdgeNode.Type type;
+
+            private Node(String from, String to, EdgeNode.Type type) {
+                this.from = from;
+                this.to = to;
+                this.type = type;
+            }
+        }
+        List<Node> nodes = new ArrayList<Node>();
+
+        Set<String> getNodes() {
+            Set<String> uniques = new HashSet<String>(nodes.size() * 2);
+            for(Node node : nodes) {
+                uniques.add(node.from);
+                uniques.add(node.to);
+            }
+            return uniques;
+        }
+    }
+
+    String input;
+    int offset;
+    Ast ast;
+
+    public GraphvizParser(String input) {
+        this.input = input.replaceAll("\\s", "");
+        this.offset = 0;
+        ast = new Ast();
+    }
+
+    private void parse() {
+        parseDigraph();
+    }
+
+    private Ast.Node parseEdgeStatement() {
+        String from = consumeAlphanumeric();
+        parseEdgeRHS();
+        String to = consumeAlphanumeric();
+        EdgeNode.Type type = consumeLabel();
+        return new Ast.Node(from, to, type);
+    }
+
+    void consume(String token) {
+        if(input.length() < offset + token.length()) {
+            throw new IllegalArgumentException("unexpected end of tokens, expected to find: '" + token + "' but the token stream is empty");
+        }
+        if(!input.startsWith(token,offset)) {
+            throw new IllegalArgumentException(String.format("unexpected value, found '%s' expected '%s", input.substring(offset, token.length()), token));
+        }
+        offset += token.length();
+    }
+
+    private void parseDigraph() {
+        consume("digraph");
+        consume("{");
+        parseStatementList();
+        consume("}");
+    }
+
+    private void parseStatementList() {
+        while(!peekChar().equals('}')) {
+            ast.nodes.add(parseEdgeStatement());
+        }
+    }
+
+    EdgeNode.Type consumeLabel() {
+        consume("[");
+        consume("label");
+        consume("=");
+        consume("\"");
+        String type = consumeAlphanumeric();
+        EdgeNode.Type result = EdgeNode.Type.valueOf(type);
+        consume("\"");
+        consume("]");
+        consume(";");
+        return result;
+    }
+
+    String consumeAlphanumeric() {
+        String[] result = input.substring(offset).split("[^a-zA-Z0-9]+", 2);
+        consume(result[0]);
+        return result[0];
+    }
+
+    Character peekChar() {
+        if(offset >= input.length()) {
+            throw new IllegalArgumentException("unexpected end of tokens");
+        }
+        return input.charAt(offset);
+    }
+
+    private void parseEdgeRHS() {
+        consume("->");
+    }
+
+    public Graph generateGraph(String constraintName) throws StandardException {
+        parse();
+        Graph g = new Graph(ast.getNodes(), constraintName);
+        for(Ast.Node node : ast.nodes) {
+            g.addEdge(node.from, node.to, node.type);
+        }
+        return g;
+    }
+}


### PR DESCRIPTION
In this PR we add few hundreds of positive and negative unit tests to the foreign key dependency graph. the sheer amount of unit tests comes from constructing each graph in the test cases using all possible edge permutations. This brute-force test uncovered one bug in graph construction mechanism causing the checker to construct an incorrect graph and ultimately causing it to accept an incorrect foreign key dependency graph. The generation of the permutations is done using [Heap's algorithm](https://en.wikipedia.org/wiki/Heap%27s_algorithm).