### PR TITLE
DB-10854 Fix txn leak in FROM FINAL TABLE.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableDescriptor.java
@@ -54,10 +54,8 @@ import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.util.IdUtil;
-import com.splicemachine.db.impl.sql.catalog.DataDictionaryCache;
+import com.splicemachine.db.impl.sql.compile.TriggerReferencingStruct;
 import com.splicemachine.db.impl.sql.execute.ColumnInfo;
-import com.splicemachine.db.impl.sql.execute.ValueRow;
-import com.splicemachine.db.impl.sql.execute.WriteCursorConstantAction;
 import splice.com.google.common.primitives.Ints;
 
 import java.util.List;
@@ -817,11 +815,11 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
                 relevantTriggers.add(tgr);
             }
         }
-        TriggerDescriptor tgr = DataDictionaryCache.fromTableTriggerDescriptor.get();
+        TriggerDescriptor tgr = TriggerReferencingStruct.fromTableTriggerDescriptor.get();
         if (tgr != null) {
             if(tgr.needsToFire(statementType,changedColumnIds)) {
                 finalTableErrorCheck(relevantTriggers, dd,
-                                     DataDictionaryCache.fromTableTriggerSPSDescriptor.get());
+                                     TriggerReferencingStruct.fromTableTriggerSPSDescriptor.get());
                 relevantTriggers.add(tgr);
             }
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
@@ -31,6 +31,7 @@
 
 package com.splicemachine.db.impl.sql.catalog;
 
+import org.apache.commons.lang3.mutable.MutableBoolean;
 import splice.com.google.common.base.Optional;
 import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.error.StandardException;
@@ -90,8 +91,6 @@ public class DataDictionaryCache {
     private ManagedCache<UUID, ConstraintDescriptorList> constraintDescriptorListCache;
     private DataDictionary dd;
 
-    public static final ThreadLocal<TriggerDescriptor> fromTableTriggerDescriptor = new ThreadLocal<>();
-    public static final ThreadLocal<SPSDescriptor> fromTableTriggerSPSDescriptor = new ThreadLocal<>();
     @SuppressFBWarnings(value = "MS_PKGPROTECT", justification = "DB-9844")
     private static final String [] cacheNames = new String[] {"oidTdCache", "nameTdCache", "spsNameCache", "sequenceGeneratorCache", "permissionsCache", "partitionStatisticsCache",
             "storedPreparedStatementCache", "conglomerateCache", "statementCache", "schemaCache", "aliasDescriptorCache", "roleCache", "defaultRoleCache", "roleGrantCache",

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DeleteNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DeleteNode.java
@@ -55,7 +55,6 @@ import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.util.ReuseFactory;
-import com.splicemachine.db.impl.sql.catalog.DataDictionaryCache;
 import com.splicemachine.db.vti.DeferModification;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.SerializationUtils;
@@ -711,7 +710,7 @@ public class DeleteNode extends DMLModStatementNode
             } else {
                 mb.push(-1);
             }
-            SPSDescriptor fromTableTriggerSPSDescriptor = DataDictionaryCache.fromTableTriggerSPSDescriptor.get();
+            SPSDescriptor fromTableTriggerSPSDescriptor = TriggerReferencingStruct.fromTableTriggerSPSDescriptor.get();
             if (fromTableTriggerSPSDescriptor == null)
                 mb.pushNull("java.lang.String");
             else {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
@@ -41,27 +41,22 @@ import com.splicemachine.db.iapi.reference.Property;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.classfile.VMOpcode;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
-import com.splicemachine.db.iapi.services.context.ContextService;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.services.io.FormatableHashtable;
 import com.splicemachine.db.iapi.services.loader.ClassInspector;
 import com.splicemachine.db.iapi.services.property.PropertyUtil;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
-import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.Statement;
 import com.splicemachine.db.iapi.sql.compile.*;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionFactory;
-import com.splicemachine.db.iapi.sql.conn.StatementContext;
 import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ExecPreparedStatement;
 import com.splicemachine.db.iapi.sql.execute.ExecutionContext;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.util.JBitSet;
-import com.splicemachine.db.impl.sql.GenericPreparedStatement;
 import com.splicemachine.db.impl.sql.GenericStatement;
 import com.splicemachine.db.impl.sql.GenericStorablePreparedStatement;
-import com.splicemachine.db.impl.sql.catalog.DataDictionaryCache;
 import com.splicemachine.db.impl.sql.execute.*;
 import com.splicemachine.db.vti.*;
 import org.apache.commons.codec.binary.Base64;
@@ -604,7 +599,7 @@ public class FromVTI extends FromTable implements VTIEnvironment {
         TriggerInfo triggerInfo = new TriggerInfo(targetTableDescriptor, null, triggerList);
         // A special location to hold the temporary trigger descriptor
         // so we don't muck around with the dictionary cache.
-        DataDictionaryCache.fromTableTriggerDescriptor.set(triggerd);
+        TriggerReferencingStruct.fromTableTriggerDescriptor.set(triggerd);
 
         TriggerExecutionContext tec =
         getNewTriggerExecutionContext(lcc, triggerd.getTriggerDefinition(0), triggerInfo, targetTableDescriptor.getUUID(),
@@ -616,7 +611,7 @@ public class FromVTI extends FromTable implements VTIEnvironment {
 
         // A special location to hold the temporary SPS descriptor
         // so we don't muck around with the dictionary cache.
-        DataDictionaryCache.fromTableTriggerSPSDescriptor.set(spsd);
+        TriggerReferencingStruct.fromTableTriggerSPSDescriptor.set(spsd);
 
         // Need to make the new TEC accessible to the outer query
         // so it knows where to find the NEW table trigger rows.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InsertNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InsertNode.java
@@ -55,7 +55,6 @@ import com.splicemachine.db.iapi.types.RowLocation;
 import com.splicemachine.db.iapi.util.ReuseFactory;
 import com.splicemachine.db.iapi.util.StringUtil;
 import com.splicemachine.db.impl.ast.RSUtils;
-import com.splicemachine.db.impl.sql.catalog.DataDictionaryCache;
 import com.splicemachine.db.vti.DeferModification;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.SerializationUtils;
@@ -1054,7 +1053,7 @@ public final class InsertNode extends DMLModStatementNode {
         mb.push(skipSampling);
         mb.push(sampleFraction);
         BaseJoinStrategy.pushNullableString(mb, indexName);
-        SPSDescriptor fromTableTriggerSPSDescriptor = DataDictionaryCache.fromTableTriggerSPSDescriptor.get();
+        SPSDescriptor fromTableTriggerSPSDescriptor = TriggerReferencingStruct.fromTableTriggerSPSDescriptor.get();
         if (fromTableTriggerSPSDescriptor == null)
             mb.pushNull("java.lang.String");
         else {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TriggerReferencingStruct.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TriggerReferencingStruct.java
@@ -31,10 +31,23 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
+import com.splicemachine.db.iapi.sql.dictionary.SPSDescriptor;
+import com.splicemachine.db.iapi.sql.dictionary.TriggerDescriptor;
+import org.apache.commons.lang3.mutable.MutableBoolean;
+
 /**
  * Rudimentary structure for containing information about a REFERENCING clause for a trigger.
  */
 public class TriggerReferencingStruct {
+
+    public static final ThreadLocal<TriggerDescriptor> fromTableTriggerDescriptor = new ThreadLocal<>();
+    public static final ThreadLocal<SPSDescriptor> fromTableTriggerSPSDescriptor = new ThreadLocal<>();
+    public static final ThreadLocal<MutableBoolean> isFromTableStatement = new ThreadLocal<MutableBoolean>() {
+        @Override
+        protected MutableBoolean initialValue() {
+            return new MutableBoolean(false);
+        }
+    };
 
     public String identifier;
     public boolean isRow;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UpdateNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UpdateNode.java
@@ -54,7 +54,6 @@ import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.util.ReuseFactory;
-import com.splicemachine.db.impl.sql.catalog.DataDictionaryCache;
 import com.splicemachine.db.vti.DeferModification;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.SerializationUtils;
@@ -897,7 +896,7 @@ public final class UpdateNode extends DMLModStatementNode
                 mb.push(this.resultSet.getFinalCostEstimate(false).getEstimatedCost());
                 mb.push(targetTableDescriptor.getVersion());
                 mb.push(this.printExplainInformationForActivation());
-                SPSDescriptor fromTableTriggerSPSDescriptor = DataDictionaryCache.fromTableTriggerSPSDescriptor.get();
+                SPSDescriptor fromTableTriggerSPSDescriptor = TriggerReferencingStruct.fromTableTriggerSPSDescriptor.get();
                 if (fromTableTriggerSPSDescriptor == null)
                     mb.pushNull("java.lang.String");
                 else {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DMLWriteOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DMLWriteOperation.java
@@ -420,16 +420,6 @@ public abstract class DMLWriteOperation extends SpliceBaseOperation {
     public void close() throws StandardException {
         if (triggerHandler!=null) {
             triggerHandler.cleanup();
-
-            // If we have triggers, wrap the next operations into another transaction to prevent the next transaction from ignoring
-            // our writes, see SPLICE-1625
-            TransactionController transactionExecute = activation.getLanguageConnectionContext().getTransactionExecute();
-            Transaction rawStoreXact = ((TransactionManager) transactionExecute).getRawStoreXact();
-            BaseSpliceTransaction rawTxn = (BaseSpliceTransaction) rawStoreXact;
-            if (rawTxn instanceof SpliceTransaction) {
-                rawTxn.setSavePoint("triggers", null);
-                ((SpliceTransaction) rawTxn).elevate(getDestinationTable());
-            }
         }
         super.close();
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ProjectRestrictOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ProjectRestrictOperation.java
@@ -38,6 +38,7 @@ import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
 import com.splicemachine.derby.stream.iapi.OperationContext;
 import com.splicemachine.derby.utils.EngineUtils;
+import com.splicemachine.si.api.txn.TxnView;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.log4j.Logger;
 import splice.com.google.common.base.Strings;
@@ -383,4 +384,13 @@ public class ProjectRestrictOperation extends SpliceBaseOperation {
 	public ScanInformation<ExecRow> getScanInformation() {
 		return source.getScanInformation();
 	}
+
+    @Override
+    public TxnView getCurrentTransaction() throws StandardException{
+        if (source instanceof VTIOperation ||
+		    source instanceof ProjectRestrictOperation)
+            return source.getCurrentTransaction();
+        else
+            return super.getCurrentTransaction();
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScrollInsensitiveOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScrollInsensitiveOperation.java
@@ -32,6 +32,7 @@ import com.splicemachine.derby.stream.function.ScrollInsensitiveFunction;
 import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
 import com.splicemachine.derby.stream.iapi.OperationContext;
+import com.splicemachine.si.api.txn.TxnView;
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.log4j.Logger;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
@@ -225,6 +226,11 @@ public class ScrollInsensitiveOperation extends SpliceBaseOperation {
     public void updateRow(ExecRow row, RowChanger rowChanger)
             throws StandardException {
 
+    }
+
+    @Override
+    public TxnView getCurrentTransaction() throws StandardException{
+        return source.getCurrentTransaction();
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
@@ -844,11 +844,19 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
         Transaction rawStoreXact=((TransactionManager)transactionExecute).getRawStoreXact();
         BaseSpliceTransaction rawTxn=(BaseSpliceTransaction)rawStoreXact;
         TxnView currentTxn = rawTxn.getActiveStateTxn();
-        if(this instanceof DMLWriteOperation) {
+        if(this instanceof DMLWriteOperation ||
+           isFromTableStatement()) {
             if (currentTxn instanceof ActiveWriteTxn)
                 return rawTxn.getActiveStateTxn();
-            else if (rawTxn instanceof  SpliceTransaction)
-                return ((SpliceTransaction) rawTxn).elevate(((DMLWriteOperation) this).getDestinationTable());
+            else if (rawTxn instanceof  SpliceTransaction) {
+                byte [] destinationTable;
+                if (this instanceof DMLWriteOperation )
+                    destinationTable = ((DMLWriteOperation) this).getDestinationTable();
+                else
+                    destinationTable = ((VTIOperation) this).getDestinationTable();
+
+                return ((SpliceTransaction) rawTxn).elevate(destinationTable);
+            }
             else
                 throw new IllegalStateException("Programmer error: " + "cannot elevate transaction");
         }
@@ -1130,5 +1138,9 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
         for (int i = 0; i < ncols;i++)
             fields[i] = resultDataTypeDescriptors[i].getStructField(ValueRow.getNamedColumn(i));
         return DataTypes.createStructType(fields);
+    }
+
+    public boolean isFromTableStatement() {
+        return false;
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TriggerHandler.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TriggerHandler.java
@@ -298,25 +298,14 @@ public class TriggerHandler {
         // If an Exception is encountered, some resources may be closed more than
         // once during unwinding of the call stack we want to make sure that
         // full cleanup isn't indefinitely deferred, and isn't unnecessarily
-        // called multiple times, so add a cleanup1Done phase to indicate
-        // the next time around, we don't defer full cleanup any longer, and
-        // a cleanup2Done phase to indicate we've already done full cleanup
-        // and we don't accidentally try to clean already-cleaned resources.
-        //
-        // This is also needed for statements such as:
-        // SELECT * FROM FINAL TABLE (INSERT INTO t1 VALUES(1,2));
-        // The first time cleanup is called, for the DML statement,
-        // we want to retain the trigger result set for consumption
-        // by the SELECT statement, but once the SELECT completes,
-        // we want to make sure any buffers or temporary conglomerates
-        // are cleaned up.
-        if (triggerActivator != null && !cleanup2Done) {
-            if (cleanup1Done)
-                cleanup2Done = true;
-            triggerActivator.cleanup(hasSpecialFromTableTrigger && !cleanup1Done);
-        }
-        if (triggerRowHolder != null && !cleanup1Done) {
+        // called multiple times, so add cleanup1Done and cleanup2Done
+        // flags to test if we've gotten here before.
+        if (triggerActivator != null && !cleanup1Done) {
             cleanup1Done = true;
+            triggerActivator.cleanup(false);
+        }
+        if (triggerRowHolder != null && !cleanup2Done) {
+            cleanup2Done = true;
             triggerRowHolder.close();
         }
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperation.java
@@ -302,12 +302,17 @@ public class VTIOperation extends SpliceBaseOperation {
         super.close();
         if (fromTableDML_ResultSet != null && !fromTableDML_ResultSet.isClosed()) {
             // Flush out any rows from execution.  Should be just one.
-            if (fromTableDML_ResultSet.returnsRows())
-                while (fromTableDML_ResultSet.getNextRow() != null) {
-                }
-            // Release resources.
-            fromTableDML_ResultSet.close();
-            fromTableDML_ResultSet = null;
+            try {
+                if (fromTableDML_ResultSet.returnsRows())
+                    while (fromTableDML_ResultSet.getNextRow() != null) {
+                    }
+                // Release resources.
+            }
+            finally {
+                if (!fromTableDML_ResultSet.isClosed())
+                    fromTableDML_ResultSet.close();
+                fromTableDML_ResultSet = null;
+            }
         }
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperation.java
@@ -39,17 +39,22 @@ import com.splicemachine.derby.catalog.TriggerNewTransitionRows;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperationContext;
 import com.splicemachine.derby.impl.SpliceMethod;
+import com.splicemachine.derby.impl.sql.execute.actions.WriteCursorConstantOperation;
 import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
 import com.splicemachine.derby.stream.iapi.OperationContext;
 import com.splicemachine.derby.vti.SpliceFileVTI;
 import com.splicemachine.derby.vti.iapi.DatasetProvider;
+import com.splicemachine.primitives.Bytes;
+import com.splicemachine.si.api.txn.TxnView;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.SerializationUtils;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+
+import static com.splicemachine.db.shared.common.reference.SQLState.LANG_INTERNAL_ERROR;
 
 /*
 
@@ -131,6 +136,7 @@ public class VTIOperation extends SpliceBaseOperation {
     private boolean convertTimestamps;
     private boolean quotedEmptyIsNull;
     private GenericStorablePreparedStatement fromTableDML_SPS = null;
+    private ResultSet fromTableDML_ResultSet = null;
 
 
 	/**
@@ -287,8 +293,52 @@ public class VTIOperation extends SpliceBaseOperation {
             LanguageConnectionContext lcc = getActivation().getLanguageConnectionContext();
             fromTableDML_SPS.setValid();
             getActivation().setSingleExecution();
-            fromTableDML_SPS.executeSubStatement(lcc, false, 0L);
+            fromTableDML_ResultSet = fromTableDML_SPS.executeSubStatement(lcc, false, 0L);
         }
+    }
+
+    @Override
+    public void close() throws StandardException{
+        super.close();
+        if (fromTableDML_ResultSet != null && !fromTableDML_ResultSet.isClosed()) {
+            // Flush out any rows from execution.  Should be just one.
+            if (fromTableDML_ResultSet.returnsRows())
+                while (fromTableDML_ResultSet.getNextRow() != null) {
+                }
+            // Release resources.
+            fromTableDML_ResultSet.close();
+            fromTableDML_ResultSet = null;
+        }
+    }
+
+    @Override
+    public TxnView getCurrentTransaction() throws StandardException{
+        if (isFromTableStatement())
+            return elevateTransaction();
+        else
+            return super.getCurrentTransaction();
+    }
+
+    @Override
+    public boolean isFromTableStatement() {
+        return fromTableDML_SPS != null;
+    }
+
+    long getFromTableTargetConglomId() throws StandardException {
+        if (fromTableDML_SPS == null)
+            return 0;
+        if (this.fromTableDML_SPS.getConstantAction() instanceof WriteCursorConstantOperation) {
+            WriteCursorConstantOperation constantOperation =
+            (WriteCursorConstantOperation) this.fromTableDML_SPS.getConstantAction();
+            return constantOperation.getTargetConglomId();
+        }
+        else
+            throw StandardException.newException(LANG_INTERNAL_ERROR,
+                   "FROM TABLE statement without target conglomerate id.");
+    }
+
+    public byte[] getDestinationTable() throws StandardException {
+        return Bytes.toBytes(Long.toString(getFromTableTargetConglomId()));
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
@@ -245,11 +245,11 @@ public class SpliceWatcher extends TestWatcher implements AutoCloseable {
      */
     public <T> List<T> queryList(String sql) throws Exception {
         List<T> resultList = Lists.newArrayList();
-        ResultSet rs = executeQuery(sql);
-        while (rs.next()) {
-            resultList.add((T) rs.getObject(1));
+        try (ResultSet rs = executeQuery(sql)) {
+            while (rs.next()) {
+                resultList.add((T) rs.getObject(1));
+            }
         }
-        rs.close();
         return resultList;
     }
 
@@ -258,15 +258,15 @@ public class SpliceWatcher extends TestWatcher implements AutoCloseable {
      */
     public <T> List<Object[]> queryListMulti(String sql, int columns) throws Exception {
         List<Object[]> resultList = Lists.newArrayList();
-        ResultSet rs = executeQuery(sql);
-        while (rs.next()) {
-            Object[] row = new Object[columns];
-            for (int i = 0; i < columns; i++) {
-                row[i] = rs.getObject(i + 1);
+        try (ResultSet rs = executeQuery(sql)) {
+            while (rs.next()) {
+                Object[] row = new Object[columns];
+                for (int i = 0; i < columns; i++) {
+                    row[i] = rs.getObject(i + 1);
+                }
+                resultList.add(row);
             }
-            resultList.add(row);
         }
-        rs.close();
         return resultList;
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
@@ -249,6 +249,7 @@ public class SpliceWatcher extends TestWatcher implements AutoCloseable {
         while (rs.next()) {
             resultList.add((T) rs.getObject(1));
         }
+        rs.close();
         return resultList;
     }
 
@@ -265,6 +266,7 @@ public class SpliceWatcher extends TestWatcher implements AutoCloseable {
             }
             resultList.add(row);
         }
+        rs.close();
         return resultList;
     }
 


### PR DESCRIPTION
- With autocommit off, the transaction stack would get pushed for every FROM FINAL TABLE statement, but never popped.
  This is due to a missing needsSavepoint flag in the outermost prepared statement plus code from SPLICE-1625 that's no longer needed (trigger logic has added an extra transaction wrapping the statement since then) which caused the transaction to be elevated when the operation was closed (elevating it upon close causes it never to get popped).
- The cleanup code in TriggerHandler was too convoluted and not kicking in, so it's been simplified.
- I also moved the ThreadLocals added by DB-10525 from DataDictionaryCache to TriggerReferencingStruct per [DB-10738](https://splicemachine.atlassian.net/browse/DB-10738).