### PR TITLE
DB-10774 Wrap SetOp subquery in a derived table so it can be flattened.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromSubquery.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromSubquery.java
@@ -897,4 +897,10 @@ public class FromSubquery extends FromTable
     private String getNewAnonymousCorrelationName() {
         return "_spliceinternal_anonym_subquery_" + anonymousSubqueries++;
     }
+
+    public void setLevel(int level){
+        super.setLevel(level);
+        if (subquery instanceof FromTable)
+            ((FromTable)subquery).setLevel(level);
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetOperatorNode.java
@@ -1164,4 +1164,13 @@ abstract class SetOperatorNode extends TableOperatorNode
 
         return this;
     }
+
+    public void setLevel(int level){
+        super.setLevel(level);
+        if (leftResultSet instanceof FromTable)
+            ((FromTable)leftResultSet).setLevel(level);
+        if (rightResultSet instanceof FromTable)
+            ((FromTable)rightResultSet).setLevel(level);
+    }
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
@@ -410,7 +410,6 @@ public class SubqueryNode extends ValueNode{
                                              String columnName,
                                              int columnPosition)   throws StandardException {
         ResultColumn rc;
-        boolean replacementDone = false;
         if (setOperatorNode.getLeftResultSet() instanceof SetOperatorNode) {
             updateColumnNamesInSetQuery((SetOperatorNode)setOperatorNode.getLeftResultSet(), columnName, columnPosition);
 
@@ -425,7 +424,7 @@ public class SubqueryNode extends ValueNode{
             rc = setOperatorNode.getRightResultSet().getResultColumns().elementAt(columnPosition);
             rc.setName(columnName);
         }
-        rc = setOperatorNode.getResultColumns().elementAt(columnPosition);;
+        rc = setOperatorNode.getResultColumns().elementAt(columnPosition);
         rc.setName(columnName);
         ColumnReference columnReference = (ColumnReference) getNodeFactory().getNode(
             C_NodeTypes.COLUMN_REFERENCE,
@@ -535,8 +534,7 @@ public class SubqueryNode extends ValueNode{
         if (resultSet instanceof SetOperatorNode &&
             this.subqueryType != SubqueryNode.FROM_SUBQUERY &&
             (resultSet.getResultColumns().size() == 1 ||
-             this.subqueryType == EXISTS_SUBQUERY     ||
-             this.subqueryType == NOT_EXISTS_SUBQUERY ))
+             this.subqueryType == EXISTS_SUBQUERY))
             wrapSetQueryInDerivedTable();
 
         resultColumns=resultSet.getResultColumns();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
@@ -45,11 +45,14 @@ import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.store.access.Qualifier;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.util.JBitSet;
+import com.splicemachine.db.iapi.util.ReuseFactory;
 import com.splicemachine.db.iapi.util.StringUtil;
 import com.splicemachine.db.impl.sql.execute.OnceResultSet;
 
 import java.lang.reflect.Modifier;
 import java.util.*;
+
+import static com.splicemachine.db.impl.sql.compile.SQLGrammarImpl.*;
 
 /**
  * A SubqueryNode represents a subquery.  Subqueries return values to their
@@ -403,6 +406,107 @@ public class SubqueryNode extends ValueNode{
         return this;
     }
 
+    private void updateColumnNamesInSetQuery(SetOperatorNode setOperatorNode,
+                                             String columnName,
+                                             int columnPosition)   throws StandardException {
+        ResultColumn rc;
+        boolean replacementDone = false;
+        if (setOperatorNode.getLeftResultSet() instanceof SetOperatorNode) {
+            updateColumnNamesInSetQuery((SetOperatorNode)setOperatorNode.getLeftResultSet(), columnName, columnPosition);
+
+        }
+        else {
+            rc = setOperatorNode.getLeftResultSet().getResultColumns().elementAt(columnPosition);
+            rc.setName(columnName);
+        }
+        if (setOperatorNode.getRightResultSet() instanceof SetOperatorNode)
+            updateColumnNamesInSetQuery((SetOperatorNode)setOperatorNode.getRightResultSet(), columnName, columnPosition);
+        else {
+            rc = setOperatorNode.getRightResultSet().getResultColumns().elementAt(columnPosition);
+            rc.setName(columnName);
+        }
+        rc = setOperatorNode.getResultColumns().elementAt(columnPosition);;
+        rc.setName(columnName);
+        ColumnReference columnReference = (ColumnReference) getNodeFactory().getNode(
+            C_NodeTypes.COLUMN_REFERENCE,
+            columnName,
+            null,
+            getContextManager());
+        rc.setExpression(columnReference);
+    }
+
+    // Subquery flattening logic only knows how to flatten a SelectNode
+    // in a subquery.  Everything else must be evaluated one row-at-a-time.
+    // Let's get around the restriction by wrapping SetOp queries
+    // (UNION, EXCEPT, INTERSECT) in a derived table, which itself
+    // is represented as a SelectNode.
+    // TODO:  Enhance subquery flattening logic to not require the
+    //        the subquery expression to be a SelectNode.
+    private void wrapSetQueryInDerivedTable() throws StandardException {
+        if (!(resultSet instanceof SetOperatorNode))
+            return;
+        SetOperatorNode setOperatorNode = (SetOperatorNode)resultSet;
+        ValueNode[] offsetClauses = new ValueNode[ OFFSET_CLAUSE_COUNT ];
+        SubqueryNode derivedTable = (SubqueryNode) getNodeFactory().getNode(
+                                        C_NodeTypes.SUBQUERY_NODE,
+                                        resultSet,  // SetOperatorNode
+                                        ReuseFactory.getInteger(SubqueryNode.FROM_SUBQUERY),
+                                        null, // leftOperand,
+                                        null, // orderCols,
+                                        offsetClauses[ OFFSET_CLAUSE ],
+                                        offsetClauses[ FETCH_FIRST_CLAUSE ],
+                                        Boolean.valueOf( true ),
+                                        getContextManager());
+
+        FromTable fromTable = (FromTable) getNodeFactory().getNode(
+                                            C_NodeTypes.FROM_SUBQUERY,
+                                            derivedTable.getResultSet(),
+                                            derivedTable.getOrderByList(),
+                                            derivedTable.getOffset(),
+                                            derivedTable.getFetchFirst(),
+                                            derivedTable.hasJDBClimitClause(),
+                                            null,   // correlationName,
+                                            null,  // derivedRCL,
+                                            null,  // optionalTableClauses
+                                            getContextManager());
+        FromList fromList = (FromList) getNodeFactory().getNode(
+                C_NodeTypes.FROM_LIST,
+                getNodeFactory().doJoinOrderOptimization(),
+                getContextManager());
+        fromList.addFromTable(fromTable);
+
+        ResultColumnList selectList = setOperatorNode.getResultColumns().copyListAndObjects();
+        String dummyColName = "###UnnamedDT_WrappedSetOpCol";
+
+        // Build a select list identical to that in the setOperatorNode,
+        // fill in exposed column names, both in our list, and the lists we're
+        // selecting from so we have a legal derived table.
+        for(int index = 0; index < selectList.size(); index++) {
+            ResultColumn rc = selectList.elementAt(index);
+            String exposedColName = dummyColName + index;
+            rc.setName(exposedColName);
+            updateColumnNamesInSetQuery(setOperatorNode, exposedColName, index);
+            ColumnReference columnReference = (ColumnReference) getNodeFactory().getNode(
+                C_NodeTypes.COLUMN_REFERENCE,
+                exposedColName,
+                null,
+                getContextManager());
+            rc.setExpression(columnReference);
+        }
+
+        SelectNode selectNode = (SelectNode) getNodeFactory().getNode(
+                            C_NodeTypes.SELECT_NODE,
+                            selectList,  //ResultColumnList
+                            null,     /* AGGREGATE list */
+                            fromList, // FromList of FromSubquery
+                            null,     // whereClause
+                            null,     // groupByList
+                            null,     // havingClause
+                            null,     // windows
+                            getContextManager());
+        resultSet = selectNode;
+    }
+
     /**
      * Bind this expression.  This means binding the sub-expressions,
      * as well as figuring out what the return type is for this expression.
@@ -424,6 +528,16 @@ public class SubqueryNode extends ValueNode{
 
         //check if subquery is allowed in expression tree
         checkReliability(CompilerContext.SUBQUERY_ILLEGAL,SQLState.LANG_SUBQUERY);
+
+        // Rewrite a set operator tree so it's wrapped in a derived table.
+        // This allows it to be flattenable, allowing for more efficient joins.
+        // Disallow multicolumn IN/NOT IN for now to be safe.
+        if (resultSet instanceof SetOperatorNode &&
+            this.subqueryType != SubqueryNode.FROM_SUBQUERY &&
+            (resultSet.getResultColumns().size() == 1 ||
+             this.subqueryType == EXISTS_SUBQUERY     ||
+             this.subqueryType == NOT_EXISTS_SUBQUERY ))
+            wrapSetQueryInDerivedTable();
 
         resultColumns=resultSet.getResultColumns();
 

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_InList_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_InList_IT.java
@@ -360,4 +360,100 @@ public class Subquery_Flattening_InList_IT extends SpliceUnitTest {
             Assert.assertEquals("42X58", e.getSQLState());
         }
     }
+
+    @Test
+    public void testSetOpInSubQFlatten() throws Exception {
+
+        String expected =
+            "A1 |A2 |\n" +
+            "--------\n" +
+            " 0 | 0 |\n" +
+            " 1 |10 |\n" +
+            " 2 |20 |\n" +
+            " 3 |30 |\n" +
+            " 4 |40 |\n" +
+            " 5 |50 |";
+        String sql = "select a1,a2 from A\n" +
+                "WHERE a1 in (select a1 from A" +
+                "            WHERE a1 in (\n" +
+                "            SELECT b1 FROM B " +
+                "            UNION " +
+                "            SELECT b1 FROM B ))";
+        assertUnorderedResult(methodWatcher.getOrCreateConnection(),
+                              sql , ZERO_SUBQUERY_NODES, expected );
+        sql = "select a1,a2 from A\n" +
+                "WHERE a1 in (select a1 from A" +
+                "            WHERE a1+a1 in (\n" +
+                "            SELECT b1+b1 FROM B " +
+                "            UNION " +
+                "            SELECT b1 FROM B ))";
+        assertUnorderedResult(methodWatcher.getOrCreateConnection(),
+                              sql , ZERO_SUBQUERY_NODES, expected );
+        sql = "select a1,a2 from A\n" +
+                "WHERE a1 in (select a1 from A" +
+                "            WHERE a1+a1 in (\n" +
+                "            SELECT b1 FROM B " +
+                "            UNION " +
+                "            SELECT b1+b1 FROM B ))";
+        assertUnorderedResult(methodWatcher.getOrCreateConnection(),
+                              sql , ZERO_SUBQUERY_NODES, expected );
+
+        sql = "select a1,a2 from A\n" +
+                "WHERE exists (select a1 from A" +
+                "            WHERE a1+a1 in (\n" +
+                "            SELECT b1 FROM B " +
+                "            UNION " +
+                "            SELECT b1+b1 FROM B ))";
+        assertUnorderedResult(methodWatcher.getOrCreateConnection(),
+                              sql , ONE_SUBQUERY_NODE, expected );
+        expected =
+            "A1 |A2 |\n" +
+            "--------\n" +
+            " 1 |10 |\n" +
+            " 2 |20 |\n" +
+            " 3 |30 |\n" +
+            " 4 |40 |\n" +
+            " 5 |50 |";
+
+        sql = "select a1,a2 from A\n" +
+                "WHERE a1 <> ANY (select a1 from A" +
+                "            WHERE a1 in (\n" +
+                "            SELECT -b1 FROM B " +
+                "            UNION " +
+                "            SELECT -b1 FROM B ))";
+        assertUnorderedResult(methodWatcher.getOrCreateConnection(),
+                              sql , ZERO_SUBQUERY_NODES, expected );
+
+        sql = "select a1,a2 from A\n" +
+                "WHERE -a1 in (select -a1 from A" +
+                "            WHERE -a1 in (\n" +
+                "            SELECT b1*2 FROM B " +
+                "            UNION ALL" +
+                "            SELECT -b1 FROM B where -b1 in (-1,-2,-3,-4,-5) " +
+                "            EXCEPT " +
+                "            SELECT b1 FROM B where b2 in (10,20,30,40,50)" +
+                "            INTERSECT " +
+                "            SELECT b1 FROM B where b1 in (10,20,30,40,50)) and a1 in (1,2,3,4,5)" +
+        ")";
+        assertUnorderedResult(methodWatcher.getOrCreateConnection(),
+                              sql , ZERO_SUBQUERY_NODES, expected );
+
+        expected =
+            "A1 |A2 |\n" +
+            "--------\n" +
+            " 1 |10 |\n" +
+            " 3 |30 |\n" +
+            " 5 |50 |";
+
+        sql = "select a1,a2 from A\n" +
+                "WHERE a1 not in (select a1 from A" +
+                "            WHERE a1 in (\n" +
+                "            SELECT b1*2 FROM B " +
+                "            UNION " +
+                "            SELECT -b1 FROM B ))";
+        assertUnorderedResult(methodWatcher.getOrCreateConnection(),
+                              sql , ONE_SUBQUERY_NODE, expected );
+
+    }
+
 }


### PR DESCRIPTION
This wraps a UNION/INTERSECT/EXCEPT subquery in a derived table so that it can be flattened and participate in join planning, e.g.

> explain
> select a1,a2 from A
>                 WHERE -a1 in (select -a1 from A
>                             WHERE -a1 in (
>                             SELECT b1*2 FROM B
>                             UNION ALL
>                             SELECT -b1 FROM B
>                             EXCEPT
>                             SELECT b1 FROM B where b1 in (10,20,30,40,50)
>                             INTERSECT
>                             SELECT b1 FROM B ));
> 
> Cursor(n=29,rows=23,updateMode=READ_ONLY (1),engine=OLTP (default))
>   ->  ScrollInsensitive(n=29,totalCost=57.712,outputRows=23,outputHeapSize=69 B,partitions=1,parallelTasks=1)
>     ->  ProjectRestrict(n=28,totalCost=49.312,outputRows=23,outputHeapSize=69 B,partitions=1,parallelTasks=1)
>       ->  ProjectRestrict(n=27,totalCost=49.312,outputRows=23,outputHeapSize=69 B,partitions=1,parallelTasks=1)
>         ->  BroadcastJoin(n=26,totalCost=49.312,outputRows=23,outputHeapSize=69 B,partitions=1,parallelTasks=1,preds=[(A1[26:3] = SQLCol1[26:4])])
>           ->  ProjectRestrict(n=24,totalCost=37.009,outputRows=29,outputHeapSize=28 B,partitions=1,parallelTasks=1)
>             ->  ProjectRestrict(n=23,totalCost=37.009,outputRows=29,outputHeapSize=28 B,partitions=1,parallelTasks=1)
>               ->  BroadcastJoin(n=22,totalCost=37.009,outputRows=29,outputHeapSize=28 B,partitions=1,parallelTasks=1,preds=[(A1[22:2] = ###UnnamedDT_WrappedSetOpCol0[22:3])])
>                 ->  Except(n=18,totalCost=32.94,outputRows=36,outputHeapSize=0 B,partitions=1,parallelTasks=1)
>                   ->  Intersect(n=17,totalCost=16.46,outputRows=9,outputHeapSize=0 B,partitions=1,parallelTasks=1)
>                     ->  TableScan[B(1696)](n=14,totalCost=4.04,scannedRows=20,outputRows=20,outputHeapSize=20 B,partitions=1,parallelTasks=1)
>                     ->  ProjectRestrict(n=12,totalCost=4.04,outputRows=18,outputHeapSize=18 B,partitions=1,parallelTasks=1,preds=[(B1[11:1] IN (10,20,30,40,50))])
>                       ->  TableScan[B(1696)](n=11,totalCost=4.04,scannedRows=20,outputRows=20,outputHeapSize=18 B,partitions=1,parallelTasks=1)
>                   ->  Union(n=10,totalCost=8.08,outputRows=40,outputHeapSize=40 B,partitions=2,parallelTasks=1)
>                     ->  ProjectRestrict(n=9,totalCost=4.04,outputRows=20,outputHeapSize=20 B,partitions=1,parallelTasks=1)
>                       ->  TableScan[B(1696)](n=7,totalCost=4.04,scannedRows=20,outputRows=20,outputHeapSize=20 B,partitions=1,parallelTasks=1)
>                     ->  ProjectRestrict(n=6,totalCost=4.04,outputRows=20,outputHeapSize=20 B,partitions=1,parallelTasks=1)
>                       ->  TableScan[B(1696)](n=4,totalCost=4.04,scannedRows=20,outputRows=20,outputHeapSize=20 B,partitions=1,parallelTasks=1)
>                 ->  ProjectRestrict(n=3,totalCost=4.04,outputRows=20,outputHeapSize=20 B,partitions=1,parallelTasks=1)
>                   ->  TableScan[A(1680)](n=2,totalCost=4.04,scannedRows=20,outputRows=20,outputHeapSize=20 B,partitions=1,parallelTasks=1)
>           ->  ProjectRestrict(n=1,totalCost=4.04,outputRows=20,outputHeapSize=40 B,partitions=1,parallelTasks=1)
>             ->  TableScan[A(1680)](n=0,totalCost=4.04,scannedRows=20,outputRows=20,outputHeapSize=40 B,partitions=1,parallelTasks=1)

Explain without the fix:

> Cursor(n=24,rows=20,updateMode=READ_ONLY (1),engine=OLTP (default))
>   ->  ScrollInsensitive(n=24,totalCost=8.24,outputRows=20,outputHeapSize=40 B,partitions=1,parallelTasks=1)
>     ->  ProjectRestrict(n=23,totalCost=4.04,outputRows=20,outputHeapSize=40 B,partitions=1,parallelTasks=1,preds=[is not null(subq=22)])
>       ->  Subquery(n=22,totalCost=8.24,outputRows=20,outputHeapSize=20 B,partitions=1,parallelTasks=1,correlated=true,expression=false,invariant=true)
>         ->  ProjectRestrict(n=22,totalCost=4.04,outputRows=20,outputHeapSize=20 B,partitions=1,parallelTasks=1,preds=[(-(A1[1:1]) = SQLCol1[21:1])])
>           ->  ProjectRestrict(n=21,totalCost=4.04,outputRows=20,outputHeapSize=20 B,partitions=1,parallelTasks=1,preds=[is not null(subq=20)])
>             ->  Subquery(n=20,totalCost=32.94,outputRows=36,outputHeapSize=0 B,partitions=1,parallelTasks=1,correlated=false,expression=false,invariant=true)
>               ->  ProjectRestrict(n=20,totalCost=32.94,outputRows=36,outputHeapSize=0 B,partitions=1,parallelTasks=1,preds=[(-(A1[3:1]) = SQLCol2[19:1])])
>                 ->  Except(n=18,totalCost=32.94,outputRows=36,outputHeapSize=0 B,partitions=1,parallelTasks=1)
>                   ->  Intersect(n=17,totalCost=16.46,outputRows=9,outputHeapSize=0 B,partitions=1,parallelTasks=1)
>                     ->  TableScan[B(1696)](n=14,totalCost=4.04,scannedRows=20,outputRows=20,outputHeapSize=20 B,partitions=1,parallelTasks=1)
>                     ->  ProjectRestrict(n=12,totalCost=4.04,outputRows=18,outputHeapSize=18 B,partitions=1,parallelTasks=1,preds=[(B1[11:1] IN (10,20,30,40,50))])
>                       ->  TableScan[B(1696)](n=11,totalCost=4.04,scannedRows=20,outputRows=20,outputHeapSize=18 B,partitions=1,parallelTasks=1)
>                   ->  Union(n=10,totalCost=12.28,outputRows=40,outputHeapSize=20 B,partitions=1,parallelTasks=1)
>                     ->  ProjectRestrict(n=9,totalCost=4.04,outputRows=20,outputHeapSize=20 B,partitions=1,parallelTasks=1)
>                       ->  TableScan[B(1696)](n=7,totalCost=4.04,scannedRows=20,outputRows=20,outputHeapSize=20 B,partitions=1,parallelTasks=1)
>                     ->  ProjectRestrict(n=6,totalCost=4.04,outputRows=20,outputHeapSize=20 B,partitions=1,parallelTasks=1)
>                       ->  TableScan[B(1696)](n=4,totalCost=4.04,scannedRows=20,outputRows=20,outputHeapSize=20 B,partitions=1,parallelTasks=1)
>             ->  ProjectRestrict(n=3,totalCost=4.04,outputRows=20,outputHeapSize=20 B,partitions=1,parallelTasks=1)
>               ->  TableScan[A(1680)](n=2,totalCost=4.04,scannedRows=20,outputRows=20,outputHeapSize=20 B,partitions=1,parallelTasks=1)
>       ->  ProjectRestrict(n=1,totalCost=4.04,outputRows=20,outputHeapSize=40 B,partitions=1,parallelTasks=1)
>         ->  TableScan[A(1680)](n=0,totalCost=4.04,scannedRows=20,outputRows=20,outputHeapSize=40 B,partitions=1,parallelTasks=1)
