### PR TITLE
DB-10885 Fix FINAL TABLE txn leak in all paths.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -1488,4 +1488,8 @@ public interface LanguageConnectionContext extends Context {
 
     void resetDB2VarcharCompatibilityMode();
 
+    void setCompilingFromTableTempTrigger(boolean newVal);
+
+    boolean isCompilingFromTableTempTrigger();
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SPSDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SPSDescriptor.java
@@ -312,7 +312,8 @@ public class SPSDescriptor extends TupleDescriptor implements UniqueSQLObjectDes
         setParams(preparedStatement.getParameterTypes());
 
         String role = lcc.getReplicationRole();
-        if (!dd.isReadOnlyUpgrade() && role.compareToIgnoreCase("REPLICA") != 0 &&
+        if (!lcc.isCompilingFromTableTempTrigger() &&
+            !dd.isReadOnlyUpgrade() && role.compareToIgnoreCase("REPLICA") != 0 &&
                 lcc.getSessionProperties().getProperty(SessionProperties.PROPERTYNAME.SNAPSHOT_TIMESTAMP) == null) {
 
             dd.startWriting(lcc);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
@@ -563,7 +563,16 @@ public class FromVTI extends FromTable implements VTIEnvironment {
         if (tempTriggerDefinition.isFinalTable()) {
             spsd.setFinalTableConglomID(tempTriggerDefinition.getTriggerTableDescriptor().getHeapConglomerateId());
         }
-        spsd.prepareAndRelease(lcc, null);
+        try {
+            // Set a flag so we can bypass pushing of a new
+            // writable transaction.  That only is applicable
+            // if we're writing to the data dictionary.
+            lcc.setCompilingFromTableTempTrigger(true);
+            spsd.prepareAndRelease(lcc, null);
+        }
+        finally {
+            lcc.setCompilingFromTableTempTrigger(false);
+        }
         DataDescriptorGenerator ddg = dd.getDataDescriptorGenerator();
         List<UUID> actionSPSIdList = new ArrayList<>();
         actionSPSIdList.add(tmpTriggerId);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetOperatorNode.java
@@ -582,6 +582,9 @@ abstract class SetOperatorNode extends TableOperatorNode
     {
         super.bindResultColumns(fromListParam);
 
+        if (TriggerReferencingStruct.fromTableTriggerDescriptor.get() != null)
+            throw StandardException.newException( SQLState.LANG_UNSUPPORTED_FROM_TABLE_QUERY,
+                                                  "set operation");
         /* Now we build our RCL */
         buildRCL();
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnionNode.java
@@ -518,6 +518,9 @@ public class UnionNode extends SetOperatorNode{
     public void bindExpressions(FromList fromListParam) throws StandardException{
         super.bindExpressions(fromListParam);
 
+        if (TriggerReferencingStruct.fromTableTriggerDescriptor.get() != null)
+            throw StandardException.newException( SQLState.LANG_UNSUPPORTED_FROM_TABLE_QUERY,
+                                                  "set operation");
         /*
         ** Each ? parameter in a table constructor that is not in an insert
         ** statement takes its type from the first non-? in its column

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -351,6 +351,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     private String replicationRole = "NONE";
     private boolean db2VarcharCompatibilityModeNeedsReset = false;
     private CharTypeCompiler charTypeCompiler = null;
+    private boolean compilingFromTableTempTrigger = false;
 
     /* constructor */
     public GenericLanguageConnectionContext(
@@ -4024,5 +4025,15 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             charTypeCompiler.setDB2VarcharCompatibilityMode(false);
             charTypeCompiler = null;
         }
+    }
+
+    @Override
+    public void setCompilingFromTableTempTrigger(boolean newVal) {
+        compilingFromTableTempTrigger = newVal;
+    }
+
+    @Override
+    public boolean isCompilingFromTableTempTrigger() {
+        return compilingFromTableTempTrigger;
     }
 }

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -820,7 +820,8 @@ public interface SQLState {
     String LANG_NO_SUCH_RUNNING_OPERATION                     = "4251P";
     String LANG_DB2_NOT_NULL_COLUMN_INVALID_DEFAULT           = "42601";
     String LANG_UNSUPPORTED_FROM_TABLE                        = "42602";
-    String LANG_MODIFIED_FINAL_TABLE                          = "42603";  
+    String LANG_MODIFIED_FINAL_TABLE                          = "42603";
+    String LANG_UNSUPPORTED_FROM_TABLE_QUERY                  = "42604";
     String LANG_DB2_INVALID_HEXADECIMAL_CONSTANT              = "42606";
     String LANG_DB2_OPERATION_NOT_SUPPORTED_IN_READ_ONLY_MODE = "51045";
     String LANG_DB2_STRING_CONSTANT_TOO_LONG                  = "54002";

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -1437,6 +1437,11 @@ Guide.
                 <arg>tableName</arg>
             </msg>
             <msg>
+                <name>42604</name>
+                <text>FROM TABLE clause not supported in a '{0}' query.</text>
+                <arg>queryType</arg>
+            </msg>
+            <msg>
                 <name>42605</name>
                 <text>The number of arguments for function '{0}' is incorrect.</text>
                 <arg>functionName</arg>

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/AnyOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/AnyOperation.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import com.splicemachine.db.iapi.sql.conn.ResubmitDistributedException;
+import com.splicemachine.si.api.txn.TxnView;
 import splice.com.google.common.base.Strings;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperationContext;
 import com.splicemachine.derby.impl.SpliceMethod;
@@ -160,5 +161,10 @@ public class AnyOperation extends SpliceBaseOperation {
     @Override
     protected void resubmitDistributed(ResubmitDistributedException e) throws StandardException {
         throw e;
+    }
+
+    @Override
+    public TxnView getCurrentTransaction() throws StandardException{
+        return source.getCurrentTransaction();
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DMLWriteOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DMLWriteOperation.java
@@ -492,4 +492,8 @@ public abstract class DMLWriteOperation extends SpliceBaseOperation {
         else
             return false;
     }
+
+    public boolean forFromTableStatement() {
+        return fromTableDmlSpsDescriptor != null;
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/GenericAggregateOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/GenericAggregateOperation.java
@@ -28,6 +28,7 @@ import com.splicemachine.derby.impl.sql.execute.operations.framework.DerbyAggreg
 import com.splicemachine.derby.impl.sql.execute.operations.framework.SpliceGenericAggregator;
 import com.splicemachine.derby.impl.sql.execute.operations.iapi.AggregateContext;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
+import com.splicemachine.si.api.txn.TxnView;
 import com.splicemachine.utils.SpliceLogUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.log4j.Logger;
@@ -182,4 +183,9 @@ public abstract class GenericAggregateOperation extends SpliceBaseOperation {
 	public ExecIndexRow getSourceExecIndexRow() {
 		return sourceExecIndexRow;
 	}
+
+    @Override
+    public TxnView getCurrentTransaction() throws StandardException{
+        return source.getCurrentTransaction();
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NormalizeOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NormalizeOperation.java
@@ -29,6 +29,7 @@ import com.splicemachine.derby.stream.function.NormalizeFunction;
 import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
 import com.splicemachine.derby.stream.iapi.OperationContext;
+import com.splicemachine.si.api.txn.TxnView;
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.log4j.Logger;
 import splice.com.google.common.base.Strings;
@@ -285,5 +286,10 @@ public class NormalizeOperation extends SpliceBaseOperation{
 
     public void setRequireNotNull(boolean requireNotNull) {
         this.requireNotNull = requireNotNull;
+    }
+
+    @Override
+    public TxnView getCurrentTransaction() throws StandardException{
+        return source.getCurrentTransaction();
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ProjectRestrictOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ProjectRestrictOperation.java
@@ -387,10 +387,6 @@ public class ProjectRestrictOperation extends SpliceBaseOperation {
 
     @Override
     public TxnView getCurrentTransaction() throws StandardException{
-        if (source instanceof VTIOperation ||
-		    source instanceof ProjectRestrictOperation)
-            return source.getCurrentTransaction();
-        else
-            return super.getCurrentTransaction();
+        return source.getCurrentTransaction();
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/RowCountOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/RowCountOperation.java
@@ -27,6 +27,7 @@ import com.splicemachine.derby.stream.function.OffsetFunction;
 import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
 import com.splicemachine.derby.stream.iapi.OperationContext;
+import com.splicemachine.si.api.txn.TxnView;
 import splice.com.google.common.base.Strings;
 
 import java.io.IOException;
@@ -195,4 +196,8 @@ public class RowCountOperation extends SpliceBaseOperation {
         return "Row Limit";
     }
 
+    @Override
+    public TxnView getCurrentTransaction() throws StandardException{
+        return source.getCurrentTransaction();
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SortOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SortOperation.java
@@ -15,6 +15,7 @@
 package com.splicemachine.derby.impl.sql.execute.operations;
 
 import com.splicemachine.derby.stream.function.CloneFunction;
+import com.splicemachine.si.api.txn.TxnView;
 import splice.com.google.common.base.Strings;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.io.FormatableArrayHolder;
@@ -195,5 +196,10 @@ public class SortOperation extends SpliceBaseOperation{
 
     public String getScopeName(){
         return (distinct ? "Sort Distinct" : "Sort");
+    }
+
+    @Override
+    public TxnView getCurrentTransaction() throws StandardException{
+        return source.getCurrentTransaction();
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperation.java
@@ -314,6 +314,14 @@ public class VTIOperation extends SpliceBaseOperation {
                 fromTableDML_ResultSet = null;
             }
         }
+        if (fromTableDML_SPS != null) {
+            LanguageConnectionContext lcc = getActivation().getLanguageConnectionContext();
+            if (lcc != null) {
+                TriggerExecutionContext tec = lcc.getTriggerExecutionContext();
+                if (tec != null)
+                    tec.clearTrigger(false);
+            }
+        }
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/WindowOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/WindowOperation.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.splicemachine.derby.stream.function.CloneFunction;
+import com.splicemachine.si.api.txn.TxnView;
 import splice.com.google.common.base.Strings;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.loader.GeneratedMethod;
@@ -174,5 +175,10 @@ public class WindowOperation extends SpliceBaseOperation {
    
     public String getScopeName() {
         return "Window Function";
+    }
+
+    @Override
+    public TxnView getCurrentTransaction() throws StandardException{
+        return source.getCurrentTransaction();
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportOperation.java
@@ -15,6 +15,7 @@
 package com.splicemachine.derby.impl.sql.execute.operations.export;
 
 import com.splicemachine.db.iapi.types.SQLLongint;
+import com.splicemachine.si.api.txn.TxnView;
 import splice.com.google.common.base.Strings;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.impl.sql.compile.ExportNode;
@@ -204,5 +205,10 @@ public class ExportOperation extends SpliceBaseOperation {
         }
         else
             return dataset;
+    }
+
+    @Override
+    public TxnView getCurrentTransaction() throws StandardException{
+        return source.getCurrentTransaction();
     }
 }


### PR DESCRIPTION
FROM FINAL Table must elevate the transaction to writeable via a call to getCurrentTransaction() in VTIOperation, but not all flavors of SpliceOperation were calling getCurrentTransaction on its source result set, so we ended up deferring the elevation of the transaction, which leaks it.

All operations that could have a VTIOperation as its source are now modified with a version of getCurrentTransaction that checks the source operation.  A new error is returned if we try to use FROM TABLE in a SetOp query.

Also, compiling the temporary trigger prepared statement caused a new transaction to be created in preparation for a write to the data dictionary, which caused in our case transactions to go to the transaction table instead of using subtransactions.  FROM TABLE does not write the temporary trigger to the data dictionary, so this new transaction is avoided in this fix.
