### PR TITLE
DB-10911 Fix Activation leak in FINAL TABLE query.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/Activation.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/Activation.java
@@ -84,7 +84,7 @@ import java.util.Hashtable;
  *
  */
 
-public interface Activation extends Dependent
+public interface Activation extends Dependent, AutoCloseable
 {
     /**
      * Resets the activation to the "pre-execution" state -

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ResultSet.java
@@ -377,4 +377,6 @@ public interface ResultSet
 	 * @return UUID of the underlying operation.
 	 */
 	default UUID getUuid() { return null; }
+
+	default void registerCloseable(AutoCloseable closeable) throws StandardException { }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericPreparedStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericPreparedStatement.java
@@ -390,13 +390,17 @@ public class GenericPreparedStatement implements ExecPreparedStatement {
 
             lccToUse.popStatementContext(statementContext, null);
 
-            if (activation.isSingleExecution() && resultSet.isClosed()) {
+            if (activation.isSingleExecution()) {
+
                 // if the result set is 'done', i.e. not openable,
                 // then we can also release the activation.
                 // Note that a result set with output parameters
                 // or rows to return is explicitly finished
                 // by the user.
-                activation.close();
+                if (resultSet.isClosed())
+                    activation.close();
+                else
+                    resultSet.registerCloseable(activation);
             }
 
             return resultSet;


### PR DESCRIPTION
The Activation that executes the INSERT/UPDATE/DELETE of a FROM TABLE query (VTIOperation.executeFromTableDML -> fromTableDML_SPS.executeSubStatement) is never saved off anywhere so that it can be closed.  So, all of the resources that it references are leaked until the LanguageConnectionContext is cleared, which may be until the sqlshell session ends.

The solution is to register the Activation as a closeable item of the SpliceOperation that's executing, so that when it closes, the Activation will automatically be closed.