### PR TITLE
DB-10895 Complete DB2 varchar compatibility for MultiProbeScan.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
@@ -39,6 +39,7 @@ import com.splicemachine.db.iapi.sql.compile.*;
 import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.store.access.ScanController;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.util.JBitSet;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -1549,4 +1550,12 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
 
     public void setOriginalInListPredList (PredicateList predList) { originalInListPredList = predList; }
 
+    public boolean isVarcharBinaryRelationalOperator() {
+        RelationalOperator relOp = getRelop();
+        if (!(relOp instanceof BinaryRelationalOperatorNode))
+            return false;
+        BinaryRelationalOperatorNode bron = (BinaryRelationalOperatorNode) relOp;
+        return bron.getLeftOperand().getTypeServices().
+                                     getTypeName().equals(TypeId.VARCHAR_NAME);
+    }
 }

--- a/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MemDatabase.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MemDatabase.java
@@ -59,7 +59,6 @@ public class MemDatabase{
             System.setProperty("com.splicemachine.enableLegacyAsserts",Boolean.TRUE.toString());
             SanityManager.DEBUG_SET("DumpOptimizedTree");
         }
-        System.setProperty("com.splicemachine.isMemPlatform",Boolean.TRUE.toString());
 
         SIDriver.loadDriver(env);
         final SIDriver driver = env.getSIDriver();

--- a/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MemDatabase.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MemDatabase.java
@@ -59,6 +59,7 @@ public class MemDatabase{
             System.setProperty("com.splicemachine.enableLegacyAsserts",Boolean.TRUE.toString());
             SanityManager.DEBUG_SET("DumpOptimizedTree");
         }
+        System.setProperty("com.splicemachine.isMemPlatform",Boolean.TRUE.toString());
 
         SIDriver.loadDriver(env);
         final SIDriver driver = env.getSIDriver();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeDerbyScanInformation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeDerbyScanInformation.java
@@ -27,6 +27,7 @@ import com.splicemachine.db.iapi.store.access.Qualifier;
 import com.splicemachine.db.iapi.store.access.ScanController;
 import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.derby.impl.SpliceMethod;
+import com.splicemachine.derby.utils.FormatableBitSetUtils;
 import com.splicemachine.derby.utils.SerializationUtils;
 import com.splicemachine.si.api.txn.TxnView;
 import com.splicemachine.storage.DataScan;
@@ -138,7 +139,11 @@ public class MultiProbeDerbyScanInformation extends DerbyScanInformation{
         List<DataScan> scans = new ArrayList<DataScan>();
         DataScan scan;
 
-        DataValueDescriptor[] probeValues = getProbeValues();
+        DataValueDescriptor[] probeValues =
+		    getProbeValues(keyDecodingMap,
+		                   FormatableBitSetUtils.
+		                   toCompactedIntArray(getAccessedColumns()),
+			               getResultRow());
 
         // Mem platform does not support the HBase MultiRangeRowFilter,
         // so we still need one scan per probe value on mem.
@@ -244,7 +249,10 @@ public class MultiProbeDerbyScanInformation extends DerbyScanInformation{
 				isMemPlatform = in.readBoolean();
 		}
 
-	public DataValueDescriptor[] getProbeValues() throws StandardException {
+    public DataValueDescriptor[]
+    getProbeValues(int[]   keyDecodingMap,
+                   int[]   keyTablePositionMap,
+                   ExecRow templateRow) throws StandardException {
         if (SanityManager.DEBUG)
         {
             SanityManager.ASSERT(
@@ -293,39 +301,64 @@ public class MultiProbeDerbyScanInformation extends DerbyScanInformation{
 					continue;
 
 				int maxSize = dtd.getMaximumWidth();
+				DataValueDescriptor targetDesc = templateRow.getColumn(keyTablePositionMap[keyDecodingMap[position]] + 1);
+				boolean targetIsSQLVarcharDB2Compatible = targetDesc instanceof SQLVarcharDB2Compatible;
 				for (int index = 0; index < probingVals.length; index++) {
 					 DataValueDescriptor dvd = probingVals[index];
 					 if (dvd instanceof ListDataType) {
 						 ListDataType listData = (ListDataType) dvd;
 						 DataValueDescriptor dvd1 = listData.getDVD(position);
-						 if (dvd1 instanceof SQLChar) {
+						 boolean isSQLVarcharDB2Compatible = dvd1 instanceof SQLVarcharDB2Compatible;
+						 if (isSQLVarcharDB2Compatible) {
+							DataValueDescriptor newDVD =
+								QualifierUtils.convertChar((SQLChar) dvd1, dvd1.getLength(),
+								                           inlistDataTypes[position].getMaximumWidth());
+							listData.setDVD(position, newDVD);
+						 }
+						 else if (dvd1 instanceof SQLChar) {
 						 	// we may prune some probe value based on the string length
-						 	if (isFixedCharType && dvd1.getLength() != maxSize) {
-								toRemove[index] = true;
-								continue;
-							} else if (isVarCharType && dvd1.getLength() > maxSize) {
+						 	if (isVarCharType && dvd1.getLength() > maxSize &&
+							    !targetIsSQLVarcharDB2Compatible) {
 								toRemove[index] = true;
 								continue;
 							}
 							 // if column is of varchar type, we need to change the probe values from SQLChar to SQLVarchar,
-							 // so that duplicate removal won't ignore the trailing spaces
-							 if (isVarCharType && !(dvd1 instanceof SQLVarchar))
-								 listData.setDVD(position, new SQLVarchar(dvd1.getString()));
+							 // so that duplicate removal won't ignore the trailing spaces,
+							 // unless we're in DB2 varchar compatibility mode.
+							 if (isVarCharType) {
+							 	if (targetIsSQLVarcharDB2Compatible) {
+							 		if (dvd1.getClass().equals(SQLVarchar.class))
+							 			listData.setDVD(position,
+										                new SQLVarcharDB2Compatible(dvd1.getString()));
+								}
+							 	else if (!(dvd1 instanceof SQLVarchar))
+								     listData.setDVD(position, new SQLVarchar(dvd1.getString()));
+							 }
 						 }
 
 					 } else {
-					 	if (dvd instanceof SQLChar) {
+					 	boolean isSQLVarcharDB2Compatible = dvd instanceof SQLVarcharDB2Compatible;
+					 	if (isSQLVarcharDB2Compatible)
+					 	    probingVals[index] =
+							QualifierUtils.convertChar((SQLChar)dvd, dvd.getLength(),
+							                           inlistDataTypes[position].getMaximumWidth());
+					 	else if (dvd instanceof SQLChar) {
 							// we may prune some probe value based on the string length
-							if (isFixedCharType && dvd.getLength() != maxSize) {
-								toRemove[index] = true;
-								continue;
-							} else if (isVarCharType && dvd.getLength() > maxSize) {
+							if (isVarCharType && dvd.getLength() > maxSize &&
+							    !targetIsSQLVarcharDB2Compatible)
+							{
 								toRemove[index] = true;
 								continue;
 							}
-
-							if (isVarCharType && !(dvd instanceof SQLVarchar))
-								probingVals[index] = new SQLVarchar(dvd.getString());
+							if (isVarCharType) {
+								if (targetIsSQLVarcharDB2Compatible) {
+									if (dvd.getClass().equals(SQLVarchar.class))
+										probingVals[index] =
+										    new SQLVarcharDB2Compatible(dvd.getString());
+								}
+								else if (!(dvd instanceof SQLVarchar))
+									probingVals[index] = new SQLVarchar(dvd.getString());
+							}
 						}
 					 }
 				}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/QualifierUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/QualifierUtils.java
@@ -299,7 +299,7 @@ public class QualifierUtils {
         return (columnFormat == StoredFormatIds.SQL_VARCHAR_ID);
     }
 
-    private static DataValueDescriptor convertChar(SQLChar source, int sourceCharSize, int targetCharSize) throws StandardException {
+    public static DataValueDescriptor convertChar(SQLChar source, int sourceCharSize, int targetCharSize) throws StandardException {
         SQLChar correctedSource;
         if (targetCharSize > sourceCharSize) {
             correctedSource = new SQLChar(StringUtil.padRight(source.getString(), SQLChar.PAD, targetCharSize));

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/Scans.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/Scans.java
@@ -426,7 +426,7 @@ public class Scans extends SpliceUtils {
                     if (!isEmpty(keyDecodingMap) && keyDecodingMap[i] >= 0 && !isEmpty(keyTablePositionMap)) {
                         int targetColFormatId = columnTypes[keyTablePositionMap[keyDecodingMap[i]]];
                         DataValueDescriptor targetDesc = templateRow.getColumn(keyTablePositionMap[keyDecodingMap[i]] + 1); // the maps are 0-based, get Column is 1-based
-                        if (startDesc.getTypeFormatId() != targetColFormatId && !rowIdKey) {
+                        if (!rowIdKey) {
                             startKeyValue[i] = QualifierUtils.adjustDataValueDescriptor(startDesc, targetDesc, dataValueFactory, true);
                         }
                     }
@@ -448,7 +448,7 @@ public class Scans extends SpliceUtils {
                     if (!isEmpty(keyDecodingMap) && !isEmpty(keyTablePositionMap)) {
                         int targetColFormatId = columnTypes[keyTablePositionMap[keyDecodingMap[i]]];
                         DataValueDescriptor targetDesc = templateRow.getColumn(keyTablePositionMap[keyDecodingMap[i]] + 1); // the maps are 0-based, get Column is 1-based
-                        if (stopDesc.getTypeFormatId() != targetColFormatId && !rowIdKey) {
+                        if (!rowIdKey) {
                             stop[i] = QualifierUtils.adjustDataValueDescriptor(stopDesc, targetDesc, dataValueFactory, false);
                         }
                     }

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
@@ -33,6 +33,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.Collection;
 
+import static com.splicemachine.derby.utils.SpliceAdmin.INVALIDATE_GLOBAL_DICTIONARY_CACHE;
 import static com.splicemachine.test_tools.Rows.row;
 import static com.splicemachine.test_tools.Rows.rows;
 import static org.junit.Assert.assertEquals;
@@ -106,12 +107,14 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
     @BeforeClass
     public static void createDataSet() throws Exception {
         createData(spliceClassWatcher.getOrCreateConnection(), spliceSchemaWatcher.toString());
+        spliceClassWatcher.executeUpdate("call syscs_util.INVALIDATE_GLOBAL_DICTIONARY_CACHE()");
         spliceClassWatcher.executeUpdate("call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', true)");
     }
 
     @AfterClass
     public static void exitDB2CompatibilityMode() throws Exception {
         spliceClassWatcher.executeUpdate("call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', null)");
+        spliceClassWatcher.executeUpdate("call syscs_util.INVALIDATE_GLOBAL_DICTIONARY_CACHE()");
     }
 
     @Test

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
@@ -17,6 +17,7 @@ package com.splicemachine.db.impl.sql.compile;
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.homeless.TestUtils;
 import com.splicemachine.test.SerialTest;
 import com.splicemachine.test_tools.TableCreator;
 import org.junit.*;
@@ -28,10 +29,13 @@ import org.junit.runners.Parameterized;
 import splice.com.google.common.collect.Lists;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.util.Collection;
 
 import static com.splicemachine.test_tools.Rows.row;
 import static com.splicemachine.test_tools.Rows.rows;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test DB2 Varchar compatibility mode (ignore trailing spaces in comparisons).
@@ -85,6 +89,17 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
 
         String sqlText = "insert into t11 select * from t1";
 		spliceClassWatcher.executeUpdate(sqlText);
+
+        new TableCreator(conn)
+                .withCreate("create table t (v varchar(10), c char(2))")
+                .withIndex("create index ti on t (v,c)")
+                .withIndex("create index ti2 on t (c,v)")
+                .withInsert("insert into t values(?, ?)")
+                .withRows(rows(
+                        row("SBVGCCC", "  "),
+                        row("SBVGCCC C", "  "),
+                        row("SBVGCCC", "A ")))
+                .create();
     }
 
     @BeforeClass
@@ -324,5 +339,141 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
 
         // Restore the flag setting to the value when this test started.
         methodWatcher.executeUpdate("call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', true)");
+    }
+
+    @Test
+    public void testMultiProbeScan() throws Exception {
+        String sqlTemplate = "select * from t a --splice-properties useSpark=" + useSpark.toString() +
+        ", index=%s\n" +
+        "where v in ('SBVGCCC    ', 'G')\n" +
+        "and c in ( ' ', CAST('A' AS CHAR(2)))";
+
+        String expected =
+        "V    | C |\n" +
+        "-------------\n" +
+        "SBVGCCC |   |\n" +
+        "SBVGCCC | A |";
+
+        String sqlText = format(sqlTemplate, "ti");
+        testQuery(sqlText, expected, methodWatcher);
+        sqlText = format(sqlTemplate, "ti2");
+        testQuery(sqlText, expected, methodWatcher);
+
+        sqlTemplate = "select * from t a --splice-properties useSpark=" + useSpark.toString() +
+        ", index=%s\n" +
+        "where v = 'SBVGCCC    ' \n" +
+        "and c in ( ' ', CAST('A' AS CHAR(2)))";
+
+        sqlText = format(sqlTemplate, "ti");
+        testQuery(sqlText, expected, methodWatcher);
+        sqlText = format(sqlTemplate, "ti2");
+        testQuery(sqlText, expected, methodWatcher);
+
+        sqlTemplate = "select * from t a --splice-properties useSpark=" + useSpark.toString() +
+        ", index=%s\n" +
+        "where v in ('SBVGCCC    ', 'G')\n" +
+        "and c = CAST('A' AS CHAR(3))";
+
+        expected =
+        "V    | C |\n" +
+        "-------------\n" +
+        "SBVGCCC | A |";
+
+        sqlText = format(sqlTemplate, "ti");
+        testQuery(sqlText, expected, methodWatcher);
+        sqlText = format(sqlTemplate, "ti2");
+        testQuery(sqlText, expected, methodWatcher);
+
+        sqlTemplate = "select * from t a --splice-properties useSpark=" + useSpark.toString() +
+        ", index=%s\n" +
+        "where c in ( ' ', CAST('A' AS CHAR(3)))";
+
+        expected =
+        "V     | C |\n" +
+        "---------------\n" +
+        " SBVGCCC  |   |\n" +
+        " SBVGCCC  | A |\n" +
+        "SBVGCCC C |   |";
+
+        sqlText = format(sqlTemplate, "ti");
+        testQuery(sqlText, expected, methodWatcher);
+        sqlText = format(sqlTemplate, "ti2");
+        testQuery(sqlText, expected, methodWatcher);
+    }
+
+    private void loadParamsAndRun(PreparedStatement ps,
+                                  boolean skipParamTwo,
+                                  boolean skipParamThree,
+                                  String sqlText,
+                                  String expected) throws Exception {
+            int i = 1;
+            ps.setString(i++, "SBVGCCC    ");
+            if (!skipParamTwo)
+                ps.setString(i++, "SBVGCCC ");
+            if (!skipParamThree)
+                ps.setString(i++, " ");
+            ps.setString(i++, "A");
+            try (ResultSet rs = ps.executeQuery()) {
+                assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+            }
+    }
+    private void testPreparedQuery1(String sqlTemplate,
+                                    String expected,
+                                    boolean skipParamTwo,
+                                    boolean skipParamThree) throws Exception  {
+        String sqlText = format(sqlTemplate, "ti");
+        try (PreparedStatement ps =
+                 methodWatcher.prepareStatement(sqlText)) {
+            loadParamsAndRun(ps, skipParamTwo, skipParamThree, sqlText, expected);
+        }
+
+        sqlText = format(sqlTemplate, "ti2");
+        try (PreparedStatement ps =
+                 methodWatcher.prepareStatement(sqlText)) {
+            loadParamsAndRun(ps, skipParamTwo, skipParamThree, sqlText, expected);
+        }
+    }
+
+    @Test
+    public void testParameterizedMultiProbeScan() throws Exception {
+        String sqlTemplate = "select * from t a --splice-properties useSpark=" + useSpark.toString() +
+        ", index=%s\n" +
+        "where v in (?, ?)\n" +
+        "and c in (?, CAST(? AS CHAR(2)))";
+
+        String expected =
+        "V    | C |\n" +
+        "-------------\n" +
+        "SBVGCCC |   |\n" +
+        "SBVGCCC | A |";
+
+        testPreparedQuery1(sqlTemplate, expected, false, false);
+
+        sqlTemplate = "select * from t a --splice-properties useSpark=" + useSpark.toString() +
+        ", index=%s\n" +
+        "where v in (?, ?)\n" +
+        "and c in (?, CAST(? AS CHAR(3)))";
+
+        testPreparedQuery1(sqlTemplate, expected, false, false);
+
+        sqlTemplate = "select * from t a --splice-properties useSpark=" + useSpark.toString() +
+        ", index=%s\n" +
+        "where v = ? \n" +
+        "and c in (?, CAST(? AS CHAR(2)))";
+
+        testPreparedQuery1(sqlTemplate, expected, true, false);
+
+        sqlTemplate = "select * from t a --splice-properties useSpark=" + useSpark.toString() +
+        ", index=%s\n" +
+        "where v in (?, ?)\n" +
+        "and c = CAST(? AS CHAR(3))";
+
+        expected =
+        "V    | C |\n" +
+        "-------------\n" +
+        "SBVGCCC | A |";
+
+        testPreparedQuery1(sqlTemplate, expected, false, true);
+
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
@@ -97,6 +97,7 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
                 .withInsert("insert into t values(?, ?)")
                 .withRows(rows(
                         row("SBVGCCC", "  "),
+                        row("SBVGCCC ", "B "),
                         row("SBVGCCC C", "  "),
                         row("SBVGCCC", "A ")))
                 .create();
@@ -344,15 +345,15 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
     @Test
     public void testMultiProbeScan() throws Exception {
         String sqlTemplate = "select * from t a --splice-properties useSpark=" + useSpark.toString() +
-        ", index=%s\n" +
-        "where v in ('SBVGCCC    ', 'G')\n" +
-        "and c in ( ' ', CAST('A' AS CHAR(2)))";
+                            ", index=%s\n" +
+                            "where v in ('SBVGCCC    ', 'G')\n" +
+                            "and c in ( ' ', CAST('A' AS CHAR(2)))";
 
         String expected =
-        "V    | C |\n" +
-        "-------------\n" +
-        "SBVGCCC |   |\n" +
-        "SBVGCCC | A |";
+            "V    | C |\n" +
+            "-------------\n" +
+            "SBVGCCC |   |\n" +
+            "SBVGCCC | A |";
 
         String sqlText = format(sqlTemplate, "ti");
         testQuery(sqlText, expected, methodWatcher);
@@ -360,9 +361,9 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
         testQuery(sqlText, expected, methodWatcher);
 
         sqlTemplate = "select * from t a --splice-properties useSpark=" + useSpark.toString() +
-        ", index=%s\n" +
-        "where v = 'SBVGCCC    ' \n" +
-        "and c in ( ' ', CAST('A' AS CHAR(2)))";
+                        ", index=%s\n" +
+                        "where v = 'SBVGCCC    ' \n" +
+                        "and c in ( ' ', CAST('A' AS CHAR(2)))";
 
         sqlText = format(sqlTemplate, "ti");
         testQuery(sqlText, expected, methodWatcher);
@@ -370,14 +371,14 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
         testQuery(sqlText, expected, methodWatcher);
 
         sqlTemplate = "select * from t a --splice-properties useSpark=" + useSpark.toString() +
-        ", index=%s\n" +
-        "where v in ('SBVGCCC    ', 'G')\n" +
-        "and c = CAST('A' AS CHAR(3))";
+                        ", index=%s\n" +
+                        "where v in ('SBVGCCC    ', 'G')\n" +
+                        "and c = CAST('A' AS CHAR(3))";
 
         expected =
-        "V    | C |\n" +
-        "-------------\n" +
-        "SBVGCCC | A |";
+            "V    | C |\n" +
+            "-------------\n" +
+            "SBVGCCC | A |";
 
         sqlText = format(sqlTemplate, "ti");
         testQuery(sqlText, expected, methodWatcher);
@@ -385,15 +386,15 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
         testQuery(sqlText, expected, methodWatcher);
 
         sqlTemplate = "select * from t a --splice-properties useSpark=" + useSpark.toString() +
-        ", index=%s\n" +
-        "where c in ( ' ', CAST('A' AS CHAR(3)))";
+                        ", index=%s\n" +
+                        "where c in ( ' ', CAST('A' AS CHAR(3)))";
 
         expected =
-        "V     | C |\n" +
-        "---------------\n" +
-        " SBVGCCC  |   |\n" +
-        " SBVGCCC  | A |\n" +
-        "SBVGCCC C |   |";
+            "V     | C |\n" +
+            "---------------\n" +
+            " SBVGCCC  |   |\n" +
+            " SBVGCCC  | A |\n" +
+            "SBVGCCC C |   |";
 
         sqlText = format(sqlTemplate, "ti");
         testQuery(sqlText, expected, methodWatcher);
@@ -437,41 +438,41 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
     @Test
     public void testParameterizedMultiProbeScan() throws Exception {
         String sqlTemplate = "select * from t a --splice-properties useSpark=" + useSpark.toString() +
-        ", index=%s\n" +
-        "where v in (?, ?)\n" +
-        "and c in (?, CAST(? AS CHAR(2)))";
+                                ", index=%s\n" +
+                                "where v in (?, ?)\n" +
+                                "and c in (?, CAST(? AS CHAR(2)))";
 
         String expected =
-        "V    | C |\n" +
-        "-------------\n" +
-        "SBVGCCC |   |\n" +
-        "SBVGCCC | A |";
+            "V    | C |\n" +
+            "-------------\n" +
+            "SBVGCCC |   |\n" +
+            "SBVGCCC | A |";
 
         testPreparedQuery1(sqlTemplate, expected, false, false);
 
         sqlTemplate = "select * from t a --splice-properties useSpark=" + useSpark.toString() +
-        ", index=%s\n" +
-        "where v in (?, ?)\n" +
-        "and c in (?, CAST(? AS CHAR(3)))";
+                        ", index=%s\n" +
+                        "where v in (?, ?)\n" +
+                        "and c in (?, CAST(? AS CHAR(3)))";
 
         testPreparedQuery1(sqlTemplate, expected, false, false);
 
         sqlTemplate = "select * from t a --splice-properties useSpark=" + useSpark.toString() +
-        ", index=%s\n" +
-        "where v = ? \n" +
-        "and c in (?, CAST(? AS CHAR(2)))";
+                        ", index=%s\n" +
+                        "where v = ? \n" +
+                        "and c in (?, CAST(? AS CHAR(2)))";
 
         testPreparedQuery1(sqlTemplate, expected, true, false);
 
         sqlTemplate = "select * from t a --splice-properties useSpark=" + useSpark.toString() +
-        ", index=%s\n" +
-        "where v in (?, ?)\n" +
-        "and c = CAST(? AS CHAR(3))";
+                        ", index=%s\n" +
+                        "where v in (?, ?)\n" +
+                        "and c = CAST(? AS CHAR(3))";
 
         expected =
-        "V    | C |\n" +
-        "-------------\n" +
-        "SBVGCCC | A |";
+            "V    | C |\n" +
+            "-------------\n" +
+            "SBVGCCC | A |";
 
         testPreparedQuery1(sqlTemplate, expected, false, true);
 


### PR DESCRIPTION
This completes the work to support DB2 varchar compatibility mode for queries using MultiProbeScan.
Trailing spaces are ignored when comparing a varchar with any other string.  Normally in Splice, comparisons of varchars do not ignore trailing spaces.  The original work was done by DB-10597, which utilizes a new SQLVarcharDB2Compatible DataValueDescriptor in place of SQLVarchar, where required.  This follow-on work uses the same approach.

> call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', true);
> create table t (v varchar(14), c char(2));
> create index ti on t (v,c);
> insert into t values ('ABC','A ');
> /* Should return one row. */
> select * from t --splice-properties index=ti
>                      WHERE v in ( ' ', 'ABC      ');