### PR TITLE
DB-10919 fix DEC conversion null in Spark for getExecRowDefinition (3.0)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/util/DecimalUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/util/DecimalUtil.java
@@ -42,7 +42,7 @@ public interface DecimalUtil {
                                              int scale,
                                              String decimalCharacter) throws StandardException {
         if (dvd == null || dvd.isNull()) {
-            return null;
+            return new SQLDecimal((BigDecimal)null);
         }
         BigDecimal bigDecimal = null;
         Calendar cal = null;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
@@ -481,8 +481,10 @@ public class ValueRow implements ExecRow, Externalizable {
 	@Override
 	public StructType schema() {
 		StructField[] fields = new StructField[ncols];
-		for (int i = 0; i < ncols;i++)
+		for (int i = 0; i < ncols;i++) {
+			assert column[i] != null;
 			fields[i] = column[i].getStructField(getNamedColumn(i));
+		}
 		return DataTypes.createStructType(fields);
 	}
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/ValueRow.java
@@ -62,6 +62,7 @@ import java.util.List;
  Basic implementation of ExecRow.
 
  */
+@SuppressFBWarnings({"EI_EXPOSE_REP2", "EI_EXPOSE_REP"})
 public class ValueRow implements ExecRow, Externalizable {
 	///////////////////////////////////////////////////////////////////////
 	//

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DecimalFunctionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DecimalFunctionIT.java
@@ -14,6 +14,7 @@
 package com.splicemachine.derby.impl.sql.execute.operations;
 
 import com.splicemachine.derby.test.framework.*;
+import com.splicemachine.homeless.TestUtils;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -42,11 +43,14 @@ public class DecimalFunctionIT extends SpliceUnitTest {
     public static final    String        CLASS_NAME         = DecimalFunctionIT.class.getSimpleName().toUpperCase();
     protected final static SpliceWatcher spliceClassWatcher = new SpliceWatcher();
     public static final    String        TABLE1_NAME        = "A";
+    public static final    String        TABLE2_NAME        = "B";
 
     protected final static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
 
     private static String tableDef = "(I INT)";
     protected final static SpliceTableWatcher spliceTableWatcher1 = new SpliceTableWatcher(TABLE1_NAME, CLASS_NAME, tableDef);
+    protected final static SpliceTableWatcher spliceTableWatcher2 = new SpliceTableWatcher(TABLE2_NAME, CLASS_NAME,
+            "(COL1 DECIMAL(15,2), COL2 CHAR(10))");
 
     @ClassRule
     public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
@@ -66,7 +70,19 @@ public class DecimalFunctionIT extends SpliceUnitTest {
                         throw new RuntimeException(e);
                     }
                 }
+            })
+            .around(spliceTableWatcher2).around(new SpliceDataWatcher() {
+                @Override
+                protected void starting(Description description) {
+                    try {
+                        spliceClassWatcher.executeUpdate(
+                                String.format("insert into %s values (0.0, 'HELLO')", spliceTableWatcher2) );
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
             });
+
     private final String functionName;
 
     @Rule
@@ -291,5 +307,16 @@ public class DecimalFunctionIT extends SpliceUnitTest {
     public void decimalFunctionWorksWithAggregates() throws Exception {
         checkQuery(String.format("select %s(max(I)) from %s", functionName, spliceTableWatcher1), "100");
         checkQuery(String.format("select %s(sum(I), 10, 2) from %s", functionName, spliceTableWatcher1), "5050.00");
+    }
+
+    // DB-10919
+    @Test
+    public void testDecOrder() throws Exception {
+        try (ResultSet rs = methodWatcher.executeQuery(String.format("SELECT %s(VE.COL1,11,2) as RES FROM %s VE " +
+                "--splice-properties useSpark=true\nORDER BY VE.COL2", functionName, spliceTableWatcher2)) ){
+            Assert.assertEquals("RES |\n" +
+                    "------\n" +
+                    "0.00 |", TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
     }
 }


### PR DESCRIPTION
DecimalUtil.getDecimalDb2 needs to return a SQL null, not a Java null.
The projection (and therefore also the getDecimalDb2 function) will be called once from Olap Server with
a"null" row from getExecRowDefinition to get the types in the result rows.
Then later, the Spark Executor will get the correct results and insert the correct values.