### PR TITLE
DB-10949 Support parameterized FROM FINAL TABLE queries.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
@@ -134,15 +134,36 @@ public class FromVTI extends FromTable implements VTIEnvironment {
     private CreateTriggerNode tempTriggerDefinition;
     private String tempTriggerSQLText;
     private String tempTriggerName;
+    private Vector<ParameterNode> fromTableParameterList;
 
     /**
      * @param invocation        The constructor or static method for the VTI
      * @param correlationName    The correlation name
      * @param derivedRCL        The derived column list
      * @param tableProperties    Properties list associated with the table
-     *
+     * @param fromTableParameterList  Parameterized FROM TABLE statement, list of parameters.
+     * @param forFromTable       If processing a FROM TABLE statement, this is a Boolean true.
      * @exception StandardException        Thrown on error
      */
+    public void init(
+            Object invocation,
+            Object correlationName,
+            Object derivedRCL,
+            Object tableProperties,
+            Object typeDescriptor,
+            Object fromTableParameterList,
+            Object forFromTable)
+            throws StandardException
+    {
+        this.fromTableParameterList = (Vector) fromTableParameterList;
+        init( invocation,
+                correlationName,
+                derivedRCL,
+                tableProperties,
+                makeTableName(null, (String) correlationName),
+                typeDescriptor);
+    }
+
     public void init(
             Object invocation,
             Object correlationName,
@@ -699,6 +720,10 @@ public class FromVTI extends FromTable implements VTIEnvironment {
                 tec = createTemporaryTrigger(tempTriggerName,
                                              fromTableDMLStmt,
                                              tempTriggerDefinition);
+                fromTableDMLStmt.getCompilerContext().setParameterList(fromTableParameterList);
+                DataTypeDescriptor[] descriptors = fromTableDMLStmt.getCompilerContext().getParameterTypes();
+                fromTableParameterList.forEach( (param) -> param.setDescriptors(descriptors));
+
                 fromTableDMLStmt.bindStatement();
                 //walkAST(lcc,fromTableDMLStmt, CompilationPhase.AFTER_BIND);
             }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -10327,7 +10327,7 @@ FromTable tableFactor() throws StandardException :
         newNode = (QueryTreeNode) nodeFactory.getNode(
                                C_NodeTypes.NEW_INVOCATION_NODE,
                                javaClassName,
-                               parameterList,
+                               new Vector(), // empty parameterList
                                getContextManager());
 
         javaToSQLNode = (JavaToSQLValueNode) nodeFactory.getNode(
@@ -10393,6 +10393,8 @@ FromTable tableFactor() throws StandardException :
                             (Properties) optionalTableClauses[OPTIONAL_TABLE_CLAUSES_TABLE_PROPERTIES] :
                             (Properties) null),
                         typeDescriptor,
+                        parameterList,
+                        new Boolean(true),
                         getContextManager());
         fromVTI.setFromTableDMLStmt(dmlStatement);
         fromVTI.setTempTriggerDefinition(tempTriggerDefinition);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerExecutionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerExecutionContext.java
@@ -325,7 +325,7 @@ public class TriggerExecutionContext implements ExecutionStmtValidator, External
             rs.open();
         triggeringRow = rs.getCurrentRow();
         try {
-            if (triggerd.isRowTrigger())
+            if (triggerd != null && triggerd.isRowTrigger())
                 rs.close();
         } catch (StandardException e) {
             // ignore - close quietly.

--- a/hbase_storage/src/main/java/com/splicemachine/access/hbase/HBasePartitionAdmin.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/hbase/HBasePartitionAdmin.java
@@ -793,4 +793,17 @@ public class HBasePartitionAdmin implements PartitionAdmin{
                         .collect(Collectors.toList());
         return upgradeTablePrioritiesFromList( admin, tableDescriptorList );
     }
+
+    @Override
+    public int getTableCount() throws IOException{
+
+        try {
+            TableName[] tableNames =  admin.listTableNames();
+            return tableNames.length;
+        }
+        catch (Exception e) {
+            SpliceLogUtils.warn(LOG, "Could not find the table count.");
+            throw e;
+        }
+    }
 }

--- a/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MEnginePartitionAdmin.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MEnginePartitionAdmin.java
@@ -152,10 +152,7 @@ public class MEnginePartitionAdmin implements PartitionAdmin{
 
     @Override
     public void markDropped(long conglomId, long txn) throws IOException {
-        // Actually drop the table on mem when marked as dropped.
-        // Mem has no vacuum, so this is the only way to free up space.
-        Long conglom = Long.valueOf(conglomId);
-        deleteTable(conglom.toString());
+        // no op
     }
 
     @Override

--- a/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MEnginePartitionAdmin.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MEnginePartitionAdmin.java
@@ -152,7 +152,10 @@ public class MEnginePartitionAdmin implements PartitionAdmin{
 
     @Override
     public void markDropped(long conglomId, long txn) throws IOException {
-        // no op
+        // Actually drop the table on mem when marked as dropped.
+        // Mem has no vacuum, so this is the only way to free up space.
+        Long conglom = new Long(conglomId);
+        deleteTable(conglom.toString());
     }
 
     @Override
@@ -185,5 +188,10 @@ public class MEnginePartitionAdmin implements PartitionAdmin{
     @Override
     public int upgradeTablePrioritiesFromList(List<String> conglomerateIdList) throws Exception {
         throw new UnsupportedOperationException("Operation not supported in mem storage engine");
+    }
+
+    @Override
+    public int getTableCount() throws IOException {
+        return admin.getTableCount();
     }
 }

--- a/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MEnginePartitionAdmin.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/lifecycle/MEnginePartitionAdmin.java
@@ -154,7 +154,7 @@ public class MEnginePartitionAdmin implements PartitionAdmin{
     public void markDropped(long conglomId, long txn) throws IOException {
         // Actually drop the table on mem when marked as dropped.
         // Mem has no vacuum, so this is the only way to free up space.
-        Long conglom = new Long(conglomId);
+        Long conglom = Long.valueOf(conglomId);
         deleteTable(conglom.toString());
     }
 

--- a/mem_storage/src/main/java/com/splicemachine/storage/MPartitionFactory.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MPartitionFactory.java
@@ -265,5 +265,10 @@ public class MPartitionFactory implements PartitionFactory<Object>{
         public int upgradeTablePrioritiesFromList(List<String> conglomerateIdList) throws Exception {
             throw new UnsupportedOperationException("Operation not supported in mem storage engine");
         }
+
+        @Override
+        public int getTableCount() throws IOException {
+            return partitionMap.size();
+        }
     }
 }

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/PartitionAdmin.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/PartitionAdmin.java
@@ -91,4 +91,6 @@ public interface PartitionAdmin extends AutoCloseable{
      */
 
     int upgradeTablePrioritiesFromList(List<String> conglomerateIdList) throws Exception;
+
+    int getTableCount() throws IOException;
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/catalog/TriggerNewTransitionRows.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/catalog/TriggerNewTransitionRows.java
@@ -96,7 +96,6 @@ public class TriggerNewTransitionRows
 	private ResultSet resultSet;
 	private DataSet<ExecRow> sourceSet;
 	private TriggerExecutionContext tec;
-	private TemporaryRowHolderResultSet temporaryRowHolderResultSet;
 	protected TriggerRowHolderImpl rowHolder = null;
 
 	public TriggerNewTransitionRows()
@@ -238,7 +237,7 @@ public class TriggerNewTransitionRows
                     else
                         triggerRows = sourceSet.union(cachedRowsSet, op.getOperationContext());
 
-                    if (!activation.isSubStatement() && tec.hasSpecialFromTableTrigger()) {
+                    if (tec.hasSpecialFromTableTrigger()) {
                         dsp.setTempTriggerConglomerate(conglomID);
                     }
                 }
@@ -335,6 +334,7 @@ public class TriggerNewTransitionRows
            sourceSet.unpersistIt();
            sourceSet = null;
        }
+       tec = null;
    }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -1121,6 +1121,13 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                             .returnType(null).isDeterministic(false)
                             .build());
 
+                    procedures.add(Procedure.newBuilder().name("SYSCS_GET_TABLE_COUNT")
+                            .numOutputParams(0)
+                            .numResultSets(1)
+                            .ownerClass(SpliceAdmin.class.getCanonicalName())
+                            .returnType(null).isDeterministic(false)
+                            .build());
+
                     procedures.add(Procedure.newBuilder().name("SYSCS_CANCEL_BACKUP")
                             .numOutputParams(0)
                             .bigint("backupId")

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -1128,6 +1128,13 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                             .returnType(null).isDeterministic(false)
                             .build());
 
+                    procedures.add(Procedure.newBuilder().name("SYSCS_IS_MEM_PLATFORM")
+                            .numOutputParams(0)
+                            .numResultSets(1)
+                            .ownerClass(SpliceAdmin.class.getCanonicalName())
+                            .returnType(null).isDeterministic(false)
+                            .build());
+
                     procedures.add(Procedure.newBuilder().name("SYSCS_CANCEL_BACKUP")
                             .numOutputParams(0)
                             .bigint("backupId")

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/TriggerRowHolderImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/TriggerRowHolderImpl.java
@@ -505,6 +505,7 @@ public class TriggerRowHolderImpl implements TemporaryRowHolder, Externalizable
         if(triggerTempPartition!=null){
             try{
                 triggerTempPartition.close();
+                triggerTempPartition = null;
             }catch(IOException e){
                 throw Exceptions.parseException(e);
             }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperation.java
@@ -290,10 +290,20 @@ public class VTIOperation extends SpliceBaseOperation {
 
     private void executeFromTableDML() throws StandardException {
         if (fromTableDML_SPS != null) {
-            LanguageConnectionContext lcc = getActivation().getLanguageConnectionContext();
+            Activation parentActivation = getActivation();
+            LanguageConnectionContext lcc = parentActivation.getLanguageConnectionContext();
             fromTableDML_SPS.setValid();
             getActivation().setSingleExecution();
-            fromTableDML_ResultSet = fromTableDML_SPS.executeSubStatement(lcc, false, 0L);
+            Activation activation = fromTableDML_SPS.getActivation(lcc, false);
+            activation.setSingleExecution();
+
+            // We are sharing the query parameters with the outer activation
+            // because both statements were compiled together.
+            activation.setParameters(parentActivation.getParameterValueSet(),
+                                     fromTableDML_SPS.getParameterTypes());
+            fromTableDML_ResultSet =
+                fromTableDML_SPS.executeSubStatement(parentActivation,
+                                                     activation, false, 0L);
         }
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperation.java
@@ -293,7 +293,6 @@ public class VTIOperation extends SpliceBaseOperation {
             Activation parentActivation = getActivation();
             LanguageConnectionContext lcc = parentActivation.getLanguageConnectionContext();
             fromTableDML_SPS.setValid();
-            getActivation().setSingleExecution();
             Activation activation = fromTableDML_SPS.getActivation(lcc, false);
             activation.setSingleExecution();
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
@@ -1322,6 +1322,32 @@ public class SpliceAdmin extends BaseAdminProcedures{
         }
     }
 
+    public static void SYSCS_GET_TABLE_COUNT(ResultSet[] resultSets) throws StandardException, SQLException{
+        try {
+            Connection conn = SpliceAdmin.getDefaultConn();
+            LanguageConnectionContext lcc = conn.unwrap(EmbedConnection.class).getLanguageConnection();
+            SIDriver driver = SIDriver.driver();
+            PartitionFactory partitionFactory = driver.getTableFactory();
+            PartitionAdmin partitionAdmin = partitionFactory.getAdmin();
+            int tableCount = partitionAdmin.getTableCount();
+
+            ResultColumnDescriptor[] rcds = {
+                    new GenericColumnDescriptor("NumTables", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.INTEGER))
+            };
+            ExecRow template = new ValueRow(1);
+
+            template.setRowArray(new DataValueDescriptor[]{new SQLInteger(tableCount)});
+            List<ExecRow> rows = Lists.newArrayList();
+            rows.add(template.getClone());
+            IteratorNoPutResultSet inprs = new IteratorNoPutResultSet(rows,rcds,lcc.getLastActivation());
+            inprs.openCore();
+            resultSets[0] = new EmbedResultSet40(conn.unwrap(EmbedConnection.class),inprs,false,null,true);
+        } catch (Throwable t) {
+            resultSets[0] = ProcedureUtils.generateResult("Error", t.getLocalizedMessage());
+            SpliceLogUtils.error(LOG, "Cannot get table count.", t);
+        }
+    }
+
     public static void SYSCS_INVALIDATE_STORED_STATEMENTS() throws SQLException{
         SystemProcedures.SYSCS_INVALIDATE_PERSISTED_STORED_STATEMENTS();
         SYSCS_EMPTY_GLOBAL_STORED_STATEMENT_CACHE();

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
@@ -1348,6 +1348,27 @@ public class SpliceAdmin extends BaseAdminProcedures{
         }
     }
 
+    public static void SYSCS_IS_MEM_PLATFORM(ResultSet[] resultSets) throws StandardException, SQLException{
+        try {
+            Connection conn = SpliceAdmin.getDefaultConn();
+            LanguageConnectionContext lcc = conn.unwrap(EmbedConnection.class).getLanguageConnection();
+            boolean isMemPlatform = EngineDriver.isMemPlatform();
+            ResultColumnDescriptor[] rcds = {
+                    new GenericColumnDescriptor("IsMemPlatform", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN))
+            };
+            ExecRow template = new ValueRow(1);
+
+            template.setRowArray(new DataValueDescriptor[]{new SQLBoolean(isMemPlatform)});
+            List<ExecRow> rows = Lists.newArrayList();
+            rows.add(template.getClone());
+            IteratorNoPutResultSet inprs = new IteratorNoPutResultSet(rows,rcds,lcc.getLastActivation());
+            inprs.openCore();
+            resultSets[0] = new EmbedResultSet40(conn.unwrap(EmbedConnection.class),inprs,false,null,true);
+        } catch (Throwable t) {
+            resultSets[0] = ProcedureUtils.generateResult("Error", t.getLocalizedMessage());
+            SpliceLogUtils.error(LOG, "Failed to test mem platform status.", t);
+        }
+    }
     public static void SYSCS_INVALIDATE_STORED_STATEMENTS() throws SQLException{
         SystemProcedures.SYSCS_INVALIDATE_PERSISTED_STORED_STATEMENTS();
         SYSCS_EMPTY_GLOBAL_STORED_STATEMENT_CACHE();

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/FromFinalTableIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/FromFinalTableIT.java
@@ -17,6 +17,7 @@ package com.splicemachine.db.impl.sql.compile;
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.homeless.TestUtils;
 import com.splicemachine.test.SerialTest;
 import com.splicemachine.test_tools.TableCreator;
 import org.junit.*;
@@ -28,6 +29,8 @@ import org.junit.runners.Parameterized;
 import splice.com.google.common.collect.Lists;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.util.Collection;
 import java.util.List;
 
@@ -411,4 +414,126 @@ public class FromFinalTableIT extends SpliceUnitTest {
         methodWatcher.rollback();
         methodWatcher.commit();
         methodWatcher.setAutoCommit(true);
-}}
+    }
+
+    private void loadParamsAndRun(PreparedStatement ps,
+                                  Integer paramOneValue,
+                                  String paramTwoValue,
+                                  String paramThreeValue,
+                                  Integer paramFourValue,
+                                  String sqlText,
+                                  String expected) throws Exception {
+            int i = 1;
+            if (paramOneValue != null)
+                ps.setInt(i++, paramOneValue);
+            if (paramTwoValue != null)
+                ps.setString(i++, paramTwoValue);
+            if (paramThreeValue != null)
+                ps.setString(i++, paramThreeValue);
+            if (paramFourValue != null)
+                ps.setInt(i++, paramFourValue);
+            try (ResultSet rs = ps.executeQuery()) {
+                assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+            }
+    }
+    private void testPreparedQuery(String sqlTemplate,
+                                   String expected,
+                                   Integer paramOneValue,
+                                   String paramTwoValue,
+                                   String paramThreeValue,
+                                   Integer paramFourValue) throws Exception  {
+        String sqlText = sqlTemplate;
+        try (PreparedStatement ps =
+                 methodWatcher.prepareStatement(sqlText)) {
+            loadParamsAndRun(ps, paramOneValue, paramTwoValue, paramThreeValue, paramFourValue, sqlText, expected);
+        }
+    }
+
+
+
+    @Test
+    public void testParameterizedFromTableQueries() throws Exception {
+        methodWatcher.setAutoCommit(false);
+
+        String expected =
+            "B  | A |\n" +
+            "----------\n" +
+            "  a  | 1 |\n" +
+            "  a  | 2 |\n" +
+            " a b | 5 |\n" +
+            " ab  | 3 |\n" +
+            " abc | 4 |\n" +
+            "abcd | 6 |";
+
+        String sqlTemplate = "SELECT b,a FROM OLD TABLE (UPDATE t1 --splice-properties useSpark=" + useSpark.toString() +
+        "\n set a = a+? where b >= ?) WHERE b < ? and a < ?";
+
+        testPreparedQuery(sqlTemplate,  expected, 2, " a", "d", 99);
+
+
+        sqlTemplate = "SELECT b,a FROM NEW TABLE (UPDATE t1 --splice-properties useSpark=" + useSpark.toString() +
+        "\n set a = a+? where b >= ?) WHERE b < ? and a < ?";
+
+        expected =
+            "B  | A |\n" +
+            "----------\n" +
+            " ab  |17 |\n" +
+            " abc |18 |\n" +
+            "abcd |20 |";
+
+        testPreparedQuery(sqlTemplate,  expected, 12, "ab", "d", 22);
+
+        sqlTemplate = "SELECT a, b FROM OLD TABLE (DELETE FROM t1 --splice-properties useSpark=" + useSpark.toString() +
+        "\n WHERE a > ? and ? in (select a from t1 b where t1.a = b.a)) ";
+
+        expected =
+            "A | B  |\n" +
+            "---------\n" +
+            "18 |abc |";
+
+        testPreparedQuery(sqlTemplate,  expected, 17, null, null, 18);
+
+        sqlTemplate = "SELECT a, b FROM FINAL TABLE (insert into t1 --splice-properties useSpark=" + useSpark.toString()  +
+                      "\n select * from t11 where a != ? and b >= ?)" +
+        " WHERE b != ? and a < ? ";
+
+        expected =
+            "A |  B  |\n" +
+            "----------\n" +
+            " 1 |  a  |\n" +
+            "11 |  z  |\n" +
+            "12 | xyz |\n" +
+            " 2 |  a  |\n" +
+            " 3 | ab  |\n" +
+            " 4 | abc |\n" +
+            " 5 | a b |\n" +
+            " 6 |abcd |";
+
+        testPreparedQuery(sqlTemplate,  expected, 0, " ", "def", 99);
+
+        sqlTemplate = "SELECT b,a FROM NEW TABLE (UPDATE t1 --splice-properties useSpark=" + useSpark.toString() +
+        "\n set a = ?, b = ? WHERE b < ? and a < ?)";
+
+        expected =
+            "B     | A |\n" +
+            "----------------\n" +
+            "Alles klar | 0 |\n" +
+            "Alles klar | 0 |\n" +
+            "Alles klar | 0 |\n" +
+            "Alles klar | 0 |\n" +
+            "Alles klar | 0 |\n" +
+            "Alles klar | 0 |\n" +
+            "Alles klar | 0 |\n" +
+            "Alles klar | 0 |\n" +
+            "Alles klar | 0 |\n" +
+            "Alles klar | 0 |\n" +
+            "Alles klar | 0 |";
+
+        testPreparedQuery(sqlTemplate,  expected, 0, "Alles klar", "x", 99);
+
+        methodWatcher.rollback();
+        methodWatcher.commit();
+        methodWatcher.setAutoCommit(true);
+    }
+
+}


### PR DESCRIPTION
Example of query this PR adds support for:
> prepare ps as 'select * from old table (update t1 set a = ?) where a >= ?';
> execute ps using 'values (2, 1)';

The parameter list is normally one per activation, but FROM TABLE queries use two activations, so this change makes sure both activations can access the same parameter list.

Two new system procedures are also added: SYSCS_GET_TABLE_COUNT and SYSCS_IS_MEM_PLATFORM

**SYSCS_GET_TABLE_COUNT** 
Returns the number of HBase user tables, or on mem, the number of tables allocated in MPartitionFactory.Admin.partitionMap.

**SYSCS_IS_MEM_PLATFORM**
Returns true if splice is running on the mem platform, otherwise false.

> splice> CALL SYSCS_UTIL.SYSCS_GET_TABLE_COUNT();
> NumTables  
> //-----------
> 111        
> 
> 1 row selected
> ELAPSED TIME = 337 milliseconds
> splice> call syscs_util.syscs_is_mem_platform();
> IsMe&
> //-----
> false

