### PR TITLE
DB-10967 added splice.function.timestampFormat (3.1)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
@@ -183,7 +183,6 @@ public interface CompilerContext extends Context
     NativeSparkModeType DEFAULT_SPLICE_NATIVE_SPARK_AGGREGATION_MODE = NativeSparkModeType.SYSTEM;
     boolean DEFAULT_SPLICE_ALLOW_OVERFLOW_SENSITIVE_NATIVE_SPARK_EXPRESSIONS = true;
     int DEFAULT_SPLICE_CURRENT_TIMESTAMP_PRECISION = 6;
-    int DEFAULT_TIMESTAMP_PRECISION = 9;
     String DEFAULT_TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss.SSSSSSSSS";
     boolean DEFAULT_OUTERJOIN_FLATTENING_DISABLED = false;
     boolean DEFAULT_SSQ_FLATTENING_FOR_UPDATE_DISABLED = false;
@@ -726,11 +725,8 @@ public interface CompilerContext extends Context
 
     void setCurrentTimestampPrecision(int newValue);
 
-    void setTimestampPrecision(int newValue);
-
     int getCurrentTimestampPrecision();
 
-    int getTimestampPrecision();
     void setTimestampFormat(String timestampFormat);
 
     String getTimestampFormat();

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
@@ -184,6 +184,7 @@ public interface CompilerContext extends Context
     boolean DEFAULT_SPLICE_ALLOW_OVERFLOW_SENSITIVE_NATIVE_SPARK_EXPRESSIONS = true;
     int DEFAULT_SPLICE_CURRENT_TIMESTAMP_PRECISION = 6;
     int DEFAULT_TIMESTAMP_PRECISION = 9;
+    String DEFAULT_TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss.SSSSSSSSS";
     boolean DEFAULT_OUTERJOIN_FLATTENING_DISABLED = false;
     boolean DEFAULT_SSQ_FLATTENING_FOR_UPDATE_DISABLED = false;
     NewMergeJoinExecutionType DEFAULT_SPLICE_NEW_MERGE_JOIN = NewMergeJoinExecutionType.SYSTEM;
@@ -730,6 +731,9 @@ public interface CompilerContext extends Context
     int getCurrentTimestampPrecision();
 
     int getTimestampPrecision();
+    void setTimestampFormat(String timestampFormat);
+
+    String getTimestampFormat();
 
     int getNextOJLevel();
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/TypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/TypeCompiler.java
@@ -219,8 +219,9 @@ public interface TypeCompiler
      *
      * @param dts        The associated DataTypeDescriptor for this TypeId.
      *
+     * @param compilerContext
      * @return int            The maximum width for this data type when cast to a char type.
      */
-    int getCastToCharWidth(DataTypeDescriptor dts);
+    int getCastToCharWidth(DataTypeDescriptor dts, CompilerContext compilerContext);
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTimestamp.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTimestamp.java
@@ -177,7 +177,7 @@ public final class SQLTimestamp extends DataType
      * see also https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
      * we support:
      * yyyy, yy, uuuu, uu, eee, EEE, MM, mm, dd, HH, hh, ss, a
-     * an arbitrary number of S, and other characters " ,.-/:"
+     * up to 9x S (nanoseconds), and other characters " ,.-/:"
      * @param format
      * @throws IllegalArgumentException if format is not supported
      * @return length of format
@@ -201,14 +201,12 @@ public final class SQLTimestamp extends DataType
             if ((l == 'y' || l == 'u') && (r == 4 || r == 2)) continue;
             else if (r == 2 &&  "MmdHhs".indexOf(l) != -1 ) continue;
             else if (r == 3 && (l == 'e' || l == 'E')) continue;
-            else if (l == 'S') continue;
-            else if (r == 1) {
-                if (l == 'a') {
-                    length++;
-                    continue;
-                }
-                if(" ,.-/:".indexOf(l) != -1) continue;
+            else if (l == 'S' && r <= 9) continue; // s fraction max 9
+            else if (r == 1 && l == 'a') {
+                length++;
+                continue;
             }
+            else if(" ,.-/:".indexOf(l) != -1) continue;
             throw new IllegalArgumentException("not supported format \"" + format + "\": '" + l + "' can't be repeated " + r + " times");
         }
         return length;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTimestamp.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLTimestamp.java
@@ -102,8 +102,6 @@ public final class SQLTimestamp extends DataType
 
     private static boolean skipDBContext = false;
 
-    private int precision = 0;
-
     public static void setSkipDBContext(boolean value) { skipDBContext = value; }
 
     private int encodedDate;
@@ -129,10 +127,6 @@ public final class SQLTimestamp extends DataType
 
     public void setTimestampFormat(String format) {
         timestampFormat = format;
-    }
-
-    public void setPrecision(int precision) {
-        this.precision = precision;
     }
 
     // Check for a version 2.0 timestamp out of bounds.
@@ -175,25 +169,7 @@ public final class SQLTimestamp extends DataType
         return BASE_MEMORY_USAGE;
     } // end of estimateMemoryUsage
 
-    private static String format(Timestamp timestamp, int precision) {
-        assert timestamp != null;
-        String ts = timestamp.toString();
-        String result = ts.substring(0, ts.indexOf('.'));
-        if(precision <= 0) {
-            return result;
-        }
-        String nanosString = ts.substring(ts.indexOf('.') + 1);
-        if(nanosString.length() == precision) {
-            return result + "." + nanosString;
-        } else if(nanosString.length() > precision) {
-            return result + "." + nanosString.substring(0, precision);
-        } else {
-            int paddingZeros = precision - nanosString.length();
-            return result + "." + nanosString + String.join("", Collections.nCopies(paddingZeros, "0"));
-        }
-    }
-
-    private static String format2(Timestamp timestamp, String timeStampFormat) {
+    private static String format(Timestamp timestamp, String timeStampFormat) {
         if(timeStampFormat == null) timeStampFormat = CompilerContext.DEFAULT_TIMESTAMP_FORMAT;
         return DateTimeFormatter
                 .ofPattern(timeStampFormat)
@@ -209,7 +185,7 @@ public final class SQLTimestamp extends DataType
         if (!isNull()) {
             Timestamp timestamp = getTimestamp(calendar);
             assert timestamp != null;
-            return format2(timestamp, timestampFormat);
+            return format(timestamp, timestampFormat);
         } else {
             return null;
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -65,6 +65,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Timestamp;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -619,6 +621,21 @@ public class GenericStatement implements Statement{
                     // just use the default setting.
                 }
                 cc.setCurrentTimestampPrecision(currentTimestampPrecision);
+
+                String timestampFormatString =
+                        PropertyUtil.getCachedDatabaseProperty(lcc, Property.SPLICE_TIMESTAMP_FORMAT);
+                if(timestampFormatString == null)
+                    cc.setTimestampFormat(CompilerContext.DEFAULT_TIMESTAMP_FORMAT);
+                else {
+                    try {
+                        // DB-10968 we shouldn't even allow setting this to the wrong value
+                        DateTimeFormatter.ofPattern(timestampFormatString);
+                    } catch(Exception e)
+                    {
+                        timestampFormatString = CompilerContext.DEFAULT_TIMESTAMP_FORMAT;
+                    }
+                    cc.setTimestampFormat(timestampFormatString);
+                }
 
                 String timestampPrecisionString =
                         PropertyUtil.getCachedDatabaseProperty(lcc, Property.SPLICE_TIMESTAMP_PRECISION);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -295,7 +295,6 @@ public class GenericStatement implements Statement{
          * 4:   generateTime
          */
         long[] timestamps = new long[5];
-        Timestamp beginTimestamp=null;
         StatementContext statementContext=null;
 
         // verify it isn't already prepared...
@@ -311,12 +310,6 @@ public class GenericStatement implements Statement{
             lcc.setOptimizerTraceOutput(getSource()+"\n");
 
         timestamps[0]=getCurrentTimeMillis(lcc);
-        /* beginTimestamp only meaningful if beginTime is meaningful.
-         * beginTime is meaningful if STATISTICS TIMING is ON.
-         */
-        if(timestamps[0]!=0){
-            beginTimestamp=new Timestamp(timestamps[0]);
-        }
 
         /** set the prepare Isolaton from the LanguageConnectionContext now as
          * we need to consider it in caching decisions
@@ -462,259 +455,27 @@ public class GenericStatement implements Statement{
                     cc.setReliability(CompilerContext.INTERNAL_SQL_LEGAL);
                 }
 
-                /* get the selectivity estimation property so that we know what strategy to use to estimate selectivity */
-                String selectivityEstimationString = PropertyUtil.getServiceProperty(lcc.getTransactionCompile(),
-                Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED);
-                Boolean selectivityEstimationIncludingSkewedDefault = Boolean.parseBoolean(selectivityEstimationString);
-
-                cc.setSelectivityEstimationIncludingSkewedDefault(selectivityEstimationIncludingSkewedDefault);
-
-                /* check if the optimization to do projection pruning is enabled or not */
-                String projectionPruningOptimizationString = PropertyUtil.getCachedDatabaseProperty(lcc,
-                Property.PROJECTION_PRUNING_DISABLED);
-                // if database property is not set, treat it as false
-                Boolean projectionPruningOptimizationDisabled = false;
-                try {
-                    if (projectionPruningOptimizationString != null)
-                        projectionPruningOptimizationDisabled = Boolean.parseBoolean(projectionPruningOptimizationString);
-                } catch (Exception e) {
-                    // If the property value failed to convert to a boolean, don't throw an error,
-                    // just use the default setting.
-                }
-                cc.setProjectionPruningEnabled(!projectionPruningOptimizationDisabled);
-
-                // User can specify the max length of multicolumn IN list the optimizer may build for
-                // use as a probe predicate.  Single-column IN lists can be combined up until the point
-                // where adding in the next IN predicate would push us over the limit.
-                String maxMulticolumnProbeValuesString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.MAX_MULTICOLUMN_PROBE_VALUES);
-                int maxMulticolumnProbeValues = CompilerContext.DEFAULT_MAX_MULTICOLUMN_PROBE_VALUES;
-                try {
-                    if (maxMulticolumnProbeValuesString != null)
-                        maxMulticolumnProbeValues = Integer.parseInt(maxMulticolumnProbeValuesString);
-                } catch (Exception e) {
-                    // If the property value failed to convert to an int, don't throw an error,
-                    // just use the default setting.
-                }
-                if (maxMulticolumnProbeValues > MAX_MULTICOLUMN_PROBE_VALUES_MAX_VALUE)
-                    maxMulticolumnProbeValues = MAX_MULTICOLUMN_PROBE_VALUES_MAX_VALUE;
-                cc.setMaxMulticolumnProbeValues(maxMulticolumnProbeValues);
-
-                String multicolumnInlistProbeOnSparkEnabledString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED);
-                boolean multicolumnInlistProbeOnSparkEnabled = CompilerContext.DEFAULT_MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED;
-                try {
-                    if (multicolumnInlistProbeOnSparkEnabledString != null)
-                        multicolumnInlistProbeOnSparkEnabled = Boolean.parseBoolean(multicolumnInlistProbeOnSparkEnabledString);
-                } catch (Exception e) {
-                    // If the property value failed to convert to a boolean, don't throw an error,
-                    // just use the default setting.
-                }
-                cc.setMulticolumnInlistProbeOnSparkEnabled(multicolumnInlistProbeOnSparkEnabled);
-
-                String convertMultiColumnDNFPredicatesToInListString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.CONVERT_MULTICOLUMN_DNF_PREDICATES_TO_INLIST);
-                boolean convertMultiColumnDNFPredicatesToInList = CompilerContext.DEFAULT_CONVERT_MULTICOLUMN_DNF_PREDICATES_TO_INLIST;
-                try {
-                    if (convertMultiColumnDNFPredicatesToInListString != null)
-                        convertMultiColumnDNFPredicatesToInList = Boolean.parseBoolean(convertMultiColumnDNFPredicatesToInListString);
-                } catch (Exception e) {
-                    // If the property value failed to convert to a boolean, don't throw an error,
-                    // just use the default setting.
-                }
-                cc.setConvertMultiColumnDNFPredicatesToInList(convertMultiColumnDNFPredicatesToInList);
-
-                String disablePredicateSimplificationString =
-                PropertyUtil.getCachedDatabaseProperty(lcc, Property.DISABLE_PREDICATE_SIMPLIFICATION);
-                boolean disablePredicateSimplification = CompilerContext.DEFAULT_DISABLE_PREDICATE_SIMPLIFICATION;
-                try {
-                    if (disablePredicateSimplificationString != null)
-                        disablePredicateSimplification =
-                        Boolean.parseBoolean(disablePredicateSimplificationString);
-                } catch (Exception e) {
-                    // If the property value failed to convert to a boolean, don't throw an error,
-                    // just use the default setting.
-                }
-                cc.setDisablePredicateSimplification(disablePredicateSimplification);
-
-                String nativeSparkAggregationModeString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.SPLICE_NATIVE_SPARK_AGGREGATION_MODE);
-                CompilerContext.NativeSparkModeType nativeSparkAggregationMode = CompilerContext.DEFAULT_SPLICE_NATIVE_SPARK_AGGREGATION_MODE;
-                try {
-                    if (nativeSparkAggregationModeString != null) {
-                        nativeSparkAggregationModeString = nativeSparkAggregationModeString.toLowerCase();
-                        switch (nativeSparkAggregationModeString) {
-                            case "on":
-                                nativeSparkAggregationMode = CompilerContext.NativeSparkModeType.ON;
-                                break;
-                            case "off":
-                                nativeSparkAggregationMode = CompilerContext.NativeSparkModeType.OFF;
-                                break;
-                            case "forced":
-                                nativeSparkAggregationMode = CompilerContext.NativeSparkModeType.FORCED;
-                                break;
-                            default:
-                                // use default value
-                                break;
-                        }
-                    }
-                } catch (Exception e) {
-                    // If the property value failed to get decoded to a valid value, don't throw an error,
-                    // just use the default setting.
-                }
-                cc.setNativeSparkAggregationMode(nativeSparkAggregationMode);
-
-                String allowOverflowSensitiveNativeSparkExpressionsString =
-                PropertyUtil.getCachedDatabaseProperty(lcc, Property.SPLICE_ALLOW_OVERFLOW_SENSITIVE_NATIVE_SPARK_EXPRESSIONS);
-                boolean allowOverflowSensitiveNativeSparkExpressions = CompilerContext.DEFAULT_SPLICE_ALLOW_OVERFLOW_SENSITIVE_NATIVE_SPARK_EXPRESSIONS;
-                try {
-                    if (allowOverflowSensitiveNativeSparkExpressionsString != null)
-                        allowOverflowSensitiveNativeSparkExpressions =
-                        Boolean.parseBoolean(allowOverflowSensitiveNativeSparkExpressionsString);
-                } catch (Exception e) {
-                    // If the property value failed to convert to a boolean, don't throw an error,
-                    // just use the default setting.
-                }
-                cc.setAllowOverflowSensitiveNativeSparkExpressions(allowOverflowSensitiveNativeSparkExpressions);
-
-                String newMergeJoinString =
-                PropertyUtil.getCachedDatabaseProperty(lcc, Property.SPLICE_NEW_MERGE_JOIN);
-                CompilerContext.NewMergeJoinExecutionType newMergeJoin =
-                CompilerContext.DEFAULT_SPLICE_NEW_MERGE_JOIN;
-                try {
-                    if (newMergeJoinString != null) {
-                        newMergeJoinString = newMergeJoinString.toLowerCase();
-                        if (newMergeJoinString.equals("on"))
-                            newMergeJoin = CompilerContext.NewMergeJoinExecutionType.ON;
-                        else if (newMergeJoinString.equals("off"))
-                            newMergeJoin = CompilerContext.NewMergeJoinExecutionType.OFF;
-                        else if (newMergeJoinString.equals("forced"))
-                            newMergeJoin = CompilerContext.NewMergeJoinExecutionType.FORCED;
-                    }
-                } catch (Exception e) {
-                    // If the property value failed to get decoded to a valid value, don't throw an error,
-                    // just use the default setting.
-                }
-                cc.setNewMergeJoin(newMergeJoin);
-
-                String disablePerParallelTaskJoinCostingString =
-                PropertyUtil.getCachedDatabaseProperty(lcc, Property.DISABLE_PARALLEL_TASKS_JOIN_COSTING);
-                boolean disablePerParallelTaskJoinCosting = CompilerContext.DEFAULT_DISABLE_PARALLEL_TASKS_JOIN_COSTING;
-                try {
-                    if (disablePerParallelTaskJoinCostingString != null)
-                        disablePerParallelTaskJoinCosting =
-                        Boolean.parseBoolean(disablePerParallelTaskJoinCostingString);
-                } catch (Exception e) {
-                    // If the property value failed to convert to a boolean, don't throw an error,
-                    // just use the default setting.
-                }
-                cc.setDisablePerParallelTaskJoinCosting(disablePerParallelTaskJoinCosting);
-
-                String currentTimestampPrecisionString =
-                PropertyUtil.getCachedDatabaseProperty(lcc, Property.SPLICE_CURRENT_TIMESTAMP_PRECISION);
-                int currentTimestampPrecision = CompilerContext.DEFAULT_SPLICE_CURRENT_TIMESTAMP_PRECISION;
-                try {
-                    if (currentTimestampPrecisionString != null)
-                        currentTimestampPrecision = Integer.parseInt(currentTimestampPrecisionString);
-                    if (currentTimestampPrecision < 0)
-                        currentTimestampPrecision = 0;
-                    if (currentTimestampPrecision > 9)
-                        currentTimestampPrecision = 9;
-                } catch (Exception e) {
-                    // If the property value failed to convert to a boolean, don't throw an error,
-                    // just use the default setting.
-                }
-                cc.setCurrentTimestampPrecision(currentTimestampPrecision);
-
-                String timestampFormatString =
-                        PropertyUtil.getCachedDatabaseProperty(lcc, Property.SPLICE_TIMESTAMP_FORMAT);
-                if(timestampFormatString == null)
-                    cc.setTimestampFormat(CompilerContext.DEFAULT_TIMESTAMP_FORMAT);
-                else {
-                    try {
-                        // DB-10968 we shouldn't even allow setting this to the wrong value
-                        DateTimeFormatter.ofPattern(timestampFormatString);
-                    } catch(Exception e)
-                    {
-                        timestampFormatString = CompilerContext.DEFAULT_TIMESTAMP_FORMAT;
-                    }
-                    cc.setTimestampFormat(timestampFormatString);
-                }
-
-                String timestampPrecisionString =
-                        PropertyUtil.getCachedDatabaseProperty(lcc, Property.SPLICE_TIMESTAMP_PRECISION);
-                int timestampPrecision = CompilerContext.DEFAULT_TIMESTAMP_PRECISION;
-                try {
-                    if (timestampPrecisionString != null)
-                        timestampPrecision = Integer.parseInt(timestampPrecisionString);
-                    if (timestampPrecision < Limits.MIN_TIMESTAMP_PRECISION)
-                        timestampPrecision = Limits.MIN_TIMESTAMP_PRECISION;
-                    if (timestampPrecision > Limits.MAX_TIMESTAMP_PRECISION)
-                        timestampPrecision = Limits.MAX_TIMESTAMP_PRECISION;
-                } catch (Exception e) {
-                    // If the property value failed to convert to a boolean, don't throw an error,
-                    // just use the default setting.
-                }
-                cc.setTimestampPrecision(timestampPrecision);
-
-                String outerJoinFlatteningDisabledString =
-                PropertyUtil.getCachedDatabaseProperty(lcc, Property.OUTERJOIN_FLATTENING_DISABLED);
-                boolean outerJoinFlatteningDisabled = CompilerContext.DEFAULT_OUTERJOIN_FLATTENING_DISABLED;
-                try {
-                    if (outerJoinFlatteningDisabledString != null)
-                        outerJoinFlatteningDisabled = Boolean.parseBoolean(outerJoinFlatteningDisabledString);
-                } catch (Exception e) {
-                    // If the property value failed to convert to a boolean, don't throw an error,
-                    // just use the default setting.
-                }
-                cc.setOuterJoinFlatteningDisabled(outerJoinFlatteningDisabled);
+                setSelectivityEstimationIncludingSkewedDefault(lcc, cc);
+                setProjectionPruningEnabled(lcc, cc);
+                setMaxMulticolumnProbeValues(lcc, cc);
+                setMulticolumnInlistProbeOnSparkEnabled(lcc, cc);
+                setConvertMultiColumnDNFPredicatesToInList(lcc, cc);
+                setDisablePredicateSimplification(lcc, cc);
+                setNativeSparkAggregationMode(lcc, cc);
+                setAllowOverflowSensitiveNativeSparkExpressions(lcc, cc);
+                setNewMergeJoin(lcc, cc);
+                setDisableParallelTaskJoinCosting(lcc, cc);
+                setCurrentTimestampPrecision(lcc, cc);
+                setOuterJoinFlatteningDisabled(lcc, cc);
 
                 if (!cc.isSparkVersionInitialized()) {
-                    // If splice.spark.version is manually set, use it...
-                    String spliceSparkVersionString = System.getProperty(SPLICE_SPARK_VERSION);
-                    SparkVersion sparkVersion = new SimpleSparkVersion(spliceSparkVersionString);
-
-                    // ... otherwise pick up the splice compile-time version of spark.
-                    if (sparkVersion.isUnknown()) {
-                        spliceSparkVersionString = System.getProperty(SPLICE_SPARK_COMPILE_VERSION);
-                        sparkVersion = new SimpleSparkVersion(spliceSparkVersionString);
-                        if (sparkVersion.isUnknown())
-                            sparkVersion = CompilerContext.DEFAULT_SPLICE_SPARK_VERSION;
-                    }
-                    cc.setSparkVersion(sparkVersion);
+                    setSparkVersion(cc);
                 }
 
-                String ssqFlatteningForUpdateDisabledString =
-                PropertyUtil.getCachedDatabaseProperty(lcc, Property.SSQ_FLATTENING_FOR_UPDATE_DISABLED);
-                boolean ssqFlatteningForUpdateDisabled = CompilerContext.DEFAULT_SSQ_FLATTENING_FOR_UPDATE_DISABLED;
-                try {
-                    if (ssqFlatteningForUpdateDisabledString != null)
-                        ssqFlatteningForUpdateDisabled =
-                        Boolean.parseBoolean(ssqFlatteningForUpdateDisabledString);
-                } catch (Exception e) {
-                    // If the property value failed to convert to a boolean, don't throw an error,
-                    // just use the default setting.
-                }
-                cc.setSSQFlatteningForUpdateDisabled(ssqFlatteningForUpdateDisabled);
-
-                String varcharDB2CompatibilityModeString =
-                PropertyUtil.getCachedDatabaseProperty(lcc, Property.SPLICE_DB2_VARCHAR_COMPATIBLE);
-                boolean varcharDB2CompatibilityMode = CompilerContext.DEFAULT_SPLICE_DB2_VARCHAR_COMPATIBLE;
-                try {
-                    if (varcharDB2CompatibilityModeString != null)
-                        varcharDB2CompatibilityMode =
-                        Boolean.parseBoolean(varcharDB2CompatibilityModeString);
-                    if (varcharDB2CompatibilityMode) {
-                        CharTypeCompiler charTC = getCurrentCharTypeCompiler(lcc);
-                        if (charTC != null) {
-                            charTC.setDB2VarcharCompatibilityMode(varcharDB2CompatibilityMode);
-                            lcc.setDB2VarcharCompatibilityModeNeedsReset(true, charTC);
-                        }
-                    }
-
-                } catch (Exception e) {
-                    // If the property value failed to convert to a boolean, don't throw an error,
-                    // just use the default setting.
-                }
-                cc.setVarcharDB2CompatibilityMode(varcharDB2CompatibilityMode);
+                setSSQFlatteningForUpdateDisabled(lcc, cc);
+                setVarcharDB2CompatibilityMode(lcc, cc);
             }
-            fourPhasePrepare(lcc,paramDefaults,timestamps,beginTimestamp,foundInCache,cc,boundAndOptimizedStatement);
+            fourPhasePrepare(lcc,paramDefaults,timestamps,foundInCache,cc,boundAndOptimizedStatement);
         }catch(StandardException se){
             if(foundInCache)
                 ((GenericLanguageConnectionContext)lcc).removeStatement(this);
@@ -743,6 +504,270 @@ public class GenericStatement implements Statement{
         return preparedStmt;
     }
 
+    private void setVarcharDB2CompatibilityMode(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        String varcharDB2CompatibilityModeString =
+        PropertyUtil.getCachedDatabaseProperty(lcc, Property.SPLICE_DB2_VARCHAR_COMPATIBLE);
+        boolean varcharDB2CompatibilityMode = CompilerContext.DEFAULT_SPLICE_DB2_VARCHAR_COMPATIBLE;
+        try {
+            if (varcharDB2CompatibilityModeString != null)
+                varcharDB2CompatibilityMode =
+                Boolean.parseBoolean(varcharDB2CompatibilityModeString);
+            if (varcharDB2CompatibilityMode) {
+                CharTypeCompiler charTC = getCurrentCharTypeCompiler(lcc);
+                if (charTC != null) {
+                    charTC.setDB2VarcharCompatibilityMode(varcharDB2CompatibilityMode);
+                    lcc.setDB2VarcharCompatibilityModeNeedsReset(true, charTC);
+                }
+            }
+
+        } catch (Exception e) {
+            // If the property value failed to convert to a boolean, don't throw an error,
+            // just use the default setting.
+        }
+        cc.setVarcharDB2CompatibilityMode(varcharDB2CompatibilityMode);
+    }
+
+    private void setSSQFlatteningForUpdateDisabled(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        String ssqFlatteningForUpdateDisabledString =
+        PropertyUtil.getCachedDatabaseProperty(lcc, Property.SSQ_FLATTENING_FOR_UPDATE_DISABLED);
+        boolean ssqFlatteningForUpdateDisabled = CompilerContext.DEFAULT_SSQ_FLATTENING_FOR_UPDATE_DISABLED;
+        try {
+            if (ssqFlatteningForUpdateDisabledString != null)
+                ssqFlatteningForUpdateDisabled =
+                Boolean.parseBoolean(ssqFlatteningForUpdateDisabledString);
+        } catch (Exception e) {
+            // If the property value failed to convert to a boolean, don't throw an error,
+            // just use the default setting.
+        }
+        cc.setSSQFlatteningForUpdateDisabled(ssqFlatteningForUpdateDisabled);
+    }
+
+    private void setSparkVersion(CompilerContext cc) {
+        // If splice.spark.version is manually set, use it...
+        String spliceSparkVersionString = System.getProperty(SPLICE_SPARK_VERSION);
+        SparkVersion sparkVersion = new SimpleSparkVersion(spliceSparkVersionString);
+
+        // ... otherwise pick up the splice compile-time version of spark.
+        if (sparkVersion.isUnknown()) {
+            spliceSparkVersionString = System.getProperty(SPLICE_SPARK_COMPILE_VERSION);
+            sparkVersion = new SimpleSparkVersion(spliceSparkVersionString);
+            if (sparkVersion.isUnknown())
+                sparkVersion = CompilerContext.DEFAULT_SPLICE_SPARK_VERSION;
+        }
+        cc.setSparkVersion(sparkVersion);
+    }
+
+    private void setOuterJoinFlatteningDisabled(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        String outerJoinFlatteningDisabledString =
+        PropertyUtil.getCachedDatabaseProperty(lcc, Property.OUTERJOIN_FLATTENING_DISABLED);
+        boolean outerJoinFlatteningDisabled = CompilerContext.DEFAULT_OUTERJOIN_FLATTENING_DISABLED;
+        try {
+            if (outerJoinFlatteningDisabledString != null)
+                outerJoinFlatteningDisabled = Boolean.parseBoolean(outerJoinFlatteningDisabledString);
+        } catch (Exception e) {
+            // If the property value failed to convert to a boolean, don't throw an error,
+            // just use the default setting.
+        }
+        cc.setOuterJoinFlatteningDisabled(outerJoinFlatteningDisabled);
+    }
+
+    private void setSelectivityEstimationIncludingSkewedDefault(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        /* get the selectivity estimation property so that we know what strategy to use to estimate selectivity */
+        String selectivityEstimationString = PropertyUtil.getServiceProperty(lcc.getTransactionCompile(),
+        Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED);
+        Boolean selectivityEstimationIncludingSkewedDefault = Boolean.parseBoolean(selectivityEstimationString);
+
+        cc.setSelectivityEstimationIncludingSkewedDefault(selectivityEstimationIncludingSkewedDefault);
+    }
+
+    private void setProjectionPruningEnabled(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        /* check if the optimization to do projection pruning is enabled or not */
+        String projectionPruningOptimizationString = PropertyUtil.getCachedDatabaseProperty(lcc,
+        Property.PROJECTION_PRUNING_DISABLED);
+        // if database property is not set, treat it as false
+        Boolean projectionPruningOptimizationDisabled = false;
+        try {
+            if (projectionPruningOptimizationString != null)
+                projectionPruningOptimizationDisabled = Boolean.parseBoolean(projectionPruningOptimizationString);
+        } catch (Exception e) {
+            // If the property value failed to convert to a boolean, don't throw an error,
+            // just use the default setting.
+        }
+        cc.setProjectionPruningEnabled(!projectionPruningOptimizationDisabled);
+    }
+
+    private void setMaxMulticolumnProbeValues(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        // User can specify the max length of multicolumn IN list the optimizer may build for
+        // use as a probe predicate.  Single-column IN lists can be combined up until the point
+        // where adding in the next IN predicate would push us over the limit.
+        String maxMulticolumnProbeValuesString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.MAX_MULTICOLUMN_PROBE_VALUES);
+        int maxMulticolumnProbeValues = CompilerContext.DEFAULT_MAX_MULTICOLUMN_PROBE_VALUES;
+        try {
+            if (maxMulticolumnProbeValuesString != null)
+                maxMulticolumnProbeValues = Integer.parseInt(maxMulticolumnProbeValuesString);
+        } catch (Exception e) {
+            // If the property value failed to convert to an int, don't throw an error,
+            // just use the default setting.
+        }
+        if (maxMulticolumnProbeValues > MAX_MULTICOLUMN_PROBE_VALUES_MAX_VALUE)
+            maxMulticolumnProbeValues = MAX_MULTICOLUMN_PROBE_VALUES_MAX_VALUE;
+        cc.setMaxMulticolumnProbeValues(maxMulticolumnProbeValues);
+    }
+
+    private void setMulticolumnInlistProbeOnSparkEnabled(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        String multicolumnInlistProbeOnSparkEnabledString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED);
+        boolean multicolumnInlistProbeOnSparkEnabled = CompilerContext.DEFAULT_MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED;
+        try {
+            if (multicolumnInlistProbeOnSparkEnabledString != null)
+                multicolumnInlistProbeOnSparkEnabled = Boolean.parseBoolean(multicolumnInlistProbeOnSparkEnabledString);
+        } catch (Exception e) {
+            // If the property value failed to convert to a boolean, don't throw an error,
+            // just use the default setting.
+        }
+        cc.setMulticolumnInlistProbeOnSparkEnabled(multicolumnInlistProbeOnSparkEnabled);
+    }
+
+    private void setConvertMultiColumnDNFPredicatesToInList(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        String convertMultiColumnDNFPredicatesToInListString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.CONVERT_MULTICOLUMN_DNF_PREDICATES_TO_INLIST);
+        boolean convertMultiColumnDNFPredicatesToInList = CompilerContext.DEFAULT_CONVERT_MULTICOLUMN_DNF_PREDICATES_TO_INLIST;
+        try {
+            if (convertMultiColumnDNFPredicatesToInListString != null)
+                convertMultiColumnDNFPredicatesToInList = Boolean.parseBoolean(convertMultiColumnDNFPredicatesToInListString);
+        } catch (Exception e) {
+            // If the property value failed to convert to a boolean, don't throw an error,
+            // just use the default setting.
+        }
+        cc.setConvertMultiColumnDNFPredicatesToInList(convertMultiColumnDNFPredicatesToInList);
+    }
+
+    private void setDisablePredicateSimplification(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        String disablePredicateSimplificationString =
+        PropertyUtil.getCachedDatabaseProperty(lcc, Property.DISABLE_PREDICATE_SIMPLIFICATION);
+        boolean disablePredicateSimplification = CompilerContext.DEFAULT_DISABLE_PREDICATE_SIMPLIFICATION;
+        try {
+            if (disablePredicateSimplificationString != null)
+                disablePredicateSimplification =
+                Boolean.parseBoolean(disablePredicateSimplificationString);
+        } catch (Exception e) {
+            // If the property value failed to convert to a boolean, don't throw an error,
+            // just use the default setting.
+        }
+        cc.setDisablePredicateSimplification(disablePredicateSimplification);
+    }
+
+    private void setNativeSparkAggregationMode(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        String nativeSparkAggregationModeString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.SPLICE_NATIVE_SPARK_AGGREGATION_MODE);
+        CompilerContext.NativeSparkModeType nativeSparkAggregationMode = CompilerContext.DEFAULT_SPLICE_NATIVE_SPARK_AGGREGATION_MODE;
+        try {
+            if (nativeSparkAggregationModeString != null) {
+                nativeSparkAggregationModeString = nativeSparkAggregationModeString.toLowerCase();
+                switch (nativeSparkAggregationModeString) {
+                    case "on":
+                        nativeSparkAggregationMode = CompilerContext.NativeSparkModeType.ON;
+                        break;
+                    case "off":
+                        nativeSparkAggregationMode = CompilerContext.NativeSparkModeType.OFF;
+                        break;
+                    case "forced":
+                        nativeSparkAggregationMode = CompilerContext.NativeSparkModeType.FORCED;
+                        break;
+                    default:
+                        // use default value
+                        break;
+                }
+            }
+        } catch (Exception e) {
+            // If the property value failed to get decoded to a valid value, don't throw an error,
+            // just use the default setting.
+        }
+        cc.setNativeSparkAggregationMode(nativeSparkAggregationMode);
+    }
+
+    private void setAllowOverflowSensitiveNativeSparkExpressions(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        String allowOverflowSensitiveNativeSparkExpressionsString =
+        PropertyUtil.getCachedDatabaseProperty(lcc, Property.SPLICE_ALLOW_OVERFLOW_SENSITIVE_NATIVE_SPARK_EXPRESSIONS);
+        boolean allowOverflowSensitiveNativeSparkExpressions = CompilerContext.DEFAULT_SPLICE_ALLOW_OVERFLOW_SENSITIVE_NATIVE_SPARK_EXPRESSIONS;
+        try {
+            if (allowOverflowSensitiveNativeSparkExpressionsString != null)
+                allowOverflowSensitiveNativeSparkExpressions =
+                Boolean.parseBoolean(allowOverflowSensitiveNativeSparkExpressionsString);
+        } catch (Exception e) {
+            // If the property value failed to convert to a boolean, don't throw an error,
+            // just use the default setting.
+        }
+        cc.setAllowOverflowSensitiveNativeSparkExpressions(allowOverflowSensitiveNativeSparkExpressions);
+    }
+
+    private void setNewMergeJoin(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        String newMergeJoinString =
+        PropertyUtil.getCachedDatabaseProperty(lcc, Property.SPLICE_NEW_MERGE_JOIN);
+        CompilerContext.NewMergeJoinExecutionType newMergeJoin =
+        CompilerContext.DEFAULT_SPLICE_NEW_MERGE_JOIN;
+        try {
+            if (newMergeJoinString != null) {
+                newMergeJoinString = newMergeJoinString.toLowerCase();
+                if (newMergeJoinString.equals("on"))
+                    newMergeJoin = CompilerContext.NewMergeJoinExecutionType.ON;
+                else if (newMergeJoinString.equals("off"))
+                    newMergeJoin = CompilerContext.NewMergeJoinExecutionType.OFF;
+                else if (newMergeJoinString.equals("forced"))
+                    newMergeJoin = CompilerContext.NewMergeJoinExecutionType.FORCED;
+            }
+        } catch (Exception e) {
+            // If the property value failed to get decoded to a valid value, don't throw an error,
+            // just use the default setting.
+        }
+        cc.setNewMergeJoin(newMergeJoin);
+    }
+
+    private void setDisableParallelTaskJoinCosting(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        String disablePerParallelTaskJoinCostingString =
+        PropertyUtil.getCachedDatabaseProperty(lcc, Property.DISABLE_PARALLEL_TASKS_JOIN_COSTING);
+        boolean disablePerParallelTaskJoinCosting = CompilerContext.DEFAULT_DISABLE_PARALLEL_TASKS_JOIN_COSTING;
+        try {
+            if (disablePerParallelTaskJoinCostingString != null)
+                disablePerParallelTaskJoinCosting =
+                Boolean.parseBoolean(disablePerParallelTaskJoinCostingString);
+        } catch (Exception e) {
+            // If the property value failed to convert to a boolean, don't throw an error,
+            // just use the default setting.
+        }
+        cc.setDisablePerParallelTaskJoinCosting(disablePerParallelTaskJoinCosting);
+    }
+
+    private void setCurrentTimestampPrecision(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        String currentTimestampPrecisionString =
+        PropertyUtil.getCachedDatabaseProperty(lcc, Property.SPLICE_CURRENT_TIMESTAMP_PRECISION);
+        int currentTimestampPrecision = CompilerContext.DEFAULT_SPLICE_CURRENT_TIMESTAMP_PRECISION;
+        try {
+            if (currentTimestampPrecisionString != null)
+                currentTimestampPrecision = Integer.parseInt(currentTimestampPrecisionString);
+            if (currentTimestampPrecision < 0)
+                currentTimestampPrecision = 0;
+            if (currentTimestampPrecision > 9)
+                currentTimestampPrecision = 9;
+        } catch (Exception e) {
+            // If the property value failed to convert to a boolean, don't throw an error,
+            // just use the default setting.
+        }
+        cc.setCurrentTimestampPrecision(currentTimestampPrecision);
+
+        String timestampFormatString =
+                PropertyUtil.getCachedDatabaseProperty(lcc, Property.SPLICE_TIMESTAMP_FORMAT);
+        if(timestampFormatString == null)
+            cc.setTimestampFormat(CompilerContext.DEFAULT_TIMESTAMP_FORMAT);
+        else {
+            try {
+                // DB-10968 we shouldn't even allow setting this to the wrong value
+                DateTimeFormatter.ofPattern(timestampFormatString);
+            } catch(Exception e)
+            {
+                timestampFormatString = CompilerContext.DEFAULT_TIMESTAMP_FORMAT;
+            }
+            cc.setTimestampFormat(timestampFormatString);
+        }
+    }
+
     /*
      * Performs the 4-phase preparation of the statement. The four
      * phases are:
@@ -755,7 +780,6 @@ public class GenericStatement implements Statement{
     private void fourPhasePrepare(LanguageConnectionContext lcc,
                                   Object[] paramDefaults,
                                   long[] timestamps,
-                                  Timestamp beginTimestamp,
                                   boolean foundInCache,
                                   CompilerContext cc,
                                   StatementNode boundAndOptimizedStatement) throws StandardException{

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayTypeCompiler.java
@@ -32,6 +32,7 @@ import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 import com.splicemachine.db.iapi.services.loader.ClassFactory;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.sql.compile.TypeCompiler;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
@@ -104,7 +105,7 @@ public class ArrayTypeCompiler extends BaseTypeCompiler
         /**
          * @see TypeCompiler#getCastToCharWidth
          */
-        public int getCastToCharWidth(DataTypeDescriptor dts)
+        public int getCastToCharWidth(DataTypeDescriptor dts, CompilerContext compilerContext)
         {
                 return dts.getMaximumWidth();
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BitTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BitTypeCompiler.java
@@ -37,6 +37,7 @@ import com.splicemachine.db.iapi.services.sanity.SanityManager;
 
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.types.TypeId;
 
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
@@ -120,7 +121,7 @@ public class BitTypeCompiler extends BaseTypeCompiler
         /**
          * @see TypeCompiler#getCastToCharWidth
          */
-        public int getCastToCharWidth(DataTypeDescriptor dts)
+        public int getCastToCharWidth(DataTypeDescriptor dts, CompilerContext compilerContext)
         {
                 return dts.getMaximumWidth();
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BooleanTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BooleanTypeCompiler.java
@@ -33,6 +33,7 @@ package com.splicemachine.db.impl.sql.compile;
 
 import com.splicemachine.db.iapi.services.loader.ClassFactory;
 
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.TypeId;
 
@@ -114,7 +115,7 @@ public class BooleanTypeCompiler extends BaseTypeCompiler
 	/**
 	 * @see TypeCompiler#getCastToCharWidth
 	 */
-	public int getCastToCharWidth(DataTypeDescriptor dts)
+	public int getCastToCharWidth(DataTypeDescriptor dts, CompilerContext compilerContext)
 	{
 		return TypeCompiler.BOOLEAN_MAXWIDTH_AS_CHAR;
 	}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CLOBTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CLOBTypeCompiler.java
@@ -35,6 +35,7 @@ import com.splicemachine.db.iapi.services.loader.ClassFactory;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.types.StringDataValue;
 import com.splicemachine.db.iapi.types.TypeId;
 
@@ -113,7 +114,7 @@ public class CLOBTypeCompiler extends BaseTypeCompiler
         /**
          * @see TypeCompiler#getCastToCharWidth
          */
-        public int getCastToCharWidth(DataTypeDescriptor dts)
+        public int getCastToCharWidth(DataTypeDescriptor dts, CompilerContext compilerContext)
         {
                 return dts.getMaximumWidth();
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CastNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CastNode.java
@@ -380,11 +380,7 @@ public class CastNode extends ValueNode
                         DataValueDescriptor dvd = ((ConstantNode) castOperand).getValue();
                         String castValue;
                         if (dvd instanceof SQLTimestamp) {
-                            int precision = getCompilerContext().getTimestampPrecision();
-                            if(SanityManager.DEBUG) {
-                                SanityManager.ASSERT(precision >= Limits.MIN_TIMESTAMP_PRECISION && precision <= Limits.MAX_TIMESTAMP_PRECISION);
-                            }
-                            ((SQLTimestamp) dvd).setPrecision(precision);
+                            ((SQLTimestamp) dvd).setTimestampFormat(getCompilerContext().getTimestampFormat());
                         }
                         if (dvd instanceof DateTimeDataValue && dateToStringFormat >= 0) {
                             ((DateTimeDataValue) dvd).setStringFormat(dateToStringFormat);
@@ -1038,12 +1034,12 @@ public class CastNode extends ValueNode
                         "setStringFormat", "void", 1);
             }
             if (sourceCTI.isDateTimeTimeStampTypeId() && sourceCTI.getJDBCTypeId() == Types.TIMESTAMP) {
-                int precision = getCompilerContext().getTimestampPrecision();
+                String timestampFormat = getCompilerContext().getTimestampFormat();
                 mb.dup();
                 mb.cast("com.splicemachine.db.iapi.types.SQLTimestamp");
-                mb.push(precision);
+                mb.push(timestampFormat);
                 mb.callMethod(VMOpcode.INVOKEVIRTUAL, "com.splicemachine.db.iapi.types.SQLTimestamp",
-                              "setPrecision", "void", 1);
+                              "setTimestampFormat", "void", 1);
             }
             if (isForSbcsData()) {
                 mb.callMethod(VMOpcode.INVOKEINTERFACE, ClassName.DataValueDescriptor,
@@ -1143,15 +1139,10 @@ public class CastNode extends ValueNode
                 else if (this.targetCharType == Types.VARCHAR)
                     length = Math.min(length, Limits.DB2_VARCHAR_MAXWIDTH);
             } else if(srcTypeId.isDateTimeTimeStampTypeId() && opndType.getJDBCTypeId() == Types.TIMESTAMP) {
-                int precision = getCompilerContext().getTimestampPrecision();
-                if(SanityManager.DEBUG) {
-                    SanityManager.ASSERT(precision >= Limits.MIN_TIMESTAMP_PRECISION && precision <= Limits.MAX_TIMESTAMP_PRECISION);
-                }
-                length = precision == 0 ? Limits.MIN_TIMESTAMP_LENGTH : Limits.MIN_TIMESTAMP_LENGTH /* the trailing dot */ + 1 + precision;
+                length = getCompilerContext().getTimestampFormat().length();
             } else {
                 TypeId typeid = opndType.getTypeId();
                 length = DataTypeUtilities.getColumnDisplaySize(typeid.getJDBCTypeId(), -1);
-
             }
             if (length < 0)
                 length = 1;  // same default as in parser

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CastNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CastNode.java
@@ -1139,7 +1139,14 @@ public class CastNode extends ValueNode
                 else if (this.targetCharType == Types.VARCHAR)
                     length = Math.min(length, Limits.DB2_VARCHAR_MAXWIDTH);
             } else if(srcTypeId.isDateTimeTimeStampTypeId() && opndType.getJDBCTypeId() == Types.TIMESTAMP) {
-                length = getCompilerContext().getTimestampFormat().length();
+                try {
+                    length = SQLTimestamp.getFormatLength(getCompilerContext().getTimestampFormat());
+                } catch(IllegalArgumentException e)
+                {
+                    // we shouldn't get here as GenericStatement should've checked that, but let's be defensive
+                    // and not throw
+                    length = getCompilerContext().getTimestampFormat().length() + 10;
+                }
             } else {
                 TypeId typeid = opndType.getTypeId();
                 length = DataTypeUtilities.getColumnDisplaySize(typeid.getJDBCTypeId(), -1);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CharTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CharTypeCompiler.java
@@ -31,12 +31,9 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
-import com.splicemachine.db.iapi.reference.Property;
 import com.splicemachine.db.iapi.services.context.ContextManager;
-import com.splicemachine.db.iapi.services.context.ContextService;
 import com.splicemachine.db.iapi.services.loader.ClassFactory;
 
-import com.splicemachine.db.iapi.services.property.PropertyUtil;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
@@ -162,7 +159,7 @@ public final class CharTypeCompiler extends BaseTypeCompiler
         /**
          * @see TypeCompiler#getCastToCharWidth
          */
-        public int getCastToCharWidth(DataTypeDescriptor dts)
+        public int getCastToCharWidth(DataTypeDescriptor dts, CompilerContext compilerContext)
         {
                 return dts.getMaximumWidth();
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
@@ -56,6 +56,7 @@ import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.util.ReuseFactory;
 import com.splicemachine.system.SparkVersion;
 import com.splicemachine.utils.Pair;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.sql.SQLWarning;
 import java.util.*;
@@ -301,20 +302,12 @@ public class CompilerContextImpl extends ContextImpl
         currentTimestampPrecision = newValue;
     }
 
-    public void setTimestampPrecision(int newValue) {
-        timestampPrecision = newValue;
-    }
-
     public void setTimestampFormat(String value) {
         timestampFormat = value;
     }
 
     public int getCurrentTimestampPrecision() {
         return currentTimestampPrecision;
-    }
-
-    public int getTimestampPrecision() {
-        return timestampPrecision;
     }
 
     public String getTimestampFormat() {
@@ -755,6 +748,7 @@ public class CompilerContextImpl extends ContextImpl
     /**
      * @see CompilerContext#getParameterTypes
      */
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     public DataTypeDescriptor[] getParameterTypes()
     {
         return parameterDescriptors;
@@ -1191,7 +1185,6 @@ public class CompilerContextImpl extends ContextImpl
     private       CompilerContext.NativeSparkModeType nativeSparkAggregationMode                   = DEFAULT_SPLICE_NATIVE_SPARK_AGGREGATION_MODE;
     private       boolean                             allowOverflowSensitiveNativeSparkExpressions = DEFAULT_SPLICE_ALLOW_OVERFLOW_SENSITIVE_NATIVE_SPARK_EXPRESSIONS;
     private       int                                 currentTimestampPrecision                    = DEFAULT_SPLICE_CURRENT_TIMESTAMP_PRECISION;
-    private       int                                 timestampPrecision                           = DEFAULT_TIMESTAMP_PRECISION;
 
     private       String                              timestampFormat                              = DEFAULT_TIMESTAMP_FORMAT;
     // Used to track the flattened half outer joins.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
@@ -305,12 +305,20 @@ public class CompilerContextImpl extends ContextImpl
         timestampPrecision = newValue;
     }
 
+    public void setTimestampFormat(String value) {
+        timestampFormat = value;
+    }
+
     public int getCurrentTimestampPrecision() {
         return currentTimestampPrecision;
     }
 
     public int getTimestampPrecision() {
         return timestampPrecision;
+    }
+
+    public String getTimestampFormat() {
+        return timestampFormat;
     }
 
     public boolean isOuterJoinFlatteningDisabled() {
@@ -1184,6 +1192,8 @@ public class CompilerContextImpl extends ContextImpl
     private       boolean                             allowOverflowSensitiveNativeSparkExpressions = DEFAULT_SPLICE_ALLOW_OVERFLOW_SENSITIVE_NATIVE_SPARK_EXPRESSIONS;
     private       int                                 currentTimestampPrecision                    = DEFAULT_SPLICE_CURRENT_TIMESTAMP_PRECISION;
     private       int                                 timestampPrecision                           = DEFAULT_TIMESTAMP_PRECISION;
+
+    private       String                              timestampFormat                              = DEFAULT_TIMESTAMP_FORMAT;
     // Used to track the flattened half outer joins.
     private       int                                 nextOJLevel                                  = 1;
     private       boolean                             outerJoinFlatteningDisabled;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConcatenationOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConcatenationOperatorNode.java
@@ -244,7 +244,7 @@ public class ConcatenationOperatorNode extends BinaryOperatorNode {
 		if (!(leftOperand.getTypeId().isStringTypeId() || leftOperand
 				.getTypeId().isBitTypeId())) {
 			int leftWidth = (tc instanceof UserDefinedTypeCompiler) ? DB2_VARCHAR_MAXWIDTH :
-			                 tc.getCastToCharWidth(leftOperand.getTypeServices());
+			                 tc.getCastToCharWidth(leftOperand.getTypeServices(), getCompilerContext());
 			DataTypeDescriptor dtd = DataTypeDescriptor.getBuiltInDataTypeDescriptor(
 					Types.VARCHAR, true, leftWidth);
 
@@ -264,7 +264,7 @@ public class ConcatenationOperatorNode extends BinaryOperatorNode {
 		if (!(rightOperand.getTypeId().isStringTypeId() || rightOperand
 				.getTypeId().isBitTypeId())) {
 			int rightWidth = (tc instanceof UserDefinedTypeCompiler) ? DB2_VARCHAR_MAXWIDTH :
-			                 tc.getCastToCharWidth(rightOperand.getTypeServices());
+			                 tc.getCastToCharWidth(rightOperand.getTypeServices(), getCompilerContext());
 			DataTypeDescriptor dtd = DataTypeDescriptor.getBuiltInDataTypeDescriptor(
 					Types.VARCHAR, true, rightWidth);
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DateTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DateTypeCompiler.java
@@ -36,6 +36,7 @@ import com.splicemachine.db.iapi.services.loader.ClassFactory;
 
 import com.splicemachine.db.iapi.error.StandardException;
 
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.TypeId;
 
@@ -117,7 +118,7 @@ public class DateTypeCompiler extends BaseTypeCompiler
 	/**
 	 * @see TypeCompiler#getCastToCharWidth
 	 */
-	public int getCastToCharWidth(DataTypeDescriptor dts)
+	public int getCastToCharWidth(DataTypeDescriptor dts, CompilerContext compilerContext)
 	{
 		return 10;
 	}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExtractOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExtractOperatorNode.java
@@ -124,7 +124,7 @@ public class ExtractOperatorNode extends UnaryOperatorNode {
 					operand, 
 					DataTypeDescriptor.getBuiltInDataTypeDescriptor(castType, true, 
 										tc.getCastToCharWidth(
-												operand.getTypeServices())),
+												operand.getTypeServices(), getCompilerContext())),
 					getContextManager());
 			((CastNode) operand).bindCastNodeOnly();
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LOBTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LOBTypeCompiler.java
@@ -37,6 +37,7 @@ import com.splicemachine.db.iapi.services.sanity.SanityManager;
 
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.types.TypeId;
 
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
@@ -113,7 +114,7 @@ public class LOBTypeCompiler extends BaseTypeCompiler
         /**
          * @see TypeCompiler#getCastToCharWidth
          */
-        public int getCastToCharWidth(DataTypeDescriptor dts)
+        public int getCastToCharWidth(DataTypeDescriptor dts, CompilerContext compilerContext)
         {
                 return dts.getMaximumWidth();
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NumericTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NumericTypeCompiler.java
@@ -32,6 +32,7 @@
 package com.splicemachine.db.impl.sql.compile;
 
 
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.services.context.ContextService;
 import com.splicemachine.db.iapi.services.loader.ClassFactory;
@@ -158,7 +159,7 @@ public final class NumericTypeCompiler extends BaseTypeCompiler
     /**
      * @see TypeCompiler#getCastToCharWidth
      */
-    public int getCastToCharWidth(DataTypeDescriptor dts)
+    public int getCastToCharWidth(DataTypeDescriptor dts, CompilerContext compilerContext)
     {
         int formatId = getStoredFormatIdFromTypeId();
         switch (formatId)

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RefTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RefTypeCompiler.java
@@ -34,6 +34,7 @@ package com.splicemachine.db.impl.sql.compile;
 import java.sql.Types;
 
 import com.splicemachine.db.iapi.services.loader.ClassFactory;
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.sql.compile.TypeCompiler;
@@ -58,7 +59,7 @@ public class RefTypeCompiler extends BaseTypeCompiler
 	/**
 	 * @see TypeCompiler#getCastToCharWidth
 	 */
-	public int getCastToCharWidth(DataTypeDescriptor dts)
+	public int getCastToCharWidth(DataTypeDescriptor dts, CompilerContext compilerContext)
 	{
 		if (SanityManager.DEBUG)
 			SanityManager.THROWASSERT( "getCastToCharWidth not implemented for SQLRef");

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SimpleLocaleStringOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SimpleLocaleStringOperatorNode.java
@@ -103,7 +103,7 @@ public class SimpleLocaleStringOperatorNode extends BinaryOperatorNode
 		TypeId operandType = leftOperand.getTypeId();
 
 		int leftWidth = leftOperand.getTypeCompiler().getCastToCharWidth(
-		        leftOperand.getTypeServices());
+		        leftOperand.getTypeServices(), getCompilerContext());
 		if (leftWidth > Limits.DB2_LOB_MAXWIDTH / 2) {
 		    throw StandardException.newException(SQLState.BLOB_LENGTH_TOO_LONG, methodName,
                     leftWidth * 2);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SimpleStringOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SimpleStringOperatorNode.java
@@ -110,7 +110,7 @@ public class SimpleStringOperatorNode extends UnaryOperatorNode
 					DataTypeDescriptor dtd = DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, true, 
 							  operand.getTypeCompiler().
 								getCastToCharWidth(
-									operand.getTypeServices()));
+									operand.getTypeServices(), getCompilerContext()));
 			
 					operand =  (ValueNode)
 						getNodeFactory().getNode(
@@ -134,7 +134,7 @@ public class SimpleStringOperatorNode extends UnaryOperatorNode
 		setType(new DataTypeDescriptor(operandType,
 				operand.getTypeServices().isNullable(),
 				operand.getTypeCompiler().
-					getCastToCharWidth(operand.getTypeServices())
+					getCastToCharWidth(operand.getTypeServices(), getCompilerContext())
 						)
 				);
 		//Result of upper()/lower() will have the same collation as the   

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
@@ -838,7 +838,7 @@ public class TernaryOperatorNode extends OperatorNode
         {
             DataTypeDescriptor dtd = DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, true,
                     vnTC.getCastToCharWidth(
-                            vn.getTypeServices()));
+                            vn.getTypeServices(), getCompilerContext()));
 
             ValueNode newNode = (ValueNode)
                         getNodeFactory().getNode(

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TimeTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TimeTypeCompiler.java
@@ -33,6 +33,7 @@ package com.splicemachine.db.impl.sql.compile;
 
 import com.splicemachine.db.iapi.services.loader.ClassFactory;
 
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.TypeId;
 
@@ -116,7 +117,7 @@ public class TimeTypeCompiler extends BaseTypeCompiler
 	/**
 	 * @see TypeCompiler#getCastToCharWidth
 	 */
-	public int getCastToCharWidth(DataTypeDescriptor dts)
+	public int getCastToCharWidth(DataTypeDescriptor dts, CompilerContext compilerContext)
 	{
 		return 8;
 	}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TimestampTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TimestampTypeCompiler.java
@@ -36,7 +36,9 @@ import com.splicemachine.db.iapi.services.loader.ClassFactory;
 
 import com.splicemachine.db.iapi.error.StandardException;
 
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+import com.splicemachine.db.iapi.types.SQLTimestamp;
 import com.splicemachine.db.iapi.types.TypeId;
 
 import com.splicemachine.db.iapi.sql.compile.TypeCompiler;
@@ -142,9 +144,9 @@ public class TimestampTypeCompiler extends BaseTypeCompiler
 	/**
 	 * @see TypeCompiler#getCastToCharWidth
 	 */
-	public int getCastToCharWidth(DataTypeDescriptor dts)
+	public int getCastToCharWidth(DataTypeDescriptor dts, CompilerContext compilerContext)
 	{
-		return 26; // DATE TIME.milliseconds (extra few for good measure)
+		return SQLTimestamp.getFormatLength(compilerContext.getTimestampFormat());
 	}
 
 	public double estimatedMemoryUsage(DataTypeDescriptor dtd)

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UserDefinedTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UserDefinedTypeCompiler.java
@@ -34,6 +34,7 @@ package com.splicemachine.db.impl.sql.compile;
 import com.splicemachine.db.iapi.services.classfile.VMOpcode;
 import com.splicemachine.db.iapi.services.context.ContextService;
 import com.splicemachine.db.iapi.services.loader.ClassFactory;
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.TypeId;
@@ -133,7 +134,7 @@ public class UserDefinedTypeCompiler extends BaseTypeCompiler
 	/**
 	 * @see TypeCompiler#getCastToCharWidth
 	 */
-	public int getCastToCharWidth(DataTypeDescriptor dts)
+	public int getCastToCharWidth(DataTypeDescriptor dts, CompilerContext compilerContext)
 	{
 		// This is the maximum maximum width for user types
 		return -1;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UserTypeConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UserTypeConstantNode.java
@@ -35,6 +35,7 @@ import com.splicemachine.db.iapi.error.StandardException;
 
 import com.splicemachine.db.iapi.reference.Limits;
 import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.sql.compile.TypeCompiler;
 
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
@@ -285,8 +286,8 @@ public class UserTypeConstantNode extends ConstantNode {
              */
             String typeName = getTypeId().getCorrespondingJavaTypeName();
             if(getTypeId().getJDBCTypeId() == Types.TIMESTAMP) {
-                int precision = getCompilerContext().getTimestampPrecision();
-                ((SQLTimestamp) value).setPrecision(precision);
+                // use default here as Timestamp.valueOf is expecting it, so no need to change valueOf
+                ((SQLTimestamp) value).setTimestampFormat(CompilerContext.DEFAULT_TIMESTAMP_FORMAT);
             }
             mb.push(value.toString());
             mb.callMethod(VMOpcode.INVOKESTATIC, typeName, "valueOf", typeName, 1);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/XMLTypeCompiler.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/XMLTypeCompiler.java
@@ -34,6 +34,7 @@ package com.splicemachine.db.impl.sql.compile;
 import com.splicemachine.db.iapi.services.loader.ClassFactory;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.sql.compile.TypeCompiler;
 
 import com.splicemachine.db.iapi.types.TypeId;
@@ -130,7 +131,7 @@ public class XMLTypeCompiler extends BaseTypeCompiler
      * can get called before we finish type checking--so we return a dummy
      * value here and let the type check throw the appropriate error.
      */
-    public int getCastToCharWidth(DataTypeDescriptor dts)
+    public int getCastToCharWidth(DataTypeDescriptor dts, CompilerContext compilerContext)
     {
         return -1;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CurrentDatetime.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CurrentDatetime.java
@@ -31,12 +31,6 @@
 
 package com.splicemachine.db.impl.sql.execute;
 
-/* can't import due to name overlap:
-import java.util.Date;
-*/
-import com.splicemachine.concurrent.TickingClock;
-import org.glassfish.jersey.spi.Contract;
-
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1468,6 +1468,8 @@ public interface Property {
      */
     String SPLICE_TIMESTAMP_PRECISION = "splice.function.timestampPrecision";
 
+    String SPLICE_TIMESTAMP_FORMAT = "splice.function.timestampFormat";
+
     String OUTERJOIN_FLATTENING_DISABLED = "derby.database.outerJoinFlatteningDisabled";
 
     String SSQ_FLATTENING_FOR_UPDATE_DISABLED = "derby.database.ssqFlatteningForUpdateDisabled";

--- a/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableUnitTests.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExternalTableUnitTests.java
@@ -18,9 +18,11 @@ package com.splicemachine.derby.impl.sql.execute.operations;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.derby.stream.spark.SparkExternalTableUtil;
 import com.splicemachine.derby.stream.utils.ExternalTableUtils;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.system.CsvOptions;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.Assert;
 import org.junit.Test;
@@ -102,14 +104,10 @@ public class ExternalTableUnitTests {
         StructType s = new StructType();
         s = s.add("ws_sold_date_sk", DataTypes.DoubleType);
 
-        try {
-            SparkExternalTableUtil.parsePartitionsFromFiles(files, true, basePaths, s,null);
-            Assert.fail("no exception");
-        }
-        catch( Exception e)
-        {
-            Assert.assertEquals(e.toString(), "java.lang.IllegalArgumentException: Column ws_sold_date_sk is double, can't parse HELLO");
-        }
+        StructType finalS = s;
+        SpliceUnitTest.assertThrows( () -> {
+            SparkExternalTableUtil.parsePartitionsFromFiles(files, true, basePaths, finalS,null); },
+                "java.lang.IllegalArgumentException: Column ws_sold_date_sk is double, can't parse HELLO");
     }
 
     @Test

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SQLTypesUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SQLTypesUnitTest.java
@@ -3,6 +3,7 @@ package com.splicemachine.derby.impl.sql.execute.operations;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.types.*;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.homeless.SerializationTest;
 import com.splicemachine.primitives.Bytes;
 import org.joda.time.DateTime;
@@ -107,17 +108,17 @@ public class SQLTypesUnitTest {
     @Test
     public void testTimestampLengthFixed() throws StandardException {
         Assert.assertEquals(SQLTimestamp.getFormatLength(CompilerContext.DEFAULT_TIMESTAMP_FORMAT), CompilerContext.DEFAULT_TIMESTAMP_FORMAT.length());
-        Assert.assertEquals(SQLTimestamp.getFormatLength("yyyy-MM-dd-HH.mm.ss.SSSSSSSSS"), "yyyy-MM-dd-HH.mm.ss.SSSSSSSSS".length());
+        Assert.assertEquals(SQLTimestamp.getFormatLength("yyyy-MM-dd  HH.mm.ss.SSSSSSSSS"), "yyyy-MM-dd  HH.mm.ss.SSSSSSSSS".length());
         Assert.assertEquals(SQLTimestamp.getFormatLength("MM/dd/yyyy HH:mm:ss.SSSSS"), "MM/dd/yyyy HH:mm:ss.SSSSS".length());
         Assert.assertEquals(SQLTimestamp.getFormatLength("yyyy.MM.dd HH mm ss.SSSSS"), "yyyy-MM-dd-HH.mm.ss.SSSSS".length());
         Assert.assertEquals(SQLTimestamp.getFormatLength("hh:mm:ss a"), "12:34:56 PM".length());
-        try {
-            SQLTimestamp.getFormatLength("h:mm:ss a");
-            Assert.fail("expected exception");
-        } catch(RuntimeException e)
-        {
-            Assert.assertEquals("not supported format \"h:mm:ss a\": 'h' can't be repeated 1 times", e.getMessage());
-        }
+
+        SpliceUnitTest.assertThrows( () -> { SQLTimestamp.getFormatLength("h:mm:ss a") ; },
+                "java.lang.IllegalArgumentException: not supported format \"h:mm:ss a\": 'h' can't be repeated 1 times");
+        SpliceUnitTest.assertThrows( () -> { SQLTimestamp.getFormatLength("mm:ss:h"); },
+                "java.lang.IllegalArgumentException: not supported format \"mm:ss:h\": 'h' can't be repeated 1 times");
+        SpliceUnitTest.assertThrows( () -> { SQLTimestamp.getFormatLength("yyyy-MM-dd  HH.mm.ss.SSSSSSSSSS"); },
+                "java.lang.IllegalArgumentException: not supported format \"yyyy-MM-dd  HH.mm.ss.SSSSSSSSSS\": 'S' can't be repeated 10 times");
     }
 
     @Test

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SQLTypesUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SQLTypesUnitTest.java
@@ -1,0 +1,135 @@
+package com.splicemachine.derby.impl.sql.execute.operations;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
+import com.splicemachine.db.iapi.types.*;
+import com.splicemachine.homeless.SerializationTest;
+import com.splicemachine.primitives.Bytes;
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+
+public class SQLTypesUnitTest {
+    @Test
+    public void testDate() throws StandardException, IOException, ClassNotFoundException {
+        SQLDate d = new SQLDate("1999-05-03", false, null);
+        Assert.assertEquals( d.toString(), "1999-05-03");
+        Assert.assertEquals( new SQLDate("05/03/1999", false, null).toString(),
+                "1999-05-03");
+        Assert.assertEquals( new SQLDate("03.05.1999", false, null).toString(),
+                "1999-05-03");
+
+        SQLInteger i = new SQLInteger();
+        Assert.assertEquals(d.getYear(i).getInt(), 1999);
+        Assert.assertEquals(d.getMonth(i).getInt(), 05);
+        Assert.assertEquals(d.getDate(i).getInt(), 03);
+        Assert.assertEquals(d.getQuarter(i).getInt(), 2);
+
+        SQLDate d2 = new SQLDate();
+        d.plus(d, new SQLInteger(4), d2);
+        Assert.assertEquals( d2.toString(), "1999-05-07");
+
+        d.minus(d, new SQLInteger(2), d2);
+        Assert.assertEquals( d2.toString(), "1999-05-01");
+
+        d.minus(d, d2, i);
+        Assert.assertEquals( i.getInt(), 2);
+
+        d.setStringFormat(DateTimeDataValue.ISO);
+        Assert.assertEquals(d.getString(), "1999-05-03");
+        d.setStringFormat(DateTimeDataValue.USA);
+        Assert.assertEquals(d.getString(), "05/03/1999");
+        d.setStringFormat(DateTimeDataValue.EUR);
+        Assert.assertEquals(d.getString(), "03.05.1999");
+    }
+
+    @Test
+    public void testTime() throws StandardException, IOException, ClassNotFoundException {
+        SQLTime t = new SQLTime("04:38:01", false, null);
+        Assert.assertEquals("04:38:01", t.toString());
+
+        t = new SQLTime("04.38.01", false, null);
+        Assert.assertEquals("04:38:01", t.toString());
+
+        t = new SQLTime("04 PM", false, null);
+        Assert.assertEquals("16:00:00", t.toString());
+
+        t = new SQLTime("04:38 PM", false, null);
+        Assert.assertEquals("16:38:00", t.toString());
+
+        t = new SQLTime("04:38:01 PM", false, null);
+        Assert.assertEquals("16:38:01", t.toString());
+    }
+
+    @Test
+    public void testTimestamp() throws StandardException, IOException, ClassNotFoundException {
+        SQLTimestamp ts = new SQLTimestamp(Timestamp.valueOf("1867-02-28 04:38:01.042612356"));
+        Assert.assertEquals("1867-02-28 04:38:01.042612356", ts.toString());
+
+        SQLTimestamp ts2 = new SQLTimestamp();
+        ts.plus(ts, new SQLInteger(5), ts2);
+        Assert.assertEquals("1867-03-05 04:38:01.042612356", ts2.toString());
+
+        SQLTimestamp ts3 = new SQLTimestamp();
+        ts2.minus(ts2, new SQLInteger(4), ts3);
+        Assert.assertEquals("1867-03-01 04:38:01.042612356", ts3.toString());
+    }
+
+    @Test
+    public void testTimestampExtractOperatorNode() throws StandardException {
+        SQLTimestamp ts = new SQLTimestamp(Timestamp.valueOf("1867-02-28 04:38:01.0426123"));
+
+        // test all methods used in ExtractOperatorNode
+        SQLInteger i = new SQLInteger();
+        Assert.assertEquals( ts.getHours(i).getInt(), 04);
+        Assert.assertEquals( ts.getMinutes(i).getInt(), 38);
+        Assert.assertEquals( ts.getSeconds(i).getInt(), 01);
+        Assert.assertEquals( ts.getNanos(), 42612300);
+
+        Assert.assertEquals( ts.getYear(i).getInt(), 1867);
+        Assert.assertEquals( ts.getMonth(i).getInt(), 02);
+        Assert.assertEquals( ts.getDate(i).getInt(), 28);
+
+        Assert.assertEquals( ts.getQuarter(i).getInt(), 1);
+        Assert.assertEquals( ts.getMonthName(null).toString(), "February");
+        Assert.assertEquals( ts.getWeek(i).getInt(), 9);
+        Assert.assertEquals( ts.getWeekDay(i).getInt(), 4);
+        Assert.assertEquals( ts.getWeekDayName(null).toString(), "Thursday");
+        Assert.assertEquals( ts.getDayOfYear(i).getInt(), 59);
+
+        DateTime dt = ts.getDateTime();
+        Assert.assertEquals( dt.toString(), "1867-02-28T04:38:01.042+00:53:28");
+    }
+
+    @Test
+    public void testTimestampLengthFixed() throws StandardException {
+        Assert.assertEquals(SQLTimestamp.getFormatLength(CompilerContext.DEFAULT_TIMESTAMP_FORMAT), CompilerContext.DEFAULT_TIMESTAMP_FORMAT.length());
+        Assert.assertEquals(SQLTimestamp.getFormatLength("yyyy-MM-dd-HH.mm.ss.SSSSSSSSS"), "yyyy-MM-dd-HH.mm.ss.SSSSSSSSS".length());
+        Assert.assertEquals(SQLTimestamp.getFormatLength("MM/dd/yyyy HH:mm:ss.SSSSS"), "MM/dd/yyyy HH:mm:ss.SSSSS".length());
+        Assert.assertEquals(SQLTimestamp.getFormatLength("yyyy.MM.dd HH mm ss.SSSSS"), "yyyy-MM-dd-HH.mm.ss.SSSSS".length());
+        Assert.assertEquals(SQLTimestamp.getFormatLength("hh:mm:ss a"), "12:34:56 PM".length());
+        try {
+            SQLTimestamp.getFormatLength("h:mm:ss a");
+            Assert.fail("expected exception");
+        } catch(RuntimeException e)
+        {
+            Assert.assertEquals("not supported format \"h:mm:ss a\": 'h' can't be repeated 1 times", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testTimestampParseJDBC() throws StandardException, IOException, ClassNotFoundException {
+        SQLTimestamp ts = new SQLTimestamp("1867-02-28 04:38:01.0426123", false, null);
+        ts.setTimestampFormat("yyyy-MM-dd-HH.mm.ss.SSSSSSSSS");
+        Assert.assertEquals("1867-02-28-04.38.01.042612300", ts.toString());
+
+    }
+    @Test
+    public void testTimestampParseIBM() throws StandardException, IOException, ClassNotFoundException {
+        SQLTimestamp ts = new SQLTimestamp("1867-02-28-04.38.01.0426123", false, null);
+        Assert.assertEquals("1867-02-28 04:38:01.042612300", ts.toString());
+    }
+}

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SQLTypesUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SQLTypesUnitTest.java
@@ -100,9 +100,6 @@ public class SQLTypesUnitTest {
         Assert.assertEquals( ts.getWeekDay(i).getInt(), 4);
         Assert.assertEquals( ts.getWeekDayName(null).toString(), "Thursday");
         Assert.assertEquals( ts.getDayOfYear(i).getInt(), 59);
-
-        DateTime dt = ts.getDateTime();
-        Assert.assertEquals( dt.toString(), "1867-02-28T04:38:01.042+00:53:28");
     }
 
     @Test

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimestampIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimestampIT.java
@@ -909,6 +909,8 @@ public class TimestampIT extends SpliceUnitTest {
         withFormat("yyyy-MM-dd HH:mm:ss.SSSSSSSSS"/*9*/); shouldEqual("2020-11-30 19:11:12", "2020-11-30 19:11:12.000000000");
         withFormat("yyyy-MM-dd HH:mm:ss.SSSSSSSSS"/*9*/); shouldEqual("2020-11-30 19:11:12.123456789", "2020-11-30 19:11:12.123456789");
 
+        withFormat("MM/dd/uuuu, hh:mm:ss.SS a"); shouldEqual("2020-11-30 19:11:12.123456789", "11/30/2020, 07:11:12.12 PM");
+
         withFormat("yyyy-MM-dd-HH.mm.ss.SSSSSSSS"/*8*/);
         shouldEqual("2020-11-30 19:11:12.123456789", "2020-11-30-19.11.12.12345678");
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimestampIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimestampIT.java
@@ -13,7 +13,9 @@
  */
 package com.splicemachine.derby.impl.sql.execute.operations;
 
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.compile.CompilerContext;
+import com.splicemachine.db.iapi.types.SQLTimestamp;
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
@@ -937,6 +939,5 @@ public class TimestampIT extends SpliceUnitTest {
             if(bOK) return;
         }
         Assert.fail("current timestamp precision didn't work");
-
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimestampIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimestampIT.java
@@ -13,6 +13,7 @@
  */
 package com.splicemachine.derby.impl.sql.execute.operations;
 
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
@@ -30,6 +31,8 @@ import splice.com.google.common.collect.Lists;
 
 import java.io.File;
 import java.sql.*;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -60,7 +63,7 @@ public class TimestampIT extends SpliceUnitTest {
 
     @Parameterized.Parameters(name = "useSpark = {0}")
     public static Collection<Object[]> data() {
-        Collection<Object[]> params = Lists.newArrayListWithCapacity(2);
+        Collection<Object[]> params = Lists.newArrayListWithCapacity(1);
         params.add(new Object[]{true});
         params.add(new Object[]{false});
         return params;
@@ -880,8 +883,8 @@ public class TimestampIT extends SpliceUnitTest {
         }
     }
 
-    private void withPrecision(int precision) throws Exception {
-        methodWatcher.executeUpdate(String.format("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'splice.function.timestampPrecision', '%d' )", precision));
+    private void withFormat(String format) throws Exception {
+        methodWatcher.executeUpdate(String.format("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'splice.function.timestampFormat', '%s' )", format));
     }
 
     private void shouldEqual(String inputTimestamp, String expectedTimestamp) throws SQLException {
@@ -895,17 +898,45 @@ public class TimestampIT extends SpliceUnitTest {
 
     @Test
     public void testConfigurableTimestampPrecision() throws Exception {
-        withPrecision(-100); shouldEqual("2020-11-30 19:11:12.123456789", "2020-11-30 19:11:12");
-        withPrecision(-100); shouldEqual("2020-11-30 19:11:12.123456789", "2020-11-30 19:11:12");
-        withPrecision(0); shouldEqual("2020-11-30 19:11:12", "2020-11-30 19:11:12");
-        withPrecision(0); shouldEqual("2020-11-30 19:11:12.123456789", "2020-11-30 19:11:12");
-        withPrecision(3); shouldEqual("2020-11-30 19:11:12", "2020-11-30 19:11:12.000");
-        withPrecision(3); shouldEqual("2020-11-30 19:11:12.123456789", "2020-11-30 19:11:12.123");
-        withPrecision(6); shouldEqual("2020-11-30 19:11:12", "2020-11-30 19:11:12.000000");
-        withPrecision(6); shouldEqual("2020-11-30 19:11:12.123456789", "2020-11-30 19:11:12.123456");
-        withPrecision(9); shouldEqual("2020-11-30 19:11:12", "2020-11-30 19:11:12.000000000");
-        withPrecision(9); shouldEqual("2020-11-30 19:11:12.123456789", "2020-11-30 19:11:12.123456789");
-        withPrecision(100); shouldEqual("2020-11-30 19:11:12", "2020-11-30 19:11:12.000000000");
-        withPrecision(100); shouldEqual("2020-11-30 19:11:12.123456789", "2020-11-30 19:11:12.123456789");
+        withFormat("yyyy-MM-dd HH:mm:ss"); shouldEqual("2020-11-30 19:11:12", "2020-11-30 19:11:12");
+        withFormat("yyyy-MM-dd HH:mm:ss"/*0*/); shouldEqual("2020-11-30 19:11:12.123456789", "2020-11-30 19:11:12");
+        withFormat("yyyy-MM-dd HH:mm:ss.SSS"/*3*/); shouldEqual("2020-11-30 19:11:12", "2020-11-30 19:11:12.000");
+        withFormat("yyyy-MM-dd HH:mm:ss.SSS"/*3*/); shouldEqual("2020-11-30 19:11:12.123456789", "2020-11-30 19:11:12.123");
+        withFormat("yyyy-MM-dd HH:mm:ss.SSSSSS"/*6*/); shouldEqual("2020-11-30 19:11:12", "2020-11-30 19:11:12.000000");
+        withFormat("yyyy-MM-dd HH:mm:ss.SSSSSS"/*6*/); shouldEqual("2020-11-30 19:11:12.123456789", "2020-11-30 19:11:12.123456");
+        withFormat("yyyy-MM-dd HH:mm:ss.SSSSSSSSS"/*9*/); shouldEqual("2020-11-30 19:11:12", "2020-11-30 19:11:12.000000000");
+        withFormat("yyyy-MM-dd HH:mm:ss.SSSSSSSSS"/*9*/); shouldEqual("2020-11-30 19:11:12.123456789", "2020-11-30 19:11:12.123456789");
+
+        withFormat("yyyy-MM-dd-HH.mm.ss.SSSSSSSS"/*8*/);
+        shouldEqual("2020-11-30 19:11:12.123456789", "2020-11-30-19.11.12.12345678");
+
+        // test code in UserTypeConstantNode
+        Assert.assertEquals("1700-12-31-23.59.58.99999900", methodWatcher.executeGetString( "values( char({ts'1700-12-31 23:59:58.999999'}) )", 1));
+
+        // reset to default
+        withFormat(CompilerContext.DEFAULT_TIMESTAMP_FORMAT);
+        Assert.assertEquals("1700-12-31 23:59:58.999999000", methodWatcher.executeGetString( "values( char({ts'1700-12-31 23:59:58.999999'}) )", 1));
+    }
+
+    @Test
+    public void testCurrentTimestampPrecision() throws Exception {
+
+        // we might get very unlucky when timestamps end in 0s, e.g.
+        // 2020-12-06 21:50:13.123456000 would have length of 2020-12-06 21:50:13.123456, even if precision is set to 9
+        // to avoid sporadics, we try this 100 times
+        for(int i=0; i<100; i++)
+        {
+            boolean bOK;
+            methodWatcher.executeUpdate("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'splice.function.currentTimestampPrecision', '1' )");
+            bOK = "2020-12-06 21:50:13.1".length()
+                    == methodWatcher.executeGetString( "values current timestamp", 1 ).length();
+            methodWatcher.executeUpdate("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'splice.function.currentTimestampPrecision', '9' )");
+            bOK = bOK && "2020-12-06 21:50:13.123456789".length()
+                    == methodWatcher.executeGetString( "values current timestamp", 1 ).length();
+
+            if(bOK) return;
+        }
+        Assert.fail("current timestamp precision didn't work");
+
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
@@ -1083,6 +1083,15 @@ public class SpliceUnitTest {
         }
     }
 
+    public static void assertThrows(Runnable r, String expectedExceptionStr) {
+        try {
+            r.run();
+            Assert.fail("expected exception");
+        } catch(Exception e) {
+            Assert.assertEquals(expectedExceptionStr, e.toString());
+        }
+    }
+
     /// execute sql query 'sqlText' and expect a certain formatted result
     public static void sqlExpectToString(SpliceWatcher methodWatcher, String sqlText, String expected, boolean sort ) throws Exception
     {


### PR DESCRIPTION
e.g.
call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'splice.function.timestampFormat', 'yyyy-MM-dd-HH.mm.ss.SSSSSSSS'); -- IBM style