### PR TITLE
DB-10770 Fix SSDS pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -888,7 +888,7 @@
             <properties>
                 <envClassifier>hdp3.1.0</envClassifier>
                 <envHbase>hbase2.0.2</envHbase>
-                <hadoop.version>3.1.1.3.1.0.61-1</hadoop.version>
+                <hadoop.version>3.1.1.3.1.0.0-78</hadoop.version>
                 <hbase.version>2.0.2.3.1.0.0-78</hbase.version>
                 <hive.version>3.1.0.3.1.2.0-4</hive.version>
                 <zookeeper.version>3.4.6.3.1.0.0-78</zookeeper.version>


### PR DESCRIPTION
Hadoop version 3.1.1.3.1.0.61-1 is not available anymore from hortonworks repo.
https://repo.hortonworks.com/content/repositories/releases/org/apache/hadoop/hadoop-common/
Set it to match the versions already referenced for hdp3.1.0.