### PR TITLE
DB-10952 use reflection to ensure created system procedures are correct (3.0)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DefaultSystemProcedureGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DefaultSystemProcedureGenerator.java
@@ -348,6 +348,22 @@ public class DefaultSystemProcedureGenerator implements SystemProcedureGenerator
         return procedures;
     }
 
+    static public List<Procedure> getSYSIBMProcedures() throws StandardException {
+        List<Procedure> procedures = new ArrayList<>();
+        procedures.addAll(sysIbmProcedures);
+        return procedures;
+    }
+    static public List<Procedure> getSQLProcedures() throws StandardException {
+        List<Procedure> procedures = new ArrayList<>();
+        procedures.addAll(sqlJProcedures);
+        return procedures;
+    }
+    static public List<Procedure> getSYSCSMProcedures() throws StandardException {
+        List<Procedure> procedures = new ArrayList<>();
+        procedures.addAll(sysCsProcedures);
+        return procedures;
+    }
+
     /**
      * Hook to be invoked only from {@link #getProcedures(DataDictionary, TransactionController)}
      * Do not call directly.
@@ -671,19 +687,12 @@ public class DefaultSystemProcedureGenerator implements SystemProcedureGenerator
                     .ownerClass(LOB_STORED_PROCEDURE)
                     .integer("LOCATOR").build()
             ,
-            Procedure.newBuilder().name("CLOBGETPROSITIONFROMSTRING").numOutputParams(0).numResultSets(0)
-                    .containsSql().returnType(DataTypeDescriptor.getCatalogType(Types.BIGINT))
-                    .isDeterministic(false).ownerClass(LOB_STORED_PROCEDURE)
-                    .integer("LOCATOR")
-                    .varchar("SEARCHSTR",Limits.DB2_VARCHAR_MAXWIDTH)
-                    .bigint("POS").build()
-            ,
             Procedure.newBuilder().name("CLOBGETPOSITIONFROMLOCATOR").numOutputParams(0).numResultSets(0)
                     .containsSql().returnType(DataTypeDescriptor.getCatalogType(Types.BIGINT))
                     .isDeterministic(false).ownerClass(LOB_STORED_PROCEDURE)
                     .integer("LOCATOR")
                     .integer("SEARCHLOCATOR")
-                    .integer("POS").build()
+                    .bigint("POS").build()
             ,
             Procedure.newBuilder().name("CLOBGETLENGTH").numOutputParams(0).numResultSets(0)
                     .containsSql().returnType(DataTypeDescriptor.getCatalogType(Types.BIGINT))

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -1565,6 +1565,13 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .build();
         procedures.add(getWalPosition);
 
+        Procedure getReplicationProgress = Procedure.newBuilder().name("GET_REPLICATION_PROGRESS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .build();
+        procedures.add(getReplicationProgress);
+
         Procedure dumpUnreplicatedWals = Procedure.newBuilder().name("DUMP_UNREPLICATED_WALS")
                 .numOutputParams(0)
                 .numResultSets(1)

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -124,1495 +124,7 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 //
 
                 if (key.equals(sysUUID)) {
-                    Procedure refreshExternalTable = Procedure.newBuilder().name("SYSCS_REFRESH_EXTERNAL_TABLE")
-                            .numOutputParams(0).numResultSets(0).ownerClass(ExternalTableSystemProcedures.class.getCanonicalName())
-                            .varchar("schema", 32672)
-                            .varchar("table", 32672)
-                            .build();
-                    procedures.add(refreshExternalTable);
-
-        			/*
-        			 * Add a system procedure to enable splitting tables once data is loaded.
-        			 *
-        			 * We do this here because this way we know we're in the SYSCS procedure set
-        			 */
-                    Procedure splitProc = Procedure.newBuilder().name("SYSCS_SPLIT_TABLE")
-                            .numOutputParams(0).numResultSets(0).ownerClass(TableSplit.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .build();
-                    procedures.add(splitProc);
-
-                    Procedure splitProc1 = Procedure.newBuilder().name("SYSCS_SPLIT_TABLE_AT_POINTS")
-                            .numOutputParams(0).numResultSets(0).ownerClass(TableSplit.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .varchar("splitPoints", 32672)
-                            .build();
-                    procedures.add(splitProc1);
-
-                    Procedure splitProc2 = Procedure.newBuilder().name("SYSCS_SPLIT_TABLE_EVENLY")
-                            .numOutputParams(0).numResultSets(0).ownerClass(TableSplit.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .integer("numSplits")
-                            .build();
-                    procedures.add(splitProc2);
-
-                    procedures.add(Procedure.newBuilder().name("SYSCS_SPLIT_REGION_AT_POINTS")
-                                           .numOutputParams(0).numResultSets(0).ownerClass(TableSplit.class.getCanonicalName())
-                                           .catalog("regionName")
-                                           .varchar("splitPoints", 32672)
-                                           .build());
-
-                    Procedure splitProc3 = Procedure.newBuilder().name("SYSCS_SPLIT_TABLE_OR_INDEX_AT_POINTS")
-                            .numOutputParams(0).numResultSets(0).ownerClass(TableSplit.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .catalog("indexName")
-                            .varchar("splitPoints", 32672)
-                            .build();
-                    procedures.add(splitProc3);
-
-                    Procedure splitProc4 = Procedure.newBuilder().name("SYSCS_SPLIT_TABLE_OR_INDEX")
-                            .numOutputParams(0).numResultSets(1).ownerClass(TableSplit.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .catalog("indexName")
-                            .varchar("columnList",32672)
-                            .varchar("fileName",32672)
-                            .varchar("columnDelimiter",5)
-                            .varchar("characterDelimiter", 5)
-                            .varchar("timestampFormat",32672)
-                            .varchar("dateFormat",32672)
-                            .varchar("timeFormat",32672)
-                            .bigint("maxBadRecords")
-                            .varchar("badRecordDirectory",32672)
-                            .varchar("oneLineRecords",5)
-                            .varchar("charset",32672)
-                            .build();
-                    procedures.add(splitProc4);
-                    
-         			/*
-        			 * Procedure get all active services
-        			 */
-                    Procedure getActiveServers = Procedure.newBuilder().name("SYSCS_GET_ACTIVE_SERVERS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .sqlControl(RoutineAliasInfo.READS_SQL_DATA)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getActiveServers);
-
-        			/*
-        			 * Procedure get all active requests
-        			 */
-                    Procedure getRequests = Procedure.newBuilder().name("SYSCS_GET_REQUESTS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getRequests);
-
-
-        			/*
-        			 * Procedure get stats info for region servers
-        			 */
-                    Procedure getRegionServerStatsInfo = Procedure.newBuilder().name("SYSCS_GET_REGION_SERVER_STATS_INFO")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .sqlControl(RoutineAliasInfo.NO_SQL)
-                            .build();
-                    procedures.add(getRegionServerStatsInfo);
-
-        			/*
-        			 * Procedure fetch logical configuration from region servers
-        			 */
-                    Procedure getRegionServerConfig = Procedure.newBuilder().name("SYSCS_GET_REGION_SERVER_CONFIG_INFO")
-                            .varchar("configRoot", 128) // fetch only config props with prefix, or null for fetch all
-                            .integer("mode")            // 0 = fetch all, 1 = fetch only props where value not same on all servers
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .sqlControl(RoutineAliasInfo.NO_SQL)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getRegionServerConfig);
-
-                    /*
-                     * Procedure get Splice Machine manifest info
-                     */
-                    Procedure getVersionInfo = Procedure.newBuilder().name("SYSCS_GET_VERSION_INFO")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .sqlControl(RoutineAliasInfo.READS_SQL_DATA)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getVersionInfo);
-
-                    Procedure getVersionInfoLocal = Procedure.newBuilder().name("SYSCS_GET_VERSION_INFO_LOCAL")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .sqlControl(RoutineAliasInfo.READS_SQL_DATA)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getVersionInfoLocal);
-
-        			/*
-        			 * Procedure get write pipeline intake info
-        			 */
-                    Procedure getWriteIntakeInfo = Procedure.newBuilder().name("SYSCS_GET_WRITE_INTAKE_INFO")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getWriteIntakeInfo);
-
-                    /*
-        			 * Procedure get exec service info
-        			 */
-                    Procedure getExecServiceInfo = Procedure.newBuilder().name("SYSCS_GET_EXEC_SERVICE_INFO")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getExecServiceInfo);
-
-                    /*
-        			 * Procedure get each individual cache info
-        			 */
-                    Procedure getCacheInfo = Procedure.newBuilder().name("SYSCS_GET_CACHE_INFO")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getCacheInfo);
-
-                    /*
-        			 * Procedure get total cache info
-        			 */
-                    Procedure getTotalCacheInfo = Procedure.newBuilder().name("SYSCS_GET_TOTAL_CACHE_INFO")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getTotalCacheInfo);
-
-        			/*
-        			 * Procedures to kill stale transactions
-        			 */
-                    Procedure killTransaction = Procedure.newBuilder().name("SYSCS_KILL_TRANSACTION")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .bigint("transactionId")
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(killTransaction);
-
-                    Procedure killStaleTransactions = Procedure.newBuilder().name("SYSCS_KILL_STALE_TRANSACTIONS")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .bigint("maximumTransactionId")
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(killStaleTransactions);
-
-//                    Procedure dumpTransactions = Procedure.newBuilder().name("SYSCS_DUMP_TRANSACTIONS")
-//                            .numOutputParams(0)
-//                            .numResultSets(1)
-//                            .ownerClass(TransactionAdmin.class.getCanonicalName())
-//                            .build();
-//                    procedures.add(dumpTransactions);
-
-                    Procedure currTxn = Procedure.newBuilder().name("SYSCS_GET_CURRENT_TRANSACTION")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(TransactionAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(currTxn);
-
-                    Procedure activeTxn = Procedure.newBuilder().name("SYSCS_GET_ACTIVE_TRANSACTION_IDS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(TransactionAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(activeTxn);
-
-                    /*
-                     * Statistics procedures
-                     */
-                    Procedure collectStatsForTable = Procedure.newBuilder().name("COLLECT_TABLE_STATISTICS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .varchar("schema",128)
-                            .varchar("table",1024)
-                            .arg("staleOnly", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
-                            .ownerClass(StatisticsAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(collectStatsForTable);
-
-                    Collection<Procedure> procs = MetadataFactoryService.newMetadataFactory().getProcedures();
-
-                    if (procs != null)
-                        procedures.addAll(procs);
-
-                    Procedure collectSampleStatsForTable = Procedure.newBuilder().name("COLLECT_TABLE_SAMPLE_STATISTICS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .varchar("schema",128)
-                            .varchar("table",1024)
-                            .arg("samplePercentage", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.DOUBLE).getCatalogType())
-                            .arg("staleOnly", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
-                            .ownerClass(StatisticsAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(collectSampleStatsForTable);
-
-                    Procedure collectNonMergedStatsForTable = Procedure.newBuilder().name("COLLECT_NONMERGED_TABLE_STATISTICS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .varchar("schema",128)
-                            .varchar("table",1024)
-                            .arg("staleOnly", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
-                            .ownerClass(StatisticsAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(collectNonMergedStatsForTable);
-
-                    Procedure collectNonMergedSampleStatsForTable = Procedure.newBuilder().name("COLLECT_NONMERGED_TABLE_SAMPLE_STATISTICS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .varchar("schema",1024)
-                            .varchar("table",1024)
-                            .arg("samplePercentage", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.DOUBLE).getCatalogType())
-                            .arg("staleOnly", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
-                            .ownerClass(StatisticsAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(collectNonMergedSampleStatsForTable);
-
-                    Procedure fakeStatsForTable = Procedure.newBuilder().name("FAKE_TABLE_STATISTICS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .modifiesSql()
-                            .catalog("schema")
-                            .catalog("table")
-                            .arg("rowCount", DataTypeDescriptor.getCatalogType(Types.BIGINT))
-                            .arg("meanRowsize", DataTypeDescriptor.getCatalogType(Types.INTEGER))
-                            .arg("numPartitions", DataTypeDescriptor.getCatalogType(Types.BIGINT))
-                            .ownerClass(StatisticsAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(fakeStatsForTable);
-
-                    Procedure fakeStatsForColumn = Procedure.newBuilder().name("FAKE_COLUMN_STATISTICS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .modifiesSql()
-                            .catalog("schema")
-                            .catalog("table")
-                            .varchar("column",1024)
-                            .arg("nullCountRatio", DataTypeDescriptor.getCatalogType(Types.DOUBLE))
-                            .arg("rowsPerValue", DataTypeDescriptor.getCatalogType(Types.BIGINT))
-                            .ownerClass(StatisticsAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(fakeStatsForColumn);
-
-                    Procedure importWithBadRecords = Procedure.newBuilder().name("IMPORT_DATA")
-                            .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .varchar("insertColumnList",32672)
-                            .varchar("fileName",32672)
-                            .varchar("columnDelimiter",5)
-                            .varchar("characterDelimiter", 5)
-                            .varchar("timestampFormat",32672)
-                            .varchar("dateFormat",32672)
-                            .varchar("timeFormat",32672)
-                            .bigint("maxBadRecords")
-                            .varchar("badRecordDirectory",32672)
-                            .varchar("oneLineRecords",5)
-                            .varchar("charset",32672)
-                            .build();
-                    procedures.add(importWithBadRecords);
-
-
-                    Procedure loadReplaceProc = Procedure.newBuilder().name("LOAD_REPLACE")
-                            .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .varchar("insertColumnList",32672)
-                            .varchar("fileName",32672)
-                            .varchar("columnDelimiter",5)
-                            .varchar("characterDelimiter", 5)
-                            .varchar("timestampFormat",32672)
-                            .varchar("dateFormat",32672)
-                            .varchar("timeFormat",32672)
-                            .bigint("maxBadRecords")
-                            .varchar("badRecordDirectory",32672)
-                            .varchar("oneLineRecords",5)
-                            .varchar("charset",32672)
-                            .build();
-                    procedures.add(loadReplaceProc);
-
-                    Procedure importUnsafe = Procedure.newBuilder().name("IMPORT_DATA_UNSAFE")
-                            .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .varchar("insertColumnList",32672)
-                            .varchar("fileName",32672)
-                            .varchar("columnDelimiter",5)
-                            .varchar("characterDelimiter", 5)
-                            .varchar("timestampFormat",32672)
-                            .varchar("dateFormat",32672)
-                            .varchar("timeFormat",32672)
-                            .bigint("maxBadRecords")
-                            .varchar("badRecordDirectory",32672)
-                            .varchar("oneLineRecords",5)
-                            .varchar("charset",32672)
-                            .build();
-                    procedures.add(importUnsafe);
-
-                   Procedure bulkImportHFile = Procedure.newBuilder().name("BULK_IMPORT_HFILE")
-                            .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .varchar("insertColumnList",32672)
-                            .varchar("fileName",32672)
-                            .varchar("columnDelimiter",5)
-                            .varchar("characterDelimiter", 5)
-                            .varchar("timestampFormat",32672)
-                            .varchar("dateFormat",32672)
-                            .varchar("timeFormat",32672)
-                            .bigint("maxBadRecords")
-                            .varchar("badRecordDirectory",32672)
-                            .varchar("oneLineRecords",5)
-                            .varchar("charset",32672)
-                            .varchar("bulkImportDirectory", 32672)
-                            .varchar("skipSampling", 5)
-                            .build();
-                    procedures.add(bulkImportHFile);
-
-
-                    Procedure sampleData = Procedure.newBuilder().name("SAMPLE_DATA")
-                            .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .varchar("insertColumnList",32672)
-                            .varchar("fileName",32672)
-                            .varchar("columnDelimiter",5)
-                            .varchar("characterDelimiter", 5)
-                            .varchar("timestampFormat",32672)
-                            .varchar("dateFormat",32672)
-                            .varchar("timeFormat",32672)
-                            .bigint("maxBadRecords")
-                            .varchar("badRecordDirectory",32672)
-                            .varchar("oneLineRecords",5)
-                            .varchar("charset",32672)
-                            .varchar("bulkImportDirectory", 32672)
-                            .build();
-                    procedures.add(sampleData);
-
-                    Procedure computeSplitKey= Procedure.newBuilder().name("COMPUTE_SPLIT_KEY")
-                            .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .catalog("indexName")
-                            .varchar("columnList",32672)
-                            .varchar("fileName",32672)
-                            .varchar("columnDelimiter",5)
-                            .varchar("characterDelimiter", 5)
-                            .varchar("timestampFormat",32672)
-                            .varchar("dateFormat",32672)
-                            .varchar("timeFormat",32672)
-                            .bigint("maxBadRecords")
-                            .varchar("badRecordDirectory",32672)
-                            .varchar("oneLineRecords",5)
-                            .varchar("charset",32672)
-                            .varchar("outputDirectory", 32672)
-                            .build();
-                    procedures.add(computeSplitKey);
-
-                    Procedure upport = Procedure.newBuilder().name("UPSERT_DATA_FROM_FILE")
-                            .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .varchar("insertColumnList",32672)
-                            .varchar("fileName",32672)
-                            .varchar("columnDelimiter",5)
-                            .varchar("characterDelimiter", 5)
-                            .varchar("timestampFormat",32672)
-                            .varchar("dateFormat",32672)
-                            .varchar("timeFormat",32672)
-                            .bigint("maxBadRecords")
-                            .varchar("badRecordDirectory",32672)
-                            .varchar("oneLineRecords",5)
-                            .varchar("charset",32672)
-                            .build();
-                    procedures.add(upport);
-
-                    Procedure merge = Procedure.newBuilder().name("MERGE_DATA_FROM_FILE")
-                            .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .varchar("insertColumnList",32672)
-                            .varchar("fileName",32672)
-                            .varchar("columnDelimiter",5)
-                            .varchar("characterDelimiter", 5)
-                            .varchar("timestampFormat",32672)
-                            .varchar("dateFormat",32672)
-                            .varchar("timeFormat",32672)
-                            .bigint("maxBadRecords")
-                            .varchar("badRecordDirectory",32672)
-                            .varchar("oneLineRecords",5)
-                            .varchar("charset",32672)
-                            .build();
-                    procedures.add(merge);
-
-                    Procedure getAutoIncLocs = Procedure.newBuilder().name("SYSCS_GET_AUTO_INCREMENT_ROW_LOCATIONS")
-                            .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .build();
-                    procedures.add(getAutoIncLocs);
-
-
-                    Procedure dropStatsForSchema = Procedure.newBuilder().name("DROP_SCHEMA_STATISTICS")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .varchar("schema",128)
-                            .ownerClass(StatisticsAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(dropStatsForSchema);
-
-                    Procedure dropStatsForTable = Procedure.newBuilder().name("DROP_TABLE_STATISTICS")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .varchar("schema",128)
-                            .varchar("table",1024)
-                            .ownerClass(StatisticsAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(dropStatsForTable);
-
-                    Procedure collectStatsForSchema = Procedure.newBuilder().name("COLLECT_SCHEMA_STATISTICS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .varchar("schema",128)
-                            .arg("staleOnly", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
-                            .ownerClass(StatisticsAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(collectStatsForSchema);
-
-                    Procedure enableStatsForColumn = Procedure.newBuilder().name("ENABLE_COLUMN_STATISTICS")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .modifiesSql()
-                            .varchar("schema",1024)
-                            .varchar("table",1024)
-                            .varchar("column",1024)
-                            .ownerClass(StatisticsAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(enableStatsForColumn);
-
-                    Procedure disableStatsForColumn = Procedure.newBuilder().name("DISABLE_COLUMN_STATISTICS")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .modifiesSql()
-                            .varchar("schema",1024)
-                            .varchar("table",1024)
-                            .varchar("column",1024)
-                            .ownerClass(StatisticsAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(disableStatsForColumn);
-
-                    Procedure enableStatsForAllColumns = Procedure.newBuilder().name("ENABLE_ALL_COLUMN_STATISTICS")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .modifiesSql()
-                            .catalog("schema")
-                            .catalog("table")
-                            .ownerClass(StatisticsAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(enableStatsForAllColumns);
-
-                    Procedure disableStatsForAllColumns = Procedure.newBuilder().name("DISABLE_ALL_COLUMN_STATISTICS")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .modifiesSql()
-                            .catalog("schema")
-                            .catalog("table")
-                            .ownerClass(StatisticsAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(disableStatsForAllColumns);
-
-                    Procedure setStatsExtrapolationForColumn = Procedure.newBuilder().name("SET_STATS_EXTRAPOLATION_FOR_COLUMN")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .modifiesSql()
-                            .varchar("schema",1024)
-                            .varchar("table",1024)
-                            .varchar("column",1024)
-                            .smallint("useExtrapolation")
-                            .ownerClass(StatisticsAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(setStatsExtrapolationForColumn);
-
-        			/*
-        			 * Procedure to get the session details
-        			 */
-                    Procedure sessionInfo = Procedure.newBuilder().name("SYSCS_GET_SESSION_INFO")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(sessionInfo);
-
-
-        			/*
-        			 * Procedure to get a list of running operations
-        			 */
-                    Procedure runningOperations = Procedure.newBuilder().name("SYSCS_GET_RUNNING_OPERATIONS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(runningOperations);
-
-        			/*
-        			 * Procedure to get a list of running operations on the local server
-        			 */
-                    Procedure runningOperationsLocal = Procedure.newBuilder().name("SYSCS_GET_RUNNING_OPERATIONS_LOCAL")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(runningOperationsLocal);
-
-
-        			/*
-        			 * Procedure to kill an executing operation
-        			 */
-                    Procedure killOperationLocal = Procedure.newBuilder().name("SYSCS_KILL_OPERATION_LOCAL")
-                            .numOutputParams(0)
-                            .varchar("uuid",128)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(killOperationLocal);
-
-        			/*
-        			 * Procedure to kill an executing operation
-        			 */
-                    Procedure killOperation = Procedure.newBuilder().name("SYSCS_KILL_OPERATION")
-                            .numOutputParams(0)
-                            .varchar("uuid",128)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(killOperation);
-
-                    /*
-                     * Procedure to kill an executing DRDA operation
-                     */
-                    Procedure killDrdaOperationLocal = Procedure.newBuilder().name("SYSCS_KILL_DRDA_OPERATION_LOCAL")
-                            .numOutputParams(0)
-                            .varchar("rdbIntTkn",512)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(killDrdaOperationLocal);
-
-                    /*
-                     * Procedure to kill an executing DRDA operation
-                     */
-                    Procedure killDrdaOperation = Procedure.newBuilder().name("SYSCS_KILL_DRDA_OPERATION")
-                            .numOutputParams(0)
-                            .varchar("rdbIntTkn",512)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(killDrdaOperation);
-
-
-                    /*
-                     * Procedure to get oldest active transaction id
-                     */
-                    Procedure getActiveTxn = Procedure.newBuilder().name("SYSCS_GET_OLDEST_ACTIVE_TRANSACTION")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getActiveTxn);
-
-                    /*
-                     * Procedure to delegate HDFS operations
-                     */
-                    Procedure hdfsOperation = Procedure.newBuilder().name("SYSCS_HDFS_OPERATION")
-                            .numOutputParams(0)
-                            .varchar("path",128)
-                            .varchar("op", 64)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(hdfsOperation);
-
-                    /*
-                     * Procedure to delegate HBase operations
-                     */
-                    Procedure hbaseOperation = Procedure.newBuilder().name("SYSCS_HBASE_OPERATION")
-                            .numOutputParams(0)
-                            .varchar("table",128)
-                            .varchar("op", 64)
-                            .blob("request")
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(hbaseOperation);
-
-                    /*
-                     * Procedure to get Splice Token
-                     */
-                    Procedure getToken = Procedure.newBuilder().name("SYSCS_GET_SPLICE_TOKEN")
-                            .numOutputParams(0)
-                            .varchar("username",256)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getToken);
-
-                    /*
-                     * Procedure to cancel a Splice Token
-                     */
-                    Procedure cancelToken = Procedure.newBuilder().name("SYSCS_CANCEL_SPLICE_TOKEN")
-                            .numOutputParams(0)
-                            .blob("request")
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(cancelToken);
-
-                    /*
-                     * Procedure to elevate a transaction
-                     */
-                    Procedure elevProc = Procedure.newBuilder().name("SYSCS_ELEVATE_TRANSACTION")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .varchar("tableName", 128) // input
-                            .ownerClass(TransactionAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(elevProc);
-
-                    /*
-                     * Procedure to start a child transaction
-                     */
-                    Procedure childTxnProc = Procedure.newBuilder().name("SYSCS_START_CHILD_TRANSACTION")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .bigint("parentTransactionId") // input
-                            .varchar("tableName", 128) // input
-                            .ownerClass(TransactionAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(childTxnProc);
-                    
-                    /*
-                     * Procedure to commit a child transaction
-                     */
-                    Procedure commitTxnProc = Procedure.newBuilder().name("SYSCS_COMMIT_CHILD_TRANSACTION")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .bigint("childTransactionId") // input
-                            .ownerClass(TransactionAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(commitTxnProc);
-
-        			/*
-        			 * Procedure to get the log level for the given logger
-        			 */
-                    Procedure getLoggerLevel = Procedure.newBuilder().name("SYSCS_GET_LOGGER_LEVEL")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .varchar("loggerName", 128)
-                            .sqlControl(RoutineAliasInfo.READS_SQL_DATA)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getLoggerLevel);
-
-                    Procedure getLoggerLevelLocal = Procedure.newBuilder().name("SYSCS_GET_LOGGER_LEVEL_LOCAL")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .varchar("loggerName", 128)
-                            .sqlControl(RoutineAliasInfo.READS_SQL_DATA)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getLoggerLevelLocal);
-
-        			/*
-        			 * Procedure to set the log level for the given logger
-        			 */
-                    Procedure setLoggerLevel = Procedure.newBuilder().name("SYSCS_SET_LOGGER_LEVEL")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .varchar("loggerName", 128)
-                            .varchar("loggerLevel", 128)
-                            .sqlControl(RoutineAliasInfo.NO_SQL)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(setLoggerLevel);
-
-                    Procedure setLoggerLevelLocal = Procedure.newBuilder().name("SYSCS_SET_LOGGER_LEVEL_LOCAL")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .varchar("loggerName", 128)
-                            .varchar("loggerLevel", 128)
-                            .sqlControl(RoutineAliasInfo.NO_SQL)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(setLoggerLevelLocal);
-
-        			/*
-        			 * Procedure to get all the splice logger names in the system
-        			 */
-                    Procedure getLoggers = Procedure.newBuilder().name("SYSCS_GET_LOGGERS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getLoggers);
-
-                    Procedure getLoggersLocal = Procedure.newBuilder().name("SYSCS_GET_LOGGERS_LOCAL")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getLoggersLocal);
-
-        			/*
-        			 * Procedure get table info in all schema
-        			 */
-                    Procedure getSchemaInfo = Procedure.newBuilder().name("SYSCS_GET_SCHEMA_INFO")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getSchemaInfo);
-
-        			/*
-        			 * Procedure to perform major compaction on all tables in a schema
-        			 */
-                    Procedure majorComactionOnSchema = Procedure.newBuilder().name("SYSCS_PERFORM_MAJOR_COMPACTION_ON_SCHEMA")
-                            .varchar("schemaName", 128)
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(majorComactionOnSchema);
-
-        			/*
-        			 * Procedure to perform major compaction on a table in a schema
-        			 */
-                    Procedure majorComactionOnTable = Procedure.newBuilder().name("SYSCS_PERFORM_MAJOR_COMPACTION_ON_TABLE")
-                            .varchar("schemaName", 128)
-                            .varchar("tableName", 128)
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(majorComactionOnTable);
-
-                    /*
-                     * Procedure to perform major flush on a table in a schema
-                     */
-                    Procedure flushTable = Procedure.newBuilder().name("SYSCS_FLUSH_TABLE")
-                            .varchar("schemaName", 128)
-                            .varchar("tableName", 128)
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(flushTable);
-
-                    /*
-                     * Procedure to delete rows from data dictionary
-                     */
-                    Procedure dictionaryDelete = Procedure.newBuilder().name("SYSCS_DICTIONARY_DELETE")
-                            .integer("conglomerateId")
-                            .varchar("rowId", 1024)
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(dictionaryDelete);
-
-        			/*
-        			 * Procedure to get all the information related to the execution plans of the stored prepared statements (metadata queries).
-        			 */
-                    Procedure getStoredStatementPlanInfo = Procedure.newBuilder().name("SYSCS_GET_STORED_STATEMENT_PLAN_INFO")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getStoredStatementPlanInfo);
-
-        			/*
-        			 * Procedure to print all of the properties (JVM, Service, Database, App).
-        			 */
-                    Procedure getAllSystemProperties = Procedure.newBuilder().name("SYSCS_GET_ALL_PROPERTIES")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getAllSystemProperties);
-
-                    Procedure vacuum = Procedure.newBuilder().name("VACUUM")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(vacuum);
-
-
-                    /*
-                     * Procedure to return timestamp generator info
-                     */
-                    procedures.add(Procedure.newBuilder().name("SYSCS_GET_TIMESTAMP_GENERATOR_INFO")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(TimestampAdmin.class.getCanonicalName())
-                            .build());
-
-                    /*
-                     * Procedure to return timestamp request info
-                     */
-                    procedures.add(Procedure.newBuilder().name("SYSCS_GET_TIMESTAMP_REQUEST_INFO")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(TimestampAdmin.class.getCanonicalName())
-                            .build());
-
-                    /*
-                     * Procedure to delete a backup
-                     */
-                    procedures.add(Procedure.newBuilder().name("SYSCS_DELETE_BACKUP")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(BackupSystemProcedures.class.getCanonicalName())
-                            .bigint("backupId")
-                            .build());
-
-                    /*
-                     * Procedure to delete backups in a time window
-                     */
-                    procedures.add(Procedure.newBuilder().name("SYSCS_DELETE_OLD_BACKUPS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(BackupSystemProcedures.class.getCanonicalName())
-                            .integer("backupWindow")
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("SYSCS_BACKUP_DATABASE_ASYNC")
-                            .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
-                            .varchar("directory", 32672)
-                            .varchar("type", 32672)
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("SYSCS_RESTORE_DATABASE_ASYNC")
-                            .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
-                            .varchar("directory", 32672)
-                            .bigint("backupId")
-                            .arg("validate", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("VALIDATE_BACKUP")
-                            .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
-                            .varchar("directory", 32672)
-                            .bigint("backupId")
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("VALIDATE_TABLE_BACKUP")
-                            .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .varchar("directory", 32672)
-                            .bigint("backupId")
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("VALIDATE_SCHEMA_BACKUP")
-                            .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .varchar("directory", 32672)
-                            .bigint("backupId")
-                            .build());
-                    /*
-                     * Procedure to get a database property on all region servers in the cluster.
-                     */
-                    procedures.add(Procedure.newBuilder().name("SYSCS_GET_GLOBAL_DATABASE_PROPERTY")
-                    		.numOutputParams(0)
-                    		.numResultSets(1)
-                    		.ownerClass(SpliceAdmin.class.getCanonicalName())
-                    		.sqlControl(RoutineAliasInfo.READS_SQL_DATA).returnType(null).isDeterministic(false)
-                    		.catalog("KEY")
-                    		.build());
-
-                    /*
-                     * Procedure to set a database property on all region servers in the cluster.
-                     */
-                    procedures.add(Procedure.newBuilder().name("SYSCS_SET_GLOBAL_DATABASE_PROPERTY")
-                    		.numOutputParams(0)
-                    		.numResultSets(0)
-                    		.ownerClass(SpliceAdmin.class.getCanonicalName())
-                    		.sqlControl(RoutineAliasInfo.MODIFIES_SQL_DATA).returnType(null).isDeterministic(false)
-                    		.catalog("KEY")
-                    		.varchar("VALUE", Limits.DB2_VARCHAR_MAXWIDTH)
-                    		.build());
-
-                    /*
-                     * Procedure to enable splice enterprise version
-                     */
-                    procedures.add(Procedure.newBuilder().name("SYSCS_ENABLE_ENTERPRISE")
-                    		.numOutputParams(0)
-                    		.numResultSets(0)
-                    		.ownerClass(SpliceAdmin.class.getCanonicalName())
-                    		.sqlControl(RoutineAliasInfo.MODIFIES_SQL_DATA).returnType(null).isDeterministic(false)
-                    		.varchar("VALUE", Limits.DB2_VARCHAR_MAXWIDTH)
-                    		.build());
-
-                    /*
-                     * Procedure to empty the statement caches on all region servers in the cluster.
-                     * Essentially a wrapper around the Derby version of SYSCS_EMPTY_STATEMENT_CACHE
-                     * which only operates on a single node.
-                     */
-                    procedures.add(Procedure.newBuilder().name("SYSCS_EMPTY_GLOBAL_STATEMENT_CACHE")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .sqlControl(RoutineAliasInfo.NO_SQL).returnType(null).isDeterministic(false)
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("SYSCS_EMPTY_GLOBAL_STORED_STATEMENT_CACHE")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .sqlControl(RoutineAliasInfo.NO_SQL).returnType(null).isDeterministic(false)
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("SYSCS_INVALIDATE_STORED_STATEMENTS")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .sqlControl(RoutineAliasInfo.NO_SQL).returnType(null).isDeterministic(false)
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("GET_ACTIVATION")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .returnType(null).isDeterministic(false)
-                            .varchar("statement", Limits.DB2_VARCHAR_MAXWIDTH)
-                            .build());
-
-                    // Stored procedure that updates the owner (authorization id) of an existing schema.
-                    procedures.add(Procedure.newBuilder().name("SYSCS_UPDATE_SCHEMA_OWNER")
-                        .numOutputParams(0)
-                        .numResultSets(0)
-                        .ownerClass(SpliceAdmin.class.getCanonicalName())
-                        .sqlControl(RoutineAliasInfo.MODIFIES_SQL_DATA)
-                        .returnType(null)
-                        .isDeterministic(false)
-                        .varchar("schemaName", 128)
-                        .varchar("ownerName", 128)
-                        .build());
-
-                    procedures.add(Procedure.newBuilder().name("SYSCS_GET_RUNNING_BACKUPS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(BackupSystemProcedures.class.getCanonicalName())
-                            .returnType(null).isDeterministic(false)
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("SYSCS_GET_TABLE_COUNT")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .returnType(null).isDeterministic(false)
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("SYSCS_IS_MEM_PLATFORM")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .returnType(null).isDeterministic(false)
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("SYSCS_CANCEL_BACKUP")
-                            .numOutputParams(0)
-                            .bigint("backupId")
-                            .numResultSets(0)
-                            .ownerClass(BackupSystemProcedures.class.getCanonicalName())
-                            .returnType(null).isDeterministic(false)
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("SYSCS_RESTORE_DATABASE_OWNER")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .sqlControl(RoutineAliasInfo.NO_SQL).returnType(null).isDeterministic(false)
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("SYSCS_BACKUP_TABLE")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(BackupSystemProcedures.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .varchar("directory", 32672)
-                            .varchar("type", 30)
-                            .returnType(null).isDeterministic(false)
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("SYSCS_RESTORE_TABLE")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(BackupSystemProcedures.class.getCanonicalName())
-                            .catalog("destSchema")
-                            .catalog("destTable")
-                            .catalog("sourceSchema")
-                            .catalog("sourceTable")
-                            .varchar("directory", 32672)
-                            .bigint("backupId")
-                            .arg("validate", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
-                            .returnType(null).isDeterministic(false)
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("SYSCS_BACKUP_SCHEMA")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(BackupSystemProcedures.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .varchar("directory", 32672)
-                            .varchar("type", 30)
-                            .returnType(null).isDeterministic(false)
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("SYSCS_RESTORE_SCHEMA")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(BackupSystemProcedures.class.getCanonicalName())
-                            .catalog("destSchema")
-                            .catalog("sourceSchema")
-                            .varchar("directory", 32672)
-                            .bigint("backupId")
-                            .arg("validate", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
-                            .returnType(null).isDeterministic(false)
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("SYSCS_RESTORE_DATABASE_TO_TIMESTAMP")
-                            .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
-                            .varchar("directory", 32672)
-                            .bigint("backupId")
-                            .arg("validate", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
-                            .varchar("pointInTime", 100)
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("SYSCS_RESTORE_DATABASE_TO_TRANSACTION")
-                            .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
-                            .varchar("directory", 32672)
-                            .bigint("backupId")
-                            .arg("validate", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
-                            .bigint("transactionId")
-                            .build());
-
-                    procedures.add(Procedure.newBuilder().name("SYSCS_SAVE_SOURCECODE")
-                            .numResultSets(0).numOutputParams(0).modifiesSql()
-                            .returnType(null).isDeterministic(false)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("objectName")
-                            .varchar("objectType", 32)
-                            .varchar("objectForm", 32)
-                            .catalog("definerName")
-                            .arg("sourceCode", DataTypeDescriptor.getCatalogType(Types.BLOB,64*1024*1024))
-                            .build());
-
-                    Procedure purgeDeletedRows = Procedure.newBuilder().name("SET_PURGE_DELETED_ROWS")
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .varchar("enable", 5)
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(purgeDeletedRows);
-
-                    Procedure minRetentionPeriod = Procedure.newBuilder().name("SET_MIN_RETENTION_PERIOD")
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .bigint("minRetentionPeriod")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(minRetentionPeriod);
-
-                    Procedure snapshotSchema = Procedure.newBuilder().name("SNAPSHOT_SCHEMA")
-                            .varchar("schemaName", 128)
-                            .varchar("snapshotName", 128)
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(snapshotSchema);
-
-                    Procedure snapshotTable = Procedure.newBuilder().name("SNAPSHOT_TABLE")
-                            .varchar("schemaName", 128)
-                            .varchar("tableName", 128)
-                            .varchar("snapshotName", 128)
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(snapshotTable);
-
-                    Procedure deleteSnapshot = Procedure.newBuilder().name("DELETE_SNAPSHOT")
-                            .varchar("snapshotName", 128)
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(deleteSnapshot);
-
-                    Procedure restoreSnapshot = Procedure.newBuilder().name("RESTORE_SNAPSHOT")
-                            .varchar("snapshotName", 128)
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(restoreSnapshot);
-
-                    Procedure getEncodedRegionName = Procedure.newBuilder().name("GET_ENCODED_REGION_NAME")
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .catalog("indexName")
-                            .varchar("splitKey", 32672)
-                            .varchar("columnDelimiter",5)
-                            .varchar("characterDelimiter", 5)
-                            .varchar("timestampFormat",32672)
-                            .varchar("dateFormat",32672)
-                            .varchar("timeFormat",32672)
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getEncodedRegionName);
-
-                    Procedure getSplitKey = Procedure.newBuilder().name("GET_START_KEY")
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .catalog("indexName")
-                            .varchar("encodedRegionName", 128)
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getSplitKey);
-
-                    Procedure compactRegion = Procedure.newBuilder().name("COMPACT_REGION")
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .catalog("indexName")
-                            .varchar("regionName", 128)
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(compactRegion);
-
-                    Procedure majorCompactRegion = Procedure.newBuilder().name("MAJOR_COMPACT_REGION")
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .catalog("indexName")
-                            .varchar("regionName", 128)
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(majorCompactRegion);
-
-                    Procedure mergeRegion = Procedure.newBuilder().name("MERGE_REGIONS")
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .catalog("indexName")
-                            .varchar("regionName1", 128)
-                            .varchar("regionName2", 128)
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(mergeRegion);
-
-                    Procedure getAllRegions = Procedure.newBuilder().name("GET_REGIONS")
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .catalog("indexName")
-                            .varchar("startKey", 32672)
-                            .varchar("endKey", 32672)
-                            .varchar("columnDelimiter",5)
-                            .varchar("characterDelimiter", 5)
-                            .varchar("timestampFormat",32672)
-                            .varchar("dateFormat",32672)
-                            .varchar("timeFormat",32672)
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(getAllRegions);
-
-                    Procedure deleteRegion = Procedure.newBuilder().name("DELETE_REGION")
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .catalog("indexName")
-                            .varchar("regionName", 128)
-                            .varchar("merge", 5)
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(deleteRegion);
-
-                    Procedure invalidateLocalCache = Procedure.newBuilder().name("INVALIDATE_DICTIONARY_CACHE")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(invalidateLocalCache);
-
-                    Procedure invalidateGlobalCache = Procedure.newBuilder().name("INVALIDATE_GLOBAL_DICTIONARY_CACHE")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(invalidateGlobalCache);
-
-                    Procedure checkTable = Procedure.newBuilder().name("CHECK_TABLE")
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .catalog("indexName")
-                            .integer("level")
-                            .varchar("outputFile", 32672)
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceTableAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(checkTable);
-
-                    Procedure fixTable = Procedure.newBuilder().name("FIX_TABLE")
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .catalog("indexName")
-                            .varchar("outputFile", 32672)
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(SpliceTableAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(fixTable);
-
-                    Procedure showCreateTable = Procedure.newBuilder().name("SHOW_CREATE_TABLE")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .varchar("schemaName", 128)
-                            .varchar("tableName", 128)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(showCreateTable);
-
-                    Procedure addPeer = Procedure.newBuilder().name("ADD_PEER")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .smallint("peerId")
-                            .varchar("clusterKey", 32672)
-                            .arg("enabled", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .build();
-                    procedures.add(addPeer);
-
-                    Procedure removePeer = Procedure.newBuilder().name("REMOVE_PEER")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .smallint("peerId")
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .build();
-                    procedures.add(removePeer);
-
-                    Procedure enablePeer = Procedure.newBuilder().name("ENABLE_PEER")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .smallint("peerId")
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .build();
-                    procedures.add(enablePeer);
-
-                    Procedure disablePeer = Procedure.newBuilder().name("DISABLE_PEER")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .smallint("peerId")
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .build();
-                    procedures.add(disablePeer);
-
-                    Procedure enableTableReplication = Procedure.newBuilder().name("ENABLE_TABLE_REPLICATION")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .build();
-                    procedures.add(enableTableReplication);
-
-                    Procedure disableTableReplication = Procedure.newBuilder().name("DISABLE_TABLE_REPLICATION")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .build();
-                    procedures.add(disableTableReplication);
-
-                    Procedure setReplicationRole = Procedure.newBuilder().name("SET_REPLICATION_ROLE")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .varchar("role", 10)
-                            .build();
-                    procedures.add(setReplicationRole);
-
-                    Procedure getReplicationRole = Procedure.newBuilder().name("GET_REPLICATION_ROLE")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .build();
-                    procedures.add(getReplicationRole);
-
-                    Procedure updateAllSystemProcedures = Procedure.newBuilder()
-                            .name("SYSCS_UPDATE_ALL_SYSTEM_PROCEDURES")
-                            .numOutputParams(0).numResultSets(0).modifiesSql()
-                            .returnType(null).isDeterministic(false)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .build();
-                    procedures.add(updateAllSystemProcedures);
-
-                    Procedure updateSystemProcedure = Procedure.newBuilder().name("SYSCS_UPDATE_SYSTEM_PROCEDURE")
-                            .numOutputParams(0).numResultSets(0).modifiesSql()
-                            .returnType(null).isDeterministic(false)
-                            .ownerClass(SpliceAdmin.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .catalog("procName")
-                            .build();
-                    procedures.add(updateSystemProcedure);
-
-                    Procedure enableSchemaReplication = Procedure.newBuilder().name("ENABLE_SCHEMA_REPLICATION")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .build();
-                    procedures.add(enableSchemaReplication);
-
-
-                    Procedure disableSchemaReplication = Procedure.newBuilder().name("DISABLE_SCHEMA_REPLICATION")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .catalog("schemaName")
-                            .build();
-                    procedures.add(disableSchemaReplication);
-
-                    Procedure enableDatabaseReplication = Procedure.newBuilder().name("ENABLE_DATABASE_REPLICATION")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .build();
-                    procedures.add(enableDatabaseReplication);
-
-                    Procedure disableDatabaseReplication = Procedure.newBuilder().name("DISABLE_DATABASE_REPLICATION")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .build();
-                    procedures.add(disableDatabaseReplication);
-
-                    Procedure getClusterKey = Procedure.newBuilder().name("GET_CLUSTER_KEY")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .build();
-                    procedures.add(getClusterKey);
-
-                    Procedure getPeers = Procedure.newBuilder().name("LIST_PEERS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .build();
-                    procedures.add(getPeers);
-
-                    Procedure getWalPositions = Procedure.newBuilder().name("GET_REPLICATED_WAL_POSITIONS")
-                            .numOutputParams(0)
-                            .smallint("peerId")
-                            .numResultSets(1)
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .build();
-                    procedures.add(getWalPositions);
-
-                    Procedure getWalPosition = Procedure.newBuilder().name("GET_REPLICATED_WAL_POSITION")
-                            .numOutputParams(0)
-                            .varchar("wal",32672)
-                            .numResultSets(1)
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .build();
-                    procedures.add(getWalPosition);
-
-                    Procedure getReplicationProgress = Procedure.newBuilder().name("GET_REPLICATION_PROGRESS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .build();
-                    procedures.add(getReplicationProgress);
-
-                    Procedure dumpUnreplicatedWals = Procedure.newBuilder().name("DUMP_UNREPLICATED_WALS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .build();
-                    procedures.add(dumpUnreplicatedWals);
-
-                    Procedure replicationEnabled = Procedure.newBuilder().name("REPLICATION_ENABLED")
-                            .numOutputParams(0)
-                            .catalog("schemaName")
-                            .catalog("tableName")
-                            .numResultSets(1)
-                            .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
-                            .build();
-                    procedures.add(replicationEnabled);
-
-                    Procedure beginRollingUpgrade = Procedure.newBuilder().name("BEGIN_ROLLING_UPGRADE")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(UpgradeSystemProcedures.class.getCanonicalName())
-                            .build();
-                    procedures.add(beginRollingUpgrade);
-
-                    Procedure endRollingUpgrade = Procedure.newBuilder().name("END_ROLLING_UPGRADE")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .ownerClass(UpgradeSystemProcedures.class.getCanonicalName())
-                            .build();
-                    procedures.add(endRollingUpgrade);
-
-                    Procedure unloadRegions = Procedure.newBuilder().name("UNLOAD_REGIONS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .varchar("hostAndPort", 32672)
-                            .ownerClass(UpgradeSystemProcedures.class.getCanonicalName())
-                            .build();
-                    procedures.add(unloadRegions);
-
-                    Procedure loadRegions = Procedure.newBuilder().name("LOAD_REGIONS")
-                            .numOutputParams(0)
-                            .numResultSets(1)
-                            .varchar("hostAndPort", 32672)
-                            .ownerClass(UpgradeSystemProcedures.class.getCanonicalName())
-                            .build();
-                    procedures.add(loadRegions);
+                    createSysUtilProcedures(procedures);
                 }  // End key == sysUUID
 
             } // End iteration through map keys (schema UUIDs)
@@ -1622,6 +134,1487 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
         } // end of synchronized block
 
         return sysProcedures;
+    }
+
+    static public void createSysUtilProcedures(List<Procedure> procedures) {
+        Procedure refreshExternalTable = Procedure.newBuilder().name("SYSCS_REFRESH_EXTERNAL_TABLE")
+                .numOutputParams(0).numResultSets(0).ownerClass(ExternalTableSystemProcedures.class.getCanonicalName())
+                .varchar("schema", 32672)
+                .varchar("table", 32672)
+                .build();
+        procedures.add(refreshExternalTable);
+
+        /*
+         * Add a system procedure to enable splitting tables once data is loaded.
+         *
+         * We do this here because this way we know we're in the SYSCS procedure set
+         */
+        Procedure splitProc = Procedure.newBuilder().name("SYSCS_SPLIT_TABLE")
+                .numOutputParams(0).numResultSets(0).ownerClass(TableSplit.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("tableName")
+                .build();
+        procedures.add(splitProc);
+
+        Procedure splitProc1 = Procedure.newBuilder().name("SYSCS_SPLIT_TABLE_AT_POINTS")
+                .numOutputParams(0).numResultSets(0).ownerClass(TableSplit.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("tableName")
+                .varchar("splitPoints", 32672)
+                .build();
+        procedures.add(splitProc1);
+
+        Procedure splitProc2 = Procedure.newBuilder().name("SYSCS_SPLIT_TABLE_EVENLY")
+                .numOutputParams(0).numResultSets(0).ownerClass(TableSplit.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("tableName")
+                .integer("numSplits")
+                .build();
+        procedures.add(splitProc2);
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_SPLIT_REGION_AT_POINTS")
+                               .numOutputParams(0).numResultSets(0).ownerClass(TableSplit.class.getCanonicalName())
+                               .catalog("regionName")
+                               .varchar("splitPoints", 32672)
+                               .build());
+
+        Procedure splitProc3 = Procedure.newBuilder().name("SYSCS_SPLIT_TABLE_OR_INDEX_AT_POINTS")
+                .numOutputParams(0).numResultSets(0).ownerClass(TableSplit.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("tableName")
+                .catalog("indexName")
+                .varchar("splitPoints", 32672)
+                .build();
+        procedures.add(splitProc3);
+
+        Procedure splitProc4 = Procedure.newBuilder().name("SYSCS_SPLIT_TABLE_OR_INDEX")
+                .numOutputParams(0).numResultSets(1).ownerClass(TableSplit.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("tableName")
+                .catalog("indexName")
+                .varchar("columnList",32672)
+                .varchar("fileName",32672)
+                .varchar("columnDelimiter",5)
+                .varchar("characterDelimiter", 5)
+                .varchar("timestampFormat",32672)
+                .varchar("dateFormat",32672)
+                .varchar("timeFormat",32672)
+                .bigint("maxBadRecords")
+                .varchar("badRecordDirectory",32672)
+                .varchar("oneLineRecords",5)
+                .varchar("charset",32672)
+                .build();
+        procedures.add(splitProc4);
+
+        /*
+        * Procedure get all active services
+        */
+        Procedure getActiveServers = Procedure.newBuilder().name("SYSCS_GET_ACTIVE_SERVERS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .sqlControl(RoutineAliasInfo.READS_SQL_DATA)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getActiveServers);
+
+        /*
+         * Procedure get all active requests
+         */
+        Procedure getRequests = Procedure.newBuilder().name("SYSCS_GET_REQUESTS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getRequests);
+
+        /*
+         * Procedure get stats info for region servers
+         */
+        Procedure getRegionServerStatsInfo = Procedure.newBuilder().name("SYSCS_GET_REGION_SERVER_STATS_INFO")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .sqlControl(RoutineAliasInfo.NO_SQL)
+                .build();
+        procedures.add(getRegionServerStatsInfo);
+
+        /*
+         * Procedure fetch logical configuration from region servers
+         */
+        Procedure getRegionServerConfig = Procedure.newBuilder().name("SYSCS_GET_REGION_SERVER_CONFIG_INFO")
+                .varchar("configRoot", 128) // fetch only config props with prefix, or null for fetch all
+                .integer("mode")            // 0 = fetch all, 1 = fetch only props where value not same on all servers
+                .numOutputParams(0)
+                .numResultSets(1)
+                .sqlControl(RoutineAliasInfo.NO_SQL)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getRegionServerConfig);
+
+        /*
+         * Procedure get Splice Machine manifest info
+         */
+        Procedure getVersionInfo = Procedure.newBuilder().name("SYSCS_GET_VERSION_INFO")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .sqlControl(RoutineAliasInfo.READS_SQL_DATA)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getVersionInfo);
+
+        Procedure getVersionInfoLocal = Procedure.newBuilder().name("SYSCS_GET_VERSION_INFO_LOCAL")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .sqlControl(RoutineAliasInfo.READS_SQL_DATA)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getVersionInfoLocal);
+
+        /*
+         * Procedure get write pipeline intake info
+         */
+        Procedure getWriteIntakeInfo = Procedure.newBuilder().name("SYSCS_GET_WRITE_INTAKE_INFO")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getWriteIntakeInfo);
+
+        /*
+         * Procedure get exec service info
+         */
+        Procedure getExecServiceInfo = Procedure.newBuilder().name("SYSCS_GET_EXEC_SERVICE_INFO")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getExecServiceInfo);
+
+        /*
+         * Procedure get each individual cache info
+         */
+        Procedure getCacheInfo = Procedure.newBuilder().name("SYSCS_GET_CACHE_INFO")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getCacheInfo);
+
+        /*
+         * Procedure get total cache info
+         */
+        Procedure getTotalCacheInfo = Procedure.newBuilder().name("SYSCS_GET_TOTAL_CACHE_INFO")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getTotalCacheInfo);
+
+        /*
+         * Procedures to kill stale transactions
+         */
+        Procedure killTransaction = Procedure.newBuilder().name("SYSCS_KILL_TRANSACTION")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .bigint("transactionId")
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(killTransaction);
+
+        Procedure killStaleTransactions = Procedure.newBuilder().name("SYSCS_KILL_STALE_TRANSACTIONS")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .bigint("maximumTransactionId")
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(killStaleTransactions);
+
+//                    Procedure dumpTransactions = Procedure.newBuilder().name("SYSCS_DUMP_TRANSACTIONS")
+//                            .numOutputParams(0)
+//                            .numResultSets(1)
+//                            .ownerClass(TransactionAdmin.class.getCanonicalName())
+//                            .build();
+//                    procedures.add(dumpTransactions);
+
+        Procedure currTxn = Procedure.newBuilder().name("SYSCS_GET_CURRENT_TRANSACTION")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(TransactionAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(currTxn);
+
+        Procedure activeTxn = Procedure.newBuilder().name("SYSCS_GET_ACTIVE_TRANSACTION_IDS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(TransactionAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(activeTxn);
+
+        /*
+         * Statistics procedures
+         */
+        Procedure collectStatsForTable = Procedure.newBuilder().name("COLLECT_TABLE_STATISTICS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .varchar("schema",128)
+                .varchar("table",1024)
+                .arg("staleOnly", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
+                .ownerClass(StatisticsAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(collectStatsForTable);
+
+        Collection<Procedure> procs = MetadataFactoryService.newMetadataFactory().getProcedures();
+
+        if (procs != null)
+            procedures.addAll(procs);
+
+        Procedure collectSampleStatsForTable = Procedure.newBuilder().name("COLLECT_TABLE_SAMPLE_STATISTICS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .varchar("schema",128)
+                .varchar("table",1024)
+                .arg("samplePercentage", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.DOUBLE).getCatalogType())
+                .arg("staleOnly", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
+                .ownerClass(StatisticsAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(collectSampleStatsForTable);
+
+        Procedure collectNonMergedStatsForTable = Procedure.newBuilder().name("COLLECT_NONMERGED_TABLE_STATISTICS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .varchar("schema",128)
+                .varchar("table",1024)
+                .arg("staleOnly", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
+                .ownerClass(StatisticsAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(collectNonMergedStatsForTable);
+
+        Procedure collectNonMergedSampleStatsForTable = Procedure.newBuilder().name("COLLECT_NONMERGED_TABLE_SAMPLE_STATISTICS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .varchar("schema",1024)
+                .varchar("table",1024)
+                .arg("samplePercentage", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.DOUBLE).getCatalogType())
+                .arg("staleOnly", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
+                .ownerClass(StatisticsAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(collectNonMergedSampleStatsForTable);
+
+        Procedure fakeStatsForTable = Procedure.newBuilder().name("FAKE_TABLE_STATISTICS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .modifiesSql()
+                .catalog("schema")
+                .catalog("table")
+                .arg("rowCount", DataTypeDescriptor.getCatalogType(Types.BIGINT))
+                .arg("meanRowsize", DataTypeDescriptor.getCatalogType(Types.INTEGER))
+                .arg("numPartitions", DataTypeDescriptor.getCatalogType(Types.BIGINT))
+                .ownerClass(StatisticsAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(fakeStatsForTable);
+
+        Procedure fakeStatsForColumn = Procedure.newBuilder().name("FAKE_COLUMN_STATISTICS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .modifiesSql()
+                .catalog("schema")
+                .catalog("table")
+                .varchar("column",1024)
+                .arg("nullCountRatio", DataTypeDescriptor.getCatalogType(Types.DOUBLE))
+                .arg("rowsPerValue", DataTypeDescriptor.getCatalogType(Types.BIGINT))
+                .ownerClass(StatisticsAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(fakeStatsForColumn);
+
+        Procedure importWithBadRecords = Procedure.newBuilder().name("IMPORT_DATA")
+                .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("tableName")
+                .varchar("insertColumnList",32672)
+                .varchar("fileName",32672)
+                .varchar("columnDelimiter",5)
+                .varchar("characterDelimiter", 5)
+                .varchar("timestampFormat",32672)
+                .varchar("dateFormat",32672)
+                .varchar("timeFormat",32672)
+                .bigint("maxBadRecords")
+                .varchar("badRecordDirectory",32672)
+                .varchar("oneLineRecords",5)
+                .varchar("charset",32672)
+                .build();
+        procedures.add(importWithBadRecords);
+
+
+        Procedure loadReplaceProc = Procedure.newBuilder().name("LOAD_REPLACE")
+                .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("tableName")
+                .varchar("insertColumnList",32672)
+                .varchar("fileName",32672)
+                .varchar("columnDelimiter",5)
+                .varchar("characterDelimiter", 5)
+                .varchar("timestampFormat",32672)
+                .varchar("dateFormat",32672)
+                .varchar("timeFormat",32672)
+                .bigint("maxBadRecords")
+                .varchar("badRecordDirectory",32672)
+                .varchar("oneLineRecords",5)
+                .varchar("charset",32672)
+                .build();
+        procedures.add(loadReplaceProc);
+
+        Procedure importUnsafe = Procedure.newBuilder().name("IMPORT_DATA_UNSAFE")
+                .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("tableName")
+                .varchar("insertColumnList",32672)
+                .varchar("fileName",32672)
+                .varchar("columnDelimiter",5)
+                .varchar("characterDelimiter", 5)
+                .varchar("timestampFormat",32672)
+                .varchar("dateFormat",32672)
+                .varchar("timeFormat",32672)
+                .bigint("maxBadRecords")
+                .varchar("badRecordDirectory",32672)
+                .varchar("oneLineRecords",5)
+                .varchar("charset",32672)
+                .build();
+        procedures.add(importUnsafe);
+
+        Procedure bulkImportHFile = Procedure.newBuilder().name("BULK_IMPORT_HFILE")
+                 .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
+                 .catalog("schemaName")
+                 .catalog("tableName")
+                 .varchar("insertColumnList",32672)
+                 .varchar("fileName",32672)
+                 .varchar("columnDelimiter",5)
+                 .varchar("characterDelimiter", 5)
+                 .varchar("timestampFormat",32672)
+                 .varchar("dateFormat",32672)
+                 .varchar("timeFormat",32672)
+                 .bigint("maxBadRecords")
+                 .varchar("badRecordDirectory",32672)
+                 .varchar("oneLineRecords",5)
+                 .varchar("charset",32672)
+                 .varchar("bulkImportDirectory", 32672)
+                 .varchar("skipSampling", 5)
+                 .build();
+        procedures.add(bulkImportHFile);
+
+
+        Procedure sampleData = Procedure.newBuilder().name("SAMPLE_DATA")
+                .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("tableName")
+                .varchar("insertColumnList",32672)
+                .varchar("fileName",32672)
+                .varchar("columnDelimiter",5)
+                .varchar("characterDelimiter", 5)
+                .varchar("timestampFormat",32672)
+                .varchar("dateFormat",32672)
+                .varchar("timeFormat",32672)
+                .bigint("maxBadRecords")
+                .varchar("badRecordDirectory",32672)
+                .varchar("oneLineRecords",5)
+                .varchar("charset",32672)
+                .varchar("bulkImportDirectory", 32672)
+                .build();
+        procedures.add(sampleData);
+
+        Procedure computeSplitKey= Procedure.newBuilder().name("COMPUTE_SPLIT_KEY")
+                .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("tableName")
+                .catalog("indexName")
+                .varchar("columnList",32672)
+                .varchar("fileName",32672)
+                .varchar("columnDelimiter",5)
+                .varchar("characterDelimiter", 5)
+                .varchar("timestampFormat",32672)
+                .varchar("dateFormat",32672)
+                .varchar("timeFormat",32672)
+                .bigint("maxBadRecords")
+                .varchar("badRecordDirectory",32672)
+                .varchar("oneLineRecords",5)
+                .varchar("charset",32672)
+                .varchar("outputDirectory", 32672)
+                .build();
+        procedures.add(computeSplitKey);
+
+        Procedure upport = Procedure.newBuilder().name("UPSERT_DATA_FROM_FILE")
+                .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("tableName")
+                .varchar("insertColumnList",32672)
+                .varchar("fileName",32672)
+                .varchar("columnDelimiter",5)
+                .varchar("characterDelimiter", 5)
+                .varchar("timestampFormat",32672)
+                .varchar("dateFormat",32672)
+                .varchar("timeFormat",32672)
+                .bigint("maxBadRecords")
+                .varchar("badRecordDirectory",32672)
+                .varchar("oneLineRecords",5)
+                .varchar("charset",32672)
+                .build();
+        procedures.add(upport);
+
+        Procedure merge = Procedure.newBuilder().name("MERGE_DATA_FROM_FILE")
+                .numOutputParams(0).numResultSets(1).ownerClass(HdfsImport.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("tableName")
+                .varchar("insertColumnList",32672)
+                .varchar("fileName",32672)
+                .varchar("columnDelimiter",5)
+                .varchar("characterDelimiter", 5)
+                .varchar("timestampFormat",32672)
+                .varchar("dateFormat",32672)
+                .varchar("timeFormat",32672)
+                .bigint("maxBadRecords")
+                .varchar("badRecordDirectory",32672)
+                .varchar("oneLineRecords",5)
+                .varchar("charset",32672)
+                .build();
+        procedures.add(merge);
+
+        Procedure dropStatsForSchema = Procedure.newBuilder().name("DROP_SCHEMA_STATISTICS")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .varchar("schema",128)
+                .ownerClass(StatisticsAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(dropStatsForSchema);
+
+        Procedure dropStatsForTable = Procedure.newBuilder().name("DROP_TABLE_STATISTICS")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .varchar("schema",128)
+                .varchar("table",1024)
+                .ownerClass(StatisticsAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(dropStatsForTable);
+
+        Procedure collectStatsForSchema = Procedure.newBuilder().name("COLLECT_SCHEMA_STATISTICS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .varchar("schema",128)
+                .arg("staleOnly", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
+                .ownerClass(StatisticsAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(collectStatsForSchema);
+
+        Procedure enableStatsForColumn = Procedure.newBuilder().name("ENABLE_COLUMN_STATISTICS")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .modifiesSql()
+                .varchar("schema",1024)
+                .varchar("table",1024)
+                .varchar("column",1024)
+                .ownerClass(StatisticsAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(enableStatsForColumn);
+
+        Procedure disableStatsForColumn = Procedure.newBuilder().name("DISABLE_COLUMN_STATISTICS")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .modifiesSql()
+                .varchar("schema",1024)
+                .varchar("table",1024)
+                .varchar("column",1024)
+                .ownerClass(StatisticsAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(disableStatsForColumn);
+
+        Procedure enableStatsForAllColumns = Procedure.newBuilder().name("ENABLE_ALL_COLUMN_STATISTICS")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .modifiesSql()
+                .catalog("schema")
+                .catalog("table")
+                .ownerClass(StatisticsAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(enableStatsForAllColumns);
+
+        Procedure disableStatsForAllColumns = Procedure.newBuilder().name("DISABLE_ALL_COLUMN_STATISTICS")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .modifiesSql()
+                .catalog("schema")
+                .catalog("table")
+                .ownerClass(StatisticsAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(disableStatsForAllColumns);
+
+        Procedure setStatsExtrapolationForColumn = Procedure.newBuilder().name("SET_STATS_EXTRAPOLATION_FOR_COLUMN")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .modifiesSql()
+                .varchar("schema",1024)
+                .varchar("table",1024)
+                .varchar("column",1024)
+                .smallint("useExtrapolation")
+                .ownerClass(StatisticsAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(setStatsExtrapolationForColumn);
+
+        /*
+         * Procedure to get the session details
+         */
+        Procedure sessionInfo = Procedure.newBuilder().name("SYSCS_GET_SESSION_INFO")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(sessionInfo);
+
+
+        /*
+         * Procedure to get a list of running operations
+         */
+        Procedure runningOperations = Procedure.newBuilder().name("SYSCS_GET_RUNNING_OPERATIONS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(runningOperations);
+
+        /*
+         * Procedure to get a list of running operations on the local server
+         */
+        Procedure runningOperationsLocal = Procedure.newBuilder().name("SYSCS_GET_RUNNING_OPERATIONS_LOCAL")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(runningOperationsLocal);
+
+
+        /*
+         * Procedure to kill an executing operation
+         */
+        Procedure killOperationLocal = Procedure.newBuilder().name("SYSCS_KILL_OPERATION_LOCAL")
+                .numOutputParams(0)
+                .varchar("uuid",128)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(killOperationLocal);
+
+        /*
+         * Procedure to kill an executing operation
+         */
+        Procedure killOperation = Procedure.newBuilder().name("SYSCS_KILL_OPERATION")
+                .numOutputParams(0)
+                .varchar("uuid",128)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(killOperation);
+
+        /*
+         * Procedure to kill an executing DRDA operation
+         */
+        Procedure killDrdaOperationLocal = Procedure.newBuilder().name("SYSCS_KILL_DRDA_OPERATION_LOCAL")
+                .numOutputParams(0)
+                .varchar("rdbIntTkn",512)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(killDrdaOperationLocal);
+
+        /*
+         * Procedure to kill an executing DRDA operation
+         */
+        Procedure killDrdaOperation = Procedure.newBuilder().name("SYSCS_KILL_DRDA_OPERATION")
+                .numOutputParams(0)
+                .varchar("rdbIntTkn",512)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(killDrdaOperation);
+
+
+        /*
+         * Procedure to get oldest active transaction id
+         */
+        Procedure getActiveTxn = Procedure.newBuilder().name("SYSCS_GET_OLDEST_ACTIVE_TRANSACTION")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getActiveTxn);
+
+        /*
+         * Procedure to delegate HDFS operations
+         */
+        Procedure hdfsOperation = Procedure.newBuilder().name("SYSCS_HDFS_OPERATION")
+                .numOutputParams(0)
+                .varchar("path",128)
+                .varchar("op", 64)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(hdfsOperation);
+
+        /*
+         * Procedure to delegate HBase operations
+         */
+        Procedure hbaseOperation = Procedure.newBuilder().name("SYSCS_HBASE_OPERATION")
+                .numOutputParams(0)
+                .varchar("table",128)
+                .varchar("op", 64)
+                .blob("request")
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(hbaseOperation);
+
+        /*
+         * Procedure to get Splice Token
+         */
+        Procedure getToken = Procedure.newBuilder().name("SYSCS_GET_SPLICE_TOKEN")
+                .numOutputParams(0)
+                .varchar("username",256)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getToken);
+
+        /*
+         * Procedure to cancel a Splice Token
+         */
+        Procedure cancelToken = Procedure.newBuilder().name("SYSCS_CANCEL_SPLICE_TOKEN")
+                .numOutputParams(0)
+                .blob("request")
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(cancelToken);
+
+        /*
+         * Procedure to elevate a transaction
+         */
+        Procedure elevProc = Procedure.newBuilder().name("SYSCS_ELEVATE_TRANSACTION")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .varchar("tableName", 128) // input
+                .ownerClass(TransactionAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(elevProc);
+
+        /*
+         * Procedure to start a child transaction
+         */
+        Procedure childTxnProc = Procedure.newBuilder().name("SYSCS_START_CHILD_TRANSACTION")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .bigint("parentTransactionId") // input
+                .varchar("tableName", 128) // input
+                .ownerClass(TransactionAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(childTxnProc);
+
+        /*
+         * Procedure to commit a child transaction
+         */
+        Procedure commitTxnProc = Procedure.newBuilder().name("SYSCS_COMMIT_CHILD_TRANSACTION")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .bigint("childTransactionId") // input
+                .ownerClass(TransactionAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(commitTxnProc);
+
+        /*
+         * Procedure to get the log level for the given logger
+         */
+        Procedure getLoggerLevel = Procedure.newBuilder().name("SYSCS_GET_LOGGER_LEVEL")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .varchar("loggerName", 128)
+                .sqlControl(RoutineAliasInfo.READS_SQL_DATA)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getLoggerLevel);
+
+        Procedure getLoggerLevelLocal = Procedure.newBuilder().name("SYSCS_GET_LOGGER_LEVEL_LOCAL")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .varchar("loggerName", 128)
+                .sqlControl(RoutineAliasInfo.READS_SQL_DATA)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getLoggerLevelLocal);
+
+        /*
+         * Procedure to set the log level for the given logger
+         */
+        Procedure setLoggerLevel = Procedure.newBuilder().name("SYSCS_SET_LOGGER_LEVEL")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .varchar("loggerName", 128)
+                .varchar("loggerLevel", 128)
+                .sqlControl(RoutineAliasInfo.NO_SQL)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(setLoggerLevel);
+
+        Procedure setLoggerLevelLocal = Procedure.newBuilder().name("SYSCS_SET_LOGGER_LEVEL_LOCAL")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .varchar("loggerName", 128)
+                .varchar("loggerLevel", 128)
+                .sqlControl(RoutineAliasInfo.NO_SQL)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(setLoggerLevelLocal);
+
+        /*
+         * Procedure to get all the splice logger names in the system
+         */
+        Procedure getLoggers = Procedure.newBuilder().name("SYSCS_GET_LOGGERS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getLoggers);
+
+        Procedure getLoggersLocal = Procedure.newBuilder().name("SYSCS_GET_LOGGERS_LOCAL")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getLoggersLocal);
+
+        /*
+         * Procedure get table info in all schema
+         */
+        Procedure getSchemaInfo = Procedure.newBuilder().name("SYSCS_GET_SCHEMA_INFO")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getSchemaInfo);
+
+        /*
+         * Procedure to perform major compaction on all tables in a schema
+         */
+        Procedure majorComactionOnSchema = Procedure.newBuilder().name("SYSCS_PERFORM_MAJOR_COMPACTION_ON_SCHEMA")
+                .varchar("schemaName", 128)
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(majorComactionOnSchema);
+
+        /*
+         * Procedure to perform major compaction on a table in a schema
+         */
+        Procedure majorComactionOnTable = Procedure.newBuilder().name("SYSCS_PERFORM_MAJOR_COMPACTION_ON_TABLE")
+                .varchar("schemaName", 128)
+                .varchar("tableName", 128)
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(majorComactionOnTable);
+
+        /*
+         * Procedure to perform major flush on a table in a schema
+         */
+        Procedure flushTable = Procedure.newBuilder().name("SYSCS_FLUSH_TABLE")
+                .varchar("schemaName", 128)
+                .varchar("tableName", 128)
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(flushTable);
+
+        /*
+         * Procedure to delete rows from data dictionary
+         */
+        Procedure dictionaryDelete = Procedure.newBuilder().name("SYSCS_DICTIONARY_DELETE")
+                .integer("conglomerateId")
+                .varchar("rowId", 1024)
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(dictionaryDelete);
+
+        /*
+         * Procedure to get all the information related to the execution plans of the stored prepared statements (metadata queries).
+         */
+        Procedure getStoredStatementPlanInfo = Procedure.newBuilder().name("SYSCS_GET_STORED_STATEMENT_PLAN_INFO")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getStoredStatementPlanInfo);
+
+        /*
+         * Procedure to print all of the properties (JVM, Service, Database, App).
+         */
+        Procedure getAllSystemProperties = Procedure.newBuilder().name("SYSCS_GET_ALL_PROPERTIES")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getAllSystemProperties);
+
+        Procedure vacuum = Procedure.newBuilder().name("VACUUM")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(vacuum);
+
+
+        /*
+         * Procedure to return timestamp generator info
+         */
+        procedures.add(Procedure.newBuilder().name("SYSCS_GET_TIMESTAMP_GENERATOR_INFO")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(TimestampAdmin.class.getCanonicalName())
+                .build());
+
+        /*
+         * Procedure to return timestamp request info
+         */
+        procedures.add(Procedure.newBuilder().name("SYSCS_GET_TIMESTAMP_REQUEST_INFO")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(TimestampAdmin.class.getCanonicalName())
+                .build());
+
+        /*
+         * Procedure to delete a backup
+         */
+        procedures.add(Procedure.newBuilder().name("SYSCS_DELETE_BACKUP")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                .bigint("backupId")
+                .build());
+
+        /*
+         * Procedure to delete backups in a time window
+         */
+        procedures.add(Procedure.newBuilder().name("SYSCS_DELETE_OLD_BACKUPS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                .integer("backupWindow")
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_BACKUP_DATABASE_ASYNC")
+                .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                .varchar("directory", 32672)
+                .varchar("type", 32672)
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_RESTORE_DATABASE_ASYNC")
+                .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                .varchar("directory", 32672)
+                .bigint("backupId")
+                .arg("validate", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("VALIDATE_BACKUP")
+                .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                .varchar("directory", 32672)
+                .bigint("backupId")
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("VALIDATE_TABLE_BACKUP")
+                .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("tableName")
+                .varchar("directory", 32672)
+                .bigint("backupId")
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("VALIDATE_SCHEMA_BACKUP")
+                .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                .catalog("schemaName")
+                .varchar("directory", 32672)
+                .bigint("backupId")
+                .build());
+        /*
+         * Procedure to get a database property on all region servers in the cluster.
+         */
+        procedures.add(Procedure.newBuilder().name("SYSCS_GET_GLOBAL_DATABASE_PROPERTY")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .sqlControl(RoutineAliasInfo.READS_SQL_DATA).returnType(null).isDeterministic(false)
+                .catalog("KEY")
+                .build());
+
+        /*
+         * Procedure to set a database property on all region servers in the cluster.
+         */
+        procedures.add(Procedure.newBuilder().name("SYSCS_SET_GLOBAL_DATABASE_PROPERTY")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .sqlControl(RoutineAliasInfo.MODIFIES_SQL_DATA).returnType(null).isDeterministic(false)
+                .catalog("KEY")
+                .varchar("VALUE", Limits.DB2_VARCHAR_MAXWIDTH)
+                .build());
+
+        /*
+         * Procedure to enable splice enterprise version
+         */
+        procedures.add(Procedure.newBuilder().name("SYSCS_ENABLE_ENTERPRISE")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .sqlControl(RoutineAliasInfo.MODIFIES_SQL_DATA).returnType(null).isDeterministic(false)
+                .varchar("VALUE", Limits.DB2_VARCHAR_MAXWIDTH)
+                .build());
+
+        /*
+         * Procedure to empty the statement caches on all region servers in the cluster.
+         * Essentially a wrapper around the Derby version of SYSCS_EMPTY_STATEMENT_CACHE
+         * which only operates on a single node.
+         */
+        procedures.add(Procedure.newBuilder().name("SYSCS_EMPTY_GLOBAL_STATEMENT_CACHE")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .sqlControl(RoutineAliasInfo.NO_SQL).returnType(null).isDeterministic(false)
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_EMPTY_GLOBAL_STORED_STATEMENT_CACHE")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .sqlControl(RoutineAliasInfo.NO_SQL).returnType(null).isDeterministic(false)
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_INVALIDATE_STORED_STATEMENTS")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .sqlControl(RoutineAliasInfo.NO_SQL).returnType(null).isDeterministic(false)
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("GET_ACTIVATION")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .returnType(null).isDeterministic(false)
+                .varchar("statement", Limits.DB2_VARCHAR_MAXWIDTH)
+                .build());
+
+        // Stored procedure that updates the owner (authorization id) of an existing schema.
+        procedures.add(Procedure.newBuilder().name("SYSCS_UPDATE_SCHEMA_OWNER")
+            .numOutputParams(0)
+            .numResultSets(0)
+            .ownerClass(SpliceAdmin.class.getCanonicalName())
+            .sqlControl(RoutineAliasInfo.MODIFIES_SQL_DATA)
+            .returnType(null)
+            .isDeterministic(false)
+            .varchar("schemaName", 128)
+            .varchar("ownerName", 128)
+            .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_GET_RUNNING_BACKUPS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                .returnType(null).isDeterministic(false)
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_GET_TABLE_COUNT")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .returnType(null).isDeterministic(false)
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_IS_MEM_PLATFORM")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .returnType(null).isDeterministic(false)
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_CANCEL_BACKUP")
+                .numOutputParams(0)
+                .bigint("backupId")
+                .numResultSets(0)
+                .ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                .returnType(null).isDeterministic(false)
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_RESTORE_DATABASE_OWNER")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .sqlControl(RoutineAliasInfo.NO_SQL).returnType(null).isDeterministic(false)
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_BACKUP_TABLE")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("tableName")
+                .varchar("directory", 32672)
+                .varchar("type", 30)
+                .returnType(null).isDeterministic(false)
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_RESTORE_TABLE")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                .catalog("destSchema")
+                .catalog("destTable")
+                .catalog("sourceSchema")
+                .catalog("sourceTable")
+                .varchar("directory", 32672)
+                .bigint("backupId")
+                .arg("validate", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
+                .returnType(null).isDeterministic(false)
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_BACKUP_SCHEMA")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                .catalog("schemaName")
+                .varchar("directory", 32672)
+                .varchar("type", 30)
+                .returnType(null).isDeterministic(false)
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_RESTORE_SCHEMA")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                .catalog("destSchema")
+                .catalog("sourceSchema")
+                .varchar("directory", 32672)
+                .bigint("backupId")
+                .arg("validate", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
+                .returnType(null).isDeterministic(false)
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_RESTORE_DATABASE_TO_TIMESTAMP")
+                .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                .varchar("directory", 32672)
+                .bigint("backupId")
+                .arg("validate", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
+                .varchar("pointInTime", 100)
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_RESTORE_DATABASE_TO_TRANSACTION")
+                .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                .varchar("directory", 32672)
+                .bigint("backupId")
+                .arg("validate", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
+                .bigint("transactionId")
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_SAVE_SOURCECODE")
+                .numResultSets(0).numOutputParams(0).modifiesSql()
+                .returnType(null).isDeterministic(false)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("objectName")
+                .varchar("objectType", 32)
+                .varchar("objectForm", 32)
+                .catalog("definerName")
+                .arg("sourceCode", DataTypeDescriptor.getCatalogType(Types.BLOB,64*1024*1024))
+                .build());
+
+        Procedure purgeDeletedRows = Procedure.newBuilder().name("SET_PURGE_DELETED_ROWS")
+                .catalog("schemaName")
+                .catalog("tableName")
+                .varchar("enable", 5)
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(purgeDeletedRows);
+
+        Procedure minRetentionPeriod = Procedure.newBuilder().name("SET_MIN_RETENTION_PERIOD")
+                .catalog("schemaName")
+                .catalog("tableName")
+                .bigint("minRetentionPeriod")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(minRetentionPeriod);
+
+        Procedure snapshotSchema = Procedure.newBuilder().name("SNAPSHOT_SCHEMA")
+                .varchar("schemaName", 128)
+                .varchar("snapshotName", 128)
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(snapshotSchema);
+
+        Procedure snapshotTable = Procedure.newBuilder().name("SNAPSHOT_TABLE")
+                .varchar("schemaName", 128)
+                .varchar("tableName", 128)
+                .varchar("snapshotName", 128)
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(snapshotTable);
+
+        Procedure deleteSnapshot = Procedure.newBuilder().name("DELETE_SNAPSHOT")
+                .varchar("snapshotName", 128)
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(deleteSnapshot);
+
+        Procedure restoreSnapshot = Procedure.newBuilder().name("RESTORE_SNAPSHOT")
+                .varchar("snapshotName", 128)
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(restoreSnapshot);
+
+        Procedure getEncodedRegionName = Procedure.newBuilder().name("GET_ENCODED_REGION_NAME")
+                .catalog("schemaName")
+                .catalog("tableName")
+                .catalog("indexName")
+                .varchar("splitKey", 32672)
+                .varchar("columnDelimiter",5)
+                .varchar("characterDelimiter", 5)
+                .varchar("timestampFormat",32672)
+                .varchar("dateFormat",32672)
+                .varchar("timeFormat",32672)
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getEncodedRegionName);
+
+        Procedure getSplitKey = Procedure.newBuilder().name("GET_START_KEY")
+                .catalog("schemaName")
+                .catalog("tableName")
+                .catalog("indexName")
+                .varchar("encodedRegionName", 128)
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getSplitKey);
+
+        Procedure compactRegion = Procedure.newBuilder().name("COMPACT_REGION")
+                .catalog("schemaName")
+                .catalog("tableName")
+                .catalog("indexName")
+                .varchar("regionName", 128)
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(compactRegion);
+
+        Procedure majorCompactRegion = Procedure.newBuilder().name("MAJOR_COMPACT_REGION")
+                .catalog("schemaName")
+                .catalog("tableName")
+                .catalog("indexName")
+                .varchar("regionName", 128)
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(majorCompactRegion);
+
+        Procedure mergeRegion = Procedure.newBuilder().name("MERGE_REGIONS")
+                .catalog("schemaName")
+                .catalog("tableName")
+                .catalog("indexName")
+                .varchar("regionName1", 128)
+                .varchar("regionName2", 128)
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(mergeRegion);
+
+        Procedure getAllRegions = Procedure.newBuilder().name("GET_REGIONS")
+                .catalog("schemaName")
+                .catalog("tableName")
+                .catalog("indexName")
+                .varchar("startKey", 32672)
+                .varchar("endKey", 32672)
+                .varchar("columnDelimiter",5)
+                .varchar("characterDelimiter", 5)
+                .varchar("timestampFormat",32672)
+                .varchar("dateFormat",32672)
+                .varchar("timeFormat",32672)
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getAllRegions);
+
+        Procedure deleteRegion = Procedure.newBuilder().name("DELETE_REGION")
+                .catalog("schemaName")
+                .catalog("tableName")
+                .catalog("indexName")
+                .varchar("regionName", 128)
+                .varchar("merge", 5)
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(deleteRegion);
+
+        Procedure invalidateLocalCache = Procedure.newBuilder().name("INVALIDATE_DICTIONARY_CACHE")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(invalidateLocalCache);
+
+        Procedure invalidateGlobalCache = Procedure.newBuilder().name("INVALIDATE_GLOBAL_DICTIONARY_CACHE")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(invalidateGlobalCache);
+
+        Procedure checkTable = Procedure.newBuilder().name("CHECK_TABLE")
+                .catalog("schemaName")
+                .catalog("tableName")
+                .catalog("indexName")
+                .integer("level")
+                .varchar("outputFile", 32672)
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceTableAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(checkTable);
+
+        Procedure fixTable = Procedure.newBuilder().name("FIX_TABLE")
+                .catalog("schemaName")
+                .catalog("tableName")
+                .catalog("indexName")
+                .varchar("outputFile", 32672)
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceTableAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(fixTable);
+
+        Procedure showCreateTable = Procedure.newBuilder().name("SHOW_CREATE_TABLE")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .varchar("schemaName", 128)
+                .varchar("tableName", 128)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(showCreateTable);
+
+        Procedure addPeer = Procedure.newBuilder().name("ADD_PEER")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .smallint("peerId")
+                .varchar("clusterKey", 32672)
+                .arg("enabled", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .build();
+        procedures.add(addPeer);
+
+        Procedure removePeer = Procedure.newBuilder().name("REMOVE_PEER")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .smallint("peerId")
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .build();
+        procedures.add(removePeer);
+
+        Procedure enablePeer = Procedure.newBuilder().name("ENABLE_PEER")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .smallint("peerId")
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .build();
+        procedures.add(enablePeer);
+
+        Procedure disablePeer = Procedure.newBuilder().name("DISABLE_PEER")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .smallint("peerId")
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .build();
+        procedures.add(disablePeer);
+
+        Procedure enableTableReplication = Procedure.newBuilder().name("ENABLE_TABLE_REPLICATION")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("tableName")
+                .build();
+        procedures.add(enableTableReplication);
+
+        Procedure disableTableReplication = Procedure.newBuilder().name("DISABLE_TABLE_REPLICATION")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("tableName")
+                .build();
+        procedures.add(disableTableReplication);
+
+        Procedure setReplicationRole = Procedure.newBuilder().name("SET_REPLICATION_ROLE")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .varchar("role", 10)
+                .build();
+        procedures.add(setReplicationRole);
+
+        Procedure getReplicationRole = Procedure.newBuilder().name("GET_REPLICATION_ROLE")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .build();
+        procedures.add(getReplicationRole);
+
+        Procedure updateAllSystemProcedures = Procedure.newBuilder()
+                .name("SYSCS_UPDATE_ALL_SYSTEM_PROCEDURES")
+                .numOutputParams(0).numResultSets(0).modifiesSql()
+                .returnType(null).isDeterministic(false)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(updateAllSystemProcedures);
+
+        Procedure updateSystemProcedure = Procedure.newBuilder().name("SYSCS_UPDATE_SYSTEM_PROCEDURE")
+                .numOutputParams(0).numResultSets(0).modifiesSql()
+                .returnType(null).isDeterministic(false)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .catalog("schemaName")
+                .catalog("procName")
+                .build();
+        procedures.add(updateSystemProcedure);
+
+        Procedure enableSchemaReplication = Procedure.newBuilder().name("ENABLE_SCHEMA_REPLICATION")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .catalog("schemaName")
+                .build();
+        procedures.add(enableSchemaReplication);
+
+
+        Procedure disableSchemaReplication = Procedure.newBuilder().name("DISABLE_SCHEMA_REPLICATION")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .catalog("schemaName")
+                .build();
+        procedures.add(disableSchemaReplication);
+
+        Procedure enableDatabaseReplication = Procedure.newBuilder().name("ENABLE_DATABASE_REPLICATION")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .build();
+        procedures.add(enableDatabaseReplication);
+
+        Procedure disableDatabaseReplication = Procedure.newBuilder().name("DISABLE_DATABASE_REPLICATION")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .build();
+        procedures.add(disableDatabaseReplication);
+
+        Procedure getClusterKey = Procedure.newBuilder().name("GET_CLUSTER_KEY")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .build();
+        procedures.add(getClusterKey);
+
+        Procedure getPeers = Procedure.newBuilder().name("LIST_PEERS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .build();
+        procedures.add(getPeers);
+
+        Procedure getWalPositions = Procedure.newBuilder().name("GET_REPLICATED_WAL_POSITIONS")
+                .numOutputParams(0)
+                .smallint("peerId")
+                .numResultSets(1)
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .build();
+        procedures.add(getWalPositions);
+
+        Procedure getWalPosition = Procedure.newBuilder().name("GET_REPLICATED_WAL_POSITION")
+                .numOutputParams(0)
+                .varchar("wal",32672)
+                .numResultSets(1)
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .build();
+        procedures.add(getWalPosition);
+
+        Procedure dumpUnreplicatedWals = Procedure.newBuilder().name("DUMP_UNREPLICATED_WALS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .build();
+        procedures.add(dumpUnreplicatedWals);
+
+        Procedure replicationEnabled = Procedure.newBuilder().name("REPLICATION_ENABLED")
+                .numOutputParams(0)
+                .catalog("schemaName")
+                .catalog("tableName")
+                .numResultSets(1)
+                .ownerClass(ReplicationSystemProcedure.class.getCanonicalName())
+                .build();
+        procedures.add(replicationEnabled);
+
+        Procedure beginRollingUpgrade = Procedure.newBuilder().name("BEGIN_ROLLING_UPGRADE")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(UpgradeSystemProcedures.class.getCanonicalName())
+                .build();
+        procedures.add(beginRollingUpgrade);
+
+        Procedure endRollingUpgrade = Procedure.newBuilder().name("END_ROLLING_UPGRADE")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(UpgradeSystemProcedures.class.getCanonicalName())
+                .build();
+        procedures.add(endRollingUpgrade);
+
+        Procedure unloadRegions = Procedure.newBuilder().name("UNLOAD_REGIONS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .varchar("hostAndPort", 32672)
+                .ownerClass(UpgradeSystemProcedures.class.getCanonicalName())
+                .build();
+        procedures.add(unloadRegions);
+
+        Procedure loadRegions = Procedure.newBuilder().name("LOAD_REGIONS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .varchar("hostAndPort", 32672)
+                .ownerClass(UpgradeSystemProcedures.class.getCanonicalName())
+                .build();
+        procedures.add(loadRegions);
+    }
+
+    static public void getSYSFUN_PROCEDURES(List<Procedure> procedures)
+    {
+        procedures.addAll(SYSFUN_PROCEDURES);
     }
 
     @SuppressWarnings("unchecked")
@@ -1925,15 +1918,6 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                             .arg("SOURCE", SystemColumnImpl
                                     .getJavaColumn("DATA", ColumnStatisticsImpl.class.getCanonicalName(), false)
                                     .getType().getCatalogType())
-                            .build(),
-                    Procedure.newBuilder().name("PARTITION_EXISTS")
-                            .numOutputParams(0)
-                            .numResultSets(0)
-                            .sqlControl(RoutineAliasInfo.NO_SQL)
-                            .returnType(DataTypeDescriptor.getCatalogType(Types.BOOLEAN))
-                            .isDeterministic(true).ownerClass(StatisticsFunctions.class.getCanonicalName())
-                            .arg("CONGLOMERATE", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BIGINT).getCatalogType())
-                            .arg("PARTITION_ID", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR).getCatalogType())
                             .build()
             ));
 

--- a/splice_machine/src/main/java/com/splicemachine/replication/ReplicationSystemProcedure.java
+++ b/splice_machine/src/main/java/com/splicemachine/replication/ReplicationSystemProcedure.java
@@ -63,6 +63,18 @@ public class ReplicationSystemProcedure {
 
     private static Logger LOG = Logger.getLogger(ReplicationSystemProcedure.class);
 
+    public static void GET_REPLICATION_PROGRESS(ResultSet[] resultSets) throws StandardException, SQLException {
+        ReplicationManager replicationManager = EngineDriver.driver().manager().getReplicationManager();
+        long ts = replicationManager.getReplicationProgress();
+        if (ts > 0) {
+            DateTime dateTime = new DateTime(ts);
+            resultSets[0] = ProcedureUtils.generateResult("Replication progress", dateTime.toString());
+        }
+        else {
+            resultSets[0] = ProcedureUtils.generateResult("Error", "Information not available");
+        }
+    }
+
     public static void REPLICATION_ENABLED(String schemaName, String tableName, ResultSet[] resultSets) throws StandardException, SQLException {
         try {
             schemaName = EngineUtils.validateSchema(schemaName);

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/ProcedureUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/ProcedureUnitTest.java
@@ -1,0 +1,180 @@
+package com.splicemachine.derby.utils;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+import com.splicemachine.db.impl.sql.catalog.DefaultSystemProcedureGenerator;
+import com.splicemachine.db.impl.sql.catalog.Procedure;
+import com.splicemachine.derby.impl.sql.catalog.SpliceSystemProcedures;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProcedureUnitTest {
+    final static String CLASS_NAME = ProcedureUnitTest.class.getCanonicalName();
+    @Test
+    public void testAddProcNoParam() throws Exception {
+        Procedure.newBuilder().name("SYSCS_GET_VERSION_INFO")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .buildCheck();
+    }
+
+    @Test
+    public void testAddProcParamResultSet() throws Exception {
+        Procedure.newBuilder().name("COLLECT_TABLE_STATISTICS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .varchar("schema",128)
+                .varchar("table",1024)
+                .arg("staleOnly", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
+                .ownerClass(StatisticsAdmin.class.getCanonicalName())
+                .buildCheck();
+    }
+
+    @Test
+    public void testAddProcParamNoResult() throws Exception {
+        Procedure.newBuilder().name("SYSCS_EMPTY_GLOBAL_STORED_STATEMENT_CACHE")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .buildCheck();
+    }
+
+    @Test
+    public void testAddProcFailsNumParameters() throws Exception {
+        try {
+            Procedure.newBuilder().name("COLLECT_TABLE_STATISTICS")
+                    .numOutputParams(0)
+                    .numResultSets(1)
+                    .varchar("schema", 128)
+                    .ownerClass(StatisticsAdmin.class.getCanonicalName())
+                    .buildCheck();
+            Assert.fail();
+        }catch(Exception e) {
+            Assert.assertEquals("could not find correct function with signature for com.splicemachine.derby.utils.StatisticsAdmin.COLLECT_TABLE_STATISTICS:\n" +
+                            " public static void com.splicemachine.derby.utils.StatisticsAdmin.COLLECT_TABLE_STATISTICS(java.lang.String,java.lang.String,boolean,java.sql.ResultSet[]) throws java.sql.SQLException:\n" +
+                            "  parameter count doesn't match: expected 2, but actual 4\n",
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void testAddProcFailsParameterTypes() throws Exception {
+        try {
+            Procedure.newBuilder().name("COLLECT_TABLE_STATISTICS")
+                    .numOutputParams(0)
+                    .numResultSets(1)
+                    .varchar("schema", 128)
+                    .integer("WRONG_TYPE")
+                    .arg("staleOnly", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
+                    .ownerClass(StatisticsAdmin.class.getCanonicalName())
+                    .buildCheck();
+            Assert.fail();
+        }catch(Exception e) {
+            Assert.assertEquals("could not find correct function with signature for com.splicemachine.derby.utils.StatisticsAdmin.COLLECT_TABLE_STATISTICS:\n" +
+                            " public static void com.splicemachine.derby.utils.StatisticsAdmin.COLLECT_TABLE_STATISTICS(java.lang.String,java.lang.String,boolean,java.sql.ResultSet[]) throws java.sql.SQLException:\n" +
+                            "  parameter 1 has wrong type: expected type is INTEGER, but actual type is VARCHAR\n",
+                    e.getMessage());
+        }
+    }
+    public void toRegisterFunc(String s) {
+    }
+
+
+    @Test
+    public void testAddProcParamResultSizeWrong() throws Exception {
+        try {
+            Procedure.newBuilder().name("toRegisterFunc")
+                    .numOutputParams(0)
+                    .numResultSets(1)
+                    .ownerClass(CLASS_NAME)
+                    .buildCheck();
+        }catch(Exception e) {
+            Assert.assertEquals("could not find correct function with signature for com.splicemachine.derby.utils.ProcedureUnitTest.toRegisterFunc:\n" +
+                            " public void com.splicemachine.derby.utils.ProcedureUnitTest.toRegisterFunc(java.lang.String):\n" +
+                            "  parameter 0 needs to be java.sql.ResultSet, but is java.lang.String\n",
+                    e.getMessage());
+        }
+        Procedure.newBuilder().name("toRegisterFunc")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .varchar("s", 10)
+                .ownerClass(CLASS_NAME)
+                .buildCheck();
+    }
+
+    @Test
+    public void testClassNameWrong() throws Exception {
+        try {
+            Procedure.newBuilder().name("toRegisterFunc")
+                    .numOutputParams(0)
+                    .numResultSets(1)
+                    .ownerClass(CLASS_NAME + "_WRONG")
+                    .buildCheck();
+        }catch(Exception e) {
+            Assert.assertEquals("java.lang.ClassNotFoundException: " + CLASS_NAME + "_WRONG",
+                    e.toString());
+        }
+    }
+
+    @Test
+    public void testFunctionNameWrong() throws Exception {
+        try {
+            Procedure.newBuilder().name("notExistingMethod")
+                    .numOutputParams(0)
+                    .numResultSets(1)
+                    .ownerClass(CLASS_NAME)
+                    .buildCheck();
+        }catch(Exception e) {
+            Assert.assertEquals("couldn't find function with name " + CLASS_NAME + ".notExistingMethod",
+                    e.getMessage());
+        }
+    }
+
+    void testProcedures(List<Procedure> procedures)
+    {
+        for( Procedure p : procedures) {
+            try {
+                p.check();
+            } catch (Exception e) {
+                Assert.fail("error :" + e.toString());
+            }
+        }
+    }
+
+    @Test
+    public void testAllSysUtilProcedures()
+    {
+        List<Procedure> procedures = new ArrayList<>();
+        SpliceSystemProcedures.createSysUtilProcedures(procedures);
+        testProcedures(procedures);
+    }
+
+    @Test
+    public void testSYSFUN_PROCEDURES()
+    {
+        List<Procedure> procedures = new ArrayList<>();
+        SpliceSystemProcedures.getSYSFUN_PROCEDURES(procedures);
+        testProcedures(procedures);
+    }
+
+    @Test
+    public void testSYSIBM() throws StandardException {
+        testProcedures(DefaultSystemProcedureGenerator.getSYSIBMProcedures());
+    }
+
+    @Test
+    public void testSQL() throws StandardException {
+        testProcedures(SpliceSystemProcedures.getSQLProcedures());
+    }
+
+    @Test
+    public void testSYSCSM() throws StandardException {
+        testProcedures(SpliceSystemProcedures.getSYSCSMProcedures());
+    }
+
+}


### PR DESCRIPTION
removes the following functions since they are not existent:

- SYSCS_GET_AUTO_INCREMENT_ROW_LOCATIONS
- PARTITION_EXISTS
- CLOBGETPROSITIONFROMSTRING

re-adding GET_REPLICATION_PROGRESS as it was removed accidentally in DB-8990