### PR TITLE
DB-11019 Use the selectivity of only one join predicate per column set.

### DIFF
--- a/db-engine/pom.xml
+++ b/db-engine/pom.xml
@@ -100,11 +100,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>com.cedarsoftware</groupId>
-          <artifactId>java-util</artifactId>
-          <version>1.61.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
         </dependency>

--- a/db-engine/pom.xml
+++ b/db-engine/pom.xml
@@ -100,6 +100,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+          <groupId>com.cedarsoftware</groupId>
+          <artifactId>java-util</artifactId>
+          <version>1.61.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
         </dependency>

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AbstractSelectivityHolder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AbstractSelectivityHolder.java
@@ -41,11 +41,13 @@ public abstract class AbstractSelectivityHolder implements SelectivityHolder {
     protected int colNum;
     protected boolean useExprIndexStats;
     protected double selectivity = -1.0d;
+    protected Predicate p;
 
-    public AbstractSelectivityHolder(boolean useExprIndexStats, int colNum, QualifierPhase phase) {
+    public AbstractSelectivityHolder(boolean useExprIndexStats, int colNum, QualifierPhase phase, Predicate pred) {
         this.phase = phase;
         this.colNum = colNum;
         this.useExprIndexStats = useExprIndexStats;
+        this.p = pred;
     }
     public int getColNum () {
         return colNum;
@@ -65,5 +67,13 @@ public abstract class AbstractSelectivityHolder implements SelectivityHolder {
         } catch (Exception e) {
             throw new RuntimeException("selectivity holder comparison failed",e);
         }
+    }
+
+    @Override
+    public int getNumReferencedTables() {
+        if (p == null)
+            return 0;
+        else
+            return p.getNumReferencedTables();
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayConstantNode.java
@@ -346,12 +346,12 @@ public class ArrayConstantNode extends ValueNode {
     /**
      * Categorize this predicate.
      *
-     * @see ValueNode#categorize(JBitSet, boolean)
+     * @see ValueNode#categorize(JBitSet, ReferencedColumnsMap, boolean)
      */
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
             throws StandardException
     {
-        return argumentsList.categorize(referencedTabs, simplePredsOnly);
+        return argumentsList.categorize(referencedTabs, referencedColumns, simplePredsOnly);
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ArrayOperatorNode.java
@@ -202,11 +202,11 @@ public class ArrayOperatorNode extends ValueNode {
     /**
      * Categorize this predicate.
      *
-     * @see ValueNode#categorize(JBitSet, boolean)
+     * @see ValueNode#categorize(JBitSet, ReferencedColumnsMap, boolean)
      */
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
             throws StandardException {
-        return operand.categorize(referencedTabs, simplePredsOnly);
+        return operand.categorize(referencedTabs, referencedColumns, simplePredsOnly);
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryListOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryListOperatorNode.java
@@ -367,7 +367,9 @@ public abstract class BinaryListOperatorNode extends ValueNode{
 
     /**
      * Categorize this predicate.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      * If the source of this ColumnReference (at the next underlying level)
      * is not a ColumnReference or a VirtualColumnNode then this predicate
      * will not be pushed down.
@@ -382,6 +384,8 @@ public abstract class BinaryListOperatorNode extends ValueNode{
      * RESOLVE - revisit this issue once we have views.
      *
      * @param referencedTabs  JBitSet with bit map of referenced FromTables
+     * @param referencedColumns  An object which maps tableNumber to the columns
+     *                           from that table which are present in the predicate.
      * @param simplePredsOnly Whether or not to consider method
      *                        calls, field references and conditional nodes
      *                        when building bit map
@@ -390,11 +394,11 @@ public abstract class BinaryListOperatorNode extends ValueNode{
      * @throws StandardException Thrown on error
      */
     @Override
-    public boolean categorize(JBitSet referencedTabs,boolean simplePredsOnly) throws StandardException{
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly) throws StandardException{
         boolean pushable = false;
 
-        pushable = leftOperandList.categorize(referencedTabs, simplePredsOnly);
-        pushable = (rightOperandList.categorize(referencedTabs, simplePredsOnly) && pushable);
+        pushable = leftOperandList.categorize(referencedTabs, referencedColumns, simplePredsOnly);
+        pushable = (rightOperandList.categorize(referencedTabs, referencedColumns, simplePredsOnly) && pushable);
 
         return pushable;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryOperatorNode.java
@@ -858,7 +858,9 @@ public class BinaryOperatorNode extends OperatorNode
 
     /**
      * Categorize this predicate.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      * If the source of this ColumnReference (at the next underlying level)
      * is not a ColumnReference or a VirtualColumnNode then this predicate
      * will not be pushed down.
@@ -873,6 +875,8 @@ public class BinaryOperatorNode extends OperatorNode
      * RESOLVE - revisit this issue once we have views.
      *
      * @param referencedTabs    JBitSet with bit map of referenced FromTables
+     * @param referencedColumns  An object which maps tableNumber to the columns
+     *                           from that table which are present in the predicate.
      * @param simplePredsOnly    Whether or not to consider method
      *                            calls, field references and conditional nodes
      *                            when building bit map
@@ -881,12 +885,17 @@ public class BinaryOperatorNode extends OperatorNode
      *                        or a VirtualColumnNode.
      * @exception StandardException            Thrown on error
      */
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs,
+                              ReferencedColumnsMap referencedColumns,
+                              boolean simplePredsOnly)
         throws StandardException
     {
         boolean pushable;
-        pushable = leftOperand.categorize(referencedTabs, simplePredsOnly);
-        pushable = (rightOperand.categorize(referencedTabs, simplePredsOnly) && pushable);
+
+        pushable = leftOperand.categorize(referencedTabs,
+                                          referencedColumns, simplePredsOnly);
+        pushable = (rightOperand.categorize(referencedTabs,
+                                            referencedColumns, simplePredsOnly) && pushable);
 
         if (leftOperand instanceof ColumnReference) {
             ColumnReference lcr = (ColumnReference) leftOperand;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CastNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CastNode.java
@@ -856,7 +856,9 @@ public class CastNode extends ValueNode
 
     /**
      * Categorize this predicate.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      * If the source of this ColumnReference (at the next underlying level)
      * is not a ColumnReference or a VirtualColumnNode then this predicate
      * will not be pushed down.
@@ -871,6 +873,8 @@ public class CastNode extends ValueNode
      * RESOLVE - revisit this issue once we have views.
      *
      * @param referencedTabs    JBitSet with bit map of referenced FromTables
+     * @param referencedColumns  An object which maps tableNumber to the columns
+     *                           from that table which are present in the predicate.
      * @param simplePredsOnly    Whether or not to consider method
      *                            calls, field references and conditional nodes
      *                            when building bit map
@@ -880,10 +884,10 @@ public class CastNode extends ValueNode
      *
      * @exception StandardException            Thrown on error
      */
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
             throws StandardException
     {
-        return castOperand.categorize(referencedTabs, simplePredsOnly);
+        return castOperand.categorize(referencedTabs, referencedColumns, simplePredsOnly);
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnReference.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnReference.java
@@ -724,7 +724,9 @@ public class ColumnReference extends ValueNode {
 
     /**
      * Categorize this predicate.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      * If the source of this ColumnReference (at the next underlying level)
      * is not a ColumnReference or a VirtualColumnNode then this predicate
      * will not be pushed down.
@@ -749,6 +751,8 @@ public class ColumnReference extends ValueNode {
      * RESOLVE - revisit this issue once we have views.
      *
      * @param referencedTabs    JBitSet with bit map of referenced FromTables
+     * @param referencedColumns  An object which maps tableNumber to the columns
+     *                           from that table which are present in the predicate.
      * @param simplePredsOnly    Whether or not to consider method
      *                            calls, field references and conditional nodes
      *                            when building bit map
@@ -756,12 +760,14 @@ public class ColumnReference extends ValueNode {
      * @return boolean        Whether or not source.expression is a ColumnReference
      *                        or a VirtualColumnNode or a ConstantNode.
      */
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly) throws StandardException
     {
         if (SanityManager.DEBUG)
             SanityManager.ASSERT(tableNumber >= 0,
                     "tableNumber is expected to be non-negative");
         referencedTabs.set(tableNumber);
+        if (referencedColumns != null)
+            referencedColumns.add(tableNumber, columnNumber);
 
         return ( ! replacesAggregate ) &&
                 ( ! replacesWindowFunctionCall ) &&

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConditionalNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConditionalNode.java
@@ -561,7 +561,9 @@ public class ConditionalNode extends ValueNode
 
     /**
      * Categorize this predicate.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      * If the source of this ColumnReference (at the next underlying level)
      * is not a ColumnReference or a VirtualColumnNode then this predicate
      * will not be pushed down.
@@ -576,6 +578,8 @@ public class ConditionalNode extends ValueNode
      * RESOLVE - revisit this issue once we have views.
      *
      * @param referencedTabs    JBitSet with bit map of referenced FromTables
+     * @param referencedColumns  An object which maps tableNumber to the columns
+     *                           from that table which are present in the predicate.
      * @param simplePredsOnly    Whether or not to consider method
      *                            calls, field references and conditional nodes
      *                            when building bit map
@@ -584,7 +588,7 @@ public class ConditionalNode extends ValueNode
      *                        or a VirtualColumnNode.
      * @exception StandardException            Thrown on error
      */
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
         throws StandardException
     {
         /* We stop here when only considering simple predicates
@@ -598,8 +602,8 @@ public class ConditionalNode extends ValueNode
 
         boolean pushable;
 
-        pushable = testCondition.categorize(referencedTabs, simplePredsOnly);
-        pushable = (thenElseList.categorize(referencedTabs, simplePredsOnly) && pushable);
+        pushable = testCondition.categorize(referencedTabs, referencedColumns, simplePredsOnly);
+        pushable = (thenElseList.categorize(referencedTabs, referencedColumns, simplePredsOnly) && pushable);
         return pushable;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstantSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstantSelectivity.java
@@ -40,7 +40,7 @@ import com.splicemachine.db.iapi.error.StandardException;
  */
 public class ConstantSelectivity extends AbstractSelectivityHolder {
     public ConstantSelectivity(double selectivity, int colNum, QualifierPhase phase){
-        super(false,colNum,phase);
+        super(false,colNum,phase,null);
         this.selectivity = selectivity;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DefaultPredicateSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DefaultPredicateSelectivity.java
@@ -33,17 +33,17 @@ package com.splicemachine.db.impl.sql.compile;
 
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.compile.Optimizable;
+import com.splicemachine.db.impl.ast.RSUtils;
 
 /**
  * Predicate Selectivity Computation
  *
  */
 public class DefaultPredicateSelectivity extends AbstractSelectivityHolder {
-    private final Predicate p;
     private final Optimizable baseTable;
     private final double selectivityFactor;
     public DefaultPredicateSelectivity(Predicate p, Optimizable baseTable, QualifierPhase phase, double selectivityFactor){
-        super(false,0,phase);
+        super(false,0,phase,p);
         this.p = p;
         this.baseTable = baseTable;
         this.selectivityFactor = selectivityFactor;
@@ -57,4 +57,14 @@ public class DefaultPredicateSelectivity extends AbstractSelectivityHolder {
         }
         return selectivity;
     }
+
+    @Override
+    public boolean shouldApplySelectivity() {
+        return
+            getNumReferencedTables() < 2             ||
+            baseTable.getCurrentAccessPath() == null ||
+            RSUtils.isNLJ(baseTable.getCurrentAccessPath());
+    }
+
+    public Predicate getPredicate() { return p; }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -3835,7 +3835,7 @@ public class FromBaseTable extends FromTable {
                         newAnd.getRightOperand(),
                         pred.getReferencedSet(),
                         getContextManager());
-                le.copyFields(pred);
+                le.copyFields(pred, false);
                 le.clearScanFlags();
                 if (pred.isStopKey()) {
                     le.markStopKey();
@@ -3856,7 +3856,7 @@ public class FromBaseTable extends FromTable {
                         newAnd,
                         pred.getReferencedSet(),
                         getContextManager());
-                ge.copyFields(pred);
+                ge.copyFields(pred, false);
                 ge.clearScanFlags();
                 if (pred.isStartKey()) {
                     ge.markStartKey();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
@@ -1149,7 +1149,7 @@ public class FromVTI extends FromTable implements VTIEnvironment {
          * (DERBY-3288)
          */
         dependencyMap = new JBitSet(numTables);
-        methodCall.categorize(dependencyMap, false);
+        methodCall.categorize(dependencyMap, null, false);
 
         // Make sure this FromVTI does not "depend" on itself.
         dependencyMap.clear(tableNumber);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FullOuterJoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FullOuterJoinNode.java
@@ -272,11 +272,11 @@ public class FullOuterJoinNode extends JoinNode {
 
                 /* only consider the left side of inlist operator, as right are ORed elements */
                 if (left instanceof InListOperatorNode) {
-                    if (!((InListOperatorNode) left).getLeftOperandList().categorize(refMap,true)) {
+                    if (!((InListOperatorNode) left).getLeftOperandList().categorize(refMap, null, true)) {
                         vn=and.getRightOperand();
                         continue;
                     }
-                } else if(!(left.categorize(refMap,true))){
+                } else if(!(left.categorize(refMap, null, true))){
                     vn=and.getRightOperand();
                     continue;
                 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GetCurrentConnectionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GetCurrentConnectionNode.java
@@ -113,7 +113,9 @@ public final class GetCurrentConnectionNode extends JavaValueNode
 
     /**
      * Categorize this predicate.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      * If the source of this ColumnReference (at the next underlying level)
      * is not a ColumnReference or a VirtualColumnNode then this predicate
      * will not be pushed down.
@@ -128,6 +130,8 @@ public final class GetCurrentConnectionNode extends JavaValueNode
      * RESOLVE - revisit this issue once we have views.
      *
      * @param referencedTabs    JBitSet with bit map of referenced FromTables
+     * @param referencedColumns  An object which maps tableNumber to the columns
+     *                           from that table which are present in the predicate.
      * @param simplePredsOnly    Whether or not to consider method
      *                            calls, field references and conditional nodes
      *                            when building bit map
@@ -135,7 +139,7 @@ public final class GetCurrentConnectionNode extends JavaValueNode
      * @return boolean        Whether or not source.expression is a ColumnReference
      *                        or a VirtualColumnNode.
      */
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
     {
         return false;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HalfOuterJoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HalfOuterJoinNode.java
@@ -648,11 +648,11 @@ public class HalfOuterJoinNode extends JoinNode{
 
 				/* only consider the left side of inlist operator, as right are ORed elements */
                 if (left instanceof InListOperatorNode) {
-                    if (!((InListOperatorNode) left).getLeftOperandList().categorize(refMap,true)) {
+                    if (!((InListOperatorNode) left).getLeftOperandList().categorize(refMap, null, true)) {
                         vn=and.getRightOperand();
                         continue;
                     }
-                } else if(!(left.categorize(refMap,true))){
+                } else if(!(left.categorize(refMap, null, true))){
                     vn=and.getRightOperand();
                     continue;
                 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListSelectivity.java
@@ -44,7 +44,6 @@ import static com.splicemachine.db.impl.sql.compile.SelectivityUtil.DEFAULT_INLI
  *
  */
 public class InListSelectivity extends AbstractSelectivityHolder {
-    private final Predicate p;
     private final StoreCostController storeCost;
     private final double selectivityFactor;
     private final int[] colNo;
@@ -55,7 +54,7 @@ public class InListSelectivity extends AbstractSelectivityHolder {
                              QualifierPhase phase, double selectivityFactor)
         throws StandardException
     {
-        super(keyColumns != null, getLeftItemColumnPosition(p, 0, keyColumns), phase);
+        super(keyColumns != null, getLeftItemColumnPosition(p, 0, keyColumns), phase, p);
 
         int numLeftItems = p.getSourceInList().leftOperandList.size();
         colNo = new int[numLeftItems];

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JavaToSQLValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JavaToSQLValueNode.java
@@ -298,7 +298,9 @@ public class JavaToSQLValueNode extends ValueNode
 
     /**
      * Categorize this predicate.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      * If the source of this ColumnReference (at the next underlying level)
      * is not a ColumnReference or a VirtualColumnNode then this predicate
      * will not be pushed down.
@@ -312,6 +314,8 @@ public class JavaToSQLValueNode extends ValueNode
      * subqueries and method calls.
      *
      * @param referencedTabs    JBitSet with bit map of referenced FromTables
+     * @param referencedColumns  An object which maps tableNumber to the columns
+     *                           from that table which are present in the predicate.
      * @param simplePredsOnly    Whether or not to consider method
      *                            calls, field references and conditional nodes
      *                            when building bit map
@@ -321,10 +325,10 @@ public class JavaToSQLValueNode extends ValueNode
      *
      * @exception StandardException            Thrown on error
      */
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
         throws StandardException
     {
-        return javaNode.categorize(referencedTabs, simplePredsOnly);
+        return javaNode.categorize(referencedTabs, referencedColumns, simplePredsOnly);
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JavaValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JavaValueNode.java
@@ -211,7 +211,7 @@ abstract class JavaValueNode extends QueryTreeNode implements ParentNode
      *
      * @exception StandardException        Thrown on error
      */
-    abstract public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    abstract public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
         throws StandardException;
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinPredicateSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinPredicateSelectivity.java
@@ -31,38 +31,20 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
-import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.iapi.store.access.StoreCostController;
-import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.db.iapi.sql.compile.Optimizable;
 
 /**
- *
- * Selectivity computation for not equals.
+ * Join Predicate Selectivity Holder
  *
  */
-public class NotEqualsSelectivity extends AbstractSelectivityHolder {
-    private final DataValueDescriptor value;
-    private final StoreCostController storeCost;
-    private final double selectivityFactor;
-    private final boolean useExtrapolation;
-
-    public NotEqualsSelectivity(StoreCostController storeCost,
-                                boolean fromExprIndex, int colNum, QualifierPhase phase,
-                                DataValueDescriptor value, double selectivityFactor, boolean useExtrapolation, Predicate pred) {
-        super(fromExprIndex, colNum, phase, pred);
-        this.value = value;
-        this.storeCost = storeCost;
-        this.selectivityFactor = selectivityFactor;
-        this.useExtrapolation = useExtrapolation;
+public class JoinPredicateSelectivity extends DefaultPredicateSelectivity {
+    public JoinPredicateSelectivity(Predicate p, Optimizable baseTable, QualifierPhase phase, double selectivity){
+        super(p, baseTable, phase, 1.0);
+        this.selectivity = selectivity;
     }
 
-    public double getSelectivity() throws StandardException {
-        if (selectivity == -1.0d) {
-            double tmpSelectivity = storeCost.getSelectivity(useExprIndexStats, colNum, value, true, value, true, useExtrapolation);
-            if (selectivityFactor > 0)
-                tmpSelectivity *= selectivityFactor;
-            selectivity = 1 - tmpSelectivity;
-        }
+    @Override
+    public double getSelectivity() {
         return selectivity;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MethodCallNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MethodCallNode.java
@@ -423,7 +423,9 @@ abstract class MethodCallNode extends JavaValueNode
 
     /**
      * Categorize this predicate.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      * If the source of this ColumnReference (at the next underlying level)
      * is not a ColumnReference or a VirtualColumnNode then this predicate
      * will not be pushed down.
@@ -438,6 +440,8 @@ abstract class MethodCallNode extends JavaValueNode
      * RESOLVE - revisit this issue once we have views.
      *
      * @param referencedTabs    JBitSet with bit map of referenced FromTables
+     * @param referencedColumns  An object which maps tableNumber to the columns
+     *                           from that table which are present in the predicate.
      * @param simplePredsOnly    Whether or not to consider method
      *                            calls, field references and conditional nodes
      *                            when building bit map
@@ -446,7 +450,7 @@ abstract class MethodCallNode extends JavaValueNode
      *                        or a VirtualColumnNode.
      * @exception StandardException            Thrown on error
      */
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
         throws StandardException
     {
         /* We stop here when only considering simple predicates
@@ -467,7 +471,7 @@ abstract class MethodCallNode extends JavaValueNode
             {
                 if (methodParms[param] != null)
                 {
-                    pushable = methodParms[param].categorize(referencedTabs, simplePredsOnly) &&
+                    pushable = methodParms[param].categorize(referencedTabs, referencedColumns, simplePredsOnly) &&
                                pushable;
                 }
             }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MultiaryFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/MultiaryFunctionNode.java
@@ -389,10 +389,10 @@ public abstract class MultiaryFunctionNode extends ValueNode
     /**
      * Categorize this predicate.
      *
-     * @see ValueNode#categorize(JBitSet, boolean)
+     * @see ValueNode#categorize(JBitSet, ReferencedColumnsMap, boolean)
      */
     @Override
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
         throws StandardException
     {
         if (simplePredsOnly)
@@ -400,7 +400,7 @@ public abstract class MultiaryFunctionNode extends ValueNode
             return false;
         }
 
-        return argumentsList.categorize(referencedTabs, simplePredsOnly);
+        return argumentsList.categorize(referencedTabs, referencedColumns, simplePredsOnly);
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NewInvocationNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NewInvocationNode.java
@@ -312,7 +312,9 @@ public class NewInvocationNode extends MethodCallNode
 
     /**
      * Categorize this predicate.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      * If the source of this ColumnReference (at the next underlying level)
      * is not a ColumnReference or a VirtualColumnNode then this predicate
      * will not be pushed down.
@@ -327,6 +329,8 @@ public class NewInvocationNode extends MethodCallNode
      * RESOLVE - revisit this issue once we have views.
      *
      * @param referencedTabs    JBitSet with bit map of referenced FromTables
+     * @param referencedColumns  An object which maps tableNumber to the columns
+     *                           from that table which are present in the predicate.
      * @param simplePredsOnly    Whether or not to consider method
      *                            calls, field references and conditional nodes
      *                            when building bit map
@@ -335,7 +339,7 @@ public class NewInvocationNode extends MethodCallNode
      *                        or a VirtualColumnNode.
      * @exception StandardException        Thrown on error
      */
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
         throws StandardException
     {
         /* We stop here when only considering simple predicates
@@ -349,7 +353,7 @@ public class NewInvocationNode extends MethodCallNode
 
         boolean pushable = true;
 
-        pushable = pushable && super.categorize(referencedTabs, simplePredsOnly);
+        pushable = pushable && super.categorize(referencedTabs, referencedColumns, simplePredsOnly);
 
         return pushable;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NonStaticMethodCallNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NonStaticMethodCallNode.java
@@ -185,8 +185,10 @@ public class NonStaticMethodCallNode extends MethodCallNode
 	}
 
 	/**
-	 * Categorize this predicate.  Initially, this means
-	 * building a bit map of the referenced tables for each predicate.
+     * Categorize this predicate.  Initially, this means
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
 	 * If the source of this ColumnReference (at the next underlying level) 
 	 * is not a ColumnReference or a VirtualColumnNode then this predicate
 	 * will not be pushed down.
@@ -201,6 +203,8 @@ public class NonStaticMethodCallNode extends MethodCallNode
 	 * RESOLVE - revisit this issue once we have views.
 	 *
 	 * @param referencedTabs	JBitSet with bit map of referenced FromTables
+	 * @param referencedColumns  An object which maps tableNumber to the columns
+     *                           from that table which are present in the predicate.
 	 * @param simplePredsOnly	Whether or not to consider method
 	 *							calls, field references and conditional nodes
 	 *							when building bit map
@@ -209,7 +213,7 @@ public class NonStaticMethodCallNode extends MethodCallNode
 	 *						or a VirtualColumnNode.
 	 * @exception StandardException			Thrown on error
 	 */
-	public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+	public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
 		throws StandardException
 	{
 		/* We stop here when only considering simple predicates
@@ -223,11 +227,11 @@ public class NonStaticMethodCallNode extends MethodCallNode
 
 		boolean pushable = true;
 
-		pushable = pushable && super.categorize(referencedTabs, simplePredsOnly);
+		pushable = pushable && super.categorize(referencedTabs, referencedColumns, simplePredsOnly);
 
 		if (receiver != null)
 		{
-			pushable = pushable && receiver.categorize(referencedTabs, simplePredsOnly);
+			pushable = pushable && receiver.categorize(referencedTabs, referencedColumns, simplePredsOnly);
 		}
 
 		return pushable;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NotNullSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NotNullSelectivity.java
@@ -42,8 +42,8 @@ import com.splicemachine.db.iapi.store.access.StoreCostController;
  */
 public class NotNullSelectivity extends AbstractSelectivityHolder {
     private final StoreCostController storeCost;
-    public NotNullSelectivity(StoreCostController storeCost, boolean fromExprIndex, int colNum, QualifierPhase phase){
-        super(fromExprIndex, colNum, phase);
+    public NotNullSelectivity(StoreCostController storeCost, boolean fromExprIndex, int colNum, QualifierPhase phase, Predicate pred){
+        super(fromExprIndex, colNum, phase, pred);
         this.storeCost = storeCost;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NullSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NullSelectivity.java
@@ -41,8 +41,8 @@ import com.splicemachine.db.iapi.store.access.StoreCostController;
  */
 public class NullSelectivity extends AbstractSelectivityHolder {
     private final StoreCostController storeCost;
-    public NullSelectivity(StoreCostController storeCost, boolean fromExprIndex, int colNum, QualifierPhase phase){
-        super(fromExprIndex, colNum, phase);
+    public NullSelectivity(StoreCostController storeCost, boolean fromExprIndex, int colNum, QualifierPhase phase, Predicate pred){
+        super(fromExprIndex, colNum, phase, pred);
         this.storeCost = storeCost;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
@@ -89,6 +89,23 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
     // to make the current combined multicolumn IN list probe predicate.
     private PredicateList originalInListPredList;
 
+    private ReferencedColumnsMap referencedColumns;
+
+    public ReferencedColumnsMap getReferencedColumns() {
+        return referencedColumns;
+    }
+
+    public int getNumReferencedTables() {
+        if (referencedColumns == null)
+            return 0;
+        else
+            return referencedColumns.getNumReferencedTables();
+    }
+
+    public void setReferencedColumns(ReferencedColumnsMap referencedColumns) {
+        this.referencedColumns = referencedColumns;
+    }
+
     public void setPulled(boolean pulled){
         this.pulled=pulled;
     }
@@ -460,12 +477,15 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
 
     /**
      * Categorize this predicate.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      *
-     * @throws StandardException Thrown on error
+     * @throws StandardException Thrown on error`
      */
     public void categorize() throws StandardException{
-        pushable=andNode.categorize(referencedSet,false);
+        referencedColumns = new ReferencedColumnsMap();
+        pushable=andNode.categorize(referencedSet, referencedColumns, false);
     }
 
     /**
@@ -752,10 +772,11 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
 
     /**
      * Copy all fields of this Predicate (except the two that
-     * are set from 'init').
+     * are set from 'init', and referencedColumns if skipReferencedColumns
+     * is true).
      */
 
-    public void copyFields(Predicate otherPred){
+    public void copyFields(Predicate otherPred, boolean skipReferencedColumns){
 
         this.equivalenceClass=otherPred.getEquivalenceClass();
         this.indexPosition=otherPred.getIndexPosition();
@@ -764,6 +785,8 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
         this.isQualifier=otherPred.isQualifier();
         this.searchClauseHT=otherPred.getSearchClauseHT();
         this.matchIndexExpression=otherPred.matchIndexExpression();
+        if (!skipReferencedColumns)
+            this.referencedColumns=new ReferencedColumnsMap(otherPred.getReferencedColumns());
 
     }
 
@@ -1014,7 +1037,8 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
         // which is important for correct pushing of the new
         // predicate.
         JBitSet tableMap=new JBitSet(childRSN.getReferencedTableMap().size());
-        newAnd.categorize(tableMap,false);
+        ReferencedColumnsMap columnsMap = new ReferencedColumnsMap();
+        newAnd.categorize(tableMap, columnsMap, false);
 
         // Now put the pieces together to get a new predicate.
         Predicate newPred=(Predicate)getNodeFactory().getNode(C_NodeTypes.PREDICATE,
@@ -1024,8 +1048,9 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
 
         // Copy all of this predicates other fields into the new predicate.
         newPred.clearScanFlags();
-        newPred.copyFields(this);
+        newPred.copyFields(this, true);
         newPred.setPushable(getPushable());
+        newPred.setReferencedColumns(columnsMap);
 
         // Take note of the fact that the new predicate is scoped for
         // the sake of pushing; we need this information during optimization

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
@@ -32,6 +32,7 @@
 package com.splicemachine.db.impl.sql.compile;
 
 import com.splicemachine.db.catalog.IndexDescriptor;
+import com.splicemachine.db.catalog.ReferencedColumns;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.ClassName;
 import com.splicemachine.db.iapi.services.classfile.VMOpcode;
@@ -1497,7 +1498,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                             andCopy,
                             thisPred.getReferencedSet(),
                             getContextManager());
-                    predCopy.copyFields(thisPred);
+                    predCopy.copyFields(thisPred, false);
                     predToPush=predCopy;
                 }else{
                     predToPush=thisPred;
@@ -1631,8 +1632,10 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
     }
 
     /**
-     * Categorize the predicates in the list.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * Categorize this predicate.  Initially, this means
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      *
      * @throws StandardException Thrown on error
      */
@@ -2631,12 +2634,14 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                     newAnd.postBindFixup();
                     // Add a new predicate to both the equijoin clauses and this list
                     JBitSet tableMap=new JBitSet(numTables);
-                    newAnd.categorize(tableMap,false);
+                    ReferencedColumnsMap columnsMap = new ReferencedColumnsMap();
+                    newAnd.categorize(tableMap, columnsMap,false);
                     Predicate newPred=(Predicate)getNodeFactory().getNode(
                             C_NodeTypes.PREDICATE,
                             newAnd,
                             tableMap,
                             getContextManager());
+                    newPred.setReferencedColumns(columnsMap);
                     newPred.setEquivalenceClass(outerEC);
                     addPredicate(newPred);
                             /* Add the new predicate right after the outer position
@@ -2869,12 +2874,14 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                     newAnd.postBindFixup();
                     // Add a new predicate to both the search clauses and this list
                     JBitSet tableMap=new JBitSet(getCompilerContext().getMaximalPossibleTableCount());
-                    newAnd.categorize(tableMap,false);
+                    ReferencedColumnsMap columnsMap = new ReferencedColumnsMap();
+                    newAnd.categorize(tableMap, columnsMap, false);
                     Predicate newPred=(Predicate)getNodeFactory().getNode(
                             C_NodeTypes.PREDICATE,
                             newAnd,
                             tableMap,
                             getContextManager());
+                    newPred.setReferencedColumns(columnsMap);
                     addPredicate(newPred);
                     searchClauses.addElement(newPred);
                 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QualifierPhase.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QualifierPhase.java
@@ -38,9 +38,8 @@ package com.splicemachine.db.impl.sql.compile;
  * BASE - > Qualifier is going against a key value in a way where splice can perform partitioning.
  * FILTER_BASE -> Qualifier for base table but does not restrict I/O from base scan.  This is evaluated prior to a possible lookup.
  * FILTER_PROJECTION -> Qualifer applied after possible lookup in the projection node on top of the base conglomerate scan.
- * JOIN -> Join predicate used to adjust the join selectivity.
  *
  */
 public enum QualifierPhase {
-    BASE,FILTER_BASE,FILTER_PROJECTION,JOIN
+    BASE,FILTER_BASE,FILTER_PROJECTION
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QualifierPhase.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QualifierPhase.java
@@ -38,8 +38,9 @@ package com.splicemachine.db.impl.sql.compile;
  * BASE - > Qualifier is going against a key value in a way where splice can perform partitioning.
  * FILTER_BASE -> Qualifier for base table but does not restrict I/O from base scan.  This is evaluated prior to a possible lookup.
  * FILTER_PROJECTION -> Qualifer applied after possible lookup in the projection node on top of the base conglomerate scan.
+ * JOIN -> Join predicate used to adjust the join selectivity.
  *
  */
 public enum QualifierPhase {
-    BASE,FILTER_BASE,FILTER_PROJECTION
+    BASE,FILTER_BASE,FILTER_PROJECTION,JOIN
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RangeSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RangeSelectivity.java
@@ -50,8 +50,8 @@ public class RangeSelectivity extends AbstractSelectivityHolder {
     private final boolean useExtrapolation;
 
     public RangeSelectivity(StoreCostController storeCost,DataValueDescriptor start, DataValueDescriptor stop,boolean includeStart, boolean includeStop,
-                            boolean fromExprIndex, int colNum, QualifierPhase phase, double selectivityFactor, boolean useExtrapolation){
-        super(fromExprIndex, colNum, phase);
+                            boolean fromExprIndex, int colNum, QualifierPhase phase, double selectivityFactor, boolean useExtrapolation, Predicate pred){
+        super(fromExprIndex, colNum, phase, pred);
         this.start = start;
         this.stop = stop;
         this.includeStart = includeStart;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ReferencedColumnsMap.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ReferencedColumnsMap.java
@@ -25,7 +25,7 @@ import static com.splicemachine.db.shared.common.reference.SQLState.LANG_INTERNA
  * A map from Table Number to a set of column numbers from that table.
  * Used primarily to track which columns in a table are referenced in a predicate.
  * Throws an error if an attempt is made to track a negative table number
- * or column number less than 1.
+ * or negative column number (ROWID columns use column number 0).
  */
 
 public final class ReferencedColumnsMap {
@@ -70,9 +70,9 @@ public final class ReferencedColumnsMap {
         if (tableNumber < 0)
             throw StandardException.newException(LANG_INTERNAL_ERROR,
                     "Attempt to add negative table number to ReferencedColumnsMap.");
-        if (columnNumber < 1)
+        if (columnNumber < 0)
             throw StandardException.newException(LANG_INTERNAL_ERROR,
-                    "Attempt to add non-positive column number to ReferencedColumnsMap.");
+                    "Attempt to add negative column number to ReferencedColumnsMap.");
 
         Set<Integer> foundSet = tableColumns.get(tableNumber);
         try {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ReferencedColumnsMap.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ReferencedColumnsMap.java
@@ -15,6 +15,7 @@ package com.splicemachine.db.impl.sql.compile;
 
 import static com.cedarsoftware.util.DeepEquals.deepEquals;
 import com.splicemachine.db.iapi.error.StandardException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import splice.com.google.common.collect.Sets;
 import java.util.*;
 
@@ -112,6 +113,7 @@ public final class ReferencedColumnsMap {
         return intersects(tableNumber, otherFoundSet);
     }
 
+    @SuppressFBWarnings(value = "EQ_SELF_USE_OBJECT",justification = "intentional")
     public boolean equals(ReferencedColumnsMap refColsToCompare) {
         Map<Integer, Set<Integer>> otherTableColumns = refColsToCompare.getTableColumns();
         if (tableColumns == otherTableColumns)
@@ -124,6 +126,10 @@ public final class ReferencedColumnsMap {
             return false;
 
         return deepEquals(tableColumns, otherTableColumns);
+    }
+
+    public int hashCode() {
+        return tableColumns.hashCode();
     }
 
     // For internal use only.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ReferencedColumnsMap.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ReferencedColumnsMap.java
@@ -112,7 +112,16 @@ public final class ReferencedColumnsMap {
         return intersects(tableNumber, otherFoundSet);
     }
 
-    @SuppressFBWarnings(value = "EQ_SELF_USE_OBJECT",justification = "intentional")
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other instanceof ReferencedColumnsMap)
+            return this.equals((ReferencedColumnsMap)other);
+
+        return false;
+    }
+
     public boolean equals(ReferencedColumnsMap refColsToCompare) {
         Map<Integer, Set<Integer>> otherTableColumns = refColsToCompare.getTableColumns();
         if (tableColumns == otherTableColumns)

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ReferencedColumnsMap.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ReferencedColumnsMap.java
@@ -13,7 +13,6 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
-import static com.cedarsoftware.util.DeepEquals.deepEquals;
 import com.splicemachine.db.iapi.error.StandardException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import splice.com.google.common.collect.Sets;
@@ -125,7 +124,19 @@ public final class ReferencedColumnsMap {
         else if (otherTableColumns.isEmpty())
             return false;
 
-        return deepEquals(tableColumns, otherTableColumns);
+        if (tableColumns.size() != otherTableColumns.size())
+            return false;
+
+        Iterator mapIterator = tableColumns.entrySet().iterator();
+        while (mapIterator.hasNext()) {
+            Map.Entry<Integer, Set<Integer>> mapElement =
+                (Map.Entry<Integer, Set<Integer>>) mapIterator.next();
+            Set<Integer> lookupSet = otherTableColumns.get(mapElement.getKey());
+            if (!mapElement.getValue().equals(lookupSet)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public int hashCode() {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ReferencedColumnsMap.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ReferencedColumnsMap.java
@@ -1,0 +1,134 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+import static com.cedarsoftware.util.DeepEquals.deepEquals;
+import com.splicemachine.db.iapi.error.StandardException;
+import splice.com.google.common.collect.Sets;
+import java.util.*;
+
+import static com.splicemachine.db.shared.common.reference.SQLState.LANG_INTERNAL_ERROR;
+
+/**
+ * A map from Table Number to a set of column numbers from that table.
+ * Used primarily to track which columns in a table are referenced in a predicate.
+ * Throws an error if an attempt is made to track a negative table number
+ * or column number less than 1.
+ */
+
+public final class ReferencedColumnsMap {
+
+    // Key:   Table Number
+    // Value: The column numbers of the ColumnReference nodes found for that table
+    private Map<Integer, Set<Integer>> tableColumns;
+
+    public ReferencedColumnsMap() {
+        tableColumns = new HashMap<>();
+    }
+
+    public ReferencedColumnsMap(ReferencedColumnsMap refColsToCopy) {
+        Map<Integer, Set<Integer>> mapToCopy = refColsToCopy.getTableColumns();
+        tableColumns = new HashMap<>(mapToCopy.size());
+
+        Iterator mapIterator = mapToCopy.entrySet().iterator();
+        // Make more than just a shallow copy because sharing the set of column numbers
+        // would mean when we call method 'add' on one ReferencedColumnsMap, the copy
+        // would get updated too, which we don't want.
+        while (mapIterator.hasNext()) {
+            Map.Entry<Integer, Set<Integer>> mapElement = (Map.Entry<Integer, Set<Integer>>) mapIterator.next();
+            Set<Integer> valueToCopy = mapElement.getValue();
+            Set<Integer> newValue = new HashSet<Integer>(valueToCopy);
+            Integer key = mapElement.getKey();
+            tableColumns.put(key, newValue);
+        }
+    }
+
+    public int getNumReferencedTables() {
+        return tableColumns.size();
+    }
+
+    // Find the referenced column numbers for a given table number.
+    public Set<Integer> get(int tableNumber) {
+        return tableColumns.get(tableNumber);
+    }
+
+    // Add to the map a reference to a columnNumber from a given tableNumber.
+    public ReferencedColumnsMap add(int tableNumber, int columnNumber) throws StandardException {
+
+        if (tableNumber < 0)
+            throw StandardException.newException(LANG_INTERNAL_ERROR,
+                    "Attempt to add negative table number to ReferencedColumnsMap.");
+        if (columnNumber < 1)
+            throw StandardException.newException(LANG_INTERNAL_ERROR,
+                    "Attempt to add non-positive column number to ReferencedColumnsMap.");
+
+        Set<Integer> foundSet = tableColumns.get(tableNumber);
+        try {
+            if (foundSet == null) {
+                // Keep the initial size small to save memory.
+                foundSet = new HashSet<>(1);
+                foundSet.add(columnNumber);
+                tableColumns.put(tableNumber, foundSet);
+            }
+            foundSet.add(columnNumber);
+        }
+        catch (Exception e) {
+            throw StandardException.newException(LANG_INTERNAL_ERROR, e,
+               "Cannot add to referenced column map.");
+        }
+        return this;
+    }
+
+    // Test if this map shares any columns with a given table number and set of column numbers.
+    private boolean intersects(int tableNumber, Set<Integer> columnNumbers) throws StandardException {
+        Set<Integer> foundSet = tableColumns.get(tableNumber);
+        try {
+            if (foundSet == null || columnNumbers == null) {
+                return false;
+            }
+            Sets.SetView<Integer> resultSet = Sets.intersection(foundSet, columnNumbers);
+            return !resultSet.isEmpty();
+        }
+        catch (Exception e) {
+            throw StandardException.newException(LANG_INTERNAL_ERROR, e,
+               "Cannot do intersection test on referenced columns map.");
+        }
+    }
+
+    // Test if this map shares any columns with another map for a given table number.
+    public boolean intersects(int tableNumber, ReferencedColumnsMap otherMap) throws StandardException {
+        Set<Integer> otherFoundSet = otherMap.get(tableNumber);
+        return intersects(tableNumber, otherFoundSet);
+    }
+
+    public boolean equals(ReferencedColumnsMap refColsToCompare) {
+        Map<Integer, Set<Integer>> otherTableColumns = refColsToCompare.getTableColumns();
+        if (tableColumns == otherTableColumns)
+            return true;
+        if (tableColumns == null || otherTableColumns == null)
+            return false;
+        else if (tableColumns.isEmpty())
+            return otherTableColumns.isEmpty();
+        else if (otherTableColumns.isEmpty())
+            return false;
+
+        return deepEquals(tableColumns, otherTableColumns);
+    }
+
+    // For internal use only.
+    private Map<Integer, Set<Integer>>  getTableColumns() {
+        return tableColumns;
+    }
+
+}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLToJavaValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLToJavaValueNode.java
@@ -224,7 +224,9 @@ public class SQLToJavaValueNode extends JavaValueNode {
 
     /**
      * Categorize this predicate.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      * If the source of this ColumnReference (at the next underlying level)
      * is not a ColumnReference or a VirtualColumnNode then this predicate
      * will not be pushed down.
@@ -239,6 +241,8 @@ public class SQLToJavaValueNode extends JavaValueNode {
      * RESOLVE - revisit this issue once we have views.
      *
      * @param referencedTabs    JBitSet with bit map of referenced FromTables
+     * @param referencedColumns  An object which maps tableNumber to the columns
+     *                           from that table which are present in the predicate.
      * @param simplePredsOnly    Whether or not to consider method
      *                            calls, field references and conditional nodes
      *                            when building bit map
@@ -248,10 +252,10 @@ public class SQLToJavaValueNode extends JavaValueNode {
      *
      * @exception StandardException            Thrown on error
      */
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
         throws StandardException
     {
-        return value.categorize(referencedTabs, simplePredsOnly);
+        return value.categorize(referencedTabs, referencedColumns, simplePredsOnly);
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityHolder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityHolder.java
@@ -47,4 +47,10 @@ public interface SelectivityHolder extends Comparable<SelectivityHolder> {
         QualifierPhase getPhase();
         int getColNum();
         boolean isRangeSelectivity();
+        int getNumReferencedTables();
+
+        // Test whether this SelectivityHolder should be counted.
+        // For example, join predicates should only be used towards
+        // the filterBaseTableSelectivity for nested loop join.
+        default boolean shouldApplySelectivity() { return true; }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
@@ -168,11 +168,12 @@ public class SelectivityUtil {
                 ReferencedColumnsMap referencedColumnsMap = p.getReferencedColumns();
 
                 Integer mapIndex = null;
-                for (Integer I:columnSet) {
-                    mapIndex = selectivityIndexMap.get(I);
-                    if (mapIndex != null)
-                        break;
-                }
+                if (columnSet != null)
+                    for (Integer I:columnSet) {
+                        mapIndex = selectivityIndexMap.get(I);
+                        if (mapIndex != null)
+                            break;
+                    }
                 if (mapIndex != null) {
                     // Compare selectivities of predicates with overlapping column sets and keep the
                     // one with the lowest value.
@@ -186,8 +187,9 @@ public class SelectivityUtil {
                 }
                 else {
                     selectivityMap.put(index, predicateSelectivity);
-                    for (Integer I : columnSet)
-                        selectivityIndexMap.put(I, index);
+                    if (columnSet != null)
+                        for (Integer I : columnSet)
+                            selectivityIndexMap.put(I, index);
                     index++;
                 }
             }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
@@ -38,7 +38,9 @@ import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.IndexRowGenerator;
 
-import java.util.List;
+import java.util.*;
+
+import static com.splicemachine.db.impl.sql.compile.ScanCostFunction.computeSqrtLevel;
 
 /**
  *
@@ -130,14 +132,71 @@ public class SelectivityUtil {
             }
         }
         double selectivity = 1.d;
+        List<JoinPredicateSelectivity> predSelectivities = new ArrayList<>();
         if (predList != null) {
             for (int i = 0; i < predList.size(); i++) {
                 Predicate p = (Predicate) predList.getOptPredicate(i);
                 if (!isTheRightJoinPredicate(p, predicateType))
                     continue;
 
-                selectivity *= p.joinSelectivity(innerTable, innerCD, innerRowCount, outerRowCount, selectivityJoinType);
+                predSelectivities.add(new JoinPredicateSelectivity(p, innerTable, QualifierPhase.JOIN,
+                                                           p.joinSelectivity(innerTable, innerCD, innerRowCount,
+                                                                             outerRowCount, selectivityJoinType)));
             }
+        }
+        if (predSelectivities.size() == 1)
+            selectivity = predSelectivities.get(0).getSelectivity();
+        else {
+            // Sort the selectivities and combine them using computeSqrtLevel
+            // as is done in ScanCostFunction.
+            Collections.sort(predSelectivities);
+
+            // Map from predicate number (in the order added to the map) to the
+            // selectivity of the predicate.
+            Map<Integer, JoinPredicateSelectivity> selectivityMap = new TreeMap<>();
+
+            // Map from column number to index into selectivityMap.
+            // This double lookup is done so that the main data structure
+            // holding selectivities has no duplicates.
+            Map<Integer,Integer> selectivityIndexMap = new HashMap<>();
+
+            int index = 0;
+            for (JoinPredicateSelectivity predicateSelectivity:predSelectivities) {
+                Predicate p = predicateSelectivity.getPredicate();
+                int tableNumber = innerTable.getTableNumber();
+                Set<Integer> columnSet = p.getReferencedColumns().get(tableNumber);
+                ReferencedColumnsMap referencedColumnsMap = p.getReferencedColumns();
+
+                Integer mapIndex = null;
+                for (Integer I:columnSet) {
+                    mapIndex = selectivityIndexMap.get(I);
+                    if (mapIndex != null)
+                        break;
+                }
+                if (mapIndex != null) {
+                    // Compare selectivities of predicates with overlapping column sets and keep the
+                    // one with the lowest value.
+                    JoinPredicateSelectivity foundEntry = selectivityMap.get(mapIndex);
+                    if (predicateSelectivity.getSelectivity() < foundEntry.getSelectivity()) {
+                        selectivityMap.put(index, predicateSelectivity);
+                        Set<Integer> columnNumbers = referencedColumnsMap.get(tableNumber);
+                        for (Integer I:columnNumbers)
+                            selectivityIndexMap.put(I, mapIndex);
+                    }
+                }
+                else {
+                    selectivityMap.put(index, predicateSelectivity);
+                    for (Integer I : columnSet)
+                        selectivityIndexMap.put(I, index);
+                    index++;
+                }
+            }
+            List<DefaultPredicateSelectivity> predicateSelectivities = new ArrayList<>(selectivityMap.size());
+            // Using a TreeMap, so the selectivities should still be in order.
+            predicateSelectivities.addAll(selectivityMap.values());
+
+            for (int i = 0; i < predicateSelectivities.size();i++)
+                selectivity = computeSqrtLevel(selectivity, i, predicateSelectivities.get(i));
         }
 
         //Left outer join selectivity should be bounded by 1 / innerRowCount, so that the outputRowCount no less than

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
@@ -139,7 +139,7 @@ public class SelectivityUtil {
                 if (!isTheRightJoinPredicate(p, predicateType))
                     continue;
 
-                predSelectivities.add(new JoinPredicateSelectivity(p, innerTable, QualifierPhase.JOIN,
+                predSelectivities.add(new JoinPredicateSelectivity(p, innerTable, QualifierPhase.FILTER_BASE,
                                                            p.joinSelectivity(innerTable, innerCD, innerRowCount,
                                                                              outerRowCount, selectivityJoinType)));
             }
@@ -168,12 +168,13 @@ public class SelectivityUtil {
                 ReferencedColumnsMap referencedColumnsMap = p.getReferencedColumns();
 
                 Integer mapIndex = null;
-                if (columnSet != null)
-                    for (Integer I:columnSet) {
+                if (columnSet != null) {
+                    for (Integer I : columnSet) {
                         mapIndex = selectivityIndexMap.get(I);
                         if (mapIndex != null)
                             break;
                     }
+                }
                 if (mapIndex != null) {
                     // Compare selectivities of predicates with overlapping column sets and keep the
                     // one with the lowest value.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StaticClassFieldReferenceNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StaticClassFieldReferenceNode.java
@@ -143,7 +143,9 @@ public final class StaticClassFieldReferenceNode extends JavaValueNode {
 
     /**
      * Categorize this predicate.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      * If the source of this ColumnReference (at the next underlying level)
      * is not a ColumnReference or a VirtualColumnNode then this predicate
      * will not be pushed down.
@@ -158,6 +160,8 @@ public final class StaticClassFieldReferenceNode extends JavaValueNode {
      * RESOLVE - revisit this issue once we have views.
      *
      * @param referencedTabs    JBitSet with bit map of referenced FromTables
+     * @param referencedColumns  An object which maps tableNumber to the columns
+     *                           from that table which are present in the predicate.
      * @param simplePredsOnly    Whether or not to consider method
      *                            calls, field references and conditional nodes
      *                            when building bit map
@@ -165,7 +169,7 @@ public final class StaticClassFieldReferenceNode extends JavaValueNode {
      * @return boolean        Whether or not source.expression is a ColumnReference
      *                        or a VirtualColumnNode.
      */
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
     {
         return true;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StaticMethodCallNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StaticMethodCallNode.java
@@ -965,7 +965,9 @@ public class StaticMethodCallNode extends MethodCallNode {
 
     /**
      * Categorize this predicate.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      * If the source of this ColumnReference (at the next underlying level)
      * is not a ColumnReference or a VirtualColumnNode then this predicate
      * will not be pushed down.
@@ -980,6 +982,8 @@ public class StaticMethodCallNode extends MethodCallNode {
      * RESOLVE - revisit this issue once we have views.
      *
      * @param referencedTabs    JBitSet with bit map of referenced FromTables
+     * @param referencedColumns  An object which maps tableNumber to the columns
+     *                           from that table which are present in the predicate.
      * @param simplePredsOnly    Whether or not to consider method
      *                            calls, field references and conditional nodes
      *                            when building bit map
@@ -989,7 +993,7 @@ public class StaticMethodCallNode extends MethodCallNode {
      *
      * @exception StandardException        Thrown on error
      */
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
         throws StandardException
     {
         /* We stop here when only considering simple predicates
@@ -1003,7 +1007,7 @@ public class StaticMethodCallNode extends MethodCallNode {
 
         boolean pushable = true;
 
-        pushable = pushable && super.categorize(referencedTabs, simplePredsOnly);
+        pushable = pushable && super.categorize(referencedTabs, referencedColumns, simplePredsOnly);
 
         return pushable;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
@@ -502,7 +502,9 @@ public class TernaryOperatorNode extends OperatorNode
 
     /**
      * Categorize this predicate.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      * If the source of this ColumnReference (at the next underlying level)
      * is not a ColumnReference or a VirtualColumnNode then this predicate
      * will not be pushed down.
@@ -517,6 +519,8 @@ public class TernaryOperatorNode extends OperatorNode
      * RESOLVE - revisit this issue once we have views.
      *
      * @param referencedTabs    JBitSet with bit map of referenced FromTables
+     * @param referencedColumns  An object which maps tableNumber to the columns
+     *                           from that table which are present in the predicate.
      * @param simplePredsOnly    Whether or not to consider method
      *                            calls, field references and conditional nodes
      *                            when building bit map
@@ -525,15 +529,15 @@ public class TernaryOperatorNode extends OperatorNode
      *                        or a VirtualColumnNode.
      * @exception StandardException            Thrown on error
      */
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
         throws StandardException
     {
         boolean pushable;
-        pushable = receiver.categorize(referencedTabs, simplePredsOnly);
-        pushable = (leftOperand.categorize(referencedTabs, simplePredsOnly) && pushable);
+        pushable = receiver.categorize(referencedTabs, referencedColumns, simplePredsOnly);
+        pushable = (leftOperand.categorize(referencedTabs, referencedColumns, simplePredsOnly) && pushable);
         if (rightOperand != null)
         {
-            pushable = (rightOperand.categorize(referencedTabs, simplePredsOnly) && pushable);
+            pushable = (rightOperand.categorize(referencedTabs, referencedColumns, simplePredsOnly) && pushable);
         }
         return pushable;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryOperatorNode.java
@@ -567,7 +567,9 @@ public class UnaryOperatorNode extends OperatorNode
 
     /**
      * Categorize this predicate.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      * If the source of this ColumnReference (at the next underlying level)
      * is not a ColumnReference or a VirtualColumnNode then this predicate
      * will not be pushed down.
@@ -582,6 +584,8 @@ public class UnaryOperatorNode extends OperatorNode
      * RESOLVE - revisit this issue once we have views.
      *
      * @param referencedTabs	JBitSet with bit map of referenced FromTables
+     * @param referencedColumns  An object which maps tableNumber to the columns
+     *                           from that table which are present in the predicate.
      * @param simplePredsOnly	Whether or not to consider method
      *							calls, field references and conditional nodes
      *							when building bit map
@@ -591,10 +595,10 @@ public class UnaryOperatorNode extends OperatorNode
      *
      * @exception StandardException			Thrown on error
      */
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
             throws StandardException
     {
-        return operand != null && operand.categorize(referencedTabs, simplePredsOnly);
+        return operand != null && operand.categorize(referencedTabs, referencedColumns, simplePredsOnly);
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNode.java
@@ -706,7 +706,9 @@ public abstract class ValueNode extends QueryTreeNode implements ParentNode
 
     /**
      * Categorize this predicate.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      * If the source of this ColumnReference (at the next underlying level)
      * is not a ColumnReference or a VirtualColumnNode then this predicate
      * will not be pushed down.
@@ -721,6 +723,8 @@ public abstract class ValueNode extends QueryTreeNode implements ParentNode
      * RESOLVE - revisit this issue once we have views.
      *
      * @param referencedTabs    JBitSet with bit map of referenced FromTables
+     * @param referencedColumns  An object which maps tableNumber to the columns
+     *                           from that table which are present in the predicate.
      * @param simplePredsOnly    Whether or not to consider method
      *                            calls, field references and conditional nodes
      *                            when building bit map
@@ -730,7 +734,7 @@ public abstract class ValueNode extends QueryTreeNode implements ParentNode
      *
      * @exception StandardException            Thrown on error
      */
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
         throws StandardException
     {
         return true;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNodeList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNodeList.java
@@ -710,7 +710,9 @@ public class ValueNodeList extends QueryTreeNodeVector
 
     /**
      * Categorize this predicate.  Initially, this means
-     * building a bit map of the referenced tables for each predicate.
+     * building a bit map of the referenced tables for each predicate,
+     * and a mapping from table number to the column numbers
+     * from that table present in the predicate.
      * If the source of this ColumnReference (at the next underlying level)
      * is not a ColumnReference or a VirtualColumnNode then this predicate
      * will not be pushed down.
@@ -725,6 +727,8 @@ public class ValueNodeList extends QueryTreeNodeVector
      * RESOLVE - revisit this issue once we have views.
      *
      * @param referencedTabs    JBitSet with bit map of referenced FromTables
+     * @param referencedColumns  An object which maps tableNumber to the columns
+     *                           from that table which are present in the predicate.
      * @param simplePredsOnly    Whether or not to consider method
      *                            calls, field references and conditional nodes
      *                            when building bit map
@@ -733,7 +737,7 @@ public class ValueNodeList extends QueryTreeNodeVector
      *                        or a VirtualColumnNode.
      * @exception StandardException        Thrown on error
      */
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly)
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
         throws StandardException
     {
         /* We stop here when only considering simple predicates
@@ -745,7 +749,7 @@ public class ValueNodeList extends QueryTreeNodeVector
 
         for (int index = 0; index < size; index++)
         {
-            pushable = ((ValueNode) elementAt(index)).categorize(referencedTabs, simplePredsOnly) &&
+            pushable = ((ValueNode) elementAt(index)).categorize(referencedTabs, referencedColumns, simplePredsOnly) &&
                        pushable;
         }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueTupleNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueTupleNode.java
@@ -117,9 +117,9 @@ public class ValueTupleNode extends ValueNode {
     }
 
     @Override
-    public boolean categorize(JBitSet referencedTabs, boolean simplePredsOnly) throws StandardException {
+    public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly) throws StandardException {
         for (ValueNode vn : tuple) {
-            if (!vn.categorize(referencedTabs, simplePredsOnly)) {
+            if (!vn.categorize(referencedTabs, referencedColumns, simplePredsOnly)) {
                 return false;
             }
         }

--- a/db-engine/src/test/java/com/splicemachine/db/impl/sql/compile/ReferencedColumnsMapTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/impl/sql/compile/ReferencedColumnsMapTest.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.splicemachine.db.iapi.types;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.*;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.impl.sql.compile.ReferencedColumnsMap;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ *
+ * Test Class for ReferencedColumnsMap
+ *
+ */
+public class ReferencedColumnsMapTest {
+
+    @Test
+    public void testFunctionality() throws Exception {
+
+        ReferencedColumnsMap map1 = new ReferencedColumnsMap();
+        ReferencedColumnsMap map2 = new ReferencedColumnsMap();
+
+        assertTrue("Failed getNumReferencedTables test.", map1.getNumReferencedTables() == 0);
+
+        map1.add(1,1).add(1,2).add(1,3);
+        map2.add(1,1);
+        assertTrue("Failed getNumReferencedTables test.", map1.getNumReferencedTables() == 1);
+        assertTrue("Failed intersection test.", map1.intersects(1, map2));
+        assertFalse("Failed intersection test.", map1.intersects(2, map2));
+        assertFalse("Failed equals test.", map1.equals(map2));
+
+        ReferencedColumnsMap map3 = new ReferencedColumnsMap(map1);
+        assertTrue("Failed equals test.", map1.equals(map3));
+
+        map1.add(2,1);
+        map2.add(2,2);
+        assertFalse("Failed intersection test.", map1.intersects(2, map2));
+        map1.add(2,2);
+        assertTrue("Failed intersection test.", map1.intersects(1, map2));
+        assertTrue("Failed getNumReferencedTables test.", map1.getNumReferencedTables() == 2);
+
+        Set<Integer> testSet = map1.get(1);
+        Set<Integer> validateSet = new HashSet<>(3);
+        validateSet.add(1); validateSet.add(2); validateSet.add(3);
+        assertTrue("Failed equals test.", testSet.equals(validateSet));
+        assertTrue("Failed equals test.", testSet.equals(map1.get(1)));
+        ReferencedColumnsMap map4 = new ReferencedColumnsMap(map1);
+        map1.add(1,2);
+        map1.add(1,2);
+        assertTrue("Failed equals test.", map1.equals(map4));
+        map1.add(1,4);
+        assertFalse("Failed equals test.", map1.equals(map4));
+
+        // Should be able to use table number of zero.
+        map1.add(0,2);
+
+        try {
+            map1.add(-1,2);
+            fail("Not supposed to be able to add a negative table number to the map.");
+        }
+        catch (StandardException e) {
+        }
+        try {
+            map1.add(1,0);
+            fail("Not supposed to be able to add a non-positive column number to the map.");
+        }
+        catch (StandardException e) {
+        }
+    }
+
+}

--- a/db-engine/src/test/java/com/splicemachine/db/impl/sql/compile/ReferencedColumnsMapTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/impl/sql/compile/ReferencedColumnsMapTest.java
@@ -75,8 +75,8 @@ public class ReferencedColumnsMapTest {
         catch (StandardException e) {
         }
         try {
-            map1.add(1,0);
-            fail("Not supposed to be able to add a non-positive column number to the map.");
+            map1.add(-100,0);
+            fail("Not supposed to be able to add a negative column number to the map.");
         }
         catch (StandardException e) {
         }

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NLJPredicatePushedToDerivedTableIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NLJPredicatePushedToDerivedTableIT.java
@@ -407,7 +407,7 @@ public class NLJPredicatePushedToDerivedTableIT extends SpliceUnitTest {
         rowContainsQuery(new int[]{4, 6, 7, 8, 9, 10}, "explain " + sqlText, methodWatcher,
                 new String[]{"NestedLoopJoin", "outputRows=3000"},
                 new String[]{"BroadcastJoin", "outputRows=1000", "preds=[(A2[6:2] = A4[6:1])]"},
-                new String[]{"TableScan[T2", "scannedRows=1,outputRows=1", "preds=[(A1[1:1] = T2.A2[4:1])]"},
+                new String[]{"TableScan[T2", "scannedRows=10000,outputRows=10000", "preds=[(A1[1:1] = T2.A2[4:1])]"},
                 new String[]{"TableScan[T4", "scannedRows=1000,outputRows=1000"},
                 new String[]{"ProjectRestrict", "outputRows=3", "preds=[(B1[0:2] IN (1,2,3))]"},
                 new String[]{"TableScan[T1", "scannedRows=3,outputRows=3"}

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SelectivityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SelectivityIT.java
@@ -272,6 +272,25 @@ public class SelectivityIT extends SpliceUnitTest {
                 BADDIR));
         ps.execute();
 
+        new TableCreator(conn)
+            .withCreate("create table t11 (a int, b int, c int, d int, e int)")
+            .withInsert("insert into t11 values(?,?,?,?,?)")
+            .withRows(rows(
+                row(1, 1, 1, 1, 1),
+                row(2, 2, 2, 2, 2),
+                row(3, 3, 3, 3, 3),
+                row(4, 4, 4, 4, 4),
+                row(5, 5, 5, 5, 5),
+                row(6, 6, 6, 6, 6),
+                row(7, 7, 7, 7, 7),
+                row(8, 8, 8, 8, 8),
+                row(9, 9, 9, 9, 9),
+                row(10, 10, 10, 10, 10))).create();
+
+        spliceClassWatcher.executeQuery(format(
+            "call SYSCS_UTIL.COLLECT_TABLE_STATISTICS('%s','T11', false)",
+            spliceSchemaWatcher.schemaName));
+
         spliceClassWatcher.executeQuery(format(
                 "call SYSCS_UTIL.COLLECT_TABLE_STATISTICS('%s','T1', false)",
                 spliceSchemaWatcher.schemaName));
@@ -795,6 +814,50 @@ public class SelectivityIT extends SpliceUnitTest {
         rowCount = parseOutputRows(getExplainMessage(3, "explain select * from t5 where a55 != 1000", methodWatcher));
         /* estimation should be the same as the total rows, as no rows should be excluded */
         Assert.assertTrue("Estimation wrong, actual rowCount="+rowCount, rowCount==5120);
+    }
+
+    @Test
+    public void testJoinPredsWithOverlappingColumns() throws Exception {
+        rowContainsQuery(2,"explain select * from t11 a, t11 b, t11 c where a.a = b.a and b.a = c.a and a.a = c.a","outputRows=10,",methodWatcher);
+        rowContainsQuery(2,"explain select * from t11 a --splice-properties joinStrategy=nestedloop\n" +
+                                               ", t11 b --splice-properties joinStrategy=nestedloop\n" +
+                                               ", t11 c --splice-properties joinStrategy=nestedloop\n" +
+                            "where a.a = b.a and b.a = c.a and a.a = c.a","outputRows=10,",methodWatcher);
+
+        // Non-overlapping columns, use new method of combining selectivities.
+        rowContainsQuery(2,"explain select * from t11 a, t11 b, t11 c where a.a = b.a and b.b = c.b and a.c = c.c","outputRows=3,",methodWatcher);
+
+        rowContainsQuery(5,"explain select * from t11 a, t11 b, t11 c where a.a = b.a and b.a = c.a and a.a = c.a " +
+                                              "and a.b = b.b and a.b = c.b","outputRows=3,",methodWatcher);
+
+        rowContainsQuery(2,"explain select * from t11 a, t11 b, t11 c where a.a = b.a and (a.b+a.a)/2 = b.a and a.a = c.a","outputRows=10,",methodWatcher);
+        rowContainsQuery(2,"explain select * from t11 a --splice-properties joinStrategy=nestedloop\n" +
+                            ", t11 b --splice-properties joinStrategy=nestedloop\n" +
+                            ", t11 c --splice-properties joinStrategy=nestedloop\n" +
+                             "where a.a = b.a and (a.b+a.a)/2 = b.a and a.a = c.a","outputRows=10,",methodWatcher);
+        rowContainsQuery(2,"explain select * from t11 a, t11 b, t11 c where a.a = b.a and (a.b+a.a)/2 between b.a-1 and b.a+1 and a.a = c.a","outputRows=10,",methodWatcher);
+        rowContainsQuery(2,"explain select * from t11 a --splice-properties joinStrategy=nestedloop\n" +
+                            ", t11 b --splice-properties joinStrategy=nestedloop\n" +
+                            ", t11 c --splice-properties joinStrategy=nestedloop\n" +
+                            "where a.a = b.a and (a.b+a.a)/2 between b.a-1 and b.a+1 and a.a = c.a","outputRows=10,",methodWatcher);
+        rowContainsQuery(2,"explain select * from t11 a, t11 b, t11 c where a.a = b.a and (c.a+a.a)/2 <> b.a and a.a = c.a","outputRows=10,",methodWatcher);
+        rowContainsQuery(2,"explain select * from t11 a --splice-properties joinStrategy=nestedloop\n" +
+                            ", t11 b --splice-properties joinStrategy=nestedloop\n" +
+                            ", t11 c --splice-properties joinStrategy=nestedloop\n" +
+                            "where a.a = b.a and (c.a+a.a)/2 <> b.a and a.a = c.a","outputRows=10,",methodWatcher);
+
+        rowContainsQuery(2,"explain select * from t11 a, t11 b, t11 c, t11 d, t11 e where a.a = b.a and b.a = c.a and c.a = d.a and d.a = e.a " +
+                                              "and a.a = c.a and a.a = d.a and a.a = e.a " +
+                                              "and b.a = d.a and b.a = e.a and c.a = e.a","outputRows=10,",methodWatcher);
+        rowContainsQuery(2,"explain select * from t11 a --splice-properties joinStrategy=nestedloop\n" +
+                            ", t11 b --splice-properties joinStrategy=nestedloop\n" +
+                            ", t11 c --splice-properties joinStrategy=nestedloop\n" +
+                            ", t11 d --splice-properties joinStrategy=nestedloop\n" +
+                            ", t11 e --splice-properties joinStrategy=nestedloop\n" +
+                              "where a.a = b.a and b.a = c.a and c.a = d.a and d.a = e.a " +
+                                              "and a.a = c.a and a.a = d.a and a.a = e.a " +
+                                              "and b.a = d.a and b.a = e.a and c.a = e.a","outputRows=10,",methodWatcher);
+
     }
 
 }


### PR DESCRIPTION
Fixes join cardinality underestimation errors, which could lead to large poorly-performing nested loop joins in large multi-table queries.

 Simplified cardinality underestimation example:
> create table t1 ( a int, b int, c int, d int, e int );
> insert into t1 values (1,1,1,1,1),(2,2,2,2,2),(3,3,3,3,3),(4,4,4,4,4),(5,5,5,5,5),(6,6,6,6,6),(7,7,7,7,7),(8,8,8,8,8),(9,9,9,9,9),(10,10,10,10,10);
> analyze table t1;
> /* The following should have an outputRows estimate of 10, not 1. */
> explain select * from t1 a, t1 b, t1 c where a.a = b.a and b.a = c.a;
> Cursor(n=11,rows=1,updateMode=READ_ONLY (1),engine=OLTP (default))
>   ->  ScrollInsensitive(n=11,totalCost=32.552,outputRows=1,outputHeapSize=60 B,partitions=1,parallelTasks=1)
>     ->  BroadcastJoin(n=8,totalCost=20.249,outputRows=1,outputHeapSize=60 B,partitions=1,parallelTasks=1,preds=[(A.A[8:1] = C.A[8:11])])
>       ->  TableScan[T1(1680)](n=6,totalCost=4.012,scannedRows=10,outputRows=10,outputHeapSize=60 B,partitions=1,parallelTasks=1)
>       ->  BroadcastJoin(n=4,totalCost=12.135,outputRows=10,outputHeapSize=400 B,partitions=1,parallelTasks=1,preds=[(A.A[4:1] = B.A[4:6])])
>         ->  TableScan[T1(1680)](n=2,totalCost=4.012,scannedRows=10,outputRows=10,outputHeapSize=400 B,partitions=1,parallelTasks=1)
>         ->  TableScan[T1(1680)](n=0,totalCost=4.012,scannedRows=10,outputRows=10,outputHeapSize=200 B,partitions=1,parallelTasks=1)


1. When there is more than one join predicate involving the same column on a table, either explicitly, or derived through transitive closure, the selectivity of the redundant term is applied.  The old formula for selectivity used only the join predicate with the lowest selectivity as the selectivity of the entire join.  The fix is to apply a similar rule.  Among a set of columns with overlapping column references, only use the predicate with lowest selectivit.  For example:  t1.a + t1.b > t2.a and t1.a = t2.a both involve column t1.a, so only one of these predicates contributes to the join selectivity.  Non-overlapping predicate selectivities will still be combined.

2.  The formula for combining join predicate selectivities is a little too aggresive (pred1.selectivity * pred2.selectivity * pred3.selectivity...) and implies absolute independence of join column values.  This change was made by SPLICE-2289, as we only counted a single predicates selectivity before, which caused row count overestimation.  The formula is now updated to match the default scan selectivity formula, which used function computeSqrtLevel to take the square root of the combined selectivity successively, the same number of times as the number of join predicates.

3.  Sometimes join predicates are applied to the scan selectivity.  This is done for nested loop join, because it applies the join predicates as scan predicates.  But this has the effect of applying a predicate's selectivity more than once when other types of joins are picked.  The solution is to only apply join predicates to the scan selectivity if the current access path uses nested loop join.

To handle part 1, new class ReferencedColumnsMap is added to map table number to column numbers, tracking the ColumnReferences present in each predicate.  Method categorize, which collects metadata about a predicate, is updated with ReferencedColumnsMap as a parameter and builds this map for each Predicate.

For part 2, a new SelectivityHolder, named JoinPredicateSelectivity, is added to facilitate the sorting of selectivities as is done for scan predicates.

For part 3, a new method is added to the SelectivityHolder API called shouldApplySelectivity() which checks the number of tables referenced in the predicate and current join strategy.
