### PR TITLE
DB-10773 Honor joinStrategy hints on the target table of an UPDATE.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromList.java
@@ -51,8 +51,7 @@ import java.util.*;
 
 public class FromList extends QueryTreeNodeVector<QueryTreeNode> implements OptimizableList{
     Properties properties;
-    // RESOLVE: The default should be false
-    boolean fixedJoinOrder=true;
+    boolean fixedJoinOrder=false;
     // true by default.
     boolean useStatistics=true;
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
@@ -84,6 +84,7 @@ public class OptimizerImpl implements Optimizer{
     private static final int JUMPING=2;
     private static final int WALK_HIGH=3;
     private static final int WALK_LOW=4;
+    private static final int PREPARED_STATEMENT_TIME_LIMIT_LOWER_BOUND = 2000;
     protected DataDictionary dDictionary;
     /* The number of tables in the query as a whole.  (Size of bit maps.) */
     protected final int numTablesInQuery;
@@ -2205,8 +2206,9 @@ public class OptimizerImpl implements Optimizer{
             // prepared statement does not need to be compiled on every
             // invocation, just once in a while.  So, it is time well
             // spent if it means we can compile a more optimal plan.
-            if (timeLimit < 2000 && isPreparedStatement())
-                timeLimit = 2000;
+            if (timeLimit < PREPARED_STATEMENT_TIME_LIMIT_LOWER_BOUND &&
+                isPreparedStatement())
+                timeLimit = PREPARED_STATEMENT_TIME_LIMIT_LOWER_BOUND;
         }
 
         /*

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
@@ -33,7 +33,11 @@ package com.splicemachine.db.impl.sql.compile;
 
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.services.context.ContextService;
+import com.splicemachine.db.iapi.services.loader.ClassFactoryContext;
 import com.splicemachine.db.iapi.sql.compile.*;
+import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
+import com.splicemachine.db.iapi.sql.conn.StatementContext;
 import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.sql.dictionary.IndexRowGenerator;
@@ -996,8 +1000,13 @@ public class OptimizerImpl implements Optimizer{
                 ** we can't really tell much by comparing the two, so for lack
                 ** of better alternative we look at the row counts.  See
                 ** CostEstimateImpl.compare() for more.
+                *
+                *  If the current access path's join strategy is null, that
+                *  means we just found a hinted join, so remember it as
+                *  our best.
                 */
-                if((!foundABestPlan) || (currentCost.compare(bestCost)<0) || bestCost.isUninitialized()){
+                if((!foundABestPlan) || (currentCost.compare(bestCost)<0) || bestCost.isUninitialized() ||
+                    curOpt.getCurrentAccessPath().getJoinStrategy() == null){
                     rememberBestCost(currentCost,Optimizer.NORMAL_PLAN);
 
                     // Since we just remembered all of the best plans,
@@ -2134,6 +2143,15 @@ public class OptimizerImpl implements Optimizer{
         assignedTableMap.xor(pullMe.getReferencedTableMap());
     }
 
+    private boolean isPreparedStatement() {
+        LanguageConnectionContext lcc =
+            (LanguageConnectionContext) ContextService.
+                getContextOrNull(LanguageConnectionContext.CONTEXT_ID);
+        if (lcc == null || lcc.getActivationCount() < 1)
+            return false;
+        return lcc.getLastActivation().getPreparedStatement() != null;
+    }
+
     /**
      * Is the cost of this join order lower than the best one we've
      * found so far?  If so, remember it.
@@ -2178,6 +2196,17 @@ public class OptimizerImpl implements Optimizer{
         // Consider consolidating all these into nanoseconds in the future.
         if((bestCost.getEstimatedCost()/NANOS_TO_MILLIS)<timeLimit) {
             timeLimit=bestCost.getEstimatedCost()/NANOS_TO_MILLIS;
+
+            // Triggers and other prepared statements may have a very low
+            // cost estimate because the size of the involved trigger rows
+            // is not known up-front.  We don't want to quit query compilation
+            // early, resulting in a bad query plan or a plan which fails to
+            // pick up query hints, especially since the
+            // prepared statement does not need to be compiled on every
+            // invocation, just once in a while.  So, it is time well
+            // spent if it means we can compile a more optimal plan.
+            if (timeLimit < 2000 && isPreparedStatement())
+                timeLimit = 2000;
         }
 
         /*

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
@@ -638,6 +638,14 @@ public class ExplainPlanIT extends SpliceUnitTest  {
     }
 
     @Test
+    public void testJoinStrategyHintOnTargetTable() throws Exception {
+        String query ="explain update t4 --splice-properties joinStrategy=nestedloop\n" +
+                             "set (a4,b4) = (select 1,1 from t1 where c1 = a4)";
+
+        rowContainsQuery(3, query, "NestedLoopJoin", methodWatcher);
+    }
+
+    @Test
     public void testReportMissingTableStatistics() throws Exception {
         String query ="explain select * from t3";
         String[] expected = {


### PR DESCRIPTION
This allows joinStragegy query hints to be applied to the target table of an UPDATE, for example, if there is a join predicate on the primary key and you'd like to use nested loop join to avoid scanning the entire table:
```
explain update t4 --splice-properties joinStrategy=nestedloop
                             set (a4,b4) = (select 1,1 from t1 where c1 = a4);
```
Sometimes such hints may be inside a trigger, but often the optimizer cost estimates are so low on triggers that the parsing time limit is set to less than a millisecond, and the query planner gives up before even considering the hinted join.  In general prepared statements such as triggers are recompiled infrequently, so it is OK if parsing uses a little extra time, especially if it means that will allow more optimal plans and plans including all query hints to get built.

A fix is added to give extra allowed parsing time to prepared statements.