### PR TITLE
DB-10961 remove node factory part 1 (3.1)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/C_NodeNames.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/C_NodeNames.java
@@ -83,13 +83,9 @@ public interface C_NodeNames
 
     String COALESCE_FUNCTION_NODE_NAME = "com.splicemachine.db.impl.sql.compile.CoalesceFunctionNode";
 
-    String DECIMAL_FUNCTION_NODE_NAME = "com.splicemachine.db.impl.sql.compile.DecimalFunctionNode";
-
     String COLUMN_DEFINITION_NODE_NAME = "com.splicemachine.db.impl.sql.compile.ColumnDefinitionNode";
 
     String COLUMN_REFERENCE_NAME = "com.splicemachine.db.impl.sql.compile.ColumnReference";
-
-    String CONCATENATION_OPERATOR_NODE_NAME = "com.splicemachine.db.impl.sql.compile.ConcatenationOperatorNode";
 
     String CONDITIONAL_NODE_NAME = "com.splicemachine.db.impl.sql.compile.ConditionalNode";
 
@@ -124,15 +120,9 @@ public interface C_NodeNames
 
     String DB2_LENGTH_OPERATOR_NODE_NAME = "com.splicemachine.db.impl.sql.compile.DB2LengthOperatorNode";
 
-    String DML_MOD_STATEMENT_NODE_NAME = "com.splicemachine.db.impl.sql.compile.DMLModStatementNode";
-
     String DEFAULT_NODE_NAME = "com.splicemachine.db.impl.sql.compile.DefaultNode";
 
-    String DELETE_NODE_NAME = "com.splicemachine.db.impl.sql.compile.DeleteNode";
-
     String DISTINCT_NODE_NAME = "com.splicemachine.db.impl.sql.compile.DistinctNode";
-
-    String DROP_ALIAS_NODE_NAME = "com.splicemachine.db.impl.sql.compile.DropAliasNode";
 
     String DROP_INDEX_NODE_NAME = "com.splicemachine.db.impl.sql.compile.DropIndexNode";
 
@@ -198,8 +188,6 @@ public interface C_NodeNames
 
     String IS_NULL_NODE_NAME = "com.splicemachine.db.impl.sql.compile.IsNullNode";
 
-    String JAVA_TO_SQL_VALUE_NODE_NAME = "com.splicemachine.db.impl.sql.compile.JavaToSQLValueNode";
-
     String JOIN_NODE_NAME = "com.splicemachine.db.impl.sql.compile.JoinNode";
 
     String LENGTH_OPERATOR_NODE_NAME = "com.splicemachine.db.impl.sql.compile.LengthOperatorNode";
@@ -217,8 +205,6 @@ public interface C_NodeNames
     String NEW_INVOCATION_NODE_NAME = "com.splicemachine.db.impl.sql.compile.NewInvocationNode";
 
     String NEXT_SEQUENCE_NODE_NAME = "com.splicemachine.db.impl.sql.compile.NextSequenceNode";
-
-    String NON_STATIC_METHOD_CALL_NODE_NAME = "com.splicemachine.db.impl.sql.compile.NonStaticMethodCallNode";
 
     String NORMALIZE_RESULT_SET_NODE_NAME = "com.splicemachine.db.impl.sql.compile.NormalizeResultSetNode";
 
@@ -280,8 +266,6 @@ public interface C_NodeNames
 
     String STATIC_CLASS_FIELD_REFERENCE_NODE_NAME = "com.splicemachine.db.impl.sql.compile.StaticClassFieldReferenceNode";
 
-    String STATIC_METHOD_CALL_NODE_NAME = "com.splicemachine.db.impl.sql.compile.StaticMethodCallNode";
-
     String STRING_AGGREGATE_NODE_NAME = "com.splicemachine.db.impl.sql.compile.StringAggregateNode";
 
     String SUBQUERY_LIST_NAME = "com.splicemachine.db.impl.sql.compile.SubqueryList";
@@ -315,8 +299,6 @@ public interface C_NodeNames
 
     String UNTYPED_NULL_CONSTANT_NODE_NAME = "com.splicemachine.db.impl.sql.compile.UntypedNullConstantNode";
 
-    String UPDATE_NODE_NAME = "com.splicemachine.db.impl.sql.compile.UpdateNode";
-
     String USERTYPE_CONSTANT_NODE_NAME = "com.splicemachine.db.impl.sql.compile.UserTypeConstantNode";
 
     String VALUE_NODE_LIST_NAME = "com.splicemachine.db.impl.sql.compile.ValueNodeList";
@@ -331,7 +313,6 @@ public interface C_NodeNames
     String WRAPPED_AGGREGATE_FUNCTION_NODE_NAME = "com.splicemachine.db.impl.sql.compile.WrappedAggregateFunctionNode";
     String ROW_NUMBER_FUNCTION_NAME = "com.splicemachine.db.impl.sql.compile.RowNumberFunctionNode";
     String RANK_FUNCTION_NAME = "com.splicemachine.db.impl.sql.compile.RankFunctionNode";
-    String DENSE_RANK_FUNCTION_NAME = "com.splicemachine.db.impl.sql.compile.DenseRankFunctionNode";
     String FIRST_LAST_VALUE_FUNCTION_NAME = "com.splicemachine.db.impl.sql.compile.FirstLastValueFunctionNode";
     String LEAD_LAG_FUNCTION_NAME = "com.splicemachine.db.impl.sql.compile.LeadLagFunctionNode";
     String WINDOW_DEFINITION_NAME = "com.splicemachine.db.impl.sql.compile.WindowDefinitionNode";
@@ -360,8 +341,6 @@ public interface C_NodeNames
 
     String FULL_OUTER_JOIN_NODE_NAME = "com.splicemachine.db.impl.sql.compile.FullOuterJoinNode";
 
-    String TIME_SPAN_NODE_NAME = "com.splicemachine.db.impl.sql.compile.TimeSpanNode";
-
     String EMPTY_DEFAULT_CONSTANT_NODE = "com.splicemachine.db.impl.sql.compile.EmptyDefaultConstantNode";
 
     String VALUE_TUPLE_NODE_NAME = "com.splicemachine.db.impl.sql.compile.ValueTupleNode";
@@ -371,6 +350,4 @@ public interface C_NodeNames
     String TO_INSTANT_NODE_NAME = "com.splicemachine.db.impl.sql.compile.ToInstantOperatorNode";
 
     String TO_HBASE_ESCAPED_NODE_NAME = "com.splicemachine.db.impl.sql.compile.ToHbaseEscapedOperatorNode";
-
-    String TYPEOF_OPERATOR_NODE_NAME = "com.splicemachine.db.impl.sql.compile.TypeofOperatorNode";
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConcatenationOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConcatenationOperatorNode.java
@@ -31,6 +31,7 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
+import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
@@ -70,7 +71,9 @@ public class ConcatenationOperatorNode extends BinaryOperatorNode {
 	 * @param rightOperand
 	 *            The right operand of the concatenation
 	 */
-	public void init(Object leftOperand, Object rightOperand) {
+	public ConcatenationOperatorNode(Object leftOperand, Object rightOperand, ContextManager cm) {
+		setContextManager(cm);
+		setNodeType(C_NodeTypes.CONCATENATION_OPERATOR_NODE);
 		super.init(leftOperand, rightOperand, "||", "concatenate",
 				ClassName.ConcatableDataValue, ClassName.ConcatableDataValue);
 	}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DecimalFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DecimalFunctionNode.java
@@ -19,7 +19,9 @@ import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.classfile.VMOpcode;
 import com.splicemachine.db.iapi.services.compiler.LocalField;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.primitives.Bytes;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -43,12 +45,14 @@ public class DecimalFunctionNode extends UnaryOperatorNode {
     int scale = -1;
     String decimalChar;
 
-    public void init(Object functionName, Object operand, Object precision, Object scale, Object decimalChar) {
-        this.functionName = (String)functionName;
-        this.operand = (ValueNode)operand;
-        this.precision = precision == null ? -1 : (int)precision;
-        this.scale = scale == null ? -1 : (int)scale;
-        this.decimalChar = decimalChar == null ? "" : (String)decimalChar;
+    public DecimalFunctionNode(String functionName, ValueNode operand, Integer precision, Integer scale, String decimalChar, ContextManager cm) {
+        setContextManager(cm);
+        setNodeType(C_NodeTypes.DECIMAL_FUNCTION_NODE);
+        this.functionName = functionName;
+        this.operand = operand;
+        this.precision = precision == null ? -1 : precision.intValue();
+        this.scale = scale == null ? -1 : scale.intValue();
+        this.decimalChar = decimalChar == null ? "" : decimalChar;
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DeleteNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DeleteNode.java
@@ -38,6 +38,7 @@ import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.classfile.VMOpcode;
 import com.splicemachine.db.iapi.services.compiler.LocalField;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.services.io.FormatableProperties;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
@@ -99,6 +100,20 @@ public class DeleteNode extends DMLModStatementNode
     private Properties targetProperties;
     private String     bulkDeleteDirectory;
     private int[] colMap;
+
+    public DeleteNode() {}
+
+    public DeleteNode(ContextManager cm, TableName targetTableName,
+               SelectNode queryExpression,
+               Properties targetProperties)
+    {
+        super.init(queryExpression);
+        setContextManager(cm);
+        setNodeType(C_NodeTypes.DELETE_NODE);
+        this.targetTableName = targetTableName;
+        this.targetProperties = targetProperties;
+    }
+
     /**
      * Initializer for a DeleteNode.
      *
@@ -106,7 +121,6 @@ public class DeleteNode extends DMLModStatementNode
      * @param queryExpression    The query expression that will generate
      *                the rows to delete from the given table
      */
-
     public void init(Object targetTableName,
                      Object queryExpression,
                      Object targetProperties)
@@ -888,9 +902,7 @@ public class DeleteNode extends DMLModStatementNode
         ((FromBaseTable) fromTable).setTableProperties(targetProperties);
 
         fromList.addFromTable(fromTable);
-        SelectNode resultSet = (SelectNode) nodeFactory.getNode(
-                                                     C_NodeTypes.SELECT_NODE,
-                                                     null,
+        SelectNode resultSet = new SelectNode( null,
                                                      null,   /* AGGREGATE list */
                                                      fromList, /* FROM list */
                                                      whereClause, /* WHERE clause */
@@ -939,9 +951,7 @@ public class DeleteNode extends DMLModStatementNode
 
         fromList.addFromTable(fromTable);
 
-        SelectNode resultSet = (SelectNode) nodeFactory.getNode(
-                                                     C_NodeTypes.SELECT_NODE,
-                                                     getSetClause(tableName, cdl),
+        SelectNode resultSet = new SelectNode(getSetClause(tableName, cdl),
                                                      null,   /* AGGREGATE list */
                                                      fromList, /* FROM list */
                                                      whereClause, /* WHERE clause */
@@ -950,12 +960,7 @@ public class DeleteNode extends DMLModStatementNode
                                                      null, /* windows */
                                                      getContextManager());
 
-        return (StatementNode) nodeFactory.getNode(
-                                                    C_NodeTypes.UPDATE_NODE,
-                                                    tableName,
-                                                    resultSet,
-                                                    getContextManager());
-
+        return new UpdateNode( tableName, resultSet, getContextManager());
     }
 
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DenseRankFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DenseRankFunctionNode.java
@@ -36,7 +36,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.types.TypeId;
 
 /**
@@ -50,7 +52,9 @@ public final class DenseRankFunctionNode extends WindowFunctionNode {
      * @param arg2 The window definition or reference
      * @throws com.splicemachine.db.iapi.error.StandardException
      */
-    public void init(Object arg1, Object arg2) throws StandardException {
+    public DenseRankFunctionNode(Object arg1, QueryTreeNode arg2, ContextManager cm) throws StandardException {
+        setContextManager(cm);
+        setNodeType(C_NodeTypes.DENSERANK_FUNCTION_NODE);
 
         // Ranking window functions get their operand columns from from the ORDER BY clause.<br/>
         // Here, we inspect and validate the window ORDER BY clause (within OVER clause) to find

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropAliasNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropAliasNode.java
@@ -185,6 +185,10 @@ public class DropAliasNode extends DDLStatementNode
 			case AliasInfo.ALIAS_TYPE_UDT_AS_CHAR:
 				typeName = "TYPE";
 				break;
+			default:
+				if (SanityManager.DEBUG) {
+					SanityManager.THROWASSERT("Unexpected nodeType = " + actualType);
+				}
 		}
 		return typeName;
 	}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropAliasNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DropAliasNode.java
@@ -31,6 +31,8 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
+import com.splicemachine.db.iapi.services.context.ContextManager;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.sql.execute.ConstantAction;
 
 import com.splicemachine.db.iapi.reference.SQLState;
@@ -54,6 +56,14 @@ public class DropAliasNode extends DDLStatementNode
 {
 	private char aliasType;
 	private char nameSpace;
+
+	public DropAliasNode() {}
+
+	public DropAliasNode(Object dropAliasName, Character aliasType, ContextManager cm) throws StandardException {
+		setContextManager(cm);
+		setNodeType(C_NodeTypes.DROP_ALIAS_NODE);
+		init(dropAliasName, aliasType);
+	}
 
 	/**
 	 * Initializer for a DropAliasNode

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JavaToSQLValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JavaToSQLValueNode.java
@@ -36,7 +36,9 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.compiler.LocalField;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.sql.compile.TypeCompiler;
 import com.splicemachine.db.iapi.sql.compile.Visitor;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
@@ -57,13 +59,13 @@ public class JavaToSQLValueNode extends ValueNode
     JavaValueNode    javaNode;
 
     /**
-     * Initializer for a JavaToSQLValueNode
-     *
-     * @param value        The Java value to convert to the SQL domain
+     * Constructor for a JavaToSQLValueNode
+     * @param value The Java value to convert to the SQL domain
      */
-    public void init(Object value)
-    {
-        this.javaNode = (JavaValueNode) value;
+    public JavaToSQLValueNode(Object value, ContextManager cm) {
+        setContextManager(cm);
+        setNodeType(C_NodeTypes.JAVA_TO_SQL_VALUE_NODE);
+        this.javaNode = (JavaValueNode)value;
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LikeEscapeOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LikeEscapeOperatorNode.java
@@ -262,9 +262,6 @@ public final class LikeEscapeOperatorNode extends TernaryOperatorNode {
 
         bindToBuiltIn();
 
-        TypeCompiler receiverTC = receiver.getTypeCompiler();
-        TypeCompiler leftTC     = leftOperand.getTypeCompiler();
-
         /* The receiver must be a string type
         */
         if (! receiver.getTypeId().isStringTypeId())
@@ -279,7 +276,6 @@ public final class LikeEscapeOperatorNode extends TernaryOperatorNode {
         if (!leftOperand.getTypeId().isStringTypeId())
         {
             leftOperand = castArgToString(leftOperand);
-            leftTC      = leftOperand.getTypeCompiler();
         }
 
         if (rightOperand != null)

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LikeEscapeOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/LikeEscapeOperatorNode.java
@@ -886,9 +886,7 @@ public final class LikeEscapeOperatorNode extends TernaryOperatorNode {
             param = new Vector(1);
         }
 
-        StaticMethodCallNode methodCall = (StaticMethodCallNode)
-            getNodeFactory().getNode(
-                C_NodeTypes.STATIC_METHOD_CALL_NODE,
+        StaticMethodCallNode methodCall = new StaticMethodCallNode(
                 methodName,
                 "com.splicemachine.db.iapi.types.Like",
                 getContextManager());
@@ -908,14 +906,7 @@ public final class LikeEscapeOperatorNode extends TernaryOperatorNode {
 
         methodCall.addParms(param);
 
-
-        ValueNode java2SQL = 
-            (ValueNode) getNodeFactory().getNode(
-                C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
-                methodCall,
-                getContextManager());
-
-
+        ValueNode java2SQL = new JavaToSQLValueNode(methodCall, getContextManager());
         java2SQL = (ValueNode) java2SQL.bindExpression(null, null, null);
 
         CastNode likeOpt = (CastNode)

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NonStaticMethodCallNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NonStaticMethodCallNode.java
@@ -34,6 +34,7 @@ package com.splicemachine.db.impl.sql.compile;
 import com.splicemachine.db.iapi.reference.SQLState;
 
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.store.access.Qualifier;
 
 
@@ -73,11 +74,11 @@ public class NonStaticMethodCallNode extends MethodCallNode
 	 * @param receiver		A JavaValueNode representing the receiving object
 	 * @exception StandardException		Thrown on error
 	 */
-	public void init(
-							Object methodName,
-							Object receiver)
+	public NonStaticMethodCallNode(Object methodName, Object receiver, ContextManager cm)
 			throws StandardException
 	{
+		setContextManager(cm);
+		setNodeType(C_NodeTypes.NON_STATIC_METHOD_CALL_NODE);
 		super.init(methodName);
 
 		/*

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NumericConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NumericConstantNode.java
@@ -31,6 +31,7 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
+import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.compile.TypeCompiler;
@@ -39,10 +40,17 @@ import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.info.JVMInfo;
 import com.splicemachine.db.iapi.types.*;
 
+import java.awt.event.ContainerEvent;
 import java.sql.Types;
 
 public final class NumericConstantNode extends ConstantNode
 {
+    public NumericConstantNode() {}
+    public NumericConstantNode(ContextManager cm, int nodeType, Object arg1) throws StandardException {
+        setContextManager(cm);
+        setNodeType(nodeType);
+        init(arg1);
+    }
     /**
      * Initializer for a typed null node
      *

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParameterNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParameterNode.java
@@ -36,6 +36,8 @@ import com.splicemachine.db.iapi.reference.ClassName;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.classfile.VMOpcode;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.context.ContextManager;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.store.access.Qualifier;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
@@ -123,6 +125,13 @@ public class ParameterNode extends ValueNode
     {
     }
 
+    public ParameterNode(ContextManager cm, Integer parameterNumber, DataValueDescriptor defaultValue)
+    {
+        setContextManager(cm);
+        setNodeType(C_NodeTypes.PARAMETER_NODE);
+        init(parameterNumber, defaultValue);
+    }
+
     /**
      * Initializer for a ParameterNode.
      *
@@ -131,7 +140,6 @@ public class ParameterNode extends ValueNode
      * @param defaultValue                The default value for this parameter
      *
      */
-
     public void init(Object parameterNumber, Object defaultValue)
     {
         this.defaultValue = (DataValueDescriptor) defaultValue;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
@@ -157,6 +157,19 @@ public class SelectNode extends ResultSetNode{
             costEstimate=optimizer.newCostEstimate();
         return costEstimate;
     }
+    public SelectNode() {}
+
+    public SelectNode(ResultColumnList selectList,
+               Object aggregateVector,
+               FromList fromList,
+               ValueNode whereClause,
+               GroupByList groupByList,
+               ValueNode havingClause,
+               WindowList windowDefinitionList, ContextManager cm) throws StandardException {
+        setContextManager(cm);
+        setNodeType(C_NodeTypes.SELECT_NODE);
+        this.init(selectList, aggregateVector, fromList, whereClause, groupByList, havingClause, windowDefinitionList);
+    }
 
     public void init(Object selectList,
                      Object aggregateVector,

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetOperatorNode.java
@@ -1035,9 +1035,7 @@ abstract class SetOperatorNode extends TableOperatorNode
         /* Create a new SELECT node of the form:
          *  SELECT * FROM <thisSetOperatorNode>
          */
-        ResultSetNode result =
-            (ResultSetNode) getNodeFactory().getNode(
-                C_NodeTypes.SELECT_NODE,
+        ResultSetNode result = new SelectNode(
                 rcl,      // ResultColumns
                 null,     // AGGREGATE list
                 fromList, // FROM list

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StaticMethodCallNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StaticMethodCallNode.java
@@ -34,6 +34,7 @@ package com.splicemachine.db.impl.sql.compile;
 import com.splicemachine.db.catalog.types.BaseTypeIdImpl;
 import com.splicemachine.db.catalog.types.TypeDescriptorImpl;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.context.Context;
 import com.splicemachine.db.iapi.services.context.ContextManager;
 
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
@@ -150,6 +151,13 @@ public class StaticMethodCallNode extends MethodCallNode {
 
     private AggregateNode   resolvedAggregate;
     private boolean appearsInGroupBy = false;
+
+    public StaticMethodCallNode() {}
+    public StaticMethodCallNode(Object methodName, String javaClassName, ContextManager cm) {
+        setContextManager(cm);
+        setNodeType(C_NodeTypes.STATIC_METHOD_CALL_NODE);
+        init(methodName, javaClassName);
+    }
     /**
      * Intializer for a NonStaticMethodCallNode
      *
@@ -346,10 +354,7 @@ public class StaticMethodCallNode extends MethodCallNode {
                             );
 
 
-                    ValueNode returnValueToSQL = (ValueNode) getNodeFactory().getNode(
-                                C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
-                                this,
-                                getContextManager());
+                    ValueNode returnValueToSQL = new JavaToSQLValueNode(this, getContextManager());
 
                     ValueNode returnValueCastNode = (ValueNode) getNodeFactory().getNode(
                                     C_NodeTypes.CAST_NODE,
@@ -642,10 +647,7 @@ public class StaticMethodCallNode extends MethodCallNode {
 
                         if (sqlParamNode == null) {
 
-                            sqlParamNode = (ValueNode) getNodeFactory().getNode(
-                                    C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
-                                    methodParms[p],
-                                    getContextManager());
+                            sqlParamNode = new JavaToSQLValueNode(methodParms[p], getContextManager());
                         }
 
                         ValueNode castNode = makeCast

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
@@ -496,8 +496,7 @@ public class SubqueryNode extends ValueNode{
             rc.setExpression(columnReference);
         }
 
-        ResultSetNode selectNode = (ResultSetNode) getNodeFactory().getNode(
-                            C_NodeTypes.SELECT_NODE,
+        ResultSetNode selectNode = new SelectNode(
                             selectList,  //ResultColumnList
                             null,     /* AGGREGATE list */
                             newFromList, // FromList of FromSubquery

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
@@ -37,6 +37,7 @@ import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.classfile.VMOpcode;
 import com.splicemachine.db.iapi.services.compiler.LocalField;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
@@ -118,6 +119,16 @@ public class TernaryOperatorNode extends OperatorNode
             {ClassName.StringDataValue, ClassName.StringDataValue, ClassName.NumberDataValue} // split_part
     };
 
+    public TernaryOperatorNode() {}
+    public TernaryOperatorNode( int nodeType, // todo: nodeType is not really used, only operatorType
+                                ValueNode receiver, ValueNode leftOperand,
+                         ValueNode rightOperand, Integer operatorType, Integer trimType, ContextManager cm )
+    {
+        setNodeType(nodeType);
+        setContextManager(cm);
+        init(receiver, leftOperand, rightOperand, operatorType, trimType);
+    }
+
     /**
      * Initializer for a TernaryOperatorNode
      *
@@ -126,7 +137,6 @@ public class TernaryOperatorNode extends OperatorNode
      * @param rightOperand    The right operand of the node
      * @param operatorType    The type of the operand
      */
-
     public void init(
                     Object receiver,
                     Object leftOperand,

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TimeSpanNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TimeSpanNode.java
@@ -33,6 +33,8 @@ package com.splicemachine.db.impl.sql.compile;
 
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.services.context.ContextManager;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.DateTimeDataValue;
 
@@ -51,11 +53,13 @@ public class TimeSpanNode extends ValueNode
     private int unit;
     private ValueNode value;
 
-    public void init(
+    public TimeSpanNode(
             Object value,
-            Object unit)
+            Object unit, ContextManager cm)
             throws StandardException
     {
+        setContextManager(cm);
+        setNodeType(C_NodeTypes.TIME_SPAN_NODE);
         this.unit = (int) unit;
         this.value = (ValueNode) value;
         switch (this.unit) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TypeofOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TypeofOperatorNode.java
@@ -19,7 +19,9 @@ import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.classfile.VMOpcode;
 import com.splicemachine.db.iapi.services.compiler.LocalField;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.DataTypeUtilities;
 import com.splicemachine.db.iapi.types.SQLTimestamp;
@@ -35,8 +37,11 @@ import java.util.List;
 @SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class TypeofOperatorNode extends UnaryOperatorNode {
 
-    public void init(Object operand) {
-        this.operand = (ValueNode)operand;
+    public TypeofOperatorNode(ValueNode operand, ContextManager cm)
+    {
+        setContextManager(cm);
+        setNodeType(C_NodeTypes.TYPEOF_OPERATOR_NODE);
+        this.operand = operand;
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UpdateNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UpdateNode.java
@@ -38,6 +38,7 @@ import com.splicemachine.db.iapi.reference.ClassName;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.classfile.VMOpcode;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.StatementType;
@@ -93,6 +94,13 @@ public final class UpdateNode extends DMLModStatementNode
     /* Subquery name for updating from multi-column subquery case */
     public static final String SUBQ_NAME = "UPDSBQ";
 
+    public UpdateNode() {}
+    public UpdateNode(TableName tableName, SelectNode resultSet, ContextManager cm) {
+        setContextManager(cm);
+        setNodeType(C_NodeTypes.UPDATE_NODE);
+        this.init(tableName, resultSet);
+    }
+
     /**
      * Initializer for an UpdateNode.
      *
@@ -100,7 +108,6 @@ public final class UpdateNode extends DMLModStatementNode
      * @param resultSet        The ResultSet that will generate
      *                the rows to update from the given table
      */
-
     public void init(
                Object targetTableName,
                Object resultSet)

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNode.java
@@ -460,10 +460,7 @@ public abstract class ValueNode extends QueryTreeNode implements ParentNode
                                     this,
                                     getContextManager());
 
-        ValueNode jtsvn = (ValueNode) getNodeFactory().getNode(
-                                    C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
-                                    stjvn,
-                                    getContextManager());
+        ValueNode jtsvn = new JavaToSQLValueNode(stjvn, getContextManager());
         DataTypeDescriptor  resultType;
         if ( (getTypeServices() != null) && getTypeId().userType() ) { resultType = getTypeServices(); }
         else { resultType = DataTypeDescriptor.getSQLDataTypeDescriptor(stjvn.getJavaTypeName()); }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -2686,17 +2686,10 @@ analyzeTableStatement() throws StandardException :
                     getContextManager());
     parameterList.addElement(b);
 
-    methodNode = (MethodCallNode) nodeFactory.getNode(
-      C_NodeTypes.STATIC_METHOD_CALL_NODE,
-      routineName,
-      null,
-      getContextManager());
+    methodNode = new StaticMethodCallNode(routineName, null, getContextManager());
     methodNode.addParms(parameterList);
 
-    value = (ValueNode) nodeFactory.getNode(
-      C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
-      methodNode,
-      getContextManager());
+    value = new JavaToSQLValueNode(methodNode, getContextManager());
   }
   {
     callStatement = (StatementNode) nodeFactory.getNode(
@@ -2743,17 +2736,10 @@ analyzeSchemaStatement() throws StandardException :
                 getContextManager());
     parameterList.addElement(b);
 
-    methodNode = (MethodCallNode) nodeFactory.getNode(
-          C_NodeTypes.STATIC_METHOD_CALL_NODE,
-          routineName,
-          null,
-          getContextManager());
+    methodNode = new StaticMethodCallNode(routineName, null, getContextManager());
     methodNode.addParms(parameterList);
 
-    value = (ValueNode) nodeFactory.getNode(
-          C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
-          methodNode,
-          getContextManager());
+    value = new JavaToSQLValueNode(methodNode, getContextManager());
   }
   {
     callStatement = (StatementNode) nodeFactory.getNode(
@@ -6250,10 +6236,7 @@ nonStaticMethodInvocation(ValueNode receiver) throws StandardException :
         ** out that this is being returned to the Java domain, we will
         ** get rid of this node.
         */
-        return (ValueNode) nodeFactory.getNode(
-                                C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
-                                methodNode,
-                                getContextManager());
+        return new JavaToSQLValueNode(methodNode, getContextManager());
     }
 |
         <PERIOD> methodNode = methodName(receiver)
@@ -6276,10 +6259,7 @@ nonStaticMethodInvocation(ValueNode receiver) throws StandardException :
         ** out that this is being returned to the Java domain, we will
         ** get rid of this node.
         */
-        return (ValueNode) nodeFactory.getNode(
-                                C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
-                                methodNode,
-                                getContextManager());
+        return new JavaToSQLValueNode(methodNode, getContextManager());
     }
 
 
@@ -6302,11 +6282,7 @@ methodName(ValueNode receiver) throws StandardException :
     */
     methodName = caseSensitiveIdentifierPlusReservedWords()
     {
-        return (MethodCallNode) nodeFactory.getNode(
-                                        C_NodeTypes.NON_STATIC_METHOD_CALL_NODE,
-                                        methodName,
-                                        receiver,
-                                        getContextManager());
+        return new NonStaticMethodCallNode(methodName,receiver, getContextManager());
     }
 }
 
@@ -6327,11 +6303,7 @@ staticMethodName(String javaClassName) throws StandardException :
     */
     methodName = caseSensitiveIdentifierPlusReservedWords()
     {
-        return (MethodCallNode) nodeFactory.getNode(
-                                C_NodeTypes.STATIC_METHOD_CALL_NODE,
-                                methodName,
-                                javaClassName,
-                                getContextManager());
+        return new StaticMethodCallNode(methodName, javaClassName, getContextManager());
     }
 }
 
@@ -6399,11 +6371,7 @@ getTimeSpan(ValueNode value) throws StandardException :
                   } )
     timeUnit = dateTimeIntervalUnit()
     {
-        return (ValueNode) nodeFactory.getNode(
-                                        C_NodeTypes.TIME_SPAN_NODE,
-                                        value,
-                                        timeUnit,
-                                        getContextManager());
+        return new TimeSpanNode(value, timeUnit, getContextManager());
     }
 |
     {
@@ -6461,8 +6429,7 @@ staticClassFieldReference(String javaClassName) throws StandardException :
 {
     fieldName = caseSensitiveIdentifierPlusReservedWords()
     {
-        return    (ValueNode) nodeFactory.getNode(
-                    C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
+        return new JavaToSQLValueNode(
                     nodeFactory.getNode(
                                 C_NodeTypes.STATIC_CLASS_FIELD_REFERENCE_NODE,
                                 javaClassName,
@@ -6650,11 +6617,7 @@ escapedSYSFUNFunction() throws StandardException :
                                 new Integer(0),
                                 getContextManager());
 
-        MethodCallNode methodNode = (MethodCallNode) nodeFactory.getNode(
-                                C_NodeTypes.STATIC_METHOD_CALL_NODE,
-                                functionName,
-                                null,
-                                getContextManager());
+        MethodCallNode methodNode = new StaticMethodCallNode(functionName, null, getContextManager());
 
         methodNode.addParms(parameterList);
 
@@ -6663,10 +6626,7 @@ escapedSYSFUNFunction() throws StandardException :
         ** out that this is being returned to the Java domain, we will
         ** get rid of this node.
         */
-        return (ValueNode) nodeFactory.getNode(
-                                C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
-                                methodNode,
-                                getContextManager());
+        return new JavaToSQLValueNode(methodNode, getContextManager());
      }
 }
 
@@ -6687,7 +6647,7 @@ timestampArithmeticFuncion() throws StandardException :
        count = additiveExpression(null,0) <COMMA>
        tstamp1 = additiveExpression(null,0) <RIGHT_PAREN>
     {
-        return (ValueNode) nodeFactory.getNode( C_NodeTypes.TIMESTAMP_ADD_FN_NODE,
+                return new TernaryOperatorNode( C_NodeTypes.TIMESTAMP_ADD_FN_NODE,
                                                 tstamp1,
                                                 intervalType,
                                                 count,
@@ -6700,7 +6660,7 @@ timestampArithmeticFuncion() throws StandardException :
        tstamp1 = additiveExpression(null,0) <COMMA>
        tstamp2 = additiveExpression(null,0) <RIGHT_PAREN>
     {
-        return (ValueNode) nodeFactory.getNode( C_NodeTypes.TIMESTAMP_DIFF_FN_NODE,
+                return new TernaryOperatorNode( C_NodeTypes.TIMESTAMP_DIFF_FN_NODE,
                                                 tstamp2,
                                                 intervalType,
                                                 tstamp1,
@@ -6774,10 +6734,7 @@ typeOfFunction() throws StandardException :
 {
     <TYPEOF> <LEFT_PAREN> value = orExpression(null) <RIGHT_PAREN>
     {
-        return (ValueNode) nodeFactory.getNode(
-            C_NodeTypes.TYPEOF_OPERATOR_NODE,
-            value,
-            getContextManager());
+        return new TypeofOperatorNode(value, getContextManager());
     }
 }
 
@@ -6859,14 +6816,7 @@ decimalFunction(String functionName) throws StandardException :
         if(decimalCharacter != null) {
             DataTypeUtilities.isValidDecimalCharacter(decimalCharacter);
         }
-        return (ValueNode)nodeFactory.getNode(
-                C_NodeTypes.DECIMAL_FUNCTION_NODE,
-                functionName,
-                value,
-                precision,
-                scale,
-                decimalCharacter,
-                getContextManager());
+        return new DecimalFunctionNode(functionName, value, precision, scale, decimalCharacter, getContextManager());
    }
 }
 
@@ -7630,9 +7580,7 @@ miscBuiltinsCore( boolean isJDBCEscape) throws StandardException :
     <GET_CURRENT_CONNECTION> <LEFT_PAREN> <RIGHT_PAREN>
     {
         checkInternalFeature("GETCURRENTCONNECTION()");
-        return (ValueNode) nodeFactory.getNode(
-                                C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
-                                nodeFactory.getNode(
+        return new JavaToSQLValueNode( nodeFactory.getNode(
                                     C_NodeTypes.GET_CURRENT_CONNECTION_NODE,
                                     getContextManager()),
                                 getContextManager());
@@ -8645,10 +8593,7 @@ newInvocation() throws StandardException :
         ** out that this is being returned to the Java domain, we will
         ** get rid of this node.
         */
-        return (JavaToSQLValueNode) nodeFactory.getNode(
-                                C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
-                                newNode,
-                                getContextManager());
+        return new JavaToSQLValueNode(newNode, getContextManager());
     }
 }
 
@@ -8710,11 +8655,7 @@ vtiTableConstruct() throws StandardException :
         if ( newNode.isBuiltinVTI() ) { invocationNode = newNode; }
         else
         {
-            methodNode = (MethodCallNode) nodeFactory.getNode(
-                C_NodeTypes.STATIC_METHOD_CALL_NODE,
-                vtiTableName,
-                null,
-                getContextManager());
+            methodNode = new StaticMethodCallNode(vtiTableName, null, getContextManager());
             methodNode.addParms(parameterList);
 
             invocationNode = methodNode;
@@ -8726,10 +8667,7 @@ vtiTableConstruct() throws StandardException :
         ** out that this is being returned to the Java domain, we will
         ** get rid of this node.
         */
-        return (JavaToSQLValueNode) nodeFactory.getNode(
-                    C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
-                    invocationNode,
-                    getContextManager());
+        return new JavaToSQLValueNode(invocationNode, getContextManager());
     }
 }
 
@@ -8752,10 +8690,7 @@ staticMethodInvocation(String javaClassName) throws StandardException :
         ** out that this is being returned to the Java domain, we will
         ** get rid of this node.
         */
-        return (ValueNode) nodeFactory.getNode(
-                                C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
-                                methodNode,
-                                getContextManager());
+        return new JavaToSQLValueNode(methodNode, getContextManager());
     }
 }
 
@@ -8811,12 +8746,7 @@ routineExpression() throws StandardException :
     routineName = qualifiedName(Limits.MAX_IDENTIFIER_LENGTH)
         methodCallParameterList(parameterList)
     {
-        methodNode = (MethodCallNode) nodeFactory.getNode(
-                                C_NodeTypes.STATIC_METHOD_CALL_NODE,
-                                routineName,
-                                null,
-                                getContextManager());
-
+        methodNode = new StaticMethodCallNode(routineName, null, getContextManager());
         methodNode.addParms(parameterList);
 
         /*
@@ -8824,10 +8754,7 @@ routineExpression() throws StandardException :
         ** out that this is being returned to the Java domain, we will
         ** get rid of this node.
         */
-        return (ValueNode) nodeFactory.getNode(
-                                C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
-                                methodNode,
-                                getContextManager());
+        return new JavaToSQLValueNode(methodNode, getContextManager());
     }
 }
 
@@ -10424,10 +10351,7 @@ FromTable tableFactor() throws StandardException :
                                new Vector(), // empty parameterList
                                getContextManager());
 
-        javaToSQLNode = (JavaToSQLValueNode) nodeFactory.getNode(
-                                C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
-                                newNode,
-                                getContextManager());
+        javaToSQLNode = new JavaToSQLValueNode(newNode, getContextManager());
 
         TriggerEventDML triggerEvent;
         String          stmtKind;
@@ -11105,11 +11029,7 @@ getNearestTransaction() throws StandardException :
        <DENSERANK> <LEFT_PAREN> <RIGHT_PAREN> window = overClause()
        {
            setWindowFrameMode(window, WindowFrameDefinition.FrameMode.ROWS);
-           winOrAgg = (ValueNode) nodeFactory.getNode(
-               C_NodeTypes.DENSERANK_FUNCTION_NODE,
-               DenseRankFunctionDefinition.class,
-               window,
-               getContextManager());
+           winOrAgg = new DenseRankFunctionNode(DenseRankFunctionDefinition.class, window, getContextManager());
            return winOrAgg;
        }
    |
@@ -11477,13 +11397,7 @@ castSpecification() throws StandardException :
          */
         if (dts.getTypeId().userType())
         {
-            treeTop = (ValueNode) nodeFactory.getNode(
-                            C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
-                            nodeFactory.getNode(
-                                            C_NodeTypes.SQL_TO_JAVA_VALUE_NODE,
-                                            treeTop,
-                                            getContextManager()),
-                            getContextManager());
+            treeTop = new JavaToSQLValueNode( nodeFactory.getNode(C_NodeTypes.SQL_TO_JAVA_VALUE_NODE,treeTop, getContextManager()), getContextManager());
         }
 
         return treeTop;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceNodeFactoryImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceNodeFactoryImpl.java
@@ -214,9 +214,6 @@ public class SpliceNodeFactoryImpl extends NodeFactory implements ModuleControl,
             case C_NodeTypes.GROUP_BY_COLUMN:
                 return C_NodeNames.GROUP_BY_COLUMN_NAME;
 
-            case C_NodeTypes.JAVA_TO_SQL_VALUE_NODE:
-                return C_NodeNames.JAVA_TO_SQL_VALUE_NODE_NAME;
-
             case C_NodeTypes.FROM_LIST:
                 return C_NodeNames.FROM_LIST_NAME;
 
@@ -247,14 +244,8 @@ public class SpliceNodeFactoryImpl extends NodeFactory implements ModuleControl,
             case C_NodeTypes.COALESCE_FUNCTION_NODE:
                 return C_NodeNames.COALESCE_FUNCTION_NODE_NAME;
 
-            case C_NodeTypes.DECIMAL_FUNCTION_NODE:
-                return C_NodeNames.DECIMAL_FUNCTION_NODE_NAME;
-
             case C_NodeTypes.SCALAR_MIN_MAX_FUNCTION_NODE:
                 return C_NodeNames.SCALAR_MIN_MAX_FUNCTION_NODE_NAME;
-
-            case C_NodeTypes.CONCATENATION_OPERATOR_NODE:
-                return C_NodeNames.CONCATENATION_OPERATOR_NODE_NAME;
 
             case C_NodeTypes.LIKE_OPERATOR_NODE:
                 return C_NodeNames.LIKE_OPERATOR_NODE_NAME;
@@ -334,9 +325,6 @@ public class SpliceNodeFactoryImpl extends NodeFactory implements ModuleControl,
             case C_NodeTypes.STATIC_CLASS_FIELD_REFERENCE_NODE:
                 return C_NodeNames.STATIC_CLASS_FIELD_REFERENCE_NODE_NAME;
 
-            case C_NodeTypes.STATIC_METHOD_CALL_NODE:
-                return C_NodeNames.STATIC_METHOD_CALL_NODE_NAME;
-
             case C_NodeTypes.EXTRACT_OPERATOR_NODE:
                 return C_NodeNames.EXTRACT_OPERATOR_NODE_NAME;
 
@@ -371,20 +359,11 @@ public class SpliceNodeFactoryImpl extends NodeFactory implements ModuleControl,
             case C_NodeTypes.DROP_COLUMN_NODE:
                 return C_NodeNames.MODIFY_COLUMN_NODE_NAME;
 
-            case C_NodeTypes.NON_STATIC_METHOD_CALL_NODE:
-                return C_NodeNames.NON_STATIC_METHOD_CALL_NODE_NAME;
-
             case C_NodeTypes.CURRENT_OF_NODE:
                 return C_NodeNames.CURRENT_OF_NODE_NAME;
 
             case C_NodeTypes.DEFAULT_NODE:
                 return C_NodeNames.DEFAULT_NODE_NAME;
-
-            case C_NodeTypes.DELETE_NODE:
-                return C_NodeNames.DELETE_NODE_NAME;
-
-            case C_NodeTypes.UPDATE_NODE:
-                return C_NodeNames.UPDATE_NODE_NAME;
 
             case C_NodeTypes.ORDER_BY_COLUMN:
                 return C_NodeNames.ORDER_BY_COLUMN_NAME;
@@ -536,9 +515,6 @@ public class SpliceNodeFactoryImpl extends NodeFactory implements ModuleControl,
             case C_NodeTypes.SQL_BOOLEAN_CONSTANT_NODE:
                 return C_NodeNames.SQL_BOOLEAN_CONSTANT_NODE_NAME;
 
-            case C_NodeTypes.DROP_ALIAS_NODE:
-                return C_NodeNames.DROP_ALIAS_NODE_NAME;
-
             case C_NodeTypes.TEST_CONSTRAINT_NODE:
                 return C_NodeNames.TEST_CONSTRAINT_NODE_NAME;
 
@@ -607,9 +583,6 @@ public class SpliceNodeFactoryImpl extends NodeFactory implements ModuleControl,
             case C_NodeTypes.ROW_COUNT_NODE:
                 return C_NodeNames.ROW_COUNT_NODE_NAME;
 
-            case C_NodeTypes.DENSERANK_FUNCTION_NODE:
-                return C_NodeNames.DENSE_RANK_FUNCTION_NAME;
-
             case C_NodeTypes.FIRST_LAST_VALUE_FUNCTION_NODE:
                 return C_NodeNames.FIRST_LAST_VALUE_FUNCTION_NAME;
 
@@ -670,9 +643,6 @@ public class SpliceNodeFactoryImpl extends NodeFactory implements ModuleControl,
             case C_NodeTypes.EMPTY_DEFAULT_CONSTANT_NODE:
                 return C_NodeNames.EMPTY_DEFAULT_CONSTANT_NODE;
 
-            case C_NodeTypes.TIME_SPAN_NODE:
-                return C_NodeNames.TIME_SPAN_NODE_NAME;
-
             case C_NodeTypes.STATEMENT_LIST_NODE:
                 return C_NodeNames.STATEMENT_LIST_NODE_NAME;
 
@@ -681,9 +651,6 @@ public class SpliceNodeFactoryImpl extends NodeFactory implements ModuleControl,
 
             case C_NodeTypes.TO_HBASE_ESCAPED_NODE:
                 return C_NodeNames.TO_HBASE_ESCAPED_NODE_NAME;
-
-            case C_NodeTypes.TYPEOF_OPERATOR_NODE:
-                return C_NodeNames.TYPEOF_OPERATOR_NODE_NAME;
 
             // WARNING: WHEN ADDING NODE TYPES HERE, YOU MUST ALSO ADD
             // THEM TO tools/jar/DBMSnodes.properties


### PR DESCRIPTION
# Description

This is a first part of starting to remove the NodeFactory (spliceengine/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/NodeFactory.java) that is currently used by our SQL Parser to create the nodes from the Syntax Tree (sqlfgrammar.jj).

# Motivation

We want to remove NodeFactory and replace with simple, strongly typed constructors, because:

1. Node Factory is quite complicated code

2. we don't have safety when constructing the nodes. Potential errors that will ONLY be detected at run time include

    1. calling getNode with wrong number of parameters. will result (at run time) in a throw in SanityManager.DEBUG, otherwise “nothing”, so Node will not be initialized)

    2. calling getNode with wrong TYPE of parameters: will result (at run time) in java.lang.ClassCastException.

    3. calling getNode, but forgot to add type to the getNode switch: will result (at run time) in a Not Implemented exception

    4. typo in C_NodeNames.XXX_NAME : will result (at run time) in ClassNotFound Exceptions

3. refactoring is very hard, as e.g. Intellij can’t help you add a parameter to all invocations. If you rename a class, you might forget rename the name in C_NodeNames.XXX_NAME.

4. adding nodes is complicated and error-prone.

For all those reasons, Derby also decided to remove the node factory a long time ago, see https://issues.apache.org/jira/browse/DERBY-673 .

This is part 1 of the removal of the Node Factory. We decided to remove it in multiple steps to make this manageable and e.g. avoid one huge change that might cause a lot of merge conflicts. I suppose we have 2-4 of these changes.

# How to test

The new code is only a refactoring and doesn’t add or remove any features or fix any bugs.

# What the old code looks like

Currently, we create nodes like this:

```
        StatementNode retval =
                (StatementNode) nodeFactory.getNode(
                        C_NodeTypes.UPDATE_NODE,
                        tableName, /* target table for update */
                        resultSet, /* SelectNode just created */
                        getContextManager());
```

which then calls this code:

`Node retval = getNode(nodeType, cm);`

Where getNode will call basically a large switch statement mapping C_NodeTypes.UPDATE_NODE to C_NodeNames.UPDATE_NODE_NAME ("com.splicemachine.db.impl.sql.compile.UpdateNode”). This alone is already a bit dangerous, as a typo at creating or if someone adds another node will not be detected at compile time, but ONLY when running integrations tests and ONLY if the tests run exactly through that code (which they of course should, but maybe not).

Next, we getNode will pass the parameters to the node like this

`retval.init(arg1, arg2);`

To be able to do this, UpdateNode extends QueryTreeNode which implements Node, which has interfaces for all counts of parameters, e.g.

```
   @Override
    public void init(Object arg1, Object arg2) throws StandardException{
        if(SanityManager.DEBUG){
            SanityManager.THROWASSERT("Two-argument init() not implemented for "+getClass().getName());
        }
    }
```

# What the new code looks like

```
        UpdateNode node = new UpdateNode(
                tableName, /* target table for update */
                resultSet, /* SelectNode just created */
                getContextManager());
```

When we finally removed the NodeFactory, we will remove C_NodeNames.java (354 lines), SpliceNodeFactoryImpl.java (663 lines), NodeFactory (605 lines) and more code in other classes, AND get type safety at run compile time.