### PR TITLE
DB-11063 Left outer broadcast join for more cases.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
@@ -167,7 +167,8 @@ public abstract class HashableJoinStrategy extends BaseJoinStrategy {
         if (hashKeyColumns == null && skipKeyCheck) {
             // For full outer join, broadcast join is the default join strategy that can be applied
             // to any kinds of join predicate, so make the eligibility check more general
-            if (outerCost.getJoinType() == JoinNode.FULLOUTERJOIN &&
+            if ((outerCost.getJoinType() == JoinNode.FULLOUTERJOIN ||
+                 outerCost.getJoinType() == JoinNode.LEFTOUTERJOIN) &&
                 (innerTable.isMaterializable() ||
                  innerTable.supportsMultipleInstantiations())) {
                 ap.setMissingHashKeyOK(true);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
@@ -1092,14 +1092,6 @@ public class OptimizerImpl implements Optimizer{
             }
         }
 
-        /*
-        ** Don't consider non-feasible join strategies.
-        */
-        if(!optimizable.feasibleJoinStrategy(predicateList,this,outerCost)){
-            tracer().trace(OptimizerFlag.INFEASIBLE_JOIN,0,0,0.0,optimizable.getCurrentAccessPath().getJoinStrategy());
-            return;
-        }
-
         /* if the current optimizable is from SSQ, we need to use outer join, set the OuterJoin flag in cost accordingly */
         int savedJoinType = JoinNode.INNERJOIN;
         if (optimizable instanceof FromTable) {
@@ -1109,6 +1101,15 @@ public class OptimizerImpl implements Optimizer{
                 outerCost.setJoinType(JoinNode.LEFTOUTERJOIN);
             }
         }
+
+        /*
+        ** Don't consider non-feasible join strategies.
+        */
+        if(!optimizable.feasibleJoinStrategy(predicateList,this,outerCost)){
+            tracer().trace(OptimizerFlag.INFEASIBLE_JOIN,0,0,0.0,optimizable.getCurrentAccessPath().getJoinStrategy());
+            return;
+        }
+
         /* Cost the optimizable at the current join position */
         optimizable.optimizeIt(this, predicateList, outerCost, currentRowOrdering);
         /* reset the OuterJoin flag so that we can cost correctly if the outer optimizable later joins with

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSpark.java
@@ -344,6 +344,7 @@ public class SpliceSpark {
 
          */
         conf.set("spark.sql.retainGroupColumns", "true");
+        conf.set("spark.sql.crossJoin.enabled", "true");
 
         // Uncomment to disable WholeStageCodeGen for debugging.
         // conf.set("spark.sql.codegen.wholeStage", "false");


### PR DESCRIPTION
Currently the Splice optimizer only allows nested loop join to perform left outer join with join predicates that don't reference left table columns, for example:
> select * from t1 left outer join t2  
> on t2.b = 1;

This Jira adds support for left outer join to use broadcast join when each join predicate only references columns from a single table (or perhaps from neither table).