### PR TITLE
DB-11047 add option splice.function.preserveLineEndings (3.0)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
@@ -193,6 +193,8 @@ public interface CompilerContext extends Context
     boolean DEFAULT_DISABLE_PARALLEL_TASKS_JOIN_COSTING = false;
     boolean DEFAULT_SPLICE_DB2_VARCHAR_COMPATIBLE = false;
 
+    boolean DEFAULT_SPLICE_SKIP_CARRIAGE_RETURN = true;
+
     /////////////////////////////////////////////////////////////////////////////////////
     //
     //    BEHAVIOR

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
@@ -193,7 +193,7 @@ public interface CompilerContext extends Context
     boolean DEFAULT_DISABLE_PARALLEL_TASKS_JOIN_COSTING = false;
     boolean DEFAULT_SPLICE_DB2_VARCHAR_COMPATIBLE = false;
 
-    boolean DEFAULT_SPLICE_SKIP_CARRIAGE_RETURN = true;
+    boolean DEFAULT_PRESERVE_LINE_ENDINGS = false;
 
     /////////////////////////////////////////////////////////////////////////////////////
     //

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1466,11 +1466,10 @@ public interface Property {
     /**
      * Fractional seconds precision of timestamp.
      */
-    String SPLICE_TIMESTAMP_PRECISION = "splice.function.timestampPrecision";
-
     String SPLICE_TIMESTAMP_FORMAT = "splice.function.timestampFormat";
 
     String FLOATING_POINT_NOTATION = "splice.function.floatingPointNotation";
+    String SPLICE_SKIP_CARRIAGE_RETURN = "splice.function.skipCarriageReturn";
 
     String OUTERJOIN_FLATTENING_DISABLED = "derby.database.outerJoinFlatteningDisabled";
 

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1469,7 +1469,7 @@ public interface Property {
     String SPLICE_TIMESTAMP_FORMAT = "splice.function.timestampFormat";
 
     String FLOATING_POINT_NOTATION = "splice.function.floatingPointNotation";
-    String SPLICE_SKIP_CARRIAGE_RETURN = "splice.function.skipCarriageReturn";
+    String SPLICE_SKIP_CARRIAGE_RETURN_IN_0D0A = "splice.function.skipCarriageReturnIn0D0A";
 
     String OUTERJOIN_FLATTENING_DISABLED = "derby.database.outerJoinFlatteningDisabled";
 

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1469,7 +1469,7 @@ public interface Property {
     String SPLICE_TIMESTAMP_FORMAT = "splice.function.timestampFormat";
 
     String FLOATING_POINT_NOTATION = "splice.function.floatingPointNotation";
-    String SPLICE_SKIP_CARRIAGE_RETURN_IN_0D0A = "splice.function.skipCarriageReturnIn0D0A";
+    String PRESERVE_LINE_ENDINGS = "splice.function.preserveLineEndings";
 
     String OUTERJOIN_FLATTENING_DISABLED = "derby.database.outerJoinFlatteningDisabled";
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/vti/KafkaVTI.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/vti/KafkaVTI.java
@@ -14,51 +14,23 @@
 
 package com.splicemachine.derby.vti;
 
-import com.splicemachine.db.iapi.error.ExceptionUtil;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.vti.VTICosting;
 import com.splicemachine.db.vti.VTIEnvironment;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
-import com.splicemachine.derby.impl.SpliceSpark;
-import com.splicemachine.derby.impl.load.ImportUtils;
-import com.splicemachine.derby.stream.function.FileFunction;
-import com.splicemachine.derby.stream.function.StreamFileFunction;
 import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
 import com.splicemachine.derby.stream.iapi.OperationContext;
-import com.splicemachine.derby.stream.iapi.PairDataSet;
-import com.splicemachine.derby.stream.spark.ExternalizableDeserializer;
-import com.splicemachine.derby.stream.spark.NativeSparkDataSet;
-import com.splicemachine.derby.stream.spark.SparkDataSet;
 import com.splicemachine.derby.vti.iapi.DatasetProvider;
-import com.splicemachine.utils.kryo.ExternalizableSerializer;
-import org.apache.kafka.clients.consumer.CommitFailedException;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.PartitionInfo;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.serialization.IntegerSerializer;
 
 import org.apache.log4j.Logger;
-import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 
-import java.io.Externalizable;
-import java.io.InputStream;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.time.Duration;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Properties;
 
 public class KafkaVTI implements DatasetProvider, VTICosting{
     private static final Logger LOG = Logger.getLogger(KafkaVTI.class.getName());

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/load/SpliceCsvReader.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/load/SpliceCsvReader.java
@@ -18,7 +18,8 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.*;
 
-import com.splicemachine.derby.stream.function.QuoteTrackingTokenizer;
+import com.splicemachine.derby.stream.function.csv.CsvParserConfig;
+import com.splicemachine.derby.stream.function.csv.QuoteTrackingTokenizer;
 import com.splicemachine.derby.stream.utils.BooleanList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.supercsv.prefs.CsvPreference;
@@ -43,17 +44,18 @@ public class SpliceCsvReader implements Iterator<List<String>> {
      *
      * @param reader
      *            the reader
-     * @param preferences
-     *            the CSV preferences
+     * @param config
+     *            CSV reader config
      * @throws NullPointerException
      *             if reader or preferences are null
      */
-    public SpliceCsvReader(Reader reader, CsvPreference preferences, boolean quotedEmptyIsNull) {
-        this.tokenizer = new QuoteTrackingTokenizer(reader,preferences, false, quotedEmptyIsNull);
+    public SpliceCsvReader(Reader reader, CsvParserConfig config) {
+        this(reader, config, -1, null);
     }
 
-    public SpliceCsvReader(Reader reader, CsvPreference preferences, boolean quotedEmptyIsNull, long scanThreshold, List<Integer> valueSizesHint) {
-        this.tokenizer = new QuoteTrackingTokenizer(reader,preferences,false, quotedEmptyIsNull, scanThreshold, valueSizesHint);
+    public SpliceCsvReader(Reader reader, CsvParserConfig config, long scanThreshold, List<Integer> valueSizesHint) {
+
+        this.tokenizer = new QuoteTrackingTokenizer(reader, config, scanThreshold, valueSizesHint);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperation.java
@@ -49,7 +49,7 @@ import com.splicemachine.ddl.DDLMessage;
 import com.splicemachine.derby.ddl.DDLUtils;
 import com.splicemachine.derby.impl.load.ImportUtils;
 import com.splicemachine.derby.impl.store.access.SpliceTransactionManager;
-import com.splicemachine.derby.stream.function.FileFunction;
+import com.splicemachine.derby.stream.function.csv.FileFunction;
 import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
 import com.splicemachine.derby.stream.iapi.OperationContext;
@@ -950,8 +950,13 @@ public class CreateIndexConstantOperation extends IndexConstantOperation impleme
             boolean quotedEmptyIsNull = !PropertyUtil.getCachedDatabaseBoolean(
                 operationContext.getActivation().getLanguageConnectionContext(),
                 Property.SPLICE_DB2_IMPORT_EMPTY_STRING_COMPATIBLE);
+            // todo: can split keys contain multi-line strings? if no, then we should have oneLineRecord =true
+            // todo: if yes, skipCarriageReturn should be false
+            boolean oneLineRecord = false;
+            boolean skipCarriageReturn = true;
             DataSet<ExecRow> dataSet = text.flatMap(new FileFunction(characterDelimiter, columnDelimiter, execRow,
-                    null, timeFormat, dateFormat, timestampFormat, false, operationContext, quotedEmptyIsNull), true);
+                    null, timeFormat, dateFormat, timestampFormat, oneLineRecord, operationContext,
+                    quotedEmptyIsNull, skipCarriageReturn), true);
             List<ExecRow> rows = dataSet.collect();
             DataHash encoder = getEncoder(td, execRow, indexRowGenerator);
             for (ExecRow row : rows) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperation.java
@@ -951,10 +951,10 @@ public class CreateIndexConstantOperation extends IndexConstantOperation impleme
                 operationContext.getActivation().getLanguageConnectionContext(),
                 Property.SPLICE_DB2_IMPORT_EMPTY_STRING_COMPATIBLE);
             boolean oneLineRecord = false;
-            boolean skipCarriageReturnIn0D0A = true;
+            boolean preserveLineEndings = false;
             DataSet<ExecRow> dataSet = text.flatMap(new FileFunction(characterDelimiter, columnDelimiter, execRow,
                     null, timeFormat, dateFormat, timestampFormat, oneLineRecord, operationContext,
-                    quotedEmptyIsNull, skipCarriageReturnIn0D0A), true);
+                    quotedEmptyIsNull, preserveLineEndings), true);
             List<ExecRow> rows = dataSet.collect();
             DataHash encoder = getEncoder(td, execRow, indexRowGenerator);
             for (ExecRow row : rows) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperation.java
@@ -950,13 +950,11 @@ public class CreateIndexConstantOperation extends IndexConstantOperation impleme
             boolean quotedEmptyIsNull = !PropertyUtil.getCachedDatabaseBoolean(
                 operationContext.getActivation().getLanguageConnectionContext(),
                 Property.SPLICE_DB2_IMPORT_EMPTY_STRING_COMPATIBLE);
-            // todo: can split keys contain multi-line strings? if no, then we should have oneLineRecord =true
-            // todo: if yes, skipCarriageReturn should be false
             boolean oneLineRecord = false;
-            boolean skipCarriageReturn = true;
+            boolean skipCarriageReturnIn0D0A = true;
             DataSet<ExecRow> dataSet = text.flatMap(new FileFunction(characterDelimiter, columnDelimiter, execRow,
                     null, timeFormat, dateFormat, timestampFormat, oneLineRecord, operationContext,
-                    quotedEmptyIsNull, skipCarriageReturn), true);
+                    quotedEmptyIsNull, skipCarriageReturnIn0D0A), true);
             List<ExecRow> rows = dataSet.collect();
             DataHash encoder = getEncoder(td, execRow, indexRowGenerator);
             for (ExecRow row : rows) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
@@ -26,7 +26,7 @@ import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.ddl.DDLMessage;
 import com.splicemachine.derby.ddl.DDLDriver;
 import com.splicemachine.derby.impl.load.ImportUtils;
-import com.splicemachine.derby.stream.function.FileFunction;
+import com.splicemachine.derby.stream.function.csv.FileFunction;
 import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
 import com.splicemachine.derby.stream.iapi.OperationContext;
@@ -742,7 +742,7 @@ public class CreateTableConstantOperation extends DDLConstantOperation {
                 operationContext.getActivation().getLanguageConnectionContext(),
                 Property.SPLICE_DB2_IMPORT_EMPTY_STRING_COMPATIBLE);
             DataSet<ExecRow> dataSet = text.flatMap(new FileFunction(characterDelimiter, columnDelimiter, execRow,
-                    null, timeFormat, dateFormat, timestampFormat, false, operationContext, quotedEmptyIsNull), true);
+                    null, timeFormat, dateFormat, timestampFormat, false, operationContext, quotedEmptyIsNull, true), true);
             List<ExecRow> rows = dataSet.collect();
             DataHash encoder = getEncoder(execRow);
             for (ExecRow row : rows) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
@@ -782,7 +782,7 @@ public class SpliceRegionAdmin {
 
         boolean quotedEmptyIsNull = !PropertyUtil.getCachedDatabaseBoolean(
                 lcc, Property.SPLICE_DB2_IMPORT_EMPTY_STRING_COMPATIBLE);
-        boolean preserveLineEndings = !PropertyUtil.getCachedDatabaseBoolean(
+        boolean preserveLineEndings = PropertyUtil.getCachedDatabaseBoolean(
                 lcc, Property.PRESERVE_LINE_ENDINGS);
 
         CsvParserConfig config = new CsvParserConfig(preference)

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
@@ -782,9 +782,11 @@ public class SpliceRegionAdmin {
 
         boolean quotedEmptyIsNull = !PropertyUtil.getCachedDatabaseBoolean(
                 lcc, Property.SPLICE_DB2_IMPORT_EMPTY_STRING_COMPATIBLE);
+        boolean preserveLineEndings = !PropertyUtil.getCachedDatabaseBoolean(
+                lcc, Property.PRESERVE_LINE_ENDINGS);
 
         CsvParserConfig config = new CsvParserConfig(preference)
-                .oneLineRecord(false).quotedEmptyIsNull(quotedEmptyIsNull).skipCarriageReturnIn0D0A(true);
+                .oneLineRecord(false).quotedEmptyIsNull(quotedEmptyIsNull).preserveLineEndings(preserveLineEndings);
         MutableCSVTokenizer tokenizer = new MutableCSVTokenizer(reader, config,
                 EngineDriver.driver().getConfiguration().getImportCsvScanThreshold(), valueSizeHints);
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
@@ -784,7 +784,7 @@ public class SpliceRegionAdmin {
                 lcc, Property.SPLICE_DB2_IMPORT_EMPTY_STRING_COMPATIBLE);
 
         CsvParserConfig config = new CsvParserConfig(preference)
-                .oneLineRecord(false).quotedEmptyIsNull(quotedEmptyIsNull).skipCarriageReturn(true);
+                .oneLineRecord(false).quotedEmptyIsNull(quotedEmptyIsNull).skipCarriageReturnIn0D0A(true);
         MutableCSVTokenizer tokenizer = new MutableCSVTokenizer(reader, config,
                 EngineDriver.driver().getConfiguration().getImportCsvScanThreshold(), valueSizeHints);
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/storage/SpliceRegionAdmin.java
@@ -25,7 +25,6 @@ import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.property.PropertyUtil;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.ResultColumnDescriptor;
-import com.splicemachine.db.iapi.sql.conn.ConnectionUtil;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
@@ -39,8 +38,9 @@ import com.splicemachine.db.impl.sql.GenericColumnDescriptor;
 import com.splicemachine.db.impl.sql.execute.IteratorNoPutResultSet;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.derby.impl.store.access.BaseSpliceTransaction;
-import com.splicemachine.derby.stream.function.FileFunction;
-import com.splicemachine.derby.stream.function.MutableCSVTokenizer;
+import com.splicemachine.derby.stream.function.csv.CsvParserConfig;
+import com.splicemachine.derby.stream.function.csv.FileFunction;
+import com.splicemachine.derby.stream.function.csv.MutableCSVTokenizer;
 import com.splicemachine.derby.stream.output.WriteReadUtils;
 import com.splicemachine.derby.stream.utils.BooleanList;
 import com.splicemachine.derby.utils.DataDictionaryUtils;
@@ -782,8 +782,12 @@ public class SpliceRegionAdmin {
 
         boolean quotedEmptyIsNull = !PropertyUtil.getCachedDatabaseBoolean(
                 lcc, Property.SPLICE_DB2_IMPORT_EMPTY_STRING_COMPATIBLE);
-        MutableCSVTokenizer tokenizer = new MutableCSVTokenizer(reader,preference, false, quotedEmptyIsNull,
+
+        CsvParserConfig config = new CsvParserConfig(preference)
+                .oneLineRecord(false).quotedEmptyIsNull(quotedEmptyIsNull).skipCarriageReturn(true);
+        MutableCSVTokenizer tokenizer = new MutableCSVTokenizer(reader, config,
                 EngineDriver.driver().getConfiguration().getImportCsvScanThreshold(), valueSizeHints);
+
         tokenizer.setLine(splitKey);
         List<String> read=tokenizer.read();
         BooleanList quotedColumns=tokenizer.getQuotedColumns();

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/AbstractFileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/AbstractFileFunction.java
@@ -12,7 +12,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.splicemachine.derby.stream.function;
+package com.splicemachine.derby.stream.function.csv;
 
 import com.splicemachine.EngineDriver;
 import com.splicemachine.access.api.SConfiguration;
@@ -25,6 +25,7 @@ import com.splicemachine.db.shared.common.reference.SQLState;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.InsertOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.VTIOperation;
+import com.splicemachine.derby.stream.function.SpliceFlatMapFunction;
 import com.splicemachine.derby.stream.iapi.OperationContext;
 import com.splicemachine.derby.stream.output.WriteReadUtils;
 import com.splicemachine.derby.stream.utils.BooleanList;
@@ -161,7 +162,8 @@ public abstract class AbstractFileFunction<I> extends SpliceFlatMapFunction<Spli
     }
 
 
-    public static ExecRow getRow(List<String> values,BooleanList quotedColumns,
+    @SuppressFBWarnings("REC_CATCH_EXCEPTION")
+    public static ExecRow getRow(List<String> values, BooleanList quotedColumns,
                                  OperationContext operationContext, ExecRow execRow,
                                  Calendar calendar, String timeFormat,
                                  String dateTimeFormat, String timestampFormat,
@@ -268,7 +270,7 @@ public abstract class AbstractFileFunction<I> extends SpliceFlatMapFunction<Spli
         }
     }
 
-    void checkPreference() {
+    public void checkPreference() {
         if (preference==null){
             SConfiguration config =EngineDriver.driver().getConfiguration();
             int maxQuotedLines = config.getImportMaxQuotedColumnLines();

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/AbstractFileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/AbstractFileFunction.java
@@ -270,7 +270,7 @@ public abstract class AbstractFileFunction<I> extends SpliceFlatMapFunction<Spli
         }
     }
 
-    public void checkPreference() {
+    protected void checkPreference() {
         if (preference==null){
             SConfiguration config =EngineDriver.driver().getConfiguration();
             int maxQuotedLines = config.getImportMaxQuotedColumnLines();

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/AbstractTokenizerCR.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/AbstractTokenizerCR.java
@@ -46,7 +46,7 @@ public abstract class AbstractTokenizerCR implements ITokenizer {
      * @throws NullPointerException
      *             if reader or preferences is null
      */
-    public AbstractTokenizerCR(final Reader reader, final CsvPreference preferences, boolean skipCarriageReturn) {
+    public AbstractTokenizerCR(final Reader reader, final CsvPreference preferences, boolean skipCarriageReturnIn0D0A) {
         if( reader == null ) {
             throw new NullPointerException("reader should not be null");
         }
@@ -54,7 +54,7 @@ public abstract class AbstractTokenizerCR implements ITokenizer {
             throw new NullPointerException("preferences should not be null");
         }
         this.preferences = preferences;
-        clr = new CsvLineReaderCR(reader, skipCarriageReturn, true);
+        clr = new CsvLineReaderCR(reader, skipCarriageReturnIn0D0A, true);
     }
 
     /**

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/AbstractTokenizerCR.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/AbstractTokenizerCR.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2007 Kasper B. Graversen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.splicemachine.derby.stream.function.csv;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.List;
+
+import org.supercsv.io.ITokenizer;
+import org.supercsv.io.Tokenizer;
+import org.supercsv.prefs.CsvPreference;
+
+/**
+ * Defines the standard behaviour of a Tokenizer. Extend this class if you want the line-reading functionality of the
+ * default {@link Tokenizer}, but want to define your own implementation of {@link #readColumns(List)}.
+ *
+ * @author James Bassett
+ * @since 2.0.0
+ */
+public abstract class AbstractTokenizerCR implements ITokenizer {
+
+    private final CsvPreference preferences;
+
+    private CsvLineReaderCR clr;
+
+    /**
+     * Constructs a new <tt>AbstractTokenizer</tt>, which reads the CSV file, line by line.
+     *
+     * @param reader
+     *            the reader
+     * @param preferences
+     *            the CSV preferences
+     * @throws NullPointerException
+     *             if reader or preferences is null
+     */
+    public AbstractTokenizerCR(final Reader reader, final CsvPreference preferences, boolean skipCarriageReturn) {
+        if( reader == null ) {
+            throw new NullPointerException("reader should not be null");
+        }
+        if( preferences == null ) {
+            throw new NullPointerException("preferences should not be null");
+        }
+        this.preferences = preferences;
+        clr = new CsvLineReaderCR(reader, skipCarriageReturn, true);
+    }
+
+    /**
+     * Closes the underlying reader.
+     */
+    public void close() throws IOException {
+        clr.close();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int getLineNumber() {
+        return clr.getLineNumber();
+    }
+
+    /**
+     * Reads a line of text. Whenever a line terminator is read the current line number is incremented.
+     *
+     * @return A String containing the contents of the line, not including any line termination characters, or
+     *         <tt>null</tt> if the end of the stream has been reached
+     * @throws IOException
+     *             If an I/O error occurs
+     */
+    protected String readLine() throws IOException {
+        return clr.readLine();
+    }
+
+    /**
+     * Gets the CSV preferences.
+     *
+     * @return the preferences
+     */
+    protected CsvPreference getPreferences() {
+        return preferences;
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/AbstractTokenizerCR.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/AbstractTokenizerCR.java
@@ -46,7 +46,7 @@ public abstract class AbstractTokenizerCR implements ITokenizer {
      * @throws NullPointerException
      *             if reader or preferences is null
      */
-    public AbstractTokenizerCR(final Reader reader, final CsvPreference preferences, boolean skipCarriageReturnIn0D0A) {
+    public AbstractTokenizerCR(final Reader reader, final CsvPreference preferences) {
         if( reader == null ) {
             throw new NullPointerException("reader should not be null");
         }
@@ -54,7 +54,7 @@ public abstract class AbstractTokenizerCR implements ITokenizer {
             throw new NullPointerException("preferences should not be null");
         }
         this.preferences = preferences;
-        clr = new CsvLineReaderCR(reader, skipCarriageReturnIn0D0A, true);
+        clr = new CsvLineReaderCR(reader);
     }
 
     /**
@@ -90,5 +90,11 @@ public abstract class AbstractTokenizerCR implements ITokenizer {
      */
     protected CsvPreference getPreferences() {
         return preferences;
+    }
+    public CsvLineReaderCR.LineEndingType getCurrentLineEndingType() {
+        return clr.getCurrentLineEndingType();
+    }
+    public String getCurrentLineEnding() {
+        return clr.getCurrentLineEnding();
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/CsvLineReaderCR.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/CsvLineReaderCR.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.stream.function.csv;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.IOException;
+import java.io.Reader;
+
+/**
+ * A buffered CSV line reader.
+ * With the option skipCarriageReturn we can define if carriage return (\r = 0x0D)
+ * is meant to be skipped or considered part of the returned string.
+ * e.g. input "Hello\r\nWorld!\n"
+ * will return lines "Hello" and "World!" with skipCarriageReturn = true,
+ * but will return "Hello\r" and "World!" with skipCarriageReturn = false.
+ * This is meant for preserving line endings.
+ */
+public class CsvLineReaderCR {
+    private final Reader reader;
+    private final boolean skipCarriageReturn;
+    private final boolean crNewline;    ;
+    private final int configInitialStringBufferSize;
+    private final int configBufferSize;
+
+    private char bufferBytes[];
+    private int bufferSize, bufferPos;
+    private int lineNumber = 0;
+
+    private StringBuffer res = null;
+    private boolean eof = false;
+
+    public enum LineEndingType {
+        ending0D0A,
+        ending0D,
+        ending0A,
+        endingNone
+    };
+
+    @SuppressFBWarnings("URF_UNREAD_FIELD")
+    LineEndingType currentLineEnding = LineEndingType.endingNone;
+
+    public CsvLineReaderCR(final Reader reader, boolean skipCarriageReturn, boolean crNewline) {
+        this(reader, skipCarriageReturn, crNewline, 80, 8192);
+    }
+
+    public CsvLineReaderCR(final Reader reader, boolean skipCarriageReturn, boolean crNewline,
+                           int configInitialStringBufferSize, int configBufferSize) {
+        if( reader == null ) {
+            throw new NullPointerException("reader should not be null");
+        }
+        this.reader = reader;
+        this.skipCarriageReturn = skipCarriageReturn;
+        this.crNewline = crNewline;
+        this.configInitialStringBufferSize = configInitialStringBufferSize;
+        this.configBufferSize = configBufferSize;
+    }
+
+    public void close() throws IOException {
+        reader.close();
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    private boolean readBuffer() throws IOException {
+        bufferPos = 0;
+        bufferSize = reader.read(bufferBytes, 0, bufferBytes.length);
+        if(bufferSize < 0) bufferSize = 0;
+        return bufferSize != 0;
+    }
+
+    private String getRes(int start, int pos)
+    {
+        lineNumber++;
+        if (res == null) {
+            return new String(bufferBytes, start, pos - start);
+        } else {
+            if(start != pos) res.append(bufferBytes, start, pos - start);
+            String s = res.toString();
+            res = null;
+            return s;
+        }
+    }
+    private void appendToRes(int start, int pos)
+    {
+        if(start == pos) return;
+        if (res == null)
+            res = new StringBuffer(configInitialStringBufferSize);
+        res.append(bufferBytes, start, pos - start);
+    }
+
+    public boolean eof()
+    {
+        return eof;
+    }
+
+    public String readLine() throws IOException {
+        if( eof ) return null;
+        if( bufferBytes == null ) {
+            bufferBytes = new char[configBufferSize];
+            if(readBuffer() == false)
+            {
+                eof = true;
+                return null;
+            }
+        }
+        boolean crBefore = false;
+        if(bufferPos >= bufferSize) {
+            if(readBuffer() == false) {
+                eof = true;
+                return null;
+            }
+        }
+        while(true) {
+
+            char c = 0;
+            int start = bufferPos;
+            for ( ;bufferPos < bufferSize; bufferPos++) {
+                c = bufferBytes[bufferPos];
+                if ((c == '\n') || (skipCarriageReturn && c == '\r')) break;
+                else crBefore = false;
+            }
+            // todo: maybe avoid using StringBuffer here totally by
+            // filling the bufferBytes up so we can return new String(bufferBytes, start, pos - start); as much as possible
+            // todo: if lines are longer than expected, increase buffer
+            if(c == '\n') {
+                // CASE 1
+                if(crBefore)
+                    currentLineEnding = LineEndingType.ending0D0A;
+                else
+                    currentLineEnding = LineEndingType.ending0A;
+                return getRes(start, bufferPos++);
+            }
+            else if(bufferPos >= bufferSize) {
+                // CASE 2
+                appendToRes(start, bufferPos);
+                currentLineEnding = LineEndingType.endingNone;
+                if(readBuffer() == false) {
+                    eof = true;
+                    return getRes(0, 0);
+                }
+            }
+            else // only c==\r
+            {
+                if( bufferPos+1 < bufferSize ) {
+                    boolean is0A = bufferBytes[bufferPos+1] == '\n';
+                    if( is0A || crNewline) {
+                        // case 3
+                        currentLineEnding = is0A ? LineEndingType.ending0D0A :
+                                LineEndingType.ending0D;
+                        String res = getRes(start, bufferPos);
+                        bufferPos += is0A ? 2 : 1;
+                        return res;
+                    }
+                    else {
+                        if(!crNewline) {
+                            // case 4
+                            // \r in the middle like "AAA\rBBB\r\n"
+                            crBefore = true;
+                            appendToRes(start, bufferPos + 1);
+                            bufferPos++;
+                        }
+                    }
+                }
+                else { // \r was last sign in buffer
+                    appendToRes(start, bufferPos);
+                    if(readBuffer() == false) {
+                        // case 5
+                        // \r then EOF
+                        eof = true;
+                        currentLineEnding = LineEndingType.ending0D;
+                        return getRes(0, 0);
+                    }
+                    boolean is0A = bufferBytes[0] == '\n';
+                    if( is0A || crNewline) {
+                        currentLineEnding = is0A ? LineEndingType.ending0D0A :
+                                LineEndingType.ending0D;
+                        // case 6
+                        // \r | \n
+                        if( is0A ) bufferPos = 1;
+                        currentLineEnding = LineEndingType.ending0D0A;
+                        return getRes(0, 0);
+                    }
+                    else {
+                        currentLineEnding = LineEndingType.ending0A;
+                        //res.append('\r');
+                        return getRes(0, 0);
+                        // case 7
+                        // \r | A
+                        // continue;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/CsvLineReaderCR.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/CsvLineReaderCR.java
@@ -32,7 +32,7 @@ public class CsvLineReaderCR {
     private int bufferSize, bufferPos;
     private int lineNumber = 0;
 
-    private StringBuffer res = null;
+    private StringBuilder res = null;
     private boolean eof = false;
 
     public enum LineEndingType {
@@ -90,7 +90,7 @@ public class CsvLineReaderCR {
     {
         if(start == pos) return;
         if (res == null)
-            res = new StringBuffer(configInitialStringBufferSize);
+            res = new StringBuilder(configInitialStringBufferSize);
         res.append(bufferBytes, start, pos - start);
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/CsvParserConfig.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/CsvParserConfig.java
@@ -24,20 +24,20 @@ public class CsvParserConfig {
     CsvPreference preferences;
     boolean oneLineRecord;
     boolean quotedEmptyIsNull;
-    boolean skipCarriageReturn;
+    boolean skipCarriageReturnIn0D0A;
 
     public CsvParserConfig(CsvPreference preferences) {
         this.preferences = preferences;
         this.oneLineRecord = false;
         this.quotedEmptyIsNull = false;
-        this.skipCarriageReturn = true;
+        this.skipCarriageReturnIn0D0A = true;
     }
     public CsvParserConfig(CsvPreference preferences,
-                           boolean oneLineRecord, boolean quotedEmptyIsNull, boolean skipCarriageReturn) {
+                           boolean oneLineRecord, boolean quotedEmptyIsNull, boolean skipCarriageReturnIn0D0A) {
         this.preferences = preferences;
         this.oneLineRecord = oneLineRecord;
         this.quotedEmptyIsNull = quotedEmptyIsNull;
-        this.skipCarriageReturn = skipCarriageReturn;
+        this.skipCarriageReturnIn0D0A = skipCarriageReturnIn0D0A;
     }
     public CsvParserConfig oneLineRecord(boolean value) {
         oneLineRecord = value;
@@ -48,21 +48,21 @@ public class CsvParserConfig {
         quotedEmptyIsNull = value;
         return this;
     }
-    public CsvParserConfig skipCarriageReturn(boolean value) {
-        skipCarriageReturn = value;
+    public CsvParserConfig skipCarriageReturnIn0D0A(boolean value) {
+        skipCarriageReturnIn0D0A = value;
         return this;
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {
         out.writeBoolean(oneLineRecord);
         out.writeBoolean(quotedEmptyIsNull);
-        out.writeBoolean(skipCarriageReturn);
+        out.writeBoolean(skipCarriageReturnIn0D0A);
     }
 
     CsvParserConfig(ObjectInput in) throws IOException {
         oneLineRecord  = in.readBoolean();
         quotedEmptyIsNull = in.readBoolean();
-        skipCarriageReturn = in.readBoolean();
+        skipCarriageReturnIn0D0A = in.readBoolean();
         preferences = null;
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/CsvParserConfig.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/CsvParserConfig.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.stream.function.csv;
+
+import org.supercsv.prefs.CsvPreference;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class CsvParserConfig {
+    CsvPreference preferences;
+    boolean oneLineRecord;
+    boolean quotedEmptyIsNull;
+    boolean skipCarriageReturn;
+
+    public CsvParserConfig(CsvPreference preferences) {
+        this.preferences = preferences;
+        this.oneLineRecord = false;
+        this.quotedEmptyIsNull = false;
+        this.skipCarriageReturn = true;
+    }
+    public CsvParserConfig(CsvPreference preferences,
+                           boolean oneLineRecord, boolean quotedEmptyIsNull, boolean skipCarriageReturn) {
+        this.preferences = preferences;
+        this.oneLineRecord = oneLineRecord;
+        this.quotedEmptyIsNull = quotedEmptyIsNull;
+        this.skipCarriageReturn = skipCarriageReturn;
+    }
+    public CsvParserConfig oneLineRecord(boolean value) {
+        oneLineRecord = value;
+        return this;
+    }
+
+    public CsvParserConfig quotedEmptyIsNull(boolean value) {
+        quotedEmptyIsNull = value;
+        return this;
+    }
+    public CsvParserConfig skipCarriageReturn(boolean value) {
+        skipCarriageReturn = value;
+        return this;
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeBoolean(oneLineRecord);
+        out.writeBoolean(quotedEmptyIsNull);
+        out.writeBoolean(skipCarriageReturn);
+    }
+
+    CsvParserConfig(ObjectInput in) throws IOException {
+        oneLineRecord  = in.readBoolean();
+        quotedEmptyIsNull = in.readBoolean();
+        skipCarriageReturn = in.readBoolean();
+        preferences = null;
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/CsvParserConfig.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/CsvParserConfig.java
@@ -24,20 +24,20 @@ public class CsvParserConfig {
     CsvPreference preferences;
     boolean oneLineRecord;
     boolean quotedEmptyIsNull;
-    boolean skipCarriageReturnIn0D0A;
+    boolean preserveLineEndings;
 
     public CsvParserConfig(CsvPreference preferences) {
         this.preferences = preferences;
         this.oneLineRecord = false;
         this.quotedEmptyIsNull = false;
-        this.skipCarriageReturnIn0D0A = true;
+        this.preserveLineEndings = true;
     }
     public CsvParserConfig(CsvPreference preferences,
-                           boolean oneLineRecord, boolean quotedEmptyIsNull, boolean skipCarriageReturnIn0D0A) {
+                           boolean oneLineRecord, boolean quotedEmptyIsNull, boolean preserveLineEndings) {
         this.preferences = preferences;
         this.oneLineRecord = oneLineRecord;
         this.quotedEmptyIsNull = quotedEmptyIsNull;
-        this.skipCarriageReturnIn0D0A = skipCarriageReturnIn0D0A;
+        this.preserveLineEndings = preserveLineEndings;
     }
     public CsvParserConfig oneLineRecord(boolean value) {
         oneLineRecord = value;
@@ -48,21 +48,21 @@ public class CsvParserConfig {
         quotedEmptyIsNull = value;
         return this;
     }
-    public CsvParserConfig skipCarriageReturnIn0D0A(boolean value) {
-        skipCarriageReturnIn0D0A = value;
+    public CsvParserConfig preserveLineEndings(boolean value) {
+        preserveLineEndings = value;
         return this;
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {
         out.writeBoolean(oneLineRecord);
         out.writeBoolean(quotedEmptyIsNull);
-        out.writeBoolean(skipCarriageReturnIn0D0A);
+        out.writeBoolean(preserveLineEndings);
     }
 
     CsvParserConfig(ObjectInput in) throws IOException {
         oneLineRecord  = in.readBoolean();
         quotedEmptyIsNull = in.readBoolean();
-        skipCarriageReturnIn0D0A = in.readBoolean();
+        preserveLineEndings = in.readBoolean();
         preferences = null;
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/FileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/FileFunction.java
@@ -53,10 +53,10 @@ public class FileFunction extends AbstractFileFunction<String> {
 
     public FileFunction(String characterDelimiter, String columnDelimiter, ExecRow execRow, int[] columnIndex, String timeFormat,
                         String dateTimeFormat, String timestampFormat, boolean oneLineRecord,
-                        OperationContext operationContext, boolean quotedEmptyIsNull, boolean skipCarriageReturnIn0D0A) {
+                        OperationContext operationContext, boolean quotedEmptyIsNull, boolean preserveLineEndings) {
         super(characterDelimiter, columnDelimiter, execRow, columnIndex, timeFormat,
                 dateTimeFormat, timestampFormat, operationContext);
-        config = new CsvParserConfig(preference, oneLineRecord, quotedEmptyIsNull, skipCarriageReturnIn0D0A);
+        config = new CsvParserConfig(preference, oneLineRecord, quotedEmptyIsNull, preserveLineEndings);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/FileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/FileFunction.java
@@ -12,17 +12,17 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.splicemachine.derby.stream.function;
+package com.splicemachine.derby.stream.function.csv;
 
 import com.splicemachine.EngineDriver;
 import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.iapi.reference.Property;
-import com.splicemachine.db.iapi.services.property.PropertyUtil;
+import com.splicemachine.db.iapi.services.io.ArrayUtil;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.VTIOperation;
 import com.splicemachine.derby.stream.iapi.OperationContext;
+import com.splicemachine.derby.stream.output.WriteReadUtils;
 import com.splicemachine.derby.stream.utils.BooleanList;
 import org.apache.commons.collections.iterators.SingletonIterator;
 
@@ -44,19 +44,31 @@ import java.util.List;
 public class FileFunction extends AbstractFileFunction<String> {
     boolean initialized = false;
     MutableCSVTokenizer tokenizer;
-    private boolean oneLineRecord;
-    private boolean quotedEmptyIsNull;
+    private CsvParserConfig config;
+    // oneLineRecord wasn't written/readExternal
 
     public FileFunction() {
         super();
     }
 
     public FileFunction(String characterDelimiter, String columnDelimiter, ExecRow execRow, int[] columnIndex, String timeFormat,
-                        String dateTimeFormat, String timestampFormat, boolean oneLineRecord, OperationContext operationContext, boolean quotedEmptyIsNull) {
+                        String dateTimeFormat, String timestampFormat, boolean oneLineRecord,
+                        OperationContext operationContext, boolean quotedEmptyIsNull, boolean skipCarriageReturn) {
         super(characterDelimiter, columnDelimiter, execRow, columnIndex, timeFormat,
                 dateTimeFormat, timestampFormat, operationContext);
-        this.oneLineRecord = oneLineRecord;
-        this.quotedEmptyIsNull = quotedEmptyIsNull;
+        config = new CsvParserConfig(preference, oneLineRecord, quotedEmptyIsNull, skipCarriageReturn);
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        super.writeExternal(out);
+        config.writeExternal(out);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        super.readExternal(in);
+        config = new CsvParserConfig(in);
     }
 
     /**
@@ -74,6 +86,7 @@ public class FileFunction extends AbstractFileFunction<String> {
             // pass the string to CSV tokenizer, this allows us to immediately
             // get rid of the string after reading it.
             checkPreference();
+            config.preferences = preference;
             List<Integer> valueSizeHints = null;
             SpliceOperation op = operationContext.getOperation();
             if (op instanceof VTIOperation) { // Currently, only VTI can provide the result set data types.
@@ -83,7 +96,8 @@ public class FileFunction extends AbstractFileFunction<String> {
                     valueSizeHints.add(dtd.getMaximumWidth());
                 }
             }
-            tokenizer = new MutableCSVTokenizer(reader, preference, oneLineRecord, quotedEmptyIsNull,
+
+            tokenizer = new MutableCSVTokenizer(reader, config,
                     EngineDriver.driver().getConfiguration().getImportCsvScanThreshold(), valueSizeHints);
             initialized = true;
         }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/FileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/FileFunction.java
@@ -53,10 +53,10 @@ public class FileFunction extends AbstractFileFunction<String> {
 
     public FileFunction(String characterDelimiter, String columnDelimiter, ExecRow execRow, int[] columnIndex, String timeFormat,
                         String dateTimeFormat, String timestampFormat, boolean oneLineRecord,
-                        OperationContext operationContext, boolean quotedEmptyIsNull, boolean skipCarriageReturn) {
+                        OperationContext operationContext, boolean quotedEmptyIsNull, boolean skipCarriageReturnIn0D0A) {
         super(characterDelimiter, columnDelimiter, execRow, columnIndex, timeFormat,
                 dateTimeFormat, timestampFormat, operationContext);
-        config = new CsvParserConfig(preference, oneLineRecord, quotedEmptyIsNull, skipCarriageReturn);
+        config = new CsvParserConfig(preference, oneLineRecord, quotedEmptyIsNull, skipCarriageReturnIn0D0A);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/FileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/FileFunction.java
@@ -59,18 +59,6 @@ public class FileFunction extends AbstractFileFunction<String> {
         config = new CsvParserConfig(preference, oneLineRecord, quotedEmptyIsNull, preserveLineEndings);
     }
 
-    @Override
-    public void writeExternal(ObjectOutput out) throws IOException {
-        super.writeExternal(out);
-        config.writeExternal(out);
-    }
-
-    @Override
-    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-        super.readExternal(in);
-        config = new CsvParserConfig(in);
-    }
-
     /**
      * Call Method for parsing the string into either a singleton List with a ExecRow or an empty list.
      *
@@ -119,14 +107,12 @@ public class FileFunction extends AbstractFileFunction<String> {
     @Override
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
         super.readExternal(in);
-        oneLineRecord = in.readBoolean();
-        quotedEmptyIsNull = in.readBoolean();
+        config = new CsvParserConfig(in);
     }
 
     @Override
     public void writeExternal(ObjectOutput out) throws IOException {
         super.writeExternal(out);
-        out.writeBoolean(oneLineRecord);
-        out.writeBoolean(quotedEmptyIsNull);
+        config.writeExternal(out);
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/MutableCSVTokenizer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/MutableCSVTokenizer.java
@@ -12,10 +12,9 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.splicemachine.derby.stream.function;
+package com.splicemachine.derby.stream.function.csv;
 
 import com.splicemachine.derby.stream.utils.BooleanList;
-import org.supercsv.prefs.CsvPreference;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -35,13 +34,10 @@ public class MutableCSVTokenizer extends QuoteTrackingTokenizer {
     private String line;
     private final List<String> columns =new ArrayList<>();
     private final BooleanList quotedColumns = new BooleanList();
-    public MutableCSVTokenizer(Reader reader, CsvPreference preferences, boolean oneLineRecord, boolean quotedEmptyIsNull) {
-        super(reader, preferences, oneLineRecord, quotedEmptyIsNull);
-    }
 
-    public MutableCSVTokenizer(Reader reader, CsvPreference preferences, boolean oneLineRecord, boolean quotedEmptyIsNull, long scanThreshold,
+    public MutableCSVTokenizer(Reader reader, CsvParserConfig config, long scanThreshold,
                                List<Integer> valueSizeHint) {
-        super(reader, preferences, oneLineRecord, quotedEmptyIsNull, scanThreshold, valueSizeHint);
+        super(reader, config, scanThreshold, valueSizeHint);
     }
 
     /**

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/QuoteTrackingTokenizer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/QuoteTrackingTokenizer.java
@@ -251,15 +251,12 @@ public class QuoteTrackingTokenizer extends AbstractTokenizerCR {
     }
 
     private void appendToRowNewLine() {
-        String newline = preserveLineEndings ? getCurrentLineEnding() : String.valueOf(NEWLINE);
         if (checkExactSizeFirst) {
-
-            currentRow.append(newline);
-
+            currentRow.append(preserveLineEndings ? getCurrentLineEnding() : String.valueOf(NEWLINE));
         } else if (exactColumnSizes != null && !oneLineRecord) {
             rowIdx++; // simulate adding a newline by moving a sequence by one
         } else {
-            currentRow.append(newline);
+            currentRow.append(preserveLineEndings ? getCurrentLineEnding() : String.valueOf(NEWLINE));
         }
     }
 
@@ -362,9 +359,7 @@ public class QuoteTrackingTokenizer extends AbstractTokenizerCR {
 
     private void addNewLineToColumn()
     {
-        if(preserveLineEndings)
-            addToColumn(NEWLINE);
-        else {
+        if(preserveLineEndings) {
             switch (getCurrentLineEndingType()) {
                 case ending0D:
                     addToColumn('\r');
@@ -381,6 +376,8 @@ public class QuoteTrackingTokenizer extends AbstractTokenizerCR {
                     return;
             }
         }
+        else
+            addToColumn(NEWLINE);
     }
 
     private void handleQuoteState() throws IOException {

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/QuoteTrackingTokenizer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/QuoteTrackingTokenizer.java
@@ -113,7 +113,7 @@ public class QuoteTrackingTokenizer extends AbstractTokenizerCR {
             if(sb == null)
                  sb = new StringBuilder(length());
             else
-                sb.delete(0, sb.length());
+                sb.setLength(0);
             for (String cb : bufferList) {
                 sb.append(cb);
             }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/QuoteTrackingTokenizer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/QuoteTrackingTokenizer.java
@@ -148,7 +148,7 @@ public class QuoteTrackingTokenizer extends AbstractTokenizerCR {
      */
     public QuoteTrackingTokenizer(Reader reader, CsvParserConfig config,
                                   final long scanThresold, final List<Integer> valueSizeHints) {
-        super(reader, config.preferences, config.skipCarriageReturn);
+        super(reader, config.preferences, config.skipCarriageReturnIn0D0A);
         this.quoteChar = config.preferences.getQuoteChar();
         this.delimeterChar = config.preferences.getDelimiterChar();
         this.surroundingSpacesNeedQuotes = config.preferences.isSurroundingSpacesNeedQuotes();

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/StreamFileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/StreamFileFunction.java
@@ -86,8 +86,7 @@ import java.util.*;
                                 return hasNext;
                             try {
                                 if (!initialized) {
-                                    // BUFFERED? it's buffered again...
-                                    reader = new BufferedReader(new InputStreamReader(s,charset));
+                                    reader = new InputStreamReader(s,charset);
                                     List<Integer> valueSizeHints = new ArrayList<>(execRow.nColumns());
                                     for(DataValueDescriptor dvd : execRow.getRowArray()) {
                                         valueSizeHints.add(dvd.estimateMemoryUsage());

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/StreamFileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/StreamFileFunction.java
@@ -33,20 +33,20 @@ import java.util.*;
     public class StreamFileFunction extends AbstractFileFunction<InputStream> {
     private String charset;
     private boolean quotedEmptyIsNull;
-    private boolean skipCarriageReturn;
+    private boolean skipCarriageReturnIn0D0A;
 
     public StreamFileFunction() {
         super();
     }
     public StreamFileFunction(String characterDelimiter, String columnDelimiter, ExecRow execRow, int[] columnIndex,
                               String timeFormat, String dateTimeFormat, String timestampFormat, String charset,
-                              OperationContext operationContext, boolean quotedEmptyIsNull, boolean skipCarriageReturn) {
+                              OperationContext operationContext, boolean quotedEmptyIsNull, boolean skipCarriageReturnIn0D0A) {
         super(characterDelimiter,columnDelimiter,execRow,columnIndex,timeFormat,
                 dateTimeFormat,timestampFormat,operationContext);
         assert charset != null;
         this.charset = charset;
         this.quotedEmptyIsNull = quotedEmptyIsNull;
-        this.skipCarriageReturn = skipCarriageReturn;
+        this.skipCarriageReturnIn0D0A = skipCarriageReturnIn0D0A;
     }
 
     @Override
@@ -54,7 +54,7 @@ import java.util.*;
         super.writeExternal(out);
         out.writeUTF(charset);
         out.writeBoolean(quotedEmptyIsNull);
-        out.writeBoolean(skipCarriageReturn);
+        out.writeBoolean(skipCarriageReturnIn0D0A);
     }
 
     @Override
@@ -62,7 +62,7 @@ import java.util.*;
         super.readExternal(in);
         charset = in.readUTF();
         quotedEmptyIsNull = in.readBoolean();
-        skipCarriageReturn = in.readBoolean();
+        skipCarriageReturnIn0D0A = in.readBoolean();
     }
 
     @Override
@@ -72,7 +72,7 @@ import java.util.*;
         checkPreference();
 
         CsvParserConfig config = new CsvParserConfig(preference).oneLineRecord(false)
-                .quotedEmptyIsNull(quotedEmptyIsNull).skipCarriageReturn(skipCarriageReturn);
+                .quotedEmptyIsNull(quotedEmptyIsNull).skipCarriageReturnIn0D0A(skipCarriageReturnIn0D0A);
 
         return new Iterator<ExecRow>() {
                     private ExecRow nextRow;

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/StreamFileFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/csv/StreamFileFunction.java
@@ -19,7 +19,6 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.derby.impl.load.SpliceCsvReader;
-import com.splicemachine.derby.stream.function.csv.AbstractFileFunction;
 import com.splicemachine.derby.stream.iapi.OperationContext;
 import com.splicemachine.derby.stream.utils.BooleanList;
 
@@ -33,20 +32,20 @@ import java.util.*;
     public class StreamFileFunction extends AbstractFileFunction<InputStream> {
     private String charset;
     private boolean quotedEmptyIsNull;
-    private boolean skipCarriageReturnIn0D0A;
+    private boolean preserveLineEndings;
 
     public StreamFileFunction() {
         super();
     }
     public StreamFileFunction(String characterDelimiter, String columnDelimiter, ExecRow execRow, int[] columnIndex,
                               String timeFormat, String dateTimeFormat, String timestampFormat, String charset,
-                              OperationContext operationContext, boolean quotedEmptyIsNull, boolean skipCarriageReturnIn0D0A) {
+                              OperationContext operationContext, boolean quotedEmptyIsNull, boolean preserveLineEndings) {
         super(characterDelimiter,columnDelimiter,execRow,columnIndex,timeFormat,
                 dateTimeFormat,timestampFormat,operationContext);
         assert charset != null;
         this.charset = charset;
         this.quotedEmptyIsNull = quotedEmptyIsNull;
-        this.skipCarriageReturnIn0D0A = skipCarriageReturnIn0D0A;
+        this.preserveLineEndings = preserveLineEndings;
     }
 
     @Override
@@ -54,7 +53,7 @@ import java.util.*;
         super.writeExternal(out);
         out.writeUTF(charset);
         out.writeBoolean(quotedEmptyIsNull);
-        out.writeBoolean(skipCarriageReturnIn0D0A);
+        out.writeBoolean(preserveLineEndings);
     }
 
     @Override
@@ -62,7 +61,7 @@ import java.util.*;
         super.readExternal(in);
         charset = in.readUTF();
         quotedEmptyIsNull = in.readBoolean();
-        skipCarriageReturnIn0D0A = in.readBoolean();
+        preserveLineEndings = in.readBoolean();
     }
 
     @Override
@@ -72,7 +71,7 @@ import java.util.*;
         checkPreference();
 
         CsvParserConfig config = new CsvParserConfig(preference).oneLineRecord(false)
-                .quotedEmptyIsNull(quotedEmptyIsNull).skipCarriageReturnIn0D0A(skipCarriageReturnIn0D0A);
+                .quotedEmptyIsNull(quotedEmptyIsNull).preserveLineEndings(preserveLineEndings);
 
         return new Iterator<ExecRow>() {
                     private ExecRow nextRow;

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceFileVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceFileVTI.java
@@ -128,15 +128,16 @@ public class SpliceFileVTI implements DatasetProvider, VTICosting {
         return new SpliceFileVTI(fileName,characterDelimiter,columnDelimiter, columnIndex,timeFormat,dateTimeFormat,timestampFormat);
     }
 
-    boolean GetSkipCarriageReturnIn0D0A(SpliceOperation op) throws StandardException {
-        boolean defaultValue = CompilerContext.DEFAULT_SPLICE_SKIP_CARRIAGE_RETURN;
+    boolean GetPreserveLineEndings(SpliceOperation op) throws StandardException {
+        boolean defaultValue = CompilerContext.DEFAULT_PRESERVE_LINE_ENDINGS;
         if( op == null || op.getActivation() == null || op.getActivation().getLanguageConnectionContext() == null )
             return defaultValue;
-        String skipCarriageReturnIn0D0AString =
-                PropertyUtil.getCachedDatabaseProperty(op.getActivation().getLanguageConnectionContext(), Property.SPLICE_SKIP_CARRIAGE_RETURN_IN_0D0A);
+        String preserveLineEndingsString =
+                PropertyUtil.getCachedDatabaseProperty(op.getActivation().getLanguageConnectionContext(),
+                        Property.PRESERVE_LINE_ENDINGS);
         try {
-            if (skipCarriageReturnIn0D0AString != null)
-                return Boolean.parseBoolean(skipCarriageReturnIn0D0AString);
+            if (preserveLineEndingsString != null)
+                return Boolean.parseBoolean(preserveLineEndingsString);
         } catch (Exception e) {
             // If the property value failed to convert to a boolean, don't throw an error,
             // just use the default setting.
@@ -160,21 +161,21 @@ public class SpliceFileVTI implements DatasetProvider, VTICosting {
                 quotedEmptyIsNull = vtiOperation.getQuotedEmptyIsNull();
             }
 
-            boolean skipCarriageReturnIn0D0A = GetSkipCarriageReturnIn0D0A(op);
-            if (oneLineRecords && skipCarriageReturnIn0D0A /* todo check if this is needed (SMTextInputFormat) */
+            boolean preserveLineEndings = GetPreserveLineEndings(op);
+            if (oneLineRecords && preserveLineEndings /* todo check if this is needed (SMTextInputFormat) */
                     && (charset==null || charset.toLowerCase().equals("utf-8"))) {
                 DataSet<String> textSet = dsp.readTextFile(fileName, op);
                 operationContext.pushScopeForOp("Parse File");
                 return textSet.flatMap(new FileFunction(characterDelimiter, columnDelimiter, execRow,
                         columnIndex, timeFormat, dateTimeFormat, timestampFormat,
-                        true, operationContext, quotedEmptyIsNull, skipCarriageReturnIn0D0A), true);
+                        true, operationContext, quotedEmptyIsNull, preserveLineEndings), true);
             } else {
                 PairDataSet<String,InputStream> streamSet = dsp.readWholeTextFile(fileName, op);
                 operationContext.pushScopeForOp("Parse File");
                 return streamSet.values(operationContext).flatMap(
                         new StreamFileFunction(characterDelimiter, columnDelimiter, execRow, columnIndex,
                                 timeFormat, dateTimeFormat, timestampFormat, charset,
-                                operationContext, quotedEmptyIsNull, skipCarriageReturnIn0D0A), true);
+                                operationContext, quotedEmptyIsNull, preserveLineEndings), true);
             }
         } finally {
             operationContext.popScope();

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceFileVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceFileVTI.java
@@ -128,7 +128,7 @@ public class SpliceFileVTI implements DatasetProvider, VTICosting {
         return new SpliceFileVTI(fileName,characterDelimiter,columnDelimiter, columnIndex,timeFormat,dateTimeFormat,timestampFormat);
     }
 
-    boolean GetPreserveLineEndings(SpliceOperation op) throws StandardException {
+    boolean getPreserveLineEndings(SpliceOperation op) throws StandardException {
         boolean defaultValue = CompilerContext.DEFAULT_PRESERVE_LINE_ENDINGS;
         if( op == null || op.getActivation() == null || op.getActivation().getLanguageConnectionContext() == null )
             return defaultValue;
@@ -161,8 +161,8 @@ public class SpliceFileVTI implements DatasetProvider, VTICosting {
                 quotedEmptyIsNull = vtiOperation.getQuotedEmptyIsNull();
             }
 
-            boolean preserveLineEndings = GetPreserveLineEndings(op);
-            if (oneLineRecords && preserveLineEndings /* todo check if this is needed (SMTextInputFormat) */
+            boolean preserveLineEndings = getPreserveLineEndings(op);
+            if (oneLineRecords && !preserveLineEndings
                     && (charset==null || charset.toLowerCase().equals("utf-8"))) {
                 DataSet<String> textSet = dsp.readTextFile(fileName, op);
                 operationContext.pushScopeForOp("Parse File");

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceFileVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceFileVTI.java
@@ -128,15 +128,15 @@ public class SpliceFileVTI implements DatasetProvider, VTICosting {
         return new SpliceFileVTI(fileName,characterDelimiter,columnDelimiter, columnIndex,timeFormat,dateTimeFormat,timestampFormat);
     }
 
-    boolean getSkipCarriageReturn(SpliceOperation op) throws StandardException {
+    boolean GetSkipCarriageReturnIn0D0A(SpliceOperation op) throws StandardException {
         boolean defaultValue = CompilerContext.DEFAULT_SPLICE_SKIP_CARRIAGE_RETURN;
         if( op == null || op.getActivation() == null || op.getActivation().getLanguageConnectionContext() == null )
             return defaultValue;
-        String skipCarriageReturnString =
-                PropertyUtil.getCachedDatabaseProperty(op.getActivation().getLanguageConnectionContext(), Property.SPLICE_SKIP_CARRIAGE_RETURN);
+        String skipCarriageReturnIn0D0AString =
+                PropertyUtil.getCachedDatabaseProperty(op.getActivation().getLanguageConnectionContext(), Property.SPLICE_SKIP_CARRIAGE_RETURN_IN_0D0A);
         try {
-            if (skipCarriageReturnString != null)
-                return Boolean.parseBoolean(skipCarriageReturnString);
+            if (skipCarriageReturnIn0D0AString != null)
+                return Boolean.parseBoolean(skipCarriageReturnIn0D0AString);
         } catch (Exception e) {
             // If the property value failed to convert to a boolean, don't throw an error,
             // just use the default setting.
@@ -160,21 +160,21 @@ public class SpliceFileVTI implements DatasetProvider, VTICosting {
                 quotedEmptyIsNull = vtiOperation.getQuotedEmptyIsNull();
             }
 
-            boolean skipCarriageReturn = getSkipCarriageReturn(op);
-            if (oneLineRecords && skipCarriageReturn /* todo check if this is needed (SMTextInputFormat) */
+            boolean skipCarriageReturnIn0D0A = GetSkipCarriageReturnIn0D0A(op);
+            if (oneLineRecords && skipCarriageReturnIn0D0A /* todo check if this is needed (SMTextInputFormat) */
                     && (charset==null || charset.toLowerCase().equals("utf-8"))) {
                 DataSet<String> textSet = dsp.readTextFile(fileName, op);
                 operationContext.pushScopeForOp("Parse File");
                 return textSet.flatMap(new FileFunction(characterDelimiter, columnDelimiter, execRow,
                         columnIndex, timeFormat, dateTimeFormat, timestampFormat,
-                        true, operationContext, quotedEmptyIsNull, skipCarriageReturn), true);
+                        true, operationContext, quotedEmptyIsNull, skipCarriageReturnIn0D0A), true);
             } else {
                 PairDataSet<String,InputStream> streamSet = dsp.readWholeTextFile(fileName, op);
                 operationContext.pushScopeForOp("Parse File");
                 return streamSet.values(operationContext).flatMap(
                         new StreamFileFunction(characterDelimiter, columnDelimiter, execRow, columnIndex,
                                 timeFormat, dateTimeFormat, timestampFormat, charset,
-                                operationContext, quotedEmptyIsNull, skipCarriageReturn), true);
+                                operationContext, quotedEmptyIsNull, skipCarriageReturnIn0D0A), true);
             }
         } finally {
             operationContext.popScope();

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceFileVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceFileVTI.java
@@ -16,16 +16,19 @@ package com.splicemachine.derby.vti;
 
 import com.splicemachine.access.api.FileInfo;
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.Property;
 import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.services.property.PropertyUtil;
 import com.splicemachine.db.iapi.sql.Activation;
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.vti.VTICosting;
 import com.splicemachine.db.vti.VTIEnvironment;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.load.ImportUtils;
 import com.splicemachine.derby.impl.sql.execute.operations.VTIOperation;
-import com.splicemachine.derby.stream.function.FileFunction;
-import com.splicemachine.derby.stream.function.StreamFileFunction;
+import com.splicemachine.derby.stream.function.csv.FileFunction;
+import com.splicemachine.derby.stream.function.csv.StreamFileFunction;
 import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
 import com.splicemachine.derby.stream.iapi.OperationContext;
@@ -125,6 +128,21 @@ public class SpliceFileVTI implements DatasetProvider, VTICosting {
         return new SpliceFileVTI(fileName,characterDelimiter,columnDelimiter, columnIndex,timeFormat,dateTimeFormat,timestampFormat);
     }
 
+    boolean getSkipCarriageReturn(SpliceOperation op) throws StandardException {
+        boolean defaultValue = CompilerContext.DEFAULT_SPLICE_SKIP_CARRIAGE_RETURN;
+        if( op == null || op.getActivation() == null || op.getActivation().getLanguageConnectionContext() == null )
+            return defaultValue;
+        String skipCarriageReturnString =
+                PropertyUtil.getCachedDatabaseProperty(op.getActivation().getLanguageConnectionContext(), Property.SPLICE_SKIP_CARRIAGE_RETURN);
+        try {
+            if (skipCarriageReturnString != null)
+                return Boolean.parseBoolean(skipCarriageReturnString);
+        } catch (Exception e) {
+            // If the property value failed to convert to a boolean, don't throw an error,
+            // just use the default setting.
+        }
+        return defaultValue;
+    }
 
     @Override
     public DataSet<ExecRow> getDataSet(SpliceOperation op, DataSetProcessor dsp, ExecRow execRow) throws StandardException {
@@ -141,14 +159,22 @@ public class SpliceFileVTI implements DatasetProvider, VTICosting {
                 VTIOperation vtiOperation = (VTIOperation)op;
                 quotedEmptyIsNull = vtiOperation.getQuotedEmptyIsNull();
             }
-            if (oneLineRecords && (charset==null || charset.toLowerCase().equals("utf-8"))) {
+
+            boolean skipCarriageReturn = getSkipCarriageReturn(op);
+            if (oneLineRecords && skipCarriageReturn /* todo check if this is needed (SMTextInputFormat) */
+                    && (charset==null || charset.toLowerCase().equals("utf-8"))) {
                 DataSet<String> textSet = dsp.readTextFile(fileName, op);
                 operationContext.pushScopeForOp("Parse File");
-                return textSet.flatMap(new FileFunction(characterDelimiter, columnDelimiter, execRow, columnIndex, timeFormat, dateTimeFormat, timestampFormat, true, operationContext, quotedEmptyIsNull), true);
+                return textSet.flatMap(new FileFunction(characterDelimiter, columnDelimiter, execRow,
+                        columnIndex, timeFormat, dateTimeFormat, timestampFormat,
+                        true, operationContext, quotedEmptyIsNull, skipCarriageReturn), true);
             } else {
                 PairDataSet<String,InputStream> streamSet = dsp.readWholeTextFile(fileName, op);
                 operationContext.pushScopeForOp("Parse File");
-                return streamSet.values(operationContext).flatMap(new StreamFileFunction(characterDelimiter, columnDelimiter, execRow, columnIndex, timeFormat, dateTimeFormat, timestampFormat, charset, operationContext, quotedEmptyIsNull), true);
+                return streamSet.values(operationContext).flatMap(
+                        new StreamFileFunction(characterDelimiter, columnDelimiter, execRow, columnIndex,
+                                timeFormat, dateTimeFormat, timestampFormat, charset,
+                                operationContext, quotedEmptyIsNull, skipCarriageReturn), true);
             }
         } finally {
             operationContext.popScope();

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/FromFinalTableIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/FromFinalTableIT.java
@@ -135,7 +135,7 @@ public class FromFinalTableIT extends SpliceUnitTest {
 
     @BeforeClass
     public static void recordNumTables() throws Exception {
-        isMemPlatform = isMemPlatform();
+        isMemPlatform = isMemPlatform(spliceClassWatcher);
         dropObjects();
         vacuum();
         numTables = getNumTables();
@@ -177,14 +177,6 @@ public class FromFinalTableIT extends SpliceUnitTest {
         try (ResultSet rs = spliceClassWatcher.executeQuery("CALL SYSCS_UTIL.SYSCS_GET_TABLE_COUNT()")) {
             rs.next();
             return ((Integer)rs.getObject(1));
-        }
-    }
-
-    public static boolean
-    isMemPlatform() throws Exception{
-        try (ResultSet rs = spliceClassWatcher.executeQuery("CALL SYSCS_UTIL.SYSCS_IS_MEM_PLATFORM()")) {
-            rs.next();
-            return ((Boolean)rs.getObject(1));
         }
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/CsvLineReaderCRTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/CsvLineReaderCRTest.java
@@ -33,40 +33,41 @@ public class CsvLineReaderCRTest {
 
     @Test
     public void testAllCases() throws IOException {
-        boolean crNewline = true;
-        test("", new String[]{}, 5);
+        for (int size = 1; size <= 20; ++size) {
+            test("", new String[]{}, size);
 
-        // CASE 1 : configBufferSize=10
-        // 1234\n
-        test("1234\n", new String[]{"1234", "\n"}, 10);
-        // CASE 2 : configBufferSize=10
-        // 1234<EOF>
-        test("1234", new String[]{"1234", ""}, 10);
+            // CASE 1
+            // 1234\n
+            test("1234\n", new String[]{"1234", "\n"}, size);
+            // CASE 2
+            // 1234<EOF>
+            test("1234", new String[]{"1234", ""}, size);
 
-        // CASE 3 : configBufferSize=20
-        // 123\r\n123\r\n
-        test("123\r\n123\r\nabc\n", new String[]{"123", "\r\n", "123", "\r\n", "abc", "\n"}, 20);
+            // CASE 3
+            // 123\r\n123\r\n
+            test("123\r\n123\r\nabc\n", new String[]{"123", "\r\n", "123", "\r\n", "abc", "\n"}, size);
 
 
-        // CASE 4 : configBufferSize=20
-        // 123\r123\r\n
+            // CASE 4
+            // 123\r123\r\n
 
-        test("123\r123\r\nabc\n", new String[]{"123", "\r", "123", "\r\n", "abc", "\n"}, 20);
+            test("123\r123\r\nabc\n", new String[]{"123", "\r", "123", "\r\n", "abc", "\n"}, size);
 
-        // CASE 5 : configBufferSize=5
-        // 1234\r<EOF>
-        test("1234\r", new String[]{"1234", "\r"}, 5);
-        //test("1234\r", new String[]{"1234\r"}, false, 5);
+            // CASE 5
+            // 1234\r<EOF>
+            test("1234\r", new String[]{"1234", "\r"}, size);
+            //test("1234\r", new String[]{"1234\r"}, false, 5);
 
-        // CASE 6 : configBufferSize=5
-        // 1234\r\n
-        // abc\r\n
-        test("1234\r\nabc\r\n", new String[]{"1234", "\r\n", "abc", "\r\n"}, 5);
+            // CASE 6
+            // 1234\r\n
+            // abc\r\n
+                test("1234\r\nabc\r\n", new String[]{"1234", "\r\n", "abc", "\r\n"}, size);
 
-        // CASE 7 : configBufferSize=5
-        // 1234\rA
-        test( "123456", new String[]{"123456", ""}, 5);
-        test( "12345", new String[]{"12345", ""}, 5);
-        test( "1234\rA", new String[]{"1234", "\r", "A", ""}, 5);
+            // CASE 7
+            // 1234\rA
+            test( "123456", new String[]{"123456", ""}, size);
+            test( "12345", new String[]{"12345", ""}, size);
+            test( "1234\rA", new String[]{"1234", "\r", "A", ""}, size);
+        }
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/CsvLineReaderCRTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/CsvLineReaderCRTest.java
@@ -1,0 +1,81 @@
+package com.splicemachine.derby.impl.load;
+
+import com.splicemachine.derby.stream.function.csv.CsvLineReaderCR;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+public class CsvLineReaderCRTest {
+    void test(String s, String[] expected, boolean skipCarriageReturn, boolean crNewline, int configBufferSize) throws IOException {
+        CsvLineReaderCR r = new CsvLineReaderCR(new StringReader(s), skipCarriageReturn, crNewline,
+                1024, configBufferSize);
+
+        for(int i=0; ; i++) {
+            String line = r.readLine();
+            if( line == null ) break;
+            Assert.assertTrue( i < expected.length );
+            Assert.assertEquals(r.getLineNumber(), i+1);
+            Assert.assertEquals( expected[i], line);
+        }
+        Assert.assertEquals( expected.length, r.getLineNumber() );
+
+    }
+    @Test
+    public void test1() throws IOException {
+        test( "Hello\nWorld\n", new String[]{"Hello", "World"}, true, false, 1024);
+        test( "Hello\nWorld\n", new String[]{"Hello", "World"}, false, false,1024);
+    }
+    @Test
+    public void test2() throws IOException {
+        test( "Hello\r\nWorld\r\n", new String[]{"Hello", "World"}, true, false,1024);
+        test( "Hello\r\nWorld\r\n", new String[]{"Hello\r", "World\r"}, false, false,1024);
+    }
+
+    @Test
+    public void test3() throws IOException {
+        boolean crNewline = true;
+        test("", new String[]{}, true, false,5);
+
+        // CASE 1 : skipCarriageReturn=true/false, configBufferSize=10
+        // 1234\n
+        test("1234\n", new String[]{"1234"}, true, false,10);
+        // CASE 2 : skipCarriageReturn=true/false, configBufferSize=10
+        // 1234<EOF>
+        test("1234", new String[]{"1234"}, true, false,10);
+
+        // CASE 3 : skipCarriageReturn=true, configBufferSize=20
+        // 123\r\n123\r\n
+        test("123\r\n123\r\nabc\n", new String[]{"123", "123", "abc"}, true, false,20);
+        test("123\r\n123\r\nabc\n", new String[]{"123\r", "123\r", "abc"}, false, false,20);
+
+
+        // CASE 4 : skipCarriageReturn=true, configBufferSize=20
+        // 123\r123\r\n
+
+        test("123\r123\r\nabc\n", new String[]{"123", "123", "abc"}, true, true, 20);
+        test("123\r123\r\nabc\n", new String[]{"123\r123\r", "abc"}, false, true, 20);
+        test("123\r123\r\nabc\n", new String[]{"123\r123", "abc"}, true, false, 20);
+        test("123\r123\r\nabc\n", new String[]{"123\r123\r", "abc"}, false, false, 20);
+
+        // CASE 5 : skipCarriageReturn=true, configBufferSize=5
+        // 1234\r<EOF>
+        test("1234\r", new String[]{"1234"}, true, false, 5);
+        test("1234\r", new String[]{"1234\r"}, false, false, 5);
+        //test("1234\r", new String[]{"1234\r"}, false, 5);
+
+        // CASE 6 : skipCarriageReturn=true, configBufferSize=5
+        // 1234\r\n
+        // abc\r\n
+        test("1234\r\nabc\r\n", new String[]{"1234", "abc"}, true, false,5);
+        test("1234\r\nabc\r\n", new String[]{"1234\r", "abc\r"}, false, false,5);
+
+        // CASE 7 : skipCarriageReturn=true, configBufferSize=5
+        // 1234\rA
+    }
+    @Test    public void test4() throws IOException {
+        test( "1234\rA", new String[]{"1234", "A"}, true, false,5);
+        //test( "1234\rA", new String[]{"1234\rA"}, true, 5);
+    }
+}

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/CsvLineReaderCRTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/CsvLineReaderCRTest.java
@@ -23,7 +23,7 @@ public class CsvLineReaderCRTest {
 
     }
     @Test
-    public void test1() throws IOException {
+    public void testSimple() throws IOException {
         test( "Hello\nWorld\n", new String[]{"Hello", "\n", "World", "\n"}, 1024);
         test( "Hello\r\nWorld\n", new String[]{"Hello", "\r\n", "World", "\n"}, 1024);
         test( "Hello\nWorld\r", new String[]{"Hello", "\n", "World", "\r"}, 1024);
@@ -32,7 +32,7 @@ public class CsvLineReaderCRTest {
     }
 
     @Test
-    public void test3() throws IOException {
+    public void testAllCases() throws IOException {
         boolean crNewline = true;
         test("", new String[]{}, 5);
 
@@ -65,8 +65,6 @@ public class CsvLineReaderCRTest {
 
         // CASE 7 : configBufferSize=5
         // 1234\rA
-    }
-    @Test    public void test4() throws IOException {
         test( "123456", new String[]{"123456", ""}, 5);
         test( "12345", new String[]{"12345", ""}, 5);
         test( "1234\rA", new String[]{"1234", "\r", "A", ""}, 5);

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/CsvLineReaderCRTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/CsvLineReaderCRTest.java
@@ -8,74 +8,67 @@ import java.io.IOException;
 import java.io.StringReader;
 
 public class CsvLineReaderCRTest {
-    void test(String s, String[] expected, boolean skipCarriageReturnIn0D0A, boolean crNewline, int configBufferSize) throws IOException {
-        CsvLineReaderCR r = new CsvLineReaderCR(new StringReader(s), skipCarriageReturnIn0D0A, crNewline,
-                1024, configBufferSize);
+    void test(String s, String[] expected, int configBufferSize) throws IOException {
+        CsvLineReaderCR r = new CsvLineReaderCR(new StringReader(s), 1024, configBufferSize);
 
         for(int i=0; ; i++) {
             String line = r.readLine();
             if( line == null ) break;
             Assert.assertTrue( i < expected.length );
             Assert.assertEquals(r.getLineNumber(), i+1);
-            Assert.assertEquals( expected[i], line);
+            Assert.assertEquals( expected[i*2], line);
+            Assert.assertEquals( expected[i*2+1], r.getCurrentLineEnding());
         }
-        Assert.assertEquals( expected.length, r.getLineNumber() );
+        Assert.assertEquals( expected.length/2, r.getLineNumber() );
 
     }
     @Test
     public void test1() throws IOException {
-        test( "Hello\nWorld\n", new String[]{"Hello", "World"}, true, false, 1024);
-        test( "Hello\nWorld\n", new String[]{"Hello", "World"}, false, false,1024);
-    }
-    @Test
-    public void test2() throws IOException {
-        test( "Hello\r\nWorld\r\n", new String[]{"Hello", "World"}, true, false,1024);
-        test( "Hello\r\nWorld\r\n", new String[]{"Hello\r", "World\r"}, false, false,1024);
+        test( "Hello\nWorld\n", new String[]{"Hello", "\n", "World", "\n"}, 1024);
+        test( "Hello\r\nWorld\n", new String[]{"Hello", "\r\n", "World", "\n"}, 1024);
+        test( "Hello\nWorld\r", new String[]{"Hello", "\n", "World", "\r"}, 1024);
+        test( "Hello\r\nWorld\r\n", new String[]{"Hello", "\r\n", "World", "\r\n"}, 1024);
+        test( "Hello\rWorld", new String[]{"Hello", "\r", "World", ""}, 1024);
     }
 
     @Test
     public void test3() throws IOException {
         boolean crNewline = true;
-        test("", new String[]{}, true, false,5);
+        test("", new String[]{}, 5);
 
-        // CASE 1 : skipCarriageReturnIn0D0A=true/false, configBufferSize=10
+        // CASE 1 : configBufferSize=10
         // 1234\n
-        test("1234\n", new String[]{"1234"}, true, false,10);
-        // CASE 2 : skipCarriageReturnIn0D0A=true/false, configBufferSize=10
+        test("1234\n", new String[]{"1234", "\n"}, 10);
+        // CASE 2 : configBufferSize=10
         // 1234<EOF>
-        test("1234", new String[]{"1234"}, true, false,10);
+        test("1234", new String[]{"1234", ""}, 10);
 
-        // CASE 3 : skipCarriageReturnIn0D0A=true, configBufferSize=20
+        // CASE 3 : configBufferSize=20
         // 123\r\n123\r\n
-        test("123\r\n123\r\nabc\n", new String[]{"123", "123", "abc"}, true, false,20);
-        test("123\r\n123\r\nabc\n", new String[]{"123\r", "123\r", "abc"}, false, false,20);
+        test("123\r\n123\r\nabc\n", new String[]{"123", "\r\n", "123", "\r\n", "abc", "\n"}, 20);
 
 
-        // CASE 4 : skipCarriageReturnIn0D0A=true, configBufferSize=20
+        // CASE 4 : configBufferSize=20
         // 123\r123\r\n
 
-        test("123\r123\r\nabc\n", new String[]{"123", "123", "abc"}, true, true, 20);
-        test("123\r123\r\nabc\n", new String[]{"123\r123\r", "abc"}, false, true, 20);
-        test("123\r123\r\nabc\n", new String[]{"123\r123", "abc"}, true, false, 20);
-        test("123\r123\r\nabc\n", new String[]{"123\r123\r", "abc"}, false, false, 20);
+        test("123\r123\r\nabc\n", new String[]{"123", "\r", "123", "\r\n", "abc", "\n"}, 20);
 
-        // CASE 5 : skipCarriageReturnIn0D0A=true, configBufferSize=5
+        // CASE 5 : configBufferSize=5
         // 1234\r<EOF>
-        test("1234\r", new String[]{"1234"}, true, false, 5);
-        test("1234\r", new String[]{"1234\r"}, false, false, 5);
+        test("1234\r", new String[]{"1234", "\r"}, 5);
         //test("1234\r", new String[]{"1234\r"}, false, 5);
 
-        // CASE 6 : skipCarriageReturnIn0D0A=true, configBufferSize=5
+        // CASE 6 : configBufferSize=5
         // 1234\r\n
         // abc\r\n
-        test("1234\r\nabc\r\n", new String[]{"1234", "abc"}, true, false,5);
-        test("1234\r\nabc\r\n", new String[]{"1234\r", "abc\r"}, false, false,5);
+        test("1234\r\nabc\r\n", new String[]{"1234", "\r\n", "abc", "\r\n"}, 5);
 
-        // CASE 7 : skipCarriageReturnIn0D0A=true, configBufferSize=5
+        // CASE 7 : configBufferSize=5
         // 1234\rA
     }
     @Test    public void test4() throws IOException {
-        test( "1234\rA", new String[]{"1234", "A"}, true, false,5);
-        //test( "1234\rA", new String[]{"1234\rA"}, true, 5);
+        test( "123456", new String[]{"123456", ""}, 5);
+        test( "12345", new String[]{"12345", ""}, 5);
+        test( "1234\rA", new String[]{"1234", "\r", "A", ""}, 5);
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/CsvLineReaderCRTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/CsvLineReaderCRTest.java
@@ -8,8 +8,8 @@ import java.io.IOException;
 import java.io.StringReader;
 
 public class CsvLineReaderCRTest {
-    void test(String s, String[] expected, boolean skipCarriageReturn, boolean crNewline, int configBufferSize) throws IOException {
-        CsvLineReaderCR r = new CsvLineReaderCR(new StringReader(s), skipCarriageReturn, crNewline,
+    void test(String s, String[] expected, boolean skipCarriageReturnIn0D0A, boolean crNewline, int configBufferSize) throws IOException {
+        CsvLineReaderCR r = new CsvLineReaderCR(new StringReader(s), skipCarriageReturnIn0D0A, crNewline,
                 1024, configBufferSize);
 
         for(int i=0; ; i++) {
@@ -38,20 +38,20 @@ public class CsvLineReaderCRTest {
         boolean crNewline = true;
         test("", new String[]{}, true, false,5);
 
-        // CASE 1 : skipCarriageReturn=true/false, configBufferSize=10
+        // CASE 1 : skipCarriageReturnIn0D0A=true/false, configBufferSize=10
         // 1234\n
         test("1234\n", new String[]{"1234"}, true, false,10);
-        // CASE 2 : skipCarriageReturn=true/false, configBufferSize=10
+        // CASE 2 : skipCarriageReturnIn0D0A=true/false, configBufferSize=10
         // 1234<EOF>
         test("1234", new String[]{"1234"}, true, false,10);
 
-        // CASE 3 : skipCarriageReturn=true, configBufferSize=20
+        // CASE 3 : skipCarriageReturnIn0D0A=true, configBufferSize=20
         // 123\r\n123\r\n
         test("123\r\n123\r\nabc\n", new String[]{"123", "123", "abc"}, true, false,20);
         test("123\r\n123\r\nabc\n", new String[]{"123\r", "123\r", "abc"}, false, false,20);
 
 
-        // CASE 4 : skipCarriageReturn=true, configBufferSize=20
+        // CASE 4 : skipCarriageReturnIn0D0A=true, configBufferSize=20
         // 123\r123\r\n
 
         test("123\r123\r\nabc\n", new String[]{"123", "123", "abc"}, true, true, 20);
@@ -59,19 +59,19 @@ public class CsvLineReaderCRTest {
         test("123\r123\r\nabc\n", new String[]{"123\r123", "abc"}, true, false, 20);
         test("123\r123\r\nabc\n", new String[]{"123\r123\r", "abc"}, false, false, 20);
 
-        // CASE 5 : skipCarriageReturn=true, configBufferSize=5
+        // CASE 5 : skipCarriageReturnIn0D0A=true, configBufferSize=5
         // 1234\r<EOF>
         test("1234\r", new String[]{"1234"}, true, false, 5);
         test("1234\r", new String[]{"1234\r"}, false, false, 5);
         //test("1234\r", new String[]{"1234\r"}, false, 5);
 
-        // CASE 6 : skipCarriageReturn=true, configBufferSize=5
+        // CASE 6 : skipCarriageReturnIn0D0A=true, configBufferSize=5
         // 1234\r\n
         // abc\r\n
         test("1234\r\nabc\r\n", new String[]{"1234", "abc"}, true, false,5);
         test("1234\r\nabc\r\n", new String[]{"1234\r", "abc\r"}, false, false,5);
 
-        // CASE 7 : skipCarriageReturn=true, configBufferSize=5
+        // CASE 7 : skipCarriageReturnIn0D0A=true, configBufferSize=5
         // 1234\rA
     }
     @Test    public void test4() throws IOException {

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsImportIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsImportIT.java
@@ -2155,7 +2155,8 @@ public class HdfsImportIT extends SpliceUnitTest {
         File tempDir = createTempDirectory(spliceSchemaWatcher.schemaName);
         String path = tempDir.toString() + "/lineEndings.csv";
         try {
-            // we're using a file here to have better control over what \r and \n we use
+            // we're writing a file here instead of having a file as resource
+            // to have better control over what \r and \n we use
             // (otherwise needs special editor, git converting line endings etc.)
             String data =
                     "\"Hello\r\nWindows\"|1|Win\r\n" + // 0D0A = Windows
@@ -2164,11 +2165,11 @@ public class HdfsImportIT extends SpliceUnitTest {
                     "\"ciao\"|4|ciao";                 // ends with EOF
             Files.write(Paths.get(path), data.getBytes());
 
-            String[] configs = {
-                    "call SYSCS_UTIL.BULK_IMPORT_HFILE('%s', '%s', null, '%s', '|', null, null, null, null, 0, '/tmp', false, null, '/tmp', false)",
-                    "call SYSCS_UTIL.IMPORT_DATA('%s', '%s', null, '%s', '|', null, null, null, null, 0, '/tmp', false, null)",
-                    "call SYSCS_UTIL.LOAD_REPLACE('%s', '%s', null, '%s', '|', null, null, null, null, 0, '/tmp', false, null)"
-                };
+            List<String> configs = new ArrayList<>();
+            configs.add("call SYSCS_UTIL.IMPORT_DATA('%s', '%s', null, '%s', '|', null, null, null, null, 0, '/tmp', false, null)");
+            configs.add("call SYSCS_UTIL.LOAD_REPLACE('%s', '%s', null, '%s', '|', null, null, null, null, 0, '/tmp', false, null)");
+            if( !isMemPlatform(spliceClassWatcher) ) // bulk import hfile not available on MEM platform
+                configs.add("call SYSCS_UTIL.BULK_IMPORT_HFILE('%s', '%s', null, '%s', '|', null, null, null, null, 0, '/tmp', false, null, '/tmp', false)");
 
             String preserveStr ="V1       |C1 | V2  |\n" +
                     "--------------------------\n" +

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsImportIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsImportIT.java
@@ -2122,27 +2122,6 @@ public class HdfsImportIT extends SpliceUnitTest {
         Assert.assertEquals(expected, result);
     }
 
-    @Test
-    public void testAnalyzeExternalTable() throws Exception {
-        String path = getResourceDirectory() + "parquet_simple_file_test";
-
-        try (ResultSet rs = methodWatcher.executeQuery("CALL SYSCS_UTIL.ANALYZE_EXTERNAL_TABLE('" + path + "')") ) {
-            StringBuilder sb = new StringBuilder();
-            while( rs.next() ) {
-                sb.append(rs.getString(1) + "\n");
-            }
-            String expected = "CREATE EXTERNAL TABLE T (\n" +
-                    " column1 CHAR/VARCHAR(x),\n" +
-                    " column2 CHAR/VARCHAR(x),\n" +
-                    " partition1 CHAR/VARCHAR(x) \n" +
-                    ") PARTITIONED BY(\n" +
-                    " partition1 \n" +
-                    ")\n" +
-                    " STORED AS PARQUET LOCATION '%s';\n";
-            Assert.assertEquals(String.format(expected, path),  sb.toString());
-        }
-    }
-
     public static void setPreserveLineEndings(Connection conn, Boolean preserve) throws Exception {
         try( Statement s = conn.createStatement()) {
             s.executeUpdate("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( " +

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsImportIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsImportIT.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.derby.impl.load;
 
+import com.splicemachine.db.iapi.reference.Property;
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceTableWatcher;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
@@ -2143,7 +2144,7 @@ public class HdfsImportIT extends SpliceUnitTest {
     public static void setSkipCarriageReturn(Connection conn, Boolean skipCR) throws Exception {
         try( Statement s = conn.createStatement()) {
             s.executeUpdate("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( " +
-                    "'splice.function.skipCarriageReturn', '" + skipCR + "' )");
+                    "'" + Property.SPLICE_SKIP_CARRIAGE_RETURN_IN_0D0A + "', '" + skipCR + "' )");
         }
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/stream/function/csv/QuoteTrackingTokenizerTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/stream/function/csv/QuoteTrackingTokenizerTest.java
@@ -145,7 +145,7 @@ public class QuoteTrackingTokenizerTest {
         String invalidRow = "\"hello\",\"wrong\ncell\",goodbye\n";
         try {
             CsvParserConfig config = new CsvParserConfig(CsvPreference.STANDARD_PREFERENCE)
-                    .oneLineRecord(true).quotedEmptyIsNull(true).skipCarriageReturnIn0D0A(true);
+                    .oneLineRecord(true).quotedEmptyIsNull(true).preserveLineEndings(true);
             QuoteTrackingTokenizer qtt = new QuoteTrackingTokenizer(new StringReader(invalidRow), config);
             List<String> columns = new ArrayList<>();
             qtt.readColumns(columns);
@@ -174,11 +174,11 @@ public class QuoteTrackingTokenizerTest {
     }
 
     private static void checkResults(String row, List<String> expectedColumns, BooleanList expectedQuotes,
-                                     boolean quotedEmptyIsNull, boolean skipCarriageReturnIn0D0A, int size,
+                                     boolean quotedEmptyIsNull, boolean preserveLineEndings, int size,
                                      boolean triggerScan) throws IOException {
         QuoteTrackingTokenizer qtt = null;
         CsvParserConfig config = new CsvParserConfig(CsvPreference.STANDARD_PREFERENCE)
-                .oneLineRecord(false).quotedEmptyIsNull(quotedEmptyIsNull).skipCarriageReturnIn0D0A(skipCarriageReturnIn0D0A);
+                .oneLineRecord(false).quotedEmptyIsNull(quotedEmptyIsNull).preserveLineEndings(preserveLineEndings);
         if(triggerScan) {
             qtt = new QuoteTrackingTokenizer(new StringReader(row), config,
                     1, Collections.nCopies(expectedColumns.size(), 10));
@@ -212,8 +212,6 @@ public class QuoteTrackingTokenizerTest {
 
     private static class CSVBuilder {
         private final boolean oneLineRecord;
-        private StringBuilder sb = new StringBuilder();
-
         private Random random = new Random();
 
         CSVBuilder(boolean oneLineRecord) {

--- a/splice_machine/src/test/java/com/splicemachine/derby/stream/function/csv/QuoteTrackingTokenizerTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/stream/function/csv/QuoteTrackingTokenizerTest.java
@@ -12,7 +12,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.splicemachine.derby.stream.function;
+package com.splicemachine.derby.stream.function.csv;
 
 import com.splicemachine.derby.stream.utils.BooleanList;
 import org.junit.Assert;
@@ -144,7 +144,9 @@ public class QuoteTrackingTokenizerTest {
     public void quotedMultiRowRecordWithOneLineRecordSetThrowsProperly() throws Exception {
         String invalidRow = "\"hello\",\"wrong\ncell\",goodbye\n";
         try {
-            QuoteTrackingTokenizer qtt = new QuoteTrackingTokenizer(new StringReader(invalidRow), CsvPreference.STANDARD_PREFERENCE, true, true);
+            CsvParserConfig config = new CsvParserConfig(CsvPreference.STANDARD_PREFERENCE)
+                    .oneLineRecord(true).quotedEmptyIsNull(true).skipCarriageReturn(true);
+            QuoteTrackingTokenizer qtt = new QuoteTrackingTokenizer(new StringReader(invalidRow), config);
             List<String> columns = new ArrayList<>();
             qtt.readColumns(columns);
             Assert.fail("expected exception to be thrown, but no exception was thrown");
@@ -156,17 +158,19 @@ public class QuoteTrackingTokenizerTest {
         Assert.fail("expected exception to be thrown, but no exception was thrown");
     }
 
-
     private static void checkResults(String row, List<String> expectedColumns, BooleanList expectedQuotes, boolean quotedEmptyIsNull, int size) throws IOException {
         checkResults(row, expectedColumns, expectedQuotes, quotedEmptyIsNull, size, false);
     }
 
     private static void checkResults(String row, List<String> expectedColumns, BooleanList expectedQuotes, boolean quotedEmptyIsNull, int size, boolean triggerScan) throws IOException {
         QuoteTrackingTokenizer qtt = null;
+        CsvParserConfig config = new CsvParserConfig(CsvPreference.STANDARD_PREFERENCE)
+                .oneLineRecord(false).quotedEmptyIsNull(quotedEmptyIsNull);
         if(triggerScan) {
-            qtt = new QuoteTrackingTokenizer(new StringReader(row), CsvPreference.STANDARD_PREFERENCE, false, quotedEmptyIsNull, 1, Collections.nCopies(expectedColumns.size(), 10));
+            qtt = new QuoteTrackingTokenizer(new StringReader(row), config,
+                    1, Collections.nCopies(expectedColumns.size(), 10));
         } else {
-            qtt = new QuoteTrackingTokenizer(new StringReader(row), CsvPreference.STANDARD_PREFERENCE, false, quotedEmptyIsNull);
+            qtt = new QuoteTrackingTokenizer(new StringReader(row), config);
         }
         List<String> actualColumns = new ArrayList<>(size);
         BooleanList actualQuotes = new BooleanList(size);
@@ -177,7 +181,9 @@ public class QuoteTrackingTokenizerTest {
 
     private static void checkResults(String column, List<List<String>> expectedColumns, List<BooleanList> expectedQuotes,
                                      List<List<Integer>> expectedValueSizes, int size, List<Integer> valueSizes, boolean oneLineRecord) throws IOException {
-        QuoteTrackingTokenizer qtt = new QuoteTrackingTokenizer(new StringReader(column), CsvPreference.STANDARD_PREFERENCE, oneLineRecord, true, 1, valueSizes);
+        CsvParserConfig config = new CsvParserConfig(CsvPreference.STANDARD_PREFERENCE)
+                .oneLineRecord(oneLineRecord).quotedEmptyIsNull(true);
+        QuoteTrackingTokenizer qtt = new QuoteTrackingTokenizer(new StringReader(column), config, 1, valueSizes);
 
         List<String> cols = new ArrayList<>(size);
         BooleanList quoteCols = new BooleanList(size);

--- a/splice_machine/src/test/java/com/splicemachine/derby/stream/function/csv/QuoteTrackingTokenizerTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/stream/function/csv/QuoteTrackingTokenizerTest.java
@@ -159,12 +159,15 @@ public class QuoteTrackingTokenizerTest {
     }
 
     @Test
-    public void testSkipCarriageReturnIn0D0A() throws Exception {
-        //String row = "abc\n\"a line\r\nis great\"\nefg\n";
+    public void testPreserveLineEndings() throws Exception {
         String row = "abc,\"a line\r\nis great\",\"another\nline!\",efg\n";
-        List<String> correctCols = Arrays.asList("abc", "a line\r\nis great", "another\nline!", "efg");
         BooleanList correctQuotes = BooleanList.wrap(false, true, true, false);
-        checkResults(row, correctCols, correctQuotes, true, false, correctCols.size(), false);
+        List<String> correctColsPreserved = Arrays.asList("abc", "a line\r\nis great", "another\nline!", "efg");
+        checkResults(row, correctColsPreserved, correctQuotes, true,
+                true, correctColsPreserved.size(), false);
+        List<String> correctColsNoPreserved = Arrays.asList("abc", "a line\nis great", "another\nline!", "efg");
+        checkResults(row, correctColsNoPreserved, correctQuotes, true,
+                false, correctColsNoPreserved.size(), false);
     }
 
     private static void checkResults(String row, List<String> expectedColumns, BooleanList expectedQuotes,

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
@@ -1221,4 +1221,11 @@ public class SpliceUnitTest {
             Assert.assertEquals(expectedOutput, rs.getString(1));
         }
     }
+
+    public static boolean isMemPlatform(SpliceWatcher watcher) throws Exception{
+        try (ResultSet rs = watcher.executeQuery("CALL SYSCS_UTIL.SYSCS_IS_MEM_PLATFORM()")) {
+            rs.next();
+            return ((Boolean)rs.getObject(1));
+        }
+    }
 }

--- a/splice_machine/src/test/test-data/newline.csv
+++ b/splice_machine/src/test/test-data/newline.csv
@@ -1,4 +1,0 @@
-"Hello
-World"|1
-"Hello
-Newline"|2

--- a/splice_machine/src/test/test-data/newline.csv
+++ b/splice_machine/src/test/test-data/newline.csv
@@ -1,0 +1,4 @@
+"Hello
+World"|1
+"Hello
+Newline"|2


### PR DESCRIPTION
if splice.function.preserveLineEndings = true, multiline strings imported into the database will contain the `\r`, `\r\n`, `\n` exactly like in file. Otherwise (current default) all these will be replaced by `\n`.