### PR TITLE
DB-11084:  Fix DB-10773 join plan performance regression.

### DIFF
--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SelectivityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SelectivityIT.java
@@ -817,7 +817,7 @@ public class SelectivityIT extends SpliceUnitTest {
     }
 
     @Test
-    @Ignore("DB-11083")
+   // @Ignore("DB-11083")
     public void testJoinPredsWithOverlappingColumns() throws Exception {
         rowContainsQuery(2,"explain select * from t11 a, t11 b, t11 c where a.a = b.a and b.a = c.a and a.a = c.a","outputRows=10,",methodWatcher);
         rowContainsQuery(2,"explain select * from t11 a --splice-properties joinStrategy=nestedloop\n" +

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SelectivityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SelectivityIT.java
@@ -817,7 +817,6 @@ public class SelectivityIT extends SpliceUnitTest {
     }
 
     @Test
-   // @Ignore("DB-11083")
     public void testJoinPredsWithOverlappingColumns() throws Exception {
         rowContainsQuery(2,"explain select * from t11 a, t11 b, t11 c where a.a = b.a and b.a = c.a and a.a = c.a","outputRows=10,",methodWatcher);
         rowContainsQuery(2,"explain select * from t11 a --splice-properties joinStrategy=nestedloop\n" +


### PR DESCRIPTION
Only unconditionally record a hinted join as best cost if the previous best cost join is not a hinted join.