### PR TITLE
DB-11067/DB-11111 SpliceCatalogUpgradeScripts UpgradeScriptForTablePriorities fix, cleanup, tests (3.1)

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -849,8 +849,8 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
         Splice_DD_Version catalogVersion=(Splice_DD_Version)tc.getProperty(SPLICE_DATA_DICTIONARY_VERSION);
         if(needToUpgrade(catalogVersion)){
             tc.elevate("dictionary");
-            SpliceCatalogUpgradeScripts scripts=new SpliceCatalogUpgradeScripts(this,catalogVersion,tc);
-            scripts.run();
+            SpliceCatalogUpgradeScripts scripts=new SpliceCatalogUpgradeScripts(this, tc);
+            scripts.runUpgrades(catalogVersion);
             tc.setProperty(SPLICE_DATA_DICTIONARY_VERSION,spliceSoftwareVersion,true);
             tc.commit();
         }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/Splice_DD_Version.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/Splice_DD_Version.java
@@ -117,4 +117,9 @@ public class Splice_DD_Version extends DD_Version {
         return majorVersionNumber * 10000000000l + minorVersionNumber * 10000000l + patchVersionNumber * 10000l + sprintVersionNumber;
     }
 
+    static public int compare(Splice_DD_Version version1,Splice_DD_Version version2){
+        long v1=version1.toLong();
+        long v2=version2.toLong();
+        return Long.compare(v1, v2);
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -21,10 +21,7 @@ import com.splicemachine.derby.impl.sql.catalog.SpliceDataDictionary;
 import com.splicemachine.derby.impl.sql.catalog.Splice_DD_Version;
 import com.splicemachine.si.impl.driver.SIDriver;
 import org.apache.log4j.Logger;
-
-import java.util.Comparator;
-import java.util.NavigableSet;
-import java.util.TreeMap;
+import java.util.*;
 
 /**
  * Created by jyuan on 10/14/14.
@@ -33,57 +30,107 @@ public class SpliceCatalogUpgradeScripts{
     protected static final Logger LOG=Logger.getLogger(SpliceCatalogUpgradeScripts.class);
 
     SpliceDataDictionary sdd;
-    Splice_DD_Version catalogVersion;
     TransactionController tc;
-    TreeMap<Splice_DD_Version, UpgradeScript> scripts;
-    Comparator<Splice_DD_Version> ddComparator;
-    
-    public SpliceCatalogUpgradeScripts(SpliceDataDictionary sdd,Splice_DD_Version catalogVersion,TransactionController tc){
+
+    List<VersionAndUpgrade> scripts;
+
+    public static class VersionAndUpgrade {
+        public Splice_DD_Version version;
+        public UpgradeScript script;
+
+        public VersionAndUpgrade(Splice_DD_Version version,UpgradeScript script) {
+            this.version = version;
+            this.script = script;
+        }
+    }
+
+    public void addUpgradeScript(Splice_DD_Version version, int sprint, UpgradeScript script)
+    {
+        scripts.add(new VersionAndUpgrade(new Splice_DD_Version(sdd, version.getMajorVersionNumber(),
+                version.getMinorVersionNumber(), version.getPatchVersionNumber(), sprint), script));
+    }
+
+    // master / branch-3.0 / branch-3.1
+    // baseVersion1 = 2.8.0 / 2.8.0 / 2.8.0
+    // baseVersion2 = 3.1.0 / 3.1.0 / 3.0.0 // 3. fork
+    // baseVersion3 = 3.1.0 / 3.1.0 / 3.0.1 // hickup on branch 3.0
+    // baseVersion4 = 3.2.0 / 3.1.0 / 3.0.1 // 3.2 fork
+
+    static final public Splice_DD_Version baseVersion1 = new Splice_DD_Version(null, 2, 8, 0);
+    static final public Splice_DD_Version baseVersion2 = new Splice_DD_Version(null, 3, 1, 0);
+    static final public Splice_DD_Version baseVersion3 = baseVersion2;
+    static final public Splice_DD_Version baseVersion4 = baseVersion2;
+
+    public SpliceCatalogUpgradeScripts(SpliceDataDictionary sdd, TransactionController tc){
         this.sdd=sdd;
-        this.catalogVersion=catalogVersion;
         this.tc=tc;
 
-        ddComparator=new Comparator<Splice_DD_Version>(){
-            @Override
-            public int compare(Splice_DD_Version version1,Splice_DD_Version version2){
-                long v1=version1.toLong();
-                long v2=version2.toLong();
+        scripts = new ArrayList<>();
+        addUpgradeScript(baseVersion1, 1901, new UpgradeScriptToRemoveUnusedBackupTables(sdd,tc));
+        addUpgradeScript(baseVersion1, 1909, new UpgradeScriptForReplication(sdd, tc));
+        addUpgradeScript(baseVersion1, 1917, new UpgradeScriptForMultiTenancy(sdd,tc));
+        addUpgradeScript(baseVersion1, 1924, new UpgradeScriptToAddPermissionViewsForMultiTenancy(sdd,tc));
 
-                if(v1<v2)
-                    return -1;
-                else if(v1==v2)
-                    return 0;
-                else
-                    return 1;
-            }
-        };
-        scripts=new TreeMap<>(ddComparator);
-        scripts.put(new Splice_DD_Version(sdd,2,8,0, 1901), new UpgradeScriptToRemoveUnusedBackupTables(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,2,8,0, 1909), new UpgradeScriptForReplication(sdd, tc));
-        scripts.put(new Splice_DD_Version(sdd,2,8,0, 1917), new UpgradeScriptForMultiTenancy(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,2,8,0, 1924), new UpgradeScriptToAddPermissionViewsForMultiTenancy(sdd,tc));
+        addUpgradeScript(baseVersion2, 1933, new UpgradeScriptToUpdateViewForSYSCONGLOMERATEINSCHEMAS(sdd,tc));
+        addUpgradeScript(baseVersion2, 1938, new UpgradeScriptForTriggerWhenClause(sdd,tc));
+        addUpgradeScript(baseVersion2, 1940, new UpgradeScriptForReplicationSystemTables(sdd,tc));
+        addUpgradeScript(baseVersion2, 1941, new UpgradeScriptForTableColumnViewInSYSIBM(sdd,tc));
 
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1933), new UpgradeScriptToUpdateViewForSYSCONGLOMERATEINSCHEMAS(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1938), new UpgradeScriptForTriggerWhenClause(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1940), new UpgradeScriptForReplicationSystemTables(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1941), new UpgradeScriptForTableColumnViewInSYSIBM(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1948), new UpgradeScriptForAddDefaultToColumnViewInSYSIBM(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1953), new UpgradeScriptForRemoveUnusedIndexInSYSFILESTable(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1959), new UpgradeScriptForTriggerMultipleStatements(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1962), new UpgradeScriptForAddDefaultToColumnViewInSYSVW(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1964), new UpgradeScriptForAliasToTableView(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1970), new UpgradeScriptForAddTablesAndViewsInSYSIBMADM(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1971), new UpgradeScriptToAddCatalogVersion(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1974), new UpgradeScriptToAddMinRetentionPeriodColumnToSYSTABLES(sdd, tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1977), new UpgradeScriptToAddSysKeyColUseViewInSYSIBM(sdd, tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1979), new UpgradeScriptForTablePriorities(sdd, tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1979), new UpgradeScriptToSetJavaClassNameColumnInSYSALIASES(sdd, tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1983), new UpgradeScriptToAddBaseTableSchemaColumnsToSysTablesInSYSIBM(sdd,tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1985), new UpgradeScriptToAddSysNaturalNumbersTable(sdd, tc));
-        scripts.put(new Splice_DD_Version(sdd,3,1,0, 1989), new UpgradeScriptToAddIndexColUseViewInSYSCAT(sdd, tc));
+        addUpgradeScript(baseVersion2, 1948, new UpgradeScriptForAddDefaultToColumnViewInSYSIBM(sdd,tc));
+        addUpgradeScript(baseVersion2, 1953, new UpgradeScriptForRemoveUnusedIndexInSYSFILESTable(sdd,tc));
+        addUpgradeScript(baseVersion2, 1959, new UpgradeScriptForTriggerMultipleStatements(sdd,tc));
+        addUpgradeScript(baseVersion2, 1962, new UpgradeScriptForAddDefaultToColumnViewInSYSVW(sdd,tc));
+
+        addUpgradeScript(baseVersion2, 1964, new UpgradeScriptForAliasToTableView(sdd,tc));
+        addUpgradeScript(baseVersion2, 1970, new UpgradeScriptForAddTablesAndViewsInSYSIBMADM(sdd,tc));
+        addUpgradeScript(baseVersion2, 1971, new UpgradeScriptToAddCatalogVersion(sdd,tc));
+        addUpgradeScript(baseVersion2, 1974, new UpgradeScriptToAddMinRetentionPeriodColumnToSYSTABLES(sdd, tc));
+
+        addUpgradeScript(baseVersion2, 1977, new UpgradeScriptToAddSysKeyColUseViewInSYSIBM(sdd, tc));
+        addUpgradeScript(baseVersion3, 1979, new UpgradeScriptToSetJavaClassNameColumnInSYSALIASES(sdd, tc));
+
+        addUpgradeScript(baseVersion4, 1983, new UpgradeScriptToAddBaseTableSchemaColumnsToSysTablesInSYSIBM(sdd,tc));
+        addUpgradeScript(baseVersion4, 1985, new UpgradeScriptToAddSysNaturalNumbersTable(sdd, tc));
+        addUpgradeScript(baseVersion4, 1989, new UpgradeScriptToAddIndexColUseViewInSYSCAT(sdd, tc));
+        addUpgradeScript(baseVersion4, 1992, new UpgradeScriptForTablePriorities(sdd, tc));
+
+        // remember to add your script to SpliceCatalogUpgradeScriptsTest too, otherwise test fails
     }
-    public void run() throws StandardException{
 
+    public static List<VersionAndUpgrade> getScriptsToUpgrade(List<VersionAndUpgrade> scripts,
+                                                              Splice_DD_Version currentVersion)
+    {
+        List<VersionAndUpgrade> upgradeNeeded = new ArrayList<>();
+        for(VersionAndUpgrade el : scripts){
+            if(currentVersion!=null){
+                if(Splice_DD_Version.compare(el.version,currentVersion)<=0){
+                    continue;
+                }
+            }
+            upgradeNeeded.add(el);
+        }
+        return upgradeNeeded;
+    }
+
+    public List<VersionAndUpgrade> getScripts() {
+        return scripts;
+    }
+
+    public static void runAllScripts(List<VersionAndUpgrade> upgradeNeeded) throws StandardException {
+        if( upgradeNeeded.size() == 0 ) {
+            LOG.info("No upgrade needed.");
+            return;
+        }
+        LOG.info("Running " + upgradeNeeded.size() + " upgrade scripts:");
+        for( VersionAndUpgrade el : upgradeNeeded ) {
+            LOG.info("Running upgrade script " + el.version + ": " + el.script.getClass().getName());
+            el.script.run();
+        }
+        LOG.info("upgrade done.");
+    }
+
+    public void runUpgrades(Splice_DD_Version catalogVersion) throws StandardException{
+        LOG.info("Catalog is on version " + catalogVersion + ". checking for upgrades...");
         // Set the current version to upgrade from.
         // This flag should only be true for the master server.
         Splice_DD_Version currentVersion=catalogVersion;
@@ -91,21 +138,13 @@ public class SpliceCatalogUpgradeScripts{
         if(configuration.upgradeForced()) {
             currentVersion=new Splice_DD_Version(null,configuration.getUpgradeForcedFrom());
         }
-
-        NavigableSet<Splice_DD_Version> keys=scripts.navigableKeySet();
-        for(Splice_DD_Version version : keys){
-            if(currentVersion!=null){
-                if(ddComparator.compare(version,currentVersion)<=0){
-                    continue;
-                }
-            }
-            UpgradeScript script=scripts.get(version);
-            script.run();
-        }
+        runAllScripts(getScriptsToUpgrade(scripts, currentVersion));
 
         // Always update system procedures and stored statements
-        sdd.clearSPSPlans();
-        sdd.createOrUpdateAllSystemProcedures(tc);
-        sdd.updateMetadataSPSes(tc);
+        if( sdd != null ) {
+            sdd.clearSPSPlans();
+            sdd.createOrUpdateAllSystemProcedures(tc);
+            sdd.updateMetadataSPSes(tc);
+        }
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -50,11 +50,21 @@ public class SpliceCatalogUpgradeScripts{
                 version.getMinorVersionNumber(), version.getPatchVersionNumber(), sprint), script));
     }
 
-    // master / branch-3.0 / branch-3.1
-    // baseVersion1 = 2.8.0 / 2.8.0 / 2.8.0
-    // baseVersion2 = 3.1.0 / 3.1.0 / 3.0.0 // 3. fork
-    // baseVersion3 = 3.1.0 / 3.1.0 / 3.0.1 // hickup on branch 3.0
-    // baseVersion4 = 3.2.0 / 3.1.0 / 3.0.1 // 3.2 fork
+    // Upgrade scripts should be mostly the same on master/3.0/3.1.
+    // However the base versions (i.e. major.minor.patch without sprint) are different.
+    // e.g. UpgradeScriptToAddSysNaturalNumbersTable is for sprint 1985, which is [baseVersion4, 1985].
+    // that means on master = 3.2.0.1985, branch-3.0 = 3.1.0.1985, branch-3.0 = 3.0.1.1985.
+
+    // following table gives an overview over different base versions in the branches
+    //                 master | branch-3.0 | branch-3.1 | remarks
+    // baseVersion1 =  2.8.0  |   2.8.0    |   2.8.0    |
+    // baseVersion2 =  3.1.0  |   3.1.0    |   3.0.0    | 2.8 -> 3.x fork
+    // baseVersion3 =  3.1.0  |   3.1.0    |   3.0.1    | hickup on branch 3.0
+    // baseVersion4 =  3.2.0  |   3.1.0    |   3.0.1    | 3.2 fork
+    // ...
+    // baseVersionX = ...                               | add here new versions
+    //
+    // also check SpliceCatalogUpgradeScriptsTest for some unit tests for this.
 
     static final public Splice_DD_Version baseVersion1 = new Splice_DD_Version(null, 2, 8, 0);
     static final public Splice_DD_Version baseVersion2 = new Splice_DD_Version(null, 3, 1, 0);

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
@@ -1,0 +1,117 @@
+package com.splicemachine.derby.utils;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.derby.impl.sql.catalog.Splice_DD_Version;
+import com.splicemachine.derby.impl.sql.catalog.upgrade.SpliceCatalogUpgradeScripts;
+import com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScript;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SpliceCatalogUpgradeScriptsTest {
+    String s1 =
+            "VERSION2.1938: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptForTriggerWhenClause\n" +
+            "VERSION2.1940: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptForReplicationSystemTables\n" +
+            "VERSION2.1941: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptForTableColumnViewInSYSIBM\n" +
+            "VERSION2.1948: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptForAddDefaultToColumnViewInSYSIBM\n" +
+            "VERSION2.1953: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptForRemoveUnusedIndexInSYSFILESTable\n" +
+            "VERSION2.1959: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptForTriggerMultipleStatements\n" +
+            "VERSION2.1962: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptForAddDefaultToColumnViewInSYSVW\n" +
+            "VERSION2.1964: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptForAliasToTableView\n" +
+            "VERSION2.1970: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptForAddTablesAndViewsInSYSIBMADM\n" +
+            "VERSION2.1971: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToAddCatalogVersion\n" +
+            "VERSION2.1974: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToAddMinRetentionPeriodColumnToSYSTABLES\n" +
+            "VERSION2.1977: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToAddSysKeyColUseViewInSYSIBM\n" +
+            "VERSION3.1979: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToSetJavaClassNameColumnInSYSALIASES\n" +
+            "VERSION4.1983: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToAddBaseTableSchemaColumnsToSysTablesInSYSIBM\n" +
+            "VERSION4.1985: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToAddSysNaturalNumbersTable\n";
+
+    String s2 = "VERSION4.1989: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToAddIndexColUseViewInSYSCAT\n" +
+            "VERSION4.1992: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptForTablePriorities\n";
+    // add more scripts here
+
+    private String replaceVersions(String s) {
+        return s.replace("VERSION2", SpliceCatalogUpgradeScripts.baseVersion2.toString())
+                .replace("VERSION3", SpliceCatalogUpgradeScripts.baseVersion3.toString())
+                .replace("VERSION4", SpliceCatalogUpgradeScripts.baseVersion4.toString());
+    }
+
+    @Test
+    public void test_since_1933()
+    {
+        SpliceCatalogUpgradeScripts s = new SpliceCatalogUpgradeScripts(null, null);
+        Splice_DD_Version version = new Splice_DD_Version(null, 3,1,0, 1933);
+        List<SpliceCatalogUpgradeScripts.VersionAndUpgrade> list =
+                SpliceCatalogUpgradeScripts.getScriptsToUpgrade(s.getScripts(), version);
+        Assert.assertEquals(replaceVersions(s1 + s2), getUpgradeScriptsToStr(list));
+    }
+
+    @Test
+    public void test_since_1987()
+    {
+        SpliceCatalogUpgradeScripts s = new SpliceCatalogUpgradeScripts(null, null);
+        Splice_DD_Version version = new Splice_DD_Version(null, 3,1,0, 1987);
+        List<SpliceCatalogUpgradeScripts.VersionAndUpgrade> list =
+                SpliceCatalogUpgradeScripts.getScriptsToUpgrade(s.getScripts(), version);
+        Assert.assertEquals(replaceVersions(s2), getUpgradeScriptsToStr(list));
+    }
+
+    @Test
+    public void test_since_2000_upgrade_empty()
+    {
+        SpliceCatalogUpgradeScripts s = new SpliceCatalogUpgradeScripts(null, null);
+        Splice_DD_Version version = new Splice_DD_Version(null, 4,0,0, 2000);
+        List<SpliceCatalogUpgradeScripts.VersionAndUpgrade> list =
+                SpliceCatalogUpgradeScripts.getScriptsToUpgrade(s.getScripts(), version);
+        Assert.assertEquals("", getUpgradeScriptsToStr(list));
+    }
+
+    @Test
+    public void test_upgrade_run() throws StandardException {
+        List<SpliceCatalogUpgradeScripts.VersionAndUpgrade> list = new ArrayList<>();
+        final int[] counter = {0};
+        UpgradeScript s = new UpgradeScript() {
+            @Override
+            public void run() throws StandardException {
+                // nothing
+                counter[0]++;
+            }
+        };
+        // add unsorted and multiple for one version
+        list.add(new SpliceCatalogUpgradeScripts.VersionAndUpgrade(new Splice_DD_Version(null, 3,1,0, 1900), s));
+        list.add(new SpliceCatalogUpgradeScripts.VersionAndUpgrade(new Splice_DD_Version(null, 3,1,0, 1900), s));
+        list.add(new SpliceCatalogUpgradeScripts.VersionAndUpgrade(new Splice_DD_Version(null, 2,8,0, 1930), s));
+        list.add(new SpliceCatalogUpgradeScripts.VersionAndUpgrade(new Splice_DD_Version(null, 3,1,0, 1940), s));
+
+        Assert.assertEquals( 4, SpliceCatalogUpgradeScripts.getScriptsToUpgrade(list,
+                new Splice_DD_Version(null, 2,7,0, 1999)).size() );
+        Assert.assertEquals( 4, SpliceCatalogUpgradeScripts.getScriptsToUpgrade(list,
+                new Splice_DD_Version(null, 2,8,0, 1900)).size() );
+        Assert.assertEquals( 3, SpliceCatalogUpgradeScripts.getScriptsToUpgrade(list,
+                new Splice_DD_Version(null, 3,0,0, 1999)).size() );
+        Assert.assertEquals( 3, SpliceCatalogUpgradeScripts.getScriptsToUpgrade(list,
+                new Splice_DD_Version(null, 3,1,0, 1899)).size() );
+        Assert.assertEquals( 1, SpliceCatalogUpgradeScripts.getScriptsToUpgrade(list,
+                new Splice_DD_Version(null, 3,1,0, 1900)).size() );
+        Assert.assertEquals( 1, SpliceCatalogUpgradeScripts.getScriptsToUpgrade(list,
+                new Splice_DD_Version(null, 3,1,0, 1939)).size() );
+        Assert.assertEquals( 0, SpliceCatalogUpgradeScripts.getScriptsToUpgrade(list,
+                new Splice_DD_Version(null, 3,1,0, 1940)).size() );
+        Assert.assertEquals( 0, SpliceCatalogUpgradeScripts.getScriptsToUpgrade(list,
+                new Splice_DD_Version(null, 4,0,0, 0)).size() );
+
+        SpliceCatalogUpgradeScripts.runAllScripts(list);
+        Assert.assertEquals(4, counter[0]);
+    }
+
+    String getUpgradeScriptsToStr(List<SpliceCatalogUpgradeScripts.VersionAndUpgrade> upgradeNeeded)
+    {
+        StringBuilder sb = new StringBuilder(100);
+        for( SpliceCatalogUpgradeScripts.VersionAndUpgrade el : upgradeNeeded ) {
+            sb.append(el.version + ": " + el.script.getClass().getName() + "\n");
+        }
+        return sb.toString();
+    }
+}

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
@@ -36,6 +36,7 @@ public class SpliceCatalogUpgradeScriptsTest {
         return s.replace("VERSION2", SpliceCatalogUpgradeScripts.baseVersion2.toString())
                 .replace("VERSION3", SpliceCatalogUpgradeScripts.baseVersion3.toString())
                 .replace("VERSION4", SpliceCatalogUpgradeScripts.baseVersion4.toString());
+        // add more base versions here.
     }
 
     @Test


### PR DESCRIPTION
- SpliceCatalogUpgradeScripts can run multiple scripts for one version 
- fix UpgradeScriptForTablePriorities not running
- added some sort of tests for SpliceCatalogUpgradeScripts
- aligned master/3.0/3.1 code
- cleaned up upgrade scripts (see DB-11111)