### PR TITLE
DB-11103 Fix Jenkins pipeline for scm pull

### DIFF
--- a/pipelines/spliceengine-branch/Jenkinsfile
+++ b/pipelines/spliceengine-branch/Jenkinsfile
@@ -113,7 +113,7 @@ node('spliceengine'){
                     echo "export newsrcver=\${newsrcver}" >> branch.env
                     echo "\${newsrcver}" > version.txt
                     mvn -B -e --fail-at-end clean -DskipTests
-                    cp pipelines/spot-bugs/template/settings.xml ~/.m2/settings.xml
+                    cp pipelines/template/settings.xml ~/.m2/settings.xml
                     sed  -i "s/REPLACE_USER/$ARTIFACT_USER/" ~/.m2/settings.xml
                     sed  -i "s/REPLACE_PASS/$ARTIFACT_PASSWORD/" ~/.m2/settings.xml
                     mvn -B -e --fail-at-end verify -Pmem,core,${params.PLATFORM},ee

--- a/pipelines/spliceengine-core/Jenkinsfile
+++ b/pipelines/spliceengine-core/Jenkinsfile
@@ -40,7 +40,7 @@ node('splice-standalone'){
                 wrap([$class: 'VaultBuildWrapper', vaultSecrets: artifact_values]) {
                     sh """
                     mvn -Dmaven.test.failure.ignore=true -B -e --fail-at-end clean install -Pcore -DskipTests
-                    cp pipelines/spot-bugs/template/settings.xml ~/.m2/settings.xml
+                    cp pipelines/template/settings.xml ~/.m2/settings.xml
                     sed  -i "s/REPLACE_USER/$ARTIFACT_USER/" ~/.m2/settings.xml
                     sed  -i "s/REPLACE_PASS/$ARTIFACT_PASSWORD/" ~/.m2/settings.xml
                     mvn -B -e --fail-at-end deploy -Pcore,splicemachine-internal,splicemachine-external

--- a/pipelines/spliceengine-jdbc/Jenkinsfile
+++ b/pipelines/spliceengine-jdbc/Jenkinsfile
@@ -49,7 +49,7 @@ node('splice-standalone'){
                 wrap([$class: 'VaultBuildWrapper', vaultSecrets: artifact_values]) {
                     sh """
                     mvn -Dmaven.test.failure.ignore=true -B -e --fail-at-end clean install -Pcore -DskipTests
-                    cp pipelines/spot-bugs/template/settings.xml ~/.m2/settings.xml
+                    cp pipelines/template/settings.xml ~/.m2/settings.xml
                     sed  -i "s/REPLACE_USER/$ARTIFACT_USER/" ~/.m2/settings.xml
                     sed  -i "s/REPLACE_PASS/$ARTIFACT_PASSWORD/" ~/.m2/settings.xml
                     mvn -B -e --fail-at-end install -Pcore,cdh3.0,ee,parcel

--- a/pipelines/spliceengine-platform/Jenkinsfile
+++ b/pipelines/spliceengine-platform/Jenkinsfile
@@ -71,7 +71,7 @@ def generateStage(platform,slackResponse) {
                         export PATH=/opt/ant/bin:/opt/maven/bin:${PATH}:${PATH}
                         export MAVEN_OPTS="-Xmx4096m -Djava.awt.headless=true -Xms64m -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=30 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=YYYY-MM-dd|HH:mm:ss,SSS"
                         mvn -B -e --fail-at-end clean install -Pcore -DskipTests
-                        cp pipelines/spot-bugs/template/settings.xml ~/.m2/settings.xml
+                        cp pipelines/template/settings.xml ~/.m2/settings.xml
                         sed  -i "s/REPLACE_USER/$ARTIFACT_USER/" ~/.m2/settings.xml
                         sed  -i "s/REPLACE_PASS/$ARTIFACT_PASSWORD/" ~/.m2/settings.xml
                         mvn -B -e --fail-at-end install -Pcore,${platform},ee -Dexcluded.categories=com.splicemachine.test.SlowTest -Dmaven.test.redirectTestOutputToFile=true

--- a/pipelines/standalone/Jenkinsfile
+++ b/pipelines/standalone/Jenkinsfile
@@ -62,7 +62,7 @@ node('spliceengine') {
             dir('infrastructure-support/build-support/scripts/standalone/spliceengine'){
                 sh """
                     mkdir -p  ~/.m2/
-                    cp pipelines/spot-bugs/template/settings.xml ~/.m2/settings.xml
+                    cp pipelines/template/settings.xml ~/.m2/settings.xml
                     sed  -i "s/REPLACE_USER/${ARTIFACT_USER}/" ~/.m2/settings.xml
                     sed  -i "s/REPLACE_PASS/${ARTIFACT_PASSWORD}/" ~/.m2/settings.xml
                 """


### PR DESCRIPTION
Fix settings.xml location in Jenkinsfile that moved the template file from spot-bugs folder to one level higher. This fixes errors in the pipeline related to not being able to find the settings.xml