### PR TITLE
DB-11117 NPE in getPreserveLineEndings/SpliceFileVTI (3.0)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextService.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextService.java
@@ -47,6 +47,7 @@ public final class ContextService{
 
     private static volatile ContextService factory;
     private static volatile boolean stopped;
+    private static int highWaterMark = 1000;
 
     private HeaderPrintWriter errorStream;
 
@@ -395,10 +396,10 @@ public final class ContextService{
 
         synchronized(allContexts) {
             allContexts.add(cm);
-        }
-
-        if (allContexts.size() > 1000) {
-            LOG.error("memoryLeakTrace:allContexts " + allContexts.size());
+            if (allContexts.size() > highWaterMark) {
+                highWaterMark += 100;
+                LOG.warn("memoryLeakTrace:allContexts " + allContexts.size());
+            }
         }
 
         return cm;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextService.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/context/ContextService.java
@@ -47,8 +47,8 @@ public final class ContextService{
 
     private static volatile ContextService factory;
     private static volatile boolean stopped;
-    private static int highWaterMark = 1000;
 
+    private int highWaterMark = 1000;
     private HeaderPrintWriter errorStream;
 
     /**
@@ -396,7 +396,7 @@ public final class ContextService{
 
         synchronized(allContexts) {
             allContexts.add(cm);
-            if (allContexts.size() > highWaterMark) {
+            if (allContexts.size() >= highWaterMark) {
                 highWaterMark += 100;
                 LOG.warn("memoryLeakTrace:allContexts " + allContexts.size());
             }


### PR DESCRIPTION
Create a delegating ContextManager. No need to push LCC using initCurrentLCC() (will be available from the parent ContextManager). Cleanup must be done on the same thread. Newly created ContextManager must be destroyed.
I'm also fixing memory leak warnings in ContextService.

