### PR TITLE
DB-11140 Fix testCrossJoinBroadcastRightNoHint

### DIFF
--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SparkExplainIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SparkExplainIT.java
@@ -833,7 +833,7 @@ public class SparkExplainIT extends SpliceUnitTest {
                 "        t1 --splice-properties useSpark=true\n" +
                 "        inner join big on 1=1";
         // expecting broadcast on the right side and BIG table is on the left side
-        String[] expectedList2 = {"BroadcastNestedLoopJoin BuildRight, Cross", ":- Scan ExistingRDD[]", "-> TableScan[BIG("};
+        String[] expectedList2 = {"BroadcastNestedLoopJoin BuildRight, Cross", "Scan ExistingRDD[]", "-> TableScan[BIG("};
         rowContainsQuery(new int[]{5, 6, 7}, sqlText, methodWatcher, expectedList2);
     }
 


### PR DESCRIPTION
Spark explain has slightly different text in spark 3.0, so need to fix up this IT.
http://nexus.splicemachine.com:8080/job/spliceengine-3.0/job/spliceengine-platform/platform=dbaas3.0/727/testReport/junit/com.splicemachine.derby.impl.sql.execute.operations/SparkExplainIT/testCrossJoinBroadcastRightNoHint_0_/