### PR TITLE
DB-11136 Use SYNC_WAL in standalone

### DIFF
--- a/platform_it/pom.xml
+++ b/platform_it/pom.xml
@@ -1099,7 +1099,7 @@
             </activation>
             <properties>
                 <memberNumber>1</memberNumber>
-                <durability>ASYNC</durability>
+                <durability>SYNC</durability>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
ASYNC_WAL doesn't eventually force a SYNC as I thought, so we need to
use SYNC_WAL if we want durability for standalone. See
https://issues.apache.org/jira/browse/HBASE-16689 for details