### PR TITLE
DB-11176 Remove cdh/hdp repository from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,26 +29,10 @@
             <id>splicemachine</id>
             <url>http://nexus.splicemachine.com/nexus/content/groups/developers</url>
         </repository>
-        <repository>
-            <id>cloudera</id>
-            <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
-        </repository>
-        <repository>
-            <id>mapr</id>
-            <url>http://repository.mapr.com/maven/</url>
-        </repository>
-        <repository>
-            <id>hortonworks-releases</id>
-            <url>http://repo.hortonworks.com/content/repositories/releases/</url>
-        </repository>
-        <repository>
-            <id>hortonworks-hadoop</id>
-            <url>http://repo.hortonworks.com/content/repositories/jetty-hadoop/</url>
-        </repository>
          <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
-	</repository>
+	    </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>


### PR DESCRIPTION
Currently we have a proxy for these repositories in our nexus repository (splicemachine). After removing my local maven cache and the repositories, my instance is able to successfully build. Therefore this PR removes the redundant endpoints since if maven is not able to find the jars in our repository, then it wouldn't find it in the other repositories either.

Also took out the mapr repo since we also mirror that repository