### PR TITLE
DB-11091 fix null expr. evluation with NOT.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateSimplificationVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateSimplificationVisitor.java
@@ -162,6 +162,13 @@ class PredicateSimplificationVisitor implements Visitor {
                 }
             }
             if (node instanceof InListOperatorNode) {
+                if(parent instanceof NotNode) {
+                    for (int i = 0; i < rightOperands.size(); i++) {
+                        if (rightOperands.elementAt(i) instanceof UntypedNullConstantNode) {
+                            return (ValueNode)rightOperands.elementAt(i);
+                        }
+                    }
+                }
                 for (int i = rightOperands.size() - 1; i >= 0; i--) {
                     if (rightOperands.elementAt(i) instanceof UntypedNullConstantNode) {
                         rightOperands.removeElementAt(i);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateSimplificationVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateSimplificationVisitor.java
@@ -100,7 +100,12 @@ class PredicateSimplificationVisitor implements Visitor {
     // parameterized queries.
     @Override
     public Visitable visit(Visitable node, QueryTreeNode parent) throws StandardException {
-        if (node instanceof AndNode) {
+        if(node instanceof NotNode) {
+            NotNode nn = (NotNode)node;
+            if(nn.operand instanceof UntypedNullConstantNode) {
+                return nn.operand;
+            }
+        } else if (node instanceof AndNode) {
             AndNode an = (AndNode)node;
             if (isBooleanTrue(an.getLeftOperand())) {
                 return an.getRightOperand();

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NullPredicateIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NullPredicateIT.java
@@ -191,9 +191,79 @@ public class NullPredicateIT extends SpliceUnitTest {
     }
 
     @Test
+    public void testNotWithNullInInList_1() throws Exception {
+        String query = format("select count(*) from T --SPLICE-PROPERTIES useSpark=%s\n" +
+                                      "where a not in (cast(null as int), 5)", useSpark);
+
+        String expected = "1 |\n" +
+                "----\n" +
+                " 1 |";
+
+        try(ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        }
+    }
+
+    @Test
+    public void testNotWithNullInInList_2() throws Exception {
+        String query = format("select count(*) from T --SPLICE-PROPERTIES useSpark=%s\n" +
+                                      "where cast(null as int) not in (3, 5)", useSpark);
+
+        String expected = "1 |\n" +
+                "----\n" +
+                " 0 |";
+
+        try(ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        }
+    }
+
+    @Test
     public void testNullInJoinCondition() throws Exception {
         String query = format("select count(*) from T --SPLICE-PROPERTIES useSpark=%s\n" +
                 " inner join T on cast(null as boolean)", useSpark);
+
+        String expected = "1 |\n" +
+                "----\n" +
+                " 0 |";
+
+        try(ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        }
+    }
+
+    @Test
+    public void testNotWithNullInJoinCondition() throws Exception {
+        String query = format("select count(*) from T --SPLICE-PROPERTIES useSpark=%s\n" +
+                                      " inner join T on not cast(null as boolean)", useSpark);
+
+        String expected = "1 |\n" +
+                "----\n" +
+                " 0 |";
+
+        try(ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        }
+    }
+
+    @Test
+    public void testInListWithNullInJoinCondition() throws Exception {
+        String query = format("select count(*) from T --SPLICE-PROPERTIES useSpark=%s\n" +
+                                      " inner join T on cast(null as boolean) in (42)", useSpark);
+
+        String expected = "1 |\n" +
+                "----\n" +
+                " 0 |";
+
+        try(ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        }
+    }
+
+    @Test
+    public void testNotWithInListWithNullInJoinCondition() throws Exception {
+        String query = format("select count(*) from T --SPLICE-PROPERTIES useSpark=%s\n" +
+                                      " inner join T on cast(null as boolean) not in (42)", useSpark);
 
         String expected = "1 |\n" +
                 "----\n" +

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NullPredicateIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NullPredicateIT.java
@@ -197,7 +197,7 @@ public class NullPredicateIT extends SpliceUnitTest {
 
         String expected = "1 |\n" +
                 "----\n" +
-                " 1 |";
+                " 0 |";
 
         try(ResultSet rs = methodWatcher.executeQuery(query)) {
             Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));


### PR DESCRIPTION
In this PR we fix an issue with evaluating `null` expressions with `NOT` operator, during simplification, we simplify expressions like `NOT <NullExpr>` to `<NullExpr>` which will be simplified further later on as in e.g. join-condition expressions where we simply replace `<NullExpr>` with `false`.

Please have a look `NullPredicateIT.java` for example cases.