### PR TITLE
DB-11186 Don't add null cell iterator to TxnPartition batchGet results.

### DIFF
--- a/mem_storage/src/main/java/com/splicemachine/si/impl/TxnPartition.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/TxnPartition.java
@@ -99,7 +99,12 @@ public class TxnPartition implements Partition{
         List<DataResult> results = new ArrayList<>(rowKeys.size());
         for(byte[] key:rowKeys){
             get.setKey(key);
-            results.add(basePartition.get(get,null));
+            // Another task may have deleted the cells associated
+            // with this rowkey.
+            // Check for null before adding to the list.
+            DataResult dataResult = basePartition.get(get,null);
+            if (dataResult != null)
+                results.add(dataResult);
         }
         return results.iterator();
     }


### PR DESCRIPTION
Fixes a malformed list of Cell iterators that may happen when running concurrent triggers.  A null Cell iterator should not be added to the list. 

> ============= begin nested exception, level (2) ===========
> java.lang.NullPointerException
>         at com.splicemachine.derby.impl.store.access.base.SpliceController.batchFetch(SpliceController.java:197)
>         at com.splicemachine.derby.impl.store.access.base.SpliceController.fetch(SpliceController.java:164)
>         at com.splicemachine.derby.impl.store.access.base.SpliceController.fetch(SpliceController.java:160)
>         at com.splicemachine.db.impl.sql.catalog.TabInfoImpl.deleteRows(TabInfoImpl.java:782)
>         at com.splicemachine.db.impl.sql.catalog.TabInfoImpl.deleteRow(TabInfoImpl.java:640)
>         at com.splicemachine.db.impl.sql.catalog.DataDictionaryImpl.dropDependentsStoredDependencies(DataDictionaryImpl.java:6182)
>         at com.splicemachine.db.impl.sql.depend.BasicDependencyManager.clearDependencies(BasicDependencyManager.java:525)
>         at com.splicemachine.db.iapi.sql.dictionary.SPSDescriptor.compileStatement(SPSDescriptor.java:324)
>         at com.splicemachine.db.iapi.sql.dictionary.SPSDescriptor.prepareAndRelease(SPSDescriptor.java:218)
>         at com.splicemachine.db.iapi.sql.dictionary.SPSDescriptor.getPreparedStatement(SPSDescriptor.java:577)
>         at com.splicemachine.db.iapi.sql.dictionary.SPSDescriptor.getPreparedStatement(SPSDescriptor.java:519)
>         at com.splicemachine.db.impl.sql.execute.GenericTriggerExecutor.compile(GenericTriggerExecutor.java:308)
>         at com.splicemachine.db.impl.sql.execute.GenericTriggerExecutor.executeSPS(GenericTriggerExecutor.java:162)
>         at com.splicemachine.db.impl.sql.execute.GenericTriggerExecutor.executeWhenClauseAndAction(GenericTriggerExecutor.java:375)
>         at com.splicemachine.db.impl.sql.execute.RowTriggerExecutor.fireTrigger(RowTriggerExecutor.java:82)
>         at com.splicemachine.db.impl.sql.execute.TriggerEventActivator$1.apply(TriggerEventActivator.java:374)
>         at com.splicemachine.db.impl.sql.execute.TriggerEventActivator$1.apply(TriggerEventActivator.java:344)
>         at com.splicemachine.derby.impl.sql.execute.operations.TriggerHandler$1$1.call(TriggerHandler.java:253)
>         at com.splicemachine.derby.impl.sql.execute.operations.TriggerHandler$1$1.call(TriggerHandler.java:237)
>         at java.util.concurrent.FutureTask.run(FutureTask.java:266)
>         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
>         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
>         at java.lang.Thread.run(Thread.java:745)
> ============= end nested exception, level (2) ===========

http://nexus.splicemachine.com:8080/job/spliceengine-master/job/spliceengine-platform/env=mem/2793/testReport/junit/com.splicemachine.triggers/Trigger_Referencing_Clause_IT/testConcurrentTriggers3_0_/