### PR TITLE
DB-11220 Re-do DB-11186.

### DIFF
--- a/mem_storage/src/main/java/com/splicemachine/si/impl/TxnPartition.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/TxnPartition.java
@@ -99,12 +99,7 @@ public class TxnPartition implements Partition{
         List<DataResult> results = new ArrayList<>(rowKeys.size());
         for(byte[] key:rowKeys){
             get.setKey(key);
-            // Another task may have deleted the cells associated
-            // with this rowkey.
-            // Check for null before adding to the list.
-            DataResult dataResult = basePartition.get(get,null);
-            if (dataResult != null)
-                results.add(dataResult);
+            results.add(basePartition.get(get,null));
         }
         return results.iterator();
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceController.java
@@ -15,6 +15,7 @@
 package com.splicemachine.derby.impl.store.access.base;
 
 import com.carrotsearch.hppc.BitSet;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import splice.com.google.common.base.Function;
 import splice.com.google.common.collect.Lists;
 import com.splicemachine.access.api.PartitionFactory;
@@ -168,6 +169,7 @@ public abstract class SpliceController implements ConglomerateController{
         return batchFetch(locations,destRows,validColumns,false);
     }
     @Override
+    @SuppressFBWarnings(value="REC_CATCH_EXCEPTION", justification = "intentional")
     public boolean batchFetch(List<RowLocation> locations, List<ExecRow> destRows, FormatableBitSet validColumns, boolean waitForLock) throws StandardException{
         if (locations.size() != destRows.size())
             return false;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceController.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceController.java
@@ -194,6 +194,10 @@ public abstract class SpliceController implements ConglomerateController{
                 ExecRow row = new ValueRow(destRow.length);
                 row.setRowArray(destRow);
                 row.resetRowArray();
+                if (result == null) {
+                    i++;
+                    continue;
+                }
                 DataCell keyValue = result.userData();
                 rowDecoder.set(keyValue.valueArray(), keyValue.valueOffset(), keyValue.valueLength());
                 rowDecoder.decode(row);


### PR DESCRIPTION
This reimplements DB-11186 by ignoring the null cell entries instead of not adding them to the list of found entries.  Some interfaces rely on checking whether a base row exists by checking the ordinal position of the results list for a null or empty cell.