### PR TITLE
DB-11225 Prepend hdfs or file URI tag when adding jars to SparkContext.

### DIFF
--- a/platform_it/pom.xml
+++ b/platform_it/pom.xml
@@ -1055,6 +1055,7 @@
                                     ${hbase.rootdir}
                                     -Dlog4j.configuration=${log4j.config.uri}
                                     -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=4025
+                                    -Dsplice.olapServerOnStandAlone=true
                                     -enableassertions
                                     -Djava.net.preferIPv4Stack=true
                                     -Djava.security.krb5.conf=${project.build.directory}/krb5.conf


### PR DESCRIPTION
For splice in the cloud (both standalone and cluster), the path names of application jar files in the UpdateLoader do not start with file:/// or hdfs:/// as expected by SparkContext.addJar.  This fix adds them, if missing, so that the fix for DB-10759 functions properly in the cloud.

See [DB-11225](https://splicemachine.atlassian.net/browse/DB-11225?focusedCommentId=73427)