### PR TITLE
DB-11126 support CURRENT TIMEZONE.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryArithmeticOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryArithmeticOperatorNode.java
@@ -134,6 +134,8 @@ public final class BinaryArithmeticOperatorNode extends BinaryOperatorNode
     public ValueNode bindExpression( FromList	fromList, SubqueryList subqueryList, List<AggregateNode> aggregateVector) throws StandardException {
         if (leftOperand instanceof TimeSpanNode || rightOperand instanceof TimeSpanNode) {
             return bindTimeSpanOperation(fromList, subqueryList, aggregateVector);
+        } else if(timezoneArithmetic(leftOperand, rightOperand)) {
+            return bindTimezoneOperation(fromList, subqueryList, aggregateVector);
         }
         super.bindExpression(fromList, subqueryList, aggregateVector);
 
@@ -220,6 +222,51 @@ public final class BinaryArithmeticOperatorNode extends BinaryOperatorNode
         );
 
         return this;
+    }
+
+    private boolean timezoneArithmetic(ValueNode left, ValueNode right) throws StandardException {
+        if(left instanceof CurrentDatetimeOperatorNode && ((CurrentDatetimeOperatorNode)left).isCurrentTimezone()) {
+            throw StandardException.newException(SQLState.LANG_INVALID_TIMEZONE_OPERATION);
+        }
+        if(!(right instanceof CurrentDatetimeOperatorNode)) {
+            return false;
+        }
+        if(!((CurrentDatetimeOperatorNode)right).isCurrentTimezone()) {
+            return false;
+        }
+        return true;
+    }
+
+    private ValueNode bindTimezoneOperation(FromList fromList,
+                                            SubqueryList subqueryList,
+                                            List<AggregateNode> aggregateVector) throws StandardException {
+        leftOperand.bindExpression(fromList, subqueryList, aggregateVector);
+        if (leftOperand.requiresTypeFromContext()) {
+            // Reference:
+            // https://www.ibm.com/support/knowledgecenter/SSEPGG_11.5.0/com.ibm.db2.luw.sql.ref.doc/doc/r0053561.html, Table 1
+            throw StandardException.newException(SQLState.LANG_DB2_INVALID_DATETIME_EXPR);
+        }
+        if (!"+".equals(operator) && !"-".equals(operator) || !leftOperand.getTypeId().isDateTimeTimeStampTypeId()) {
+            throw StandardException.newException(SQLState.LANG_INVALID_TIMEZONE_OPERATION);
+        }
+        String functionName = "TIMEZONE_SUBTRACT";
+        if(operator.equals("+")) {
+            functionName = "TIMEZONE_ADD";
+        }
+        MethodCallNode methodNode = (MethodCallNode) getNodeFactory().getNode(
+                C_NodeTypes.STATIC_METHOD_CALL_NODE,
+                functionName,
+                "com.splicemachine.derby.utils.SpliceDateFunctions",
+                getContextManager()
+        );
+        Vector<ValueNode> parameterList = new Vector<>();
+        parameterList.addElement(leftOperand);
+        parameterList.addElement(rightOperand);
+        methodNode.addParms(parameterList);
+        return ((ValueNode) getNodeFactory().getNode(
+                C_NodeTypes.JAVA_TO_SQL_VALUE_NODE,
+                methodNode,
+                getContextManager())).bindExpression(fromList, subqueryList, aggregateVector);
     }
 
     private ValueNode bindTimeSpanOperation(FromList fromList,

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryArithmeticOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryArithmeticOperatorNode.java
@@ -246,7 +246,10 @@ public final class BinaryArithmeticOperatorNode extends BinaryOperatorNode
             // https://www.ibm.com/support/knowledgecenter/SSEPGG_11.5.0/com.ibm.db2.luw.sql.ref.doc/doc/r0053561.html, Table 1
             throw StandardException.newException(SQLState.LANG_DB2_INVALID_DATETIME_EXPR);
         }
-        if (!"+".equals(operator) && !"-".equals(operator) || !leftOperand.getTypeId().isDateTimeTimeStampTypeId()) {
+        if (!"+".equals(operator) && !"-".equals(operator)) {
+            throw StandardException.newException(SQLState.LANG_INVALID_TIMEZONE_OPERATION);
+        }
+        if(leftOperand.getTypeId().getJDBCTypeId() != Types.TIMESTAMP && leftOperand.getTypeId().getJDBCTypeId() != Types.TIME) {
             throw StandardException.newException(SQLState.LANG_INVALID_TIMEZONE_OPERATION);
         }
         String functionName = "TIMEZONE_SUBTRACT";

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CurrentDatetimeOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CurrentDatetimeOperatorNode.java
@@ -150,6 +150,8 @@ public class CurrentDatetimeOperatorNode extends ValueNode {
             case CURRENT_TIMEZONE:
                 setType(DataTypeDescriptor.getSQLDataTypeDescriptor("java.math.BigDecimal", 6, 0, true, 6));
                 break;
+            default:
+                assert false;
         }
 
         return this;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExpressionClassBuilder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExpressionClassBuilder.java
@@ -63,393 +63,393 @@ import java.lang.reflect.Modifier;
  * FilterClassBuilder. See the documentation on ActivationClassBuilder.
  *
  */
-public abstract	class ExpressionClassBuilder implements ExpressionClassBuilderInterface
+public abstract class ExpressionClassBuilder implements ExpressionClassBuilderInterface
 {
-	///////////////////////////////////////////////////////////////////////
-	//
-	// CONSTANTS
-	//
-	///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    //
+    // CONSTANTS
+    //
+    ///////////////////////////////////////////////////////////////////////
 
-	static final protected String currentDatetimeFieldName = "cdt";
+    static final protected String currentDatetimeFieldName = "cdt";
 
-	///////////////////////////////////////////////////////////////////////
-	//
-	// STATE
-	//
-	///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    //
+    // STATE
+    //
+    ///////////////////////////////////////////////////////////////////////
 
-	protected ClassBuilder cb;
-	protected GeneratedClass gc;
-	protected int nextExprNum;
-	protected int nextNonFastExpr;
-	protected int nextFieldNum;
-	protected MethodBuilder constructor;
-	CompilerContext myCompCtx;
-	MethodBuilder executeMethod; // to find it fast
+    protected ClassBuilder cb;
+    protected GeneratedClass gc;
+    protected int nextExprNum;
+    protected int nextNonFastExpr;
+    protected int nextFieldNum;
+    protected MethodBuilder constructor;
+    CompilerContext myCompCtx;
+    MethodBuilder executeMethod; // to find it fast
     MethodBuilder materializationMethod;
-	MethodBuilder subqueryResultSetMethod;
+    MethodBuilder subqueryResultSetMethod;
 
-	protected LocalField cdtField;
+    protected LocalField cdtField;
 
-	//protected final JavaFactory javaFac;
+    //protected final JavaFactory javaFac;
 
-	private String currentRowScanResultSetName;
+    private String currentRowScanResultSetName;
 
 
-	///////////////////////////////////////////////////////////////////////
-	//
-	// CONSTRUCTORS
-	//
-	///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    //
+    // CONSTRUCTORS
+    //
+    ///////////////////////////////////////////////////////////////////////
 
-	/**
-	 * By the time this is done, it has constructed the following class:
-	 * <pre>
-	 *    public class #className extends #superClass {
-	 *		public #className() { super(); }
-	 *    }
-	 * </pre>
-	 *
-	 * @exception StandardException thrown on failure
-	 */
-	ExpressionClassBuilder (String superClass, String className, CompilerContext cc ) 
-		throws StandardException
-	{
-		int modifiers = Modifier.PUBLIC | Modifier.FINAL;
+    /**
+     * By the time this is done, it has constructed the following class:
+     * <pre>
+     *    public class #className extends #superClass {
+     *  public #className() { super(); }
+     *    }
+     * </pre>
+     *
+     * @exception StandardException thrown on failure
+     */
+    ExpressionClassBuilder (String superClass, String className, CompilerContext cc )
+        throws StandardException
+    {
+        int modifiers = Modifier.PUBLIC | Modifier.FINAL;
 
-		myCompCtx = cc;
-		JavaFactory javaFac = myCompCtx.getJavaFactory();
+        myCompCtx = cc;
+        JavaFactory javaFac = myCompCtx.getJavaFactory();
 
-		if ( className == null ) { className = myCompCtx.getUniqueClassName(); }
+        if ( className == null ) { className = myCompCtx.getUniqueClassName(); }
 
-		// start the class
-		cb = javaFac.newClassBuilder(myCompCtx.getClassFactory(),
-			getPackageName(), modifiers,
-			className, superClass);
+        // start the class
+        cb = javaFac.newClassBuilder(myCompCtx.getClassFactory(),
+            getPackageName(), modifiers,
+            className, superClass);
 
-		beginConstructor();
-	}
+        beginConstructor();
+    }
 
-	///////////////////////////////////////////////////////////////////////
-	//
-	// ABSTRACT METHODS TO BE IMPLEMENTED BY CHILDREN
-	//
-	///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    //
+    // ABSTRACT METHODS TO BE IMPLEMENTED BY CHILDREN
+    //
+    ///////////////////////////////////////////////////////////////////////
 
-	/**
-	 * Get the name of the package that the generated class will live in.
-	 *
-	 *	@return	name of package that the generated class will live in.
-	 */
-	abstract	String	getPackageName();
+    /**
+     * Get the name of the package that the generated class will live in.
+     *
+     * @return name of package that the generated class will live in.
+     */
+    abstract String getPackageName();
 
-	/**
-	 * Get the number of ExecRows that must be allocated
-	 *
-	 *	@return	number of ExecRows that must be allocated
-	 *
-	 * 	@exception StandardException thrown on failure
-	 */
-	abstract	int		getRowCount()
-		 throws StandardException;
+    /**
+     * Get the number of ExecRows that must be allocated
+     *
+     * @return number of ExecRows that must be allocated
+     *
+     *  @exception StandardException thrown on failure
+     */
+    abstract int  getRowCount()
+         throws StandardException;
 
-	/**
-	 * Sets the number of subqueries under this expression
-	 *
-	 *
-	 * 	@exception StandardException thrown on failure
-	 */
-	abstract	void 	setNumSubqueries()
-		 throws StandardException;
+    /**
+     * Sets the number of subqueries under this expression
+     *
+     *
+     *  @exception StandardException thrown on failure
+     */
+    abstract void  setNumSubqueries()
+         throws StandardException;
 
     abstract void setDataSetProcessorType(DataSetProcessorType type)
          throws StandardException;
 
-	abstract void setSparkExecutionType(SparkExecutionType type)
-			throws StandardException;
+    abstract void setSparkExecutionType(SparkExecutionType type)
+            throws StandardException;
 
-	///////////////////////////////////////////////////////////////////////
-	//
-	// ACCESSORS
-	//
-	///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    //
+    // ACCESSORS
+    //
+    ///////////////////////////////////////////////////////////////////////
 
-	/**
-		Return the base class of the activation's hierarchy
-		(the subclass of Object).
+    /**
+        Return the base class of the activation's hierarchy
+        (the subclass of Object).
 
-		This class is expected to hold methods used by all
-		compilation code, such as datatype compilation code,
-		e.g. getDataValueFactory.
-	 */
-	abstract String getBaseClassName();
+        This class is expected to hold methods used by all
+        compilation code, such as datatype compilation code,
+        e.g. getDataValueFactory.
+     */
+    abstract String getBaseClassName();
 
-	MethodBuilder getConstructor() {
-		return constructor;
-	}
+    MethodBuilder getConstructor() {
+        return constructor;
+    }
 
-	ClassBuilder getClassBuilder() {
-		return cb;
-	}
+    ClassBuilder getClassBuilder() {
+        return cb;
+    }
 
-	/**
+    /**
      * Get the execute method in order to add code to it.
      * Added code will be executed for each execution
      * of the activation. StatementNode completes the
      * execute method so that code added by other nodes
      * will be executed before the ResultSet is created
      * using fillResultSet. 
-	 */
-	MethodBuilder getExecuteMethod() {
-		return executeMethod;
-	}
+     */
+    MethodBuilder getExecuteMethod() {
+        return executeMethod;
+    }
 
-	MethodBuilder getMaterializationMethod() {
+    MethodBuilder getMaterializationMethod() {
         return materializationMethod;
     }
 
-	MethodBuilder getSubqueryResultSetMethod() {
-		return subqueryResultSetMethod;
-	}
-	///////////////////////////////////////////////////////////////////////
-	//
-	// CONSTRUCTOR MANAGEMENT
-	//
-	///////////////////////////////////////////////////////////////////////
+    MethodBuilder getSubqueryResultSetMethod() {
+        return subqueryResultSetMethod;
+    }
+    ///////////////////////////////////////////////////////////////////////
+    //
+    // CONSTRUCTOR MANAGEMENT
+    //
+    ///////////////////////////////////////////////////////////////////////
 
-	private void	beginConstructor()
-	{
-		// create a constructor that just calls super.  
-		MethodBuilder realConstructor =
-			cb.newConstructorBuilder(Modifier.PUBLIC);
-		realConstructor.callSuper();
-		realConstructor.methodReturn();
-		realConstructor.complete();
+    private void beginConstructor()
+    {
+        // create a constructor that just calls super.
+        MethodBuilder realConstructor =
+            cb.newConstructorBuilder(Modifier.PUBLIC);
+        realConstructor.callSuper();
+        realConstructor.methodReturn();
+        realConstructor.complete();
 
-		constructor = cb.newMethodBuilder(Modifier.PUBLIC, "void", "postConstructor");
-		constructor.addThrownException(ClassName.StandardException);
-	}
+        constructor = cb.newMethodBuilder(Modifier.PUBLIC, "void", "postConstructor");
+        constructor.addThrownException(ClassName.StandardException);
+    }
 
-	/**
-	 * Finish the constructor by newing the array of Rows and putting a return 
-	 * at the end of it.
-	 *
-	 * @exception StandardException thrown on failure
-	 */
+    /**
+     * Finish the constructor by newing the array of Rows and putting a return
+     * at the end of it.
+     *
+     * @exception StandardException thrown on failure
+     */
 
-	void finishConstructor()
-		 throws StandardException
-	{
-		int				numResultSets;
+    void finishConstructor()
+         throws StandardException
+    {
+        int    numResultSets;
 
-		/* Set the number of subqueries */
-		setNumSubqueries();
+        /* Set the number of subqueries */
+        setNumSubqueries();
 
-		numResultSets = getRowCount();
+        numResultSets = getRowCount();
 
-		/* Generate the new of ExecRow[numResultSets] when there are ResultSets
-		 * which return Rows.
-		 */
-		if (numResultSets >= 1)
-		{
-			addNewArrayOfRows(numResultSets);
-		}
+        /* Generate the new of ExecRow[numResultSets] when there are ResultSets
+         * which return Rows.
+         */
+        if (numResultSets >= 1)
+        {
+            addNewArrayOfRows(numResultSets);
+        }
 
-		/* Generated code is:
-		 *		return;
-		 */
-		constructor.methodReturn();
-		constructor.complete();
-	}
+        /* Generated code is:
+         *  return;
+         */
+        constructor.methodReturn();
+        constructor.complete();
+    }
 
-	/**
-	 * Generate the assignment for row = new ExecRow[numResultSets]
-	 *
-	 * @param numResultSets	The size of the array.
-	 */
-	private void addNewArrayOfRows(int numResultSets)
-	{
-		/* Generated code is:
-		 *		row = new ExecRow[numResultSets];
-		 */
+    /**
+     * Generate the assignment for row = new ExecRow[numResultSets]
+     *
+     * @param numResultSets The size of the array.
+     */
+    private void addNewArrayOfRows(int numResultSets)
+    {
+        /* Generated code is:
+         *  row = new ExecRow[numResultSets];
+         */
 
-		constructor.pushThis();
-		constructor.pushNewArray(ClassName.ExecRow, numResultSets);
-		constructor.putField(ClassName.BaseActivation, "row", ClassName.ExecRow + "[]");
-		constructor.endStatement();
-	}
+        constructor.pushThis();
+        constructor.pushNewArray(ClassName.ExecRow, numResultSets);
+        constructor.putField(ClassName.BaseActivation, "row", ClassName.ExecRow + "[]");
+        constructor.endStatement();
+    }
 
-	///////////////////////////////////////////////////////////////////////
-	//
-	// ADD FIELDS TO GENERATED CLASS
-	//
-	///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    //
+    // ADD FIELDS TO GENERATED CLASS
+    //
+    ///////////////////////////////////////////////////////////////////////
 
-	/**
-	 * Add a field declaration to the generated class
-	 * 
-	 * @param modifiers	The | of the modifier values such as public, static, etc.
-	 * @param type		The type of the field in java language.
-	 * @param name		The name of the field.
-	 *
-	 * @return None.
-	 */
-	LocalField newFieldDeclaration(int modifiers, String type, String name)
-	{
-		return cb.addField(type, name, modifiers);
-	}
+    /**
+     * Add a field declaration to the generated class
+     *
+     * @param modifiers The | of the modifier values such as public, static, etc.
+     * @param type  The type of the field in java language.
+     * @param name  The name of the field.
+     *
+     * @return None.
+     */
+    LocalField newFieldDeclaration(int modifiers, String type, String name)
+    {
+        return cb.addField(type, name, modifiers);
+    }
 
-	/**
-	 * Add an arbitrarily named field to the generated class.
-	 *
-	 * This is used to generate fields where the caller doesn't care what
-	 * the field is named.  It is especially useful for generating arbitrary
-	 * numbers of fields, where the caller doesn't know in advance how many
-	 * fields will be used.  For example, it is used for generating fields
-	 * to hold intermediate values from expressions.
-	 *
-	 * @param modifiers	The | of the modifier values such as public, static, etc.
-	 * @param type		The type of the field in java language.
-	 *
-	 * @return	The name of the new field
-	 */
+    /**
+     * Add an arbitrarily named field to the generated class.
+     *
+     * This is used to generate fields where the caller doesn't care what
+     * the field is named.  It is especially useful for generating arbitrary
+     * numbers of fields, where the caller doesn't know in advance how many
+     * fields will be used.  For example, it is used for generating fields
+     * to hold intermediate values from expressions.
+     *
+     * @param modifiers The | of the modifier values such as public, static, etc.
+     * @param type  The type of the field in java language.
+     *
+     * @return The name of the new field
+     */
 
-	LocalField newFieldDeclaration(int modifiers, String type)
-	{
-		return cb.addField(type, newFieldName(), modifiers);
-	}
+    LocalField newFieldDeclaration(int modifiers, String type)
+    {
+        return cb.addField(type, newFieldName(), modifiers);
+    }
 
-	///////////////////////////////////////////////////////////////////////
-	//
-	// ADD FUNCTIONS TO GENERATED CLASS
-	//
-	///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    //
+    // ADD FUNCTIONS TO GENERATED CLASS
+    //
+    ///////////////////////////////////////////////////////////////////////
 
-	/**
-	 * Activations might have need of internal functions
-	 * that are not used by the result sets, but by other
-	 * activation functions. Thus, we make it possible
-	 * for functions to be generated directly as well
-	 * as through the newExprFun interface.  newExprFun
-	 * should be used when a static field pointing to the
-	 * expression function is needed.
-	 * <p>
-	 * The generated function will generally have a generated name
-	 * that can be viewed through the MethodBuilder interface.
-	 * This name is generated to ensure uniqueness from other
-	 * function names in the activation class. If you pass in a function
-	 * name, think carefully about whether it will collide with other names.
-	 *
-	 * @param returnType the return type of the function
-	 * @param modifiers the modifiers on the function
-	 *
-	 * @see #newExprFun
-	 */
-	MethodBuilder newGeneratedFun(String returnType, int modifiers) {
+    /**
+     * Activations might have need of internal functions
+     * that are not used by the result sets, but by other
+     * activation functions. Thus, we make it possible
+     * for functions to be generated directly as well
+     * as through the newExprFun interface.  newExprFun
+     * should be used when a static field pointing to the
+     * expression function is needed.
+     * <p>
+     * The generated function will generally have a generated name
+     * that can be viewed through the MethodBuilder interface.
+     * This name is generated to ensure uniqueness from other
+     * function names in the activation class. If you pass in a function
+     * name, think carefully about whether it will collide with other names.
+     *
+     * @param returnType the return type of the function
+     * @param modifiers the modifiers on the function
+     *
+     * @see #newExprFun
+     */
+    MethodBuilder newGeneratedFun(String returnType, int modifiers) {
 
-		return newGeneratedFun(returnType, modifiers,
-							   (String[]) null);
-	}
+        return newGeneratedFun(returnType, modifiers,
+                               (String[]) null);
+    }
 
-	MethodBuilder newGeneratedFun(String returnType, 
-										 int modifiers,
-										 String[] params) {
+    MethodBuilder newGeneratedFun(String returnType,
+                                         int modifiers,
+                                         String[] params) {
 
-		String exprName = "g" + Integer.toString(nextNonFastExpr++);
-		return newGeneratedFun(exprName, returnType, modifiers,
-							   params);
+        String exprName = "g" + Integer.toString(nextNonFastExpr++);
+        return newGeneratedFun(exprName, returnType, modifiers,
+                               params);
 
-	}
+    }
 
-	private MethodBuilder newGeneratedFun(String exprName, String returnType, 
-										 int modifiers,
-										 String[] params) {
+    private MethodBuilder newGeneratedFun(String exprName, String returnType,
+                                         int modifiers,
+                                         String[] params) {
 
 
 
-		//
-		// create a new method supplying the given modifiers and return Type
-		// Java: #modifiers #returnType #exprName { }
-		//
-		MethodBuilder exprMethod;
-		if (params == null)
-		{
-			exprMethod = cb.newMethodBuilder(modifiers, returnType, exprName);
-		}
-		else
-		{
-			exprMethod = cb.newMethodBuilder(modifiers, returnType, 
-										     exprName, params);
-		}
+        //
+        // create a new method supplying the given modifiers and return Type
+        // Java: #modifiers #returnType #exprName { }
+        //
+        MethodBuilder exprMethod;
+        if (params == null)
+        {
+            exprMethod = cb.newMethodBuilder(modifiers, returnType, exprName);
+        }
+        else
+        {
+            exprMethod = cb.newMethodBuilder(modifiers, returnType,
+                                             exprName, params);
+        }
 
-		//
-		// declare it to throw StandardException
-		// Java: #modifiers #returnType #exprName throws StandardException { }
-		//
-		exprMethod.addThrownException(ClassName.StandardException);
+        //
+        // declare it to throw StandardException
+        // Java: #modifiers #returnType #exprName throws StandardException { }
+        //
+        exprMethod.addThrownException(ClassName.StandardException);
 
-		return exprMethod;
-	}
+        return exprMethod;
+    }
 
-	/**
-	 * "ExprFun"s are the "expression functions" that
-	 * are specific to a given JSQL statement. For example,
-	 * an ExprFun is generated to evaluate the where clause
-	 * of a select statement and return a boolean result.
-	 * <p>
-	 *
-	 * All methods return by this are expected to be called
-	 * via the GeneratedMethod interface. Thus the methods
-	 * are public and return java.lang.Object.
-	 * <p>
-	 * Once the exprfun has been created, the
-	 * caller will need to add statements to it,
-	 * minimally a return statement.
-	 * <p>
-	 * ExprFuns  return Object types, since they
-	 * are invoked through reflection and thus their
-	 * return type would get wrapped in an object anyway.
-	 * For example: return java.lang.Boolean, not boolean.
-	 */
-	MethodBuilder newExprFun()
-	{
-		// get next generated function 
-		String exprName = "e" + Integer.toString(nextExprNum++);
+    /**
+     * "ExprFun"s are the "expression functions" that
+     * are specific to a given JSQL statement. For example,
+     * an ExprFun is generated to evaluate the where clause
+     * of a select statement and return a boolean result.
+     * <p>
+     *
+     * All methods return by this are expected to be called
+     * via the GeneratedMethod interface. Thus the methods
+     * are public and return java.lang.Object.
+     * <p>
+     * Once the exprfun has been created, the
+     * caller will need to add statements to it,
+     * minimally a return statement.
+     * <p>
+     * ExprFuns  return Object types, since they
+     * are invoked through reflection and thus their
+     * return type would get wrapped in an object anyway.
+     * For example: return java.lang.Boolean, not boolean.
+     */
+    MethodBuilder newExprFun()
+    {
+        // get next generated function
+        String exprName = "e" + Integer.toString(nextExprNum++);
 
-		return newGeneratedFun(exprName, "java.lang.Object", Modifier.PUBLIC, (String[]) null);
-	}
+        return newGeneratedFun(exprName, "java.lang.Object", Modifier.PUBLIC, (String[]) null);
+    }
 
-	/**
-		Push an expression that is a GeneratedMethod reference to the
-		passed in method. aka. a "function pointer".
-	*/
-	void pushMethodReference(MethodBuilder mb, MethodBuilder exprMethod) {
+    /**
+        Push an expression that is a GeneratedMethod reference to the
+        passed in method. aka. a "function pointer".
+    */
+    void pushMethodReference(MethodBuilder mb, MethodBuilder exprMethod) {
 
-		mb.pushThis(); // instance
-		mb.push(exprMethod.getName()); // arg
-		mb.callMethod(VMOpcode.INVOKEINTERFACE, ClassName.GeneratedByteCode,
-				"getMethod",
-				ClassName.GeneratedMethod,
-				1
-				);
-	}
+        mb.pushThis(); // instance
+        mb.push(exprMethod.getName()); // arg
+        mb.callMethod(VMOpcode.INVOKEINTERFACE, ClassName.GeneratedByteCode,
+                "getMethod",
+                ClassName.GeneratedMethod,
+                1
+                );
+    }
 
-	/**
-	 * Start a user expression.  The difference between a normal expression
-	 * (returned by newExprFun)
-	 * and a user expression is that a user expression catches all exceptions
-	 * (because we don't want random exceptions thrown from user methods to
-	 * propagate to the rest of the system.
-	 *
-	 * @return	A new MethodBuilder
-	 */
-	MethodBuilder newUserExprFun() {
+    /**
+     * Start a user expression.  The difference between a normal expression
+     * (returned by newExprFun)
+     * and a user expression is that a user expression catches all exceptions
+     * (because we don't want random exceptions thrown from user methods to
+     * propagate to the rest of the system.
+     *
+     * @return A new MethodBuilder
+     */
+    MethodBuilder newUserExprFun() {
 
-		MethodBuilder mb = newExprFun();
-		mb.addThrownException("java.lang.Exception");
-		return mb;
-	}
+        MethodBuilder mb = newExprFun();
+        mb.addThrownException("java.lang.Exception");
+        return mb;
+    }
 
     MethodBuilder newUserExprToStringFun() {
 
@@ -460,492 +460,502 @@ public abstract	class ExpressionClassBuilder implements ExpressionClassBuilderIn
         mb.addThrownException("java.lang.Exception");
         return mb;
     }
-	///////////////////////////////////////////////////////////////////////
-	//
-	// CURRENT DATE/TIME SUPPORT
-	//
-	///////////////////////////////////////////////////////////////////////
-
-	/**
-		This utility method returns an expression for CURRENT_DATE.
-		Get the expression this way, because the activation needs to 
-		generate support information for CURRENT_DATE,
-		that would otherwise be painful to create manually.
-	 */
-	void getCurrentDateExpression(MethodBuilder mb) {
-		// do any needed setup
-		LocalField lf = getCurrentSetup();
-
-		// generated Java:
-		//	  this.cdt.getCurrentDate();
-		mb.getField(lf);
-		mb.callMethod(VMOpcode.INVOKEVIRTUAL, (String) null, "getCurrentDate", "java.sql.Date", 0);
-	}
-
-	/**
-		This utility method returns an expression for CURRENT_TIME.
-		Get the expression this way, because the activation needs to 
-		generate support information for CURRENT_TIME,
-		that would otherwise be painful to create manually.
-	 */
-	void getCurrentTimeExpression(MethodBuilder mb) {
-		// do any needed setup
-		LocalField lf = getCurrentSetup();
-
-		// generated Java:
-		//	  this.cdt.getCurrentTime();
-		mb.getField(lf);
-		mb.callMethod(VMOpcode.INVOKEVIRTUAL, (String) null, "getCurrentTime", "java.sql.Time", 0);
-	}
-
-	/**
-		This utility method generates an expression for CURRENT_TIMESTAMP.
-		Get the expression this way, because the activation needs to 
-		generate support information for CURRENT_TIMESTAMP,
-		that would otherwise be painful to create manually.
-	 */
-	void getCurrentTimestampExpression(MethodBuilder mb) {
-		// do any needed setup
-		LocalField lf = getCurrentSetup();
-
-		// generated Java:
-		//	  this.cdt.getCurrentTimestamp();
-		mb.getField(lf);
-		mb.callMethod(VMOpcode.INVOKEVIRTUAL, (String) null,
-			"getCurrentTimestamp", "java.sql.Timestamp", 0);
-	}
-
-	///////////////////////////////////////////////////////////////////////
-	//
-	// COLUMN ORDERING
-	//
-	///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    //
+    // CURRENT DATE/TIME SUPPORT
+    //
+    ///////////////////////////////////////////////////////////////////////
 
     /**
-		These utility methods buffers compilation from the IndexColumnOrder
-		class.
+        This utility method returns an expression for CURRENT_DATE.
+        Get the expression this way, because the activation needs to
+        generate support information for CURRENT_DATE,
+        that would otherwise be painful to create manually.
+     */
+    void getCurrentDateExpression(MethodBuilder mb) {
+        // do any needed setup
+        LocalField lf = getCurrentSetup();
 
-		They create an ordering based on their parameter, stuff that into
-		the prepared statement, and then return the entry # for
-		use in the generated code.
+        // generated Java:
+        //   this.cdt.getCurrentDate();
+        mb.getField(lf);
+        mb.callMethod(VMOpcode.INVOKEVIRTUAL, (String) null, "getCurrentDate", "java.sql.Date", 0);
+    }
 
-		We could write another utility method to generate code to
-		turn an entry # back into an object, but so far no-one needs it.
-	
-		WARNING: this is a crafty method that ASSUMES that 
-		you want every column in the list ordered, and that every
-		column in the list is the entire actual result colunm.
-		It is only useful for DISTINCT in select.	
-	 */
-	FormatableArrayHolder getColumnOrdering(ResultColumnList rclist)
-	{
-		IndexColumnOrder[] ordering;
-		int numCols = (rclist == null) ? 0 : rclist.size();
-		//skip the columns which are not exclusively part of the insert list
+    /**
+        This utility method returns an expression for CURRENT_TIME.
+        Get the expression this way, because the activation needs to
+        generate support information for CURRENT_TIME,
+        that would otherwise be painful to create manually.
+     */
+    void getCurrentTimeExpression(MethodBuilder mb) {
+        // do any needed setup
+        LocalField lf = getCurrentSetup();
+
+        // generated Java:
+        // this.cdt.getCurrentTime();
+        mb.getField(lf);
+        mb.callMethod(VMOpcode.INVOKEVIRTUAL, (String) null, "getCurrentTime", "java.sql.Time", 0);
+    }
+    
+    void getCurrentTimezoneExpression(MethodBuilder mb) {
+        // do any needed setup
+        LocalField lf = getCurrentSetup();
+
+        // generated Java:
+        // this.cdg.getCurrentTimezone();
+        mb.getField(lf);
+        mb.callMethod(VMOpcode.INVOKEVIRTUAL, null, "getCurrentTimezone", "java.math.BigDecimal", 0);
+    }
+
+    /**
+        This utility method generates an expression for CURRENT_TIMESTAMP.
+        Get the expression this way, because the activation needs to
+        generate support information for CURRENT_TIMESTAMP,
+        that would otherwise be painful to create manually.
+     */
+    void getCurrentTimestampExpression(MethodBuilder mb) {
+        // do any needed setup
+        LocalField lf = getCurrentSetup();
+
+        // generated Java:
+        //   this.cdt.getCurrentTimestamp();
+        mb.getField(lf);
+        mb.callMethod(VMOpcode.INVOKEVIRTUAL, (String) null,
+            "getCurrentTimestamp", "java.sql.Timestamp", 0);
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+    //
+    // COLUMN ORDERING
+    //
+    ///////////////////////////////////////////////////////////////////////
+
+    /**
+        These utility methods buffers compilation from the IndexColumnOrder
+        class.
+
+        They create an ordering based on their parameter, stuff that into
+        the prepared statement, and then return the entry # for
+        use in the generated code.
+
+        We could write another utility method to generate code to
+        turn an entry # back into an object, but so far no-one needs it.
+
+        WARNING: this is a crafty method that ASSUMES that
+        you want every column in the list ordered, and that every
+        column in the list is the entire actual result colunm.
+        It is only useful for DISTINCT in select.
+     */
+    FormatableArrayHolder getColumnOrdering(ResultColumnList rclist)
+    {
+        IndexColumnOrder[] ordering;
+        int numCols = (rclist == null) ? 0 : rclist.size();
+        //skip the columns which are not exclusively part of the insert list
     //ie columns with default and autoincrement. These columns will not
     //be part of ordering.
-		int numRealCols = 0;
-		for (int i=0; i<numCols; i++)
-		{
-			if (!(rclist.getResultColumn(i+1).isGeneratedForUnmatchedColumnInInsert()))
-				numRealCols++;
-		}
+        int numRealCols = 0;
+        for (int i=0; i<numCols; i++)
+        {
+            if (!(rclist.getResultColumn(i+1).isGeneratedForUnmatchedColumnInInsert()))
+                numRealCols++;
+        }
 
-		ordering = new IndexColumnOrder[numRealCols];
-		for (int i=0, j=0; i<numCols; i++)
-		{
-			if (!(rclist.getResultColumn(i+1).isGeneratedForUnmatchedColumnInInsert()))
-			{
-				ordering[j] = new IndexColumnOrder(i);
-				j++;
-			}
-		}
-		return new FormatableArrayHolder(ordering);
-	}
+        ordering = new IndexColumnOrder[numRealCols];
+        for (int i=0, j=0; i<numCols; i++)
+        {
+            if (!(rclist.getResultColumn(i+1).isGeneratedForUnmatchedColumnInInsert()))
+            {
+                ordering[j] = new IndexColumnOrder(i);
+                j++;
+            }
+        }
+        return new FormatableArrayHolder(ordering);
+    }
 
-	/**
-	 * Add a column to the existing Ordering list.  Takes
-	 * a column id and only adds it if it isn't in the list.
-	 *
-	 *
-	 * @return the ColumnOrdering array
-	 */
-	FormatableArrayHolder addColumnToOrdering(
-						FormatableArrayHolder orderingHolder,
-						int columnNum)
-	{
-		/*
-		** We don't expect a lot of order by columns, so
-		** linear search.
-		*/
-		ColumnOrdering[] ordering = (ColumnOrdering[])orderingHolder.
-										getArray(ColumnOrdering.class);
-		int length = ordering.length;
+    /**
+     * Add a column to the existing Ordering list.  Takes
+     * a column id and only adds it if it isn't in the list.
+     *
+     *
+     * @return the ColumnOrdering array
+     */
+    FormatableArrayHolder addColumnToOrdering(
+                        FormatableArrayHolder orderingHolder,
+                        int columnNum)
+    {
+        /*
+        ** We don't expect a lot of order by columns, so
+        ** linear search.
+        */
+        ColumnOrdering[] ordering = (ColumnOrdering[])orderingHolder.
+                                        getArray(ColumnOrdering.class);
+        int length = ordering.length;
         for (ColumnOrdering anOrdering : ordering) {
             if (anOrdering.getColumnId() == columnNum)
                 return orderingHolder;
         }
 
-		/*
-		** Didn't find it.  Allocate a bigger array
-		** and add it to the end
-		*/
-		IndexColumnOrder[] newOrdering = new IndexColumnOrder[length+1];
-		System.arraycopy(ordering, 0, newOrdering, 0, length);
-		newOrdering[length] = new IndexColumnOrder(columnNum);
-		
-		return new FormatableArrayHolder(newOrdering);
-	}	
+        /*
+        ** Didn't find it.  Allocate a bigger array
+        ** and add it to the end
+        */
+        IndexColumnOrder[] newOrdering = new IndexColumnOrder[length+1];
+        System.arraycopy(ordering, 0, newOrdering, 0, length);
+        newOrdering[length] = new IndexColumnOrder(columnNum);
+
+        return new FormatableArrayHolder(newOrdering);
+    }
 
 
-	FormatableArrayHolder getColumnOrdering(OrderedColumnList  oclist) {
-		int numCols = (oclist == null) ? 0 : oclist.size();
+    FormatableArrayHolder getColumnOrdering(OrderedColumnList  oclist) {
+        int numCols = (oclist == null) ? 0 : oclist.size();
 
-		if (numCols == 0)
-		{
-			return new FormatableArrayHolder(new IndexColumnOrder[0]);
-		}
+        if (numCols == 0)
+        {
+            return new FormatableArrayHolder(new IndexColumnOrder[0]);
+        }
 
-		return new FormatableArrayHolder(oclist.getColumnOrdering());
-	}
+        return new FormatableArrayHolder(oclist.getColumnOrdering());
+    }
 
-	int addItem(Object o) 
-	{
-		if (SanityManager.DEBUG)
-		{
-			if ((o != null) && !(o instanceof Serializable))
-			{
-				SanityManager.THROWASSERT(
-					"o (" + o.getClass().getName() +
-					") expected to be instanceof java.io.Serializable");
-			}
-		}
-		return myCompCtx.addSavedObject(o);
-	}
+    int addItem(Object o)
+    {
+        if (SanityManager.DEBUG)
+        {
+            if ((o != null) && !(o instanceof Serializable))
+            {
+                SanityManager.THROWASSERT(
+                    "o (" + o.getClass().getName() +
+                    ") expected to be instanceof java.io.Serializable");
+            }
+        }
+        return myCompCtx.addSavedObject(o);
+    }
 
-	///////////////////////////////////////////////////////////////////////
-	//
-	// Caching resuable Expressions
-	//
-	///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    //
+    // Caching resuable Expressions
+    //
+    ///////////////////////////////////////////////////////////////////////
 
-	/**
-	 * Get/reuse the Expression for getting the DataValueFactory
-	 */
-	private Object getDVF;
-	void pushDataValueFactory(MethodBuilder mb)
-	{
-		// generates:
-		//	   getDataValueFactory()
-		//
+    /**
+     * Get/reuse the Expression for getting the DataValueFactory
+     */
+    private Object getDVF;
+    void pushDataValueFactory(MethodBuilder mb)
+    {
+        // generates:
+        //    getDataValueFactory()
+        //
 
-		if (getDVF == null) {
-			getDVF = mb.describeMethod(VMOpcode.INVOKEVIRTUAL,
-										getBaseClassName(),
-										"getDataValueFactory",
-										ClassName.DataValueFactory);
-		}
+        if (getDVF == null) {
+            getDVF = mb.describeMethod(VMOpcode.INVOKEVIRTUAL,
+                                        getBaseClassName(),
+                                        "getDataValueFactory",
+                                        ClassName.DataValueFactory);
+        }
 
-		mb.pushThis();
-		mb.callMethod(getDVF);
-	}
+        mb.pushThis();
+        mb.callMethod(getDVF);
+    }
 
-	///////////////////////////////////////////////////////////////////////
-	//
-	// RESULT SET SUPPORT
-	//
-	///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
+    //
+    // RESULT SET SUPPORT
+    //
+    ///////////////////////////////////////////////////////////////////////
 
-	/**
-		This is a utility method to get a common expression --
-		"BaseActivation.getResultSetFactory()".
-		<p>
-		BaseActivation gets the factory from the context and
-		caches it for faster retrieval.
-	 */
-	private Object getRSF;
-	void pushGetResultSetFactoryExpression(MethodBuilder mb) {
-		// generated Java:
-		//	this.getResultSetFactory()
-		//
-		
-		
-		if (getRSF == null) {
-			getRSF = mb.describeMethod(VMOpcode.INVOKEVIRTUAL, getBaseClassName(),
-					"getResultSetFactory",
-					ClassName.ResultSetFactory);
-		}
-		mb.pushThis();
-		mb.callMethod(getRSF);
-	}
-
-	/**
-		This is a utility method to get a common expression --
-		"BaseActivation.getExecutionFactory()".
-		REVISIT: could the same expression objects be reused within
-		the tree and have the correct java generated each time?
-		<p>
-		BaseActivation gets the factory from the context and
-		caches it for faster retrieval. 
-	 */
-	private Object getEF;
-	void pushGetExecutionFactoryExpression(MethodBuilder mb) {
-		if (getEF == null) {
-			getEF = mb.describeMethod(VMOpcode.INVOKEVIRTUAL, getBaseClassName(),
-					"getExecutionFactory",
-					ClassName.ExecutionFactory);
-		}
-
-		// generated Java:
-		//	this.getExecutionFactory()
-		//
-		mb.pushThis();
-		mb.callMethod(getEF);
-	}
-
-	/**
-	 * Generate a reference to the row array that
-	 * all activations use.
-	 * 
-	 * @param eb the expression block
-	 *
-	 * @return expression
-	 */
-	//private void pushRowArrayReference(MethodBuilder mb)
-	//{ 		
-		// PUSHCOMPILE - cache
-	//	mb.pushThis();
-	//	mb.getField(ClassName.BaseActivation, "row", ClassName.ExecRow + "[]");
-	//}
-
-	/**
-	 * Generate a reference to a colunm in a result set.
-	 * 
-	 * @param rsNumber the result set number
-	 * @param colId the column number
-	 */
-	void pushColumnReference(MethodBuilder mb, int rsNumber, int colId)
-	{
-		mb.pushThis();
-		mb.push(rsNumber);
-		mb.push(colId);
-		mb.callMethod(VMOpcode.INVOKEVIRTUAL, ClassName.BaseActivation, "getColumnFromRow",
-						ClassName.DataValueDescriptor, 2);
-
-		//System.out.println("pushColumnReference ");
-		//pushRowArrayReference(mb);
-		//mb.getArrayElement(rsNumber); // instance for getColumn
-		//mb.push(colId); // first arg
-		//mb.callMethod(VMOpcode.INVOKEINTERFACE, ClassName.Row, "getColumn", ClassName.DataValueDescriptor, 1);
-	}
-
-	/**
-	 * Generate a reference to the parameter value
-	 * set that all activations use.
-	 * 
-	 */
-	void pushPVSReference(MethodBuilder mb)
-	{
-		// PUSHCOMPILER-WASCACHED
-		mb.pushThis();
-		mb.getField(ClassName.BaseActivation, "pvs", ClassName.ParameterValueSet);
-	}
-
-	///////////////////////////////////////////////////////////////////////
-	//
-	// CLASS IMPLEMENTATION
-	//
-	///////////////////////////////////////////////////////////////////////
-
-	/*
-		The first time a current datetime is needed, create the class
-		level support for it.
-	 */
-	protected LocalField getCurrentSetup() {
-		if (cdtField != null)
-			return cdtField;
-
-		// generated Java:
-		// 1) the field "cdt" is created:
-		//    private CurrentDatetime cdt;
-		cdtField = newFieldDeclaration(
-			Modifier.PRIVATE,
-			ClassName.CurrentDatetime,
-			currentDatetimeFieldName);
-
-		// 2) the constructor gets a statement to init CurrentDatetime:
-		//	  cdt = new CurrentDatetime();
-
-		constructor.pushNewStart(ClassName.CurrentDatetime);
-		constructor.pushNewComplete(0);
-		constructor.setField(cdtField);
-
-		return cdtField;
-	}
-
-	/**
-	 * generated the next field name available.
-	 * these are of the form 'e#', where # is
-	 * incremented each time.
-	 * This shares the name space with the expression methods
-	 * as Java allows names and fields to have the same name.
-	 * This reduces the number of constant pool entries created
-	 * for a generated class file.
-	 */
-	private String newFieldName()
-	{
-		return "e" + Integer.toString(nextFieldNum++);
-	}
+    /**
+        This is a utility method to get a common expression --
+        "BaseActivation.getResultSetFactory()".
+        <p>
+        BaseActivation gets the factory from the context and
+        caches it for faster retrieval.
+     */
+    private Object getRSF;
+    void pushGetResultSetFactoryExpression(MethodBuilder mb) {
+        // generated Java:
+        // this.getResultSetFactory()
+        //
 
 
-	///////////////////////////////////////////////////////////////////////
-	//
-	// DEBUG
-	//
-	///////////////////////////////////////////////////////////////////////
+        if (getRSF == null) {
+            getRSF = mb.describeMethod(VMOpcode.INVOKEVIRTUAL, getBaseClassName(),
+                    "getResultSetFactory",
+                    ClassName.ResultSetFactory);
+        }
+        mb.pushThis();
+        mb.callMethod(getRSF);
+    }
+
+    /**
+        This is a utility method to get a common expression --
+        "BaseActivation.getExecutionFactory()".
+        REVISIT: could the same expression objects be reused within
+        the tree and have the correct java generated each time?
+        <p>
+        BaseActivation gets the factory from the context and
+        caches it for faster retrieval.
+     */
+    private Object getEF;
+    void pushGetExecutionFactoryExpression(MethodBuilder mb) {
+        if (getEF == null) {
+            getEF = mb.describeMethod(VMOpcode.INVOKEVIRTUAL, getBaseClassName(),
+                    "getExecutionFactory",
+                    ClassName.ExecutionFactory);
+        }
+
+        // generated Java:
+        // this.getExecutionFactory()
+        //
+        mb.pushThis();
+        mb.callMethod(getEF);
+    }
+
+    /**
+     * Generate a reference to the row array that
+     * all activations use.
+     *
+     * @param eb the expression block
+     *
+     * @return expression
+     */
+    //private void pushRowArrayReference(MethodBuilder mb)
+    //{
+        // PUSHCOMPILE - cache
+    // mb.pushThis();
+    // mb.getField(ClassName.BaseActivation, "row", ClassName.ExecRow + "[]");
+    //}
+
+    /**
+     * Generate a reference to a colunm in a result set.
+     *
+     * @param rsNumber the result set number
+     * @param colId the column number
+     */
+    void pushColumnReference(MethodBuilder mb, int rsNumber, int colId)
+    {
+        mb.pushThis();
+        mb.push(rsNumber);
+        mb.push(colId);
+        mb.callMethod(VMOpcode.INVOKEVIRTUAL, ClassName.BaseActivation, "getColumnFromRow",
+                        ClassName.DataValueDescriptor, 2);
+
+        //System.out.println("pushColumnReference ");
+        //pushRowArrayReference(mb);
+        //mb.getArrayElement(rsNumber); // instance for getColumn
+        //mb.push(colId); // first arg
+        //mb.callMethod(VMOpcode.INVOKEINTERFACE, ClassName.Row, "getColumn", ClassName.DataValueDescriptor, 1);
+    }
+
+    /**
+     * Generate a reference to the parameter value
+     * set that all activations use.
+     *
+     */
+    void pushPVSReference(MethodBuilder mb)
+    {
+        // PUSHCOMPILER-WASCACHED
+        mb.pushThis();
+        mb.getField(ClassName.BaseActivation, "pvs", ClassName.ParameterValueSet);
+    }
+
+    ///////////////////////////////////////////////////////////////////////
+    //
+    // CLASS IMPLEMENTATION
+    //
+    ///////////////////////////////////////////////////////////////////////
+
+    /*
+        The first time a current datetime is needed, create the class
+        level support for it.
+     */
+    protected LocalField getCurrentSetup() {
+        if (cdtField != null)
+            return cdtField;
+
+        // generated Java:
+        // 1) the field "cdt" is created:
+        //    private CurrentDatetime cdt;
+        cdtField = newFieldDeclaration(
+            Modifier.PRIVATE,
+            ClassName.CurrentDatetime,
+            currentDatetimeFieldName);
+
+        // 2) the constructor gets a statement to init CurrentDatetime:
+        //   cdt = new CurrentDatetime();
+
+        constructor.pushNewStart(ClassName.CurrentDatetime);
+        constructor.pushNewComplete(0);
+        constructor.setField(cdtField);
+
+        return cdtField;
+    }
+
+    /**
+     * generated the next field name available.
+     * these are of the form 'e#', where # is
+     * incremented each time.
+     * This shares the name space with the expression methods
+     * as Java allows names and fields to have the same name.
+     * This reduces the number of constant pool entries created
+     * for a generated class file.
+     */
+    private String newFieldName()
+    {
+        return "e" + Integer.toString(nextFieldNum++);
+    }
 
 
-	///////////////////////////////////////////////////////////////////////
-	//
-	// DATATYPES
-	//
-	///////////////////////////////////////////////////////////////////////
-	/**
-	 * Get the TypeCompiler associated with the given TypeId
-	 *
-	 * @param typeId	The TypeId to get a TypeCompiler for
-	 *
-	 * @return	The corresponding TypeCompiler
-	 *
-	 */
-	protected TypeCompiler getTypeCompiler(TypeId typeId)
-	{
-		return myCompCtx.getTypeCompilerFactory().getTypeCompiler(typeId);
-	}
+    ///////////////////////////////////////////////////////////////////////
+    //
+    // DEBUG
+    //
+    ///////////////////////////////////////////////////////////////////////
 
-	///////////////////////////////////////////////////////////////////////
-	//
-	// GENERATE BYTE CODE
-	//
-	///////////////////////////////////////////////////////////////////////
 
-	/**
-	 * Take the generated class, and turn it into an
-	 * actual class.
-	 * <p> This method assumes, does not check, that
-	 * the class and its parts are all complete.
- 	 *
-	 * @param savedBytes place to save generated bytes.
-	 *	if null, it is ignored
-	 * @exception StandardException thrown when exception occurs
-	 */
-	GeneratedClass getGeneratedClass(ByteArray savedBytes) throws StandardException {
-		if (gc != null) return gc;
+    ///////////////////////////////////////////////////////////////////////
+    //
+    // DATATYPES
+    //
+    ///////////////////////////////////////////////////////////////////////
+    /**
+     * Get the TypeCompiler associated with the given TypeId
+     *
+     * @param typeId The TypeId to get a TypeCompiler for
+     *
+     * @return The corresponding TypeCompiler
+     *
+     */
+    protected TypeCompiler getTypeCompiler(TypeId typeId)
+    {
+        return myCompCtx.getTypeCompilerFactory().getTypeCompiler(typeId);
+    }
 
-		if (savedBytes != null)
-		{
-			ByteArray classBytecode = cb.getClassBytecode();
+    ///////////////////////////////////////////////////////////////////////
+    //
+    // GENERATE BYTE CODE
+    //
+    ///////////////////////////////////////////////////////////////////////
 
-			// note: be sure to set the length since
-			// the class builder allocates the byte array
-			// in big chunks
-			savedBytes.setBytes(classBytecode.getArray());
-			savedBytes.setLength(classBytecode.getLength());
-		}
+    /**
+     * Take the generated class, and turn it into an
+     * actual class.
+     * <p> This method assumes, does not check, that
+     * the class and its parts are all complete.
+     *
+     * @param savedBytes place to save generated bytes.
+     * if null, it is ignored
+     * @exception StandardException thrown when exception occurs
+     */
+    GeneratedClass getGeneratedClass(ByteArray savedBytes) throws StandardException {
+        if (gc != null) return gc;
 
-	    gc =  cb.getGeneratedClass();
+        if (savedBytes != null)
+        {
+            ByteArray classBytecode = cb.getClassBytecode();
 
-		return gc; // !! yippee !! here it is...
-	}
+            // note: be sure to set the length since
+            // the class builder allocates the byte array
+            // in big chunks
+            savedBytes.setBytes(classBytecode.getArray());
+            savedBytes.setLength(classBytecode.getLength());
+        }
 
-	/**
-	 * Get a "this" expression declared as an Activation.
-	 * This is the commonly used type of the this expression.
-	 *
-	 */
-	void pushThisAsActivation(MethodBuilder mb) {
-		// PUSHCOMPILER - WASCACHED
-		mb.pushThis();
-		mb.upCast(ClassName.Activation);
-	}
+        gc =  cb.getGeneratedClass();
 
-	/**
-	 * Get a "this" expression declared as a BaseExecutableIndexExpression.
-	 */
-	void pushThisAsBaseExecIndexExpr(MethodBuilder mb) {
-		mb.pushThis();
-		mb.upCast(ClassName.BaseExecutableIndexExpression);
-	}
+        return gc; // !! yippee !! here it is...
+    }
 
-	/**
-		Generate a Null data value.
-		Nothing is required on the stack, a SQL null data value
-		is pushed.
-	*/
-	void generateNull(MethodBuilder mb, TypeCompiler tc, DataTypeDescriptor dtd) {
-		LocalField field = null;
-		if (dtd.getTypeId().isArray()) {
-			MethodBuilder acbConstructor = getConstructor();
-			TypeDescriptor td = ((TypeDescriptorImpl) dtd.getCatalogType()).getChildren()[0];
-			field = newFieldDeclaration(Modifier.PRIVATE, DataValueDescriptor.class.getCanonicalName());
-			generateNull(acbConstructor, getTypeCompiler(TypeId.getBuiltInTypeId(td.getJDBCTypeId())),
-					DataTypeDescriptor.getType(td));
-			acbConstructor.setField(field);
-		}
-		pushDataValueFactory(mb);
-		mb.pushNull(tc.interfaceName());
-		tc.generateNull(mb, dtd, new LocalField[]{field});
-	}
+    /**
+     * Get a "this" expression declared as an Activation.
+     * This is the commonly used type of the this expression.
+     *
+     */
+    void pushThisAsActivation(MethodBuilder mb) {
+        // PUSHCOMPILER - WASCACHED
+        mb.pushThis();
+        mb.upCast(ClassName.Activation);
+    }
 
-	/**
-		Generate a Null data value.
-		The express value is required on the stack and will be popped, a SQL null data value
-		is pushed.
-	*/
-	void generateNullWithExpress(MethodBuilder mb, TypeCompiler tc,
-								 DataTypeDescriptor dtd, LocalField[] localFields) {
-		pushDataValueFactory(mb);
-		mb.swap(); // need the dvf as the instance
-		mb.cast(tc.interfaceName());
-		tc.generateNull(mb, dtd, localFields);
-	}
+    /**
+     * Get a "this" expression declared as a BaseExecutableIndexExpression.
+     */
+    void pushThisAsBaseExecIndexExpr(MethodBuilder mb) {
+        mb.pushThis();
+        mb.upCast(ClassName.BaseExecutableIndexExpression);
+    }
 
-	/**
-		Generate a data value.
-		The value is to be set in the SQL data value is required
-		on the stack and will be popped, a SQL data value
-		is pushed.
-	*/
-	void generateDataValue(MethodBuilder mb, TypeCompiler tc, 
-			int collationType, LocalField field) {
-		pushDataValueFactory(mb);
-		mb.swap(); // need the dvf as the instance
-		tc.generateDataValue(mb, collationType, field);
-	}
+    /**
+        Generate a Null data value.
+        Nothing is required on the stack, a SQL null data value
+        is pushed.
+    */
+    void generateNull(MethodBuilder mb, TypeCompiler tc, DataTypeDescriptor dtd) {
+        LocalField field = null;
+        if (dtd.getTypeId().isArray()) {
+            MethodBuilder acbConstructor = getConstructor();
+            TypeDescriptor td = ((TypeDescriptorImpl) dtd.getCatalogType()).getChildren()[0];
+            field = newFieldDeclaration(Modifier.PRIVATE, DataValueDescriptor.class.getCanonicalName());
+            generateNull(acbConstructor, getTypeCompiler(TypeId.getBuiltInTypeId(td.getJDBCTypeId())),
+                    DataTypeDescriptor.getType(td));
+            acbConstructor.setField(field);
+        }
+        pushDataValueFactory(mb);
+        mb.pushNull(tc.interfaceName());
+        tc.generateNull(mb, dtd, new LocalField[]{field});
+    }
 
-	
-	/**
-	 *generates a variable name for the rowscanresultset.
-	 *This can not be a fixed name because in cases like
-	 *cascade delete same activation class will be dealing 
-	 * more than one RowScanResultSets for dependent tables.
-	*/
+    /**
+        Generate a Null data value.
+        The express value is required on the stack and will be popped, a SQL null data value
+        is pushed.
+    */
+    void generateNullWithExpress(MethodBuilder mb, TypeCompiler tc,
+                                 DataTypeDescriptor dtd, LocalField[] localFields) {
+        pushDataValueFactory(mb);
+        mb.swap(); // need the dvf as the instance
+        mb.cast(tc.interfaceName());
+        tc.generateNull(mb, dtd, localFields);
+    }
 
-	String newRowLocationScanResultSetName()
-	{
-		currentRowScanResultSetName = newFieldName();
-		return currentRowScanResultSetName;
-	}
+    /**
+        Generate a data value.
+        The value is to be set in the SQL data value is required
+        on the stack and will be popped, a SQL data value
+        is pushed.
+    */
+    void generateDataValue(MethodBuilder mb, TypeCompiler tc,
+            int collationType, LocalField field) {
+        pushDataValueFactory(mb);
+        mb.swap(); // need the dvf as the instance
+        tc.generateDataValue(mb, collationType, field);
+    }
 
-	// return the Name of ResultSet with the RowLocations to be modified (deleted or updated).
-	String getRowLocationScanResultSetName()
-	{
-		return currentRowScanResultSetName;
-	}
 
-	public int getNextFieldNum() {
-		return this.nextFieldNum;
-	}
+    /**
+     *generates a variable name for the rowscanresultset.
+     *This can not be a fixed name because in cases like
+     *cascade delete same activation class will be dealing
+     * more than one RowScanResultSets for dependent tables.
+    */
+
+    String newRowLocationScanResultSetName()
+    {
+        currentRowScanResultSetName = newFieldName();
+        return currentRowScanResultSetName;
+    }
+
+    // return the Name of ResultSet with the RowLocations to be modified (deleted or updated).
+    String getRowLocationScanResultSetName()
+    {
+        return currentRowScanResultSetName;
+    }
+
+    public int getNextFieldNum() {
+        return this.nextFieldNum;
+    }
 
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -482,8 +482,10 @@ public class SQLParser extends SQLGrammarImpl
         if (tokKind == CURRENT_DATE ||
             tokKind == CURRENT_TIME ||
             tokKind == CURRENT_TIMESTAMP ||
+            tokKind == CURRENT_TIMEZONE ||
             tokKind == NOW ||
             tokKind == CURRENT && (isDATETIME(getToken(2).kind)) ||
+            tokKind == CURRENT && getToken(2).kind == TIMEZONE ||
             tokKind == CURRENT && getToken(2).kind == SERVER ||
             tokKind == CURRENT_SERVER ||
             tokKind == CURRENT && getToken(2).kind == DATABASE ||
@@ -735,6 +737,7 @@ public class SQLParser extends SQLGrammarImpl
           case CURRENT_DATE:
           case CURRENT_TIME:
           case CURRENT_TIMESTAMP:
+          case CURRENT_TIMEZONE:
           case CURRENT_SERVER:
           case CURRENT_DATABASE:
           case NOW:
@@ -742,7 +745,7 @@ public class SQLParser extends SQLGrammarImpl
             break;
 
           case CURRENT:
-            if (isDATETIME(getToken(2).kind) || getToken(2).kind == SERVER || getToken(2).kind == DATABASE)
+            if (isDATETIME(getToken(2).kind) || getToken(2).kind == TIMEZONE || getToken(2).kind == SERVER || getToken(2).kind == DATABASE)
                 retval = true;
             break;
 
@@ -1612,6 +1615,7 @@ TOKEN [IGNORE_CASE] :
 |    <CURRENT_SERVER: "current_server">
 |    <CURRENT_TIME: "current_time">
 |    <CURRENT_TIMESTAMP: "current_timestamp">
+|    <CURRENT_TIMEZONE: "current_timezone">
 |    <CURRENT_USER: "current_user">
 |    <CURSOR: "cursor">
 |    <D: "d">
@@ -1755,6 +1759,7 @@ TOKEN [IGNORE_CASE] :
 |    <SYSTEM_USER: "system_user">
 |    <TABLE: "table">
 |    <TEMPORARY: "temporary">
+|    <TIMEZONE : "timezone">
 |    <TIMEZONE_HOUR: "timezone_hour">
 |    <TIMEZONE_MINUTE: "timezone_minute">
 |    <TINYINT: "tinyint">
@@ -10977,6 +10982,23 @@ datetimeValueFunction() throws StandardException :
                             getContextManager());
     }
 |
+    LOOKAHEAD({(getToken(1).kind == CURRENT && getToken(2).kind == TIMEZONE)}) <CURRENT> <TIMEZONE>
+    {
+        return (ValueNode) nodeFactory.getNode(
+                            C_NodeTypes.CURRENT_DATETIME_OPERATOR_NODE,
+                            ReuseFactory.getInteger(
+                                CurrentDatetimeOperatorNode.CURRENT_TIMEZONE),
+                            getContextManager());
+    }
+    | <CURRENT_TIMEZONE>
+    {
+        return (ValueNode) nodeFactory.getNode(
+                            C_NodeTypes.CURRENT_DATETIME_OPERATOR_NODE,
+                            ReuseFactory.getInteger(
+                                CurrentDatetimeOperatorNode.CURRENT_TIMEZONE),
+                            getContextManager());
+    }
+|
     LOOKAHEAD({(getToken(1).kind == CURRENT && getToken(2).kind == TIMESTAMP)}) <CURRENT> <TIMESTAMP>
     {
         return (ValueNode) nodeFactory.getNode(
@@ -13789,7 +13811,8 @@ DB2DefaultOption(String columnName) throws StandardException :
     LOOKAHEAD({
                 getToken(1).kind == DATE ||
                 getToken(1).kind == TIME ||
-                getToken(1).kind == TIMESTAMP
+                getToken(1).kind == TIMESTAMP ||
+                getToken(1).kind == TIMEZONE
             })
     value = miscBuiltins()
     { // these functions are allowed as valid <cast-function> defaults.
@@ -17118,6 +17141,7 @@ reservedKeyword() :
 |    tok = <CURRENT_SERVER>
 |    tok = <CURRENT_TIME>
 |    tok = <CURRENT_TIMESTAMP>
+|    tok = <CURRENT_TIMEZONE>
 |    tok = <CURRENT_USER>
 |    tok = <CURSOR>
 |    tok = <DEALLOCATE>
@@ -17264,6 +17288,7 @@ reservedKeyword() :
 |    tok = <SYSTEM_USER>
 |    tok = <TABLE>
 |    tok = <TEMPORARY>
+|    tok = <TIMEZONE>
 |    tok = <TIMEZONE_HOUR>
 |    tok = <TIMEZONE_MINUTE>
 |    tok = <TO>

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CurrentDatetime.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CurrentDatetime.java
@@ -143,9 +143,11 @@ public class CurrentDatetime {
     }
 
     public BigDecimal getCurrentTimezone() {
-        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("IST")); // no support for explicit TZ settings, use the current one
-        Duration duration = Duration.ofMillis(cal.get(Calendar.ZONE_OFFSET));
-        long seconds = duration.getSeconds();
+        return getCurrentTimezone(Duration.ofMillis(Calendar.getInstance().get(Calendar.ZONE_OFFSET)));
+    }
+
+    public BigDecimal getCurrentTimezone(Duration timezoneOffsetDuration) {
+        long seconds = timezoneOffsetDuration.getSeconds();
         long absSeconds = Math.abs(seconds);
         int hour = (int)((absSeconds / 3600) % 24);
         int minute = (int)(absSeconds % 3600) / 60;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CurrentDatetime.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CurrentDatetime.java
@@ -31,10 +31,17 @@
 
 package com.splicemachine.db.impl.sql.execute;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+import java.util.Calendar;
+import java.util.TimeZone;
 
 /**
     CurrentDatetime provides execution support for ensuring
@@ -133,6 +140,23 @@ public class CurrentDatetime {
             currentTimestamp.setNanos(newNanos);
         }
         return currentTimestamp;
+    }
+
+    public BigDecimal getCurrentTimezone() {
+        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("IST")); // no support for explicit TZ settings, use the current one
+        Duration duration = Duration.ofMillis(cal.get(Calendar.ZONE_OFFSET));
+        long seconds = duration.getSeconds();
+        long absSeconds = Math.abs(seconds);
+        int hour = (int)((absSeconds / 3600) % 24);
+        int minute = (int)(absSeconds % 3600) / 60;
+        int second = (int)(absSeconds % 60);
+        long result = hour * 10000;
+        result += minute * 100;
+        result += second;
+        if(seconds < 0) {
+            result *= -1;
+        }
+        return new BigDecimal(result);
     }
 
     /**

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -752,6 +752,7 @@ public interface SQLState {
     String LANG_INVALID_AGGREGATION_DATATYPE          = "2202E";
     String LANG_INVALID_TIME_SPAN_OPERATION           = "2202F";
     String LANG_FIELD_POSITION_ZERO                   = "22030";
+    String LANG_INVALID_TIMEZONE_OPERATION            = "22031";
     /*
      ** Integrity violations.
      */

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -911,6 +911,11 @@ Guide.
                 <text>Field position must be greater than zero.</text>
             </msg>
 
+            <msg>
+                <name>22031</name>
+                <text>Invalid timezone arithmetic operation.</text>
+            </msg>
+
 
         </family>
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateFunctions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceDateFunctions.java
@@ -69,17 +69,42 @@ public class SpliceDateFunctions {
     }
 
     public static Timestamp TIMEZONE_SUBTRACT(Timestamp leftOperand, BigDecimal timezoneDiffNode) throws StandardException {
-        return TIMEZONE_ARITHMETIC(leftOperand, timezoneDiffNode, true);
+        if (leftOperand == null) {
+            return null;
+        }
+        Timestamp result = new Timestamp(TIMEZONE_ARITHMETIC(leftOperand.getTime(), timezoneDiffNode, true));
+        result.setNanos(leftOperand.getNanos());
+        return result;
+    }
+
+    public static Time TIMEZONE_SUBTRACT(Time leftOperand, BigDecimal timezoneDiffNode) throws StandardException {
+        if (leftOperand == null) {
+            return null;
+        }
+        return new Time(TIMEZONE_ARITHMETIC(leftOperand.getTime(), timezoneDiffNode, true));
     }
 
     public static Timestamp TIMEZONE_ADD(Timestamp leftOperand, BigDecimal timezoneDiffNode) throws StandardException {
         return TIMEZONE_ARITHMETIC(leftOperand, timezoneDiffNode, false);
     }
 
+    public static Time TIMEZONE_ADD(Time leftOperand, BigDecimal timezoneDiffNode) throws StandardException {
+        if (leftOperand == null) {
+            return null;
+        }
+        return new Time(TIMEZONE_ARITHMETIC(leftOperand.getTime(), timezoneDiffNode, false));
+    }
+
     private static Timestamp TIMEZONE_ARITHMETIC(Timestamp leftOperand, BigDecimal timezoneDiffNode, boolean subtract) throws StandardException {
         if (leftOperand == null) {
             return null;
         }
+        Timestamp result = new Timestamp(TIMEZONE_ARITHMETIC(leftOperand.getTime(), timezoneDiffNode, false));
+        result.setNanos(leftOperand.getNanos());
+        return result;
+    }
+
+    private static long TIMEZONE_ARITHMETIC(long time, BigDecimal timezoneDiffNode, boolean subtract) throws StandardException {
         long timezoneDiff = timezoneDiffNode.longValue();
         boolean isNegative = timezoneDiff < 0;
         timezoneDiff = Math.abs(timezoneDiff);
@@ -94,7 +119,7 @@ public class SpliceDateFunctions {
         if(subtract) {
             timezoneDiffSeconds *= -1;
         }
-        return new Timestamp(leftOperand.getTime() + timezoneDiffSeconds * 1000);
+        return time + timezoneDiffSeconds * 1000;
     }
 
     /**

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimestampIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimestampIT.java
@@ -13,7 +13,9 @@
  */
 package com.splicemachine.derby.impl.sql.execute.operations;
 
+import com.splicemachine.db.client.am.SqlState;
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.types.SQLTimestamp;
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
@@ -950,5 +952,21 @@ public class TimestampIT extends SpliceUnitTest {
             if(bOK) return;
         }
         Assert.fail("current timestamp precision didn't work");
+    }
+
+    private static void verifyCurrentTimezoneInvalid(String query) throws Exception {
+        try {
+            methodWatcher.executeQuery(query);
+        } catch(Exception e) {
+            Assert.assertTrue(e instanceof SQLException);
+            SQLException sqlException = (SQLException)e;
+            Assert.assertEquals(SQLState.LANG_INVALID_TIMEZONE_OPERATION, sqlException.getSQLState());
+        }
+    }
+
+    @Test
+    public void testCurrentTimezoneInvalidExpressions() throws Exception {
+        verifyCurrentTimezoneInvalid("select current_timezone - current_timestamp from sysibm.sysdummy1");
+        verifyCurrentTimezoneInvalid("select date('2020-10-10') - current_timezone from sysibm.sysdummy1");
     }
 }


### PR DESCRIPTION
In this PR we provide support to [DB2's CURRENT TIMEZONE](https://www.ibm.com/support/producthub/db2/docs/content/SSEPGG_11.5.0/com.ibm.db2.luw.sql.ref.doc/doc/r0005887.html?pos=2).

According to the documentation, `CURRENT TIMEZONE` (or `CURRENT_TIMEZONE`) returns the server's timezone offset as `DEC(6,0)`. We can also use with a timestamp expression to return it in UTC (GMT).

Some example how this works (all examples assume that the server is running in IST (05:30+GMT)

```
splice> select current_timezone from t1;
1
-------
53000 -- decimal(6,0)

splice> select current_timestamp from  t1;
1
-----------------------------
2021-01-20 20:23:10.516897

splice> select current_timestamp - current_timezone from t1;
1
-----------------------------
2021-01-20 14:53:02.12 -- we shift 5:30 hours earlier

splice> select current_timestamp + current_timezone from t1;
1
-----------------------------
2021-01-21 01:53:24.504 -- we shift 5:30 hours later

-- it can also work with expressions
splice> select timestampadd(sql_tsi_year, 3, timestamp('2020-11-11 13:10:11.12345')) - current_timezone from   t1;
1
-----------------------------
2023-11-11 07:40:11.123
```

Adding integration tests to this feature is somehow difficult since it requires starting the cluster with different timezones e.g. [as explained here](https://docs.oracle.com/javase/9/troubleshoot/time-zone-settings-jre.htm#JSTGD377). Therefore, I think we would cooperate with the QA team to test this feature end to end.