### PR TITLE
DB-10968/DB-11156 SET_GLOBAL_DATABASE_PROPERTY should check existence of properties, restrict execution of GET_REGION_SERVER_CONFIG_INFO

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/catalog/SystemProcedures.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/SystemProcedures.java
@@ -36,6 +36,7 @@ import com.splicemachine.db.iapi.db.PropertyInfo;
 import com.splicemachine.db.iapi.error.PublicAPI;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.Property;
+import com.splicemachine.db.iapi.reference.PropertyHelper;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.i18n.MessageService;
 import com.splicemachine.db.iapi.services.property.PropertyUtil;
@@ -55,15 +56,11 @@ import com.splicemachine.db.shared.common.reference.AuditEventType;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.log4j.Logger;
 import com.splicemachine.utils.StringUtils;
-import splice.com.google.common.collect.Lists;
-import splice.com.google.common.net.HostAndPort;
 
-import java.io.IOException;
 import java.security.AccessController;
 import java.security.Policy;
 import java.security.PrivilegedAction;
 import java.sql.*;
-import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.StringTokenizer;
@@ -2084,9 +2081,9 @@ public class SystemProcedures{
                 throw StandardException.newException(SQLState.AUTH_INVALID_USER_NAME, (Object) null);
 
             String addListProperty;
-            if(Property.FULL_ACCESS.equals(connectionPermission)){
+            if(PropertyHelper.FULL_ACCESS.equals(connectionPermission)){
                 addListProperty=Property.FULL_ACCESS_USERS_PROPERTY;
-            }else if(Property.READ_ONLY_ACCESS.equals(connectionPermission)){
+            }else if(PropertyHelper.READ_ONLY_ACCESS.equals(connectionPermission)){
                 addListProperty=Property.READ_ONLY_ACCESS_USERS_PROPERTY;
             }else if(connectionPermission==null){
                 // Remove from the lists but don't add back into any.

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/property/PropertyUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/property/PropertyUtil.java
@@ -31,15 +31,11 @@
 
 package com.splicemachine.db.iapi.services.property;
 
+import com.splicemachine.db.iapi.reference.*;
 import splice.com.google.common.base.Optional;
 import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.iapi.reference.Attribute;
-import com.splicemachine.db.iapi.reference.EngineType;
-import com.splicemachine.db.iapi.reference.Property;
-import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.monitor.ModuleFactory;
 import com.splicemachine.db.iapi.services.monitor.Monitor;
-import com.splicemachine.db.iapi.sql.conn.ConnectionUtil;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.util.IdUtil;
 import com.splicemachine.db.iapi.util.StringUtil;
@@ -98,7 +94,7 @@ public class PropertyUtil {
             Property.LOCKS_ESCALATION_THRESHOLD,
             Property.DATABASE_PROPERTIES_ONLY,
             Property.DEFAULT_CONNECTION_MODE_PROPERTY,
-            Property.AUTHENTICATION_BUILTIN_ALGORITHM,
+            PropertyHelper.AUTHENTICATION_BUILTIN_ALGORITHM,
             Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED
     };
 
@@ -653,7 +649,7 @@ public class PropertyUtil {
      * value of Property.AUTHENTICATION_PROVIDER_PARAMETER.
      */
     private static boolean nativeAuthenticationEnabled( String authenticationProvider ) {
-        return authenticationProvider != null && StringUtil.SQLToUpperCase(authenticationProvider).startsWith(Property.AUTHENTICATION_PROVIDER_NATIVE);
+        return authenticationProvider != null && StringUtil.SQLToUpperCase(authenticationProvider).startsWith(PropertyHelper.AUTHENTICATION_PROVIDER_NATIVE);
 
     }
     
@@ -671,7 +667,7 @@ public class PropertyUtil {
              );
 
         return StringUtil.SQLToUpperCase( authenticationProvider ).endsWith
-            ( Property.AUTHENTICATION_PROVIDER_LOCAL_SUFFIX );
+            ( PropertyHelper.AUTHENTICATION_PROVIDER_LOCAL_SUFFIX );
     }
 
     /**
@@ -679,7 +675,7 @@ public class PropertyUtil {
      */
     public static boolean createNativeAuthenticationCredentialsDatabaseEnabled(Properties properties)
     {
-        return "true".equals(getPropertyFromSet(properties, Property.AUTHENTICATION_NATIVE_CREATE_CREDENTIALS_DATABASE));
+        return "true".equals(getPropertyFromSet(properties, PropertyHelper.AUTHENTICATION_NATIVE_CREATE_CREDENTIALS_DATABASE));
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataTypeDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataTypeDescriptor.java
@@ -37,7 +37,7 @@ import com.splicemachine.db.catalog.types.RowMultiSetImpl;
 import com.splicemachine.db.catalog.types.TypeDescriptorImpl;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.Limits;
-import com.splicemachine.db.iapi.reference.Property;
+import com.splicemachine.db.iapi.reference.PropertyHelper;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.io.Formatable;
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
@@ -55,7 +55,6 @@ import java.sql.Types;
 import java.text.RuleBasedCollator;
 
 import static com.splicemachine.db.iapi.types.TypeId.CHAR_ID;
-import static com.splicemachine.db.iapi.types.TypeId.DECFLOAT_PRECISION;
 
 /**
  * DataTypeDescriptor describes a runtime SQL type.
@@ -1014,17 +1013,17 @@ public class DataTypeDescriptor implements Formatable{
      * @return The collation type, or -1 if not recognized.
      */
     public static int getCollationType(String collationName){
-        if(collationName.equalsIgnoreCase(Property.UCS_BASIC_COLLATION))
+        if(collationName.equalsIgnoreCase(PropertyHelper.UCS_BASIC_COLLATION))
             return StringDataValue.COLLATION_TYPE_UCS_BASIC;
-        else if(collationName.equalsIgnoreCase(Property.TERRITORY_BASED_COLLATION))
+        else if(collationName.equalsIgnoreCase(PropertyHelper.TERRITORY_BASED_COLLATION))
             return StringDataValue.COLLATION_TYPE_TERRITORY_BASED;
-        else if(collationName.equalsIgnoreCase(Property.TERRITORY_BASED_PRIMARY_COLLATION))
+        else if(collationName.equalsIgnoreCase(PropertyHelper.TERRITORY_BASED_PRIMARY_COLLATION))
             return StringDataValue.COLLATION_TYPE_TERRITORY_BASED_PRIMARY;
-        else if(collationName.equalsIgnoreCase(Property.TERRITORY_BASED_SECONDARY_COLLATION))
+        else if(collationName.equalsIgnoreCase(PropertyHelper.TERRITORY_BASED_SECONDARY_COLLATION))
             return StringDataValue.COLLATION_TYPE_TERRITORY_BASED_SECONDARY;
-        else if(collationName.equalsIgnoreCase(Property.TERRITORY_BASED_TERTIARY_COLLATION))
+        else if(collationName.equalsIgnoreCase(PropertyHelper.TERRITORY_BASED_TERTIARY_COLLATION))
             return StringDataValue.COLLATION_TYPE_TERRITORY_BASED_TERTIARY;
-        else if(collationName.equalsIgnoreCase(Property.TERRITORY_BASED_IDENTICAL_COLLATION))
+        else if(collationName.equalsIgnoreCase(PropertyHelper.TERRITORY_BASED_IDENTICAL_COLLATION))
             return StringDataValue.COLLATION_TYPE_TERRITORY_BASED_IDENTICAL;
         else
             return -1;
@@ -1042,7 +1041,7 @@ public class DataTypeDescriptor implements Formatable{
      */
     public String getCollationName(){
         if(getCollationDerivation()==StringDataValue.COLLATION_DERIVATION_NONE)
-            return Property.COLLATION_NONE;
+            return PropertyHelper.COLLATION_NONE;
         else
             return getCollationName(getCollationType());
     }
@@ -1056,17 +1055,17 @@ public class DataTypeDescriptor implements Formatable{
     public static String getCollationName(int collationType){
         switch(collationType){
             case StringDataValue.COLLATION_TYPE_TERRITORY_BASED:
-                return Property.TERRITORY_BASED_COLLATION;
+                return PropertyHelper.TERRITORY_BASED_COLLATION;
             case StringDataValue.COLLATION_TYPE_TERRITORY_BASED_PRIMARY:
-                return Property.TERRITORY_BASED_PRIMARY_COLLATION;
+                return PropertyHelper.TERRITORY_BASED_PRIMARY_COLLATION;
             case StringDataValue.COLLATION_TYPE_TERRITORY_BASED_SECONDARY:
-                return Property.TERRITORY_BASED_SECONDARY_COLLATION;
+                return PropertyHelper.TERRITORY_BASED_SECONDARY_COLLATION;
             case StringDataValue.COLLATION_TYPE_TERRITORY_BASED_TERTIARY:
-                return Property.TERRITORY_BASED_TERTIARY_COLLATION;
+                return PropertyHelper.TERRITORY_BASED_TERTIARY_COLLATION;
             case StringDataValue.COLLATION_TYPE_TERRITORY_BASED_IDENTICAL:
-                return Property.TERRITORY_BASED_IDENTICAL_COLLATION;
+                return PropertyHelper.TERRITORY_BASED_IDENTICAL_COLLATION;
             default:
-                return Property.UCS_BASIC_COLLATION;
+                return PropertyHelper.UCS_BASIC_COLLATION;
         }
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/AuthenticationServiceBase.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/AuthenticationServiceBase.java
@@ -470,14 +470,14 @@ public abstract class AuthenticationServiceBase
 		if ( key.startsWith(Property.USER_PROPERTY_PREFIX) ) { return true; }
 
         String      stringValue = (String) value;
-        boolean     settingToNativeLocal = Property.AUTHENTICATION_PROVIDER_NATIVE_LOCAL.equals( stringValue );
+        boolean     settingToNativeLocal = PropertyHelper.AUTHENTICATION_PROVIDER_NATIVE_LOCAL.equals( stringValue );
         
         if ( Property.AUTHENTICATION_PROVIDER_PARAMETER.equals( key ) )
         {
             // NATIVE + LOCAL is the only value of this property which can be persisted
             if (
                 ( stringValue != null ) &&
-                ( stringValue.startsWith( Property.AUTHENTICATION_PROVIDER_NATIVE ) )&&
+                ( stringValue.startsWith( PropertyHelper.AUTHENTICATION_PROVIDER_NATIVE ) )&&
                 !settingToNativeLocal
                 )
             {
@@ -486,7 +486,7 @@ public abstract class AuthenticationServiceBase
 
             // once set to NATIVE authentication, you can't change it
             String  oldValue = (String) p.get( Property.AUTHENTICATION_PROVIDER_PARAMETER );
-            if ( (oldValue != null) && oldValue.startsWith( Property.AUTHENTICATION_PROVIDER_NATIVE ) )
+            if ( (oldValue != null) && oldValue.startsWith( PropertyHelper.AUTHENTICATION_PROVIDER_NATIVE ) )
             {
                 throw StandardException.newException( SQLState.PROPERTY_CANT_UNDO_NATIVE );
             }
@@ -507,21 +507,21 @@ public abstract class AuthenticationServiceBase
             }
         }
 
-        if ( Property.AUTHENTICATION_NATIVE_PASSWORD_LIFETIME.equals( key ) )
+        if ( PropertyHelper.AUTHENTICATION_NATIVE_PASSWORD_LIFETIME.equals( key ) )
         {
             if ( parsePasswordLifetime( stringValue ) == null )
             {
                 throw StandardException.newException
-                    ( SQLState.BAD_PASSWORD_LIFETIME, Property.AUTHENTICATION_NATIVE_PASSWORD_LIFETIME );
+                    ( SQLState.BAD_PASSWORD_LIFETIME, PropertyHelper.AUTHENTICATION_NATIVE_PASSWORD_LIFETIME );
             }
         }
         
-        if ( Property.AUTHENTICATION_PASSWORD_EXPIRATION_THRESHOLD.equals( key ) )
+        if ( PropertyHelper.AUTHENTICATION_PASSWORD_EXPIRATION_THRESHOLD.equals( key ) )
         {
             if ( parsePasswordThreshold( stringValue ) == null )
             {
                 throw StandardException.newException
-                    ( SQLState.BAD_PASSWORD_LIFETIME, Property.AUTHENTICATION_PASSWORD_EXPIRATION_THRESHOLD );
+                    ( SQLState.BAD_PASSWORD_LIFETIME, PropertyHelper.AUTHENTICATION_PASSWORD_EXPIRATION_THRESHOLD );
             }
         }
         
@@ -577,7 +577,7 @@ public abstract class AuthenticationServiceBase
 			(String)p.get(Property.AUTHENTICATION_PROVIDER_PARAMETER);
 
 		if ((authService != null) &&
-			 (StringUtil.SQLEqualsIgnoreCase(authService, Property.AUTHENTICATION_PROVIDER_LDAP)))
+			 (StringUtil.SQLEqualsIgnoreCase(authService, PropertyHelper.AUTHENTICATION_PROVIDER_LDAP)))
 			return null;
 
 		// Ok, we can hash this password in the db

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/BasicAuthenticationServiceImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/BasicAuthenticationServiceImpl.java
@@ -32,6 +32,7 @@
 package com.splicemachine.db.impl.jdbc.authentication;
 
 import com.splicemachine.db.iapi.reference.Property;
+import com.splicemachine.db.iapi.reference.PropertyHelper;
 import com.splicemachine.db.iapi.sql.dictionary.PasswordHasher;
 import com.splicemachine.db.iapi.reference.Attribute;
 import com.splicemachine.db.iapi.reference.SQLState;
@@ -95,7 +96,7 @@ public final class BasicAuthenticationServiceImpl
         return !((authenticationProvider != null) &&
                 (!authenticationProvider.isEmpty()) &&
                 (!(StringUtil.SQLEqualsIgnoreCase(authenticationProvider,
-                        Property.AUTHENTICATION_PROVIDER_BUILTIN))));
+                        PropertyHelper.AUTHENTICATION_PROVIDER_BUILTIN))));
 	}
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/NativeAuthenticationServiceImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/NativeAuthenticationServiceImpl.java
@@ -47,6 +47,7 @@ import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.util.IdUtil;
 import com.splicemachine.db.impl.jdbc.Util;
 import com.splicemachine.db.jdbc.InternalDriver;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.sql.DataSource;
 import java.security.MessageDigest;
@@ -387,9 +388,6 @@ public final class NativeAuthenticationServiceImpl
     private boolean isCredentialsService( String canonicalDatabaseName )
         throws StandardException {
         String canonicalCredentialsDBName = getCanonicalServiceName(_credentialsDB);
-
-        String canonicalDB = Monitor.getMonitor().getCanonicalServiceName(canonicalDatabaseName);
-
         return canonicalCredentialsDBName != null && canonicalCredentialsDBName.equals(canonicalDatabaseName);
     }
 
@@ -493,7 +491,10 @@ public final class NativeAuthenticationServiceImpl
 	 * @param userPassword	The user's password used to connect to JBMS system
 	 * @param databaseName	The database which the user wants to connect to.
 	 */
-	private boolean	authenticateLocally
+	@SuppressFBWarnings({"RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", // intentional, DERBY-5539
+            "RV_RETURN_VALUE_IGNORED" // false positive
+	    })
+    private boolean	authenticateLocally
         (
          String userName,
          String userPassword,

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/NativeAuthenticationServiceImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/NativeAuthenticationServiceImpl.java
@@ -36,6 +36,7 @@ import com.splicemachine.db.iapi.error.SQLWarningFactory;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.Attribute;
 import com.splicemachine.db.iapi.reference.Property;
+import com.splicemachine.db.iapi.reference.PropertyHelper;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.monitor.Monitor;
 import com.splicemachine.db.iapi.services.property.PropertyUtil;
@@ -97,8 +98,8 @@ public final class NativeAuthenticationServiceImpl
     
     private String      _credentialsDB;
     private boolean _authenticateDatabaseOperationsLocally;
-    private long        _passwordLifetimeMillis = Property.AUTHENTICATION_NATIVE_PASSWORD_LIFETIME_DEFAULT;
-    private double      _passwordExpirationThreshold = Property.AUTHENTICATION_PASSWORD_EXPIRATION_THRESHOLD_DEFAULT;
+    private long        _passwordLifetimeMillis = PropertyHelper.AUTHENTICATION_NATIVE_PASSWORD_LIFETIME_DEFAULT;
+    private double      _passwordExpirationThreshold = PropertyHelper.AUTHENTICATION_PASSWORD_EXPIRATION_THRESHOLD_DEFAULT;
     private String      _badlyFormattedPasswordProperty;
 
     ///////////////////////////////////////////////////////////////////////////////////
@@ -170,7 +171,7 @@ public final class NativeAuthenticationServiceImpl
         String passwordLifetimeString = PropertyUtil.getPropertyFromSet
             (
              properties,
-             Property.AUTHENTICATION_NATIVE_PASSWORD_LIFETIME
+             PropertyHelper.AUTHENTICATION_NATIVE_PASSWORD_LIFETIME
              );
         if ( passwordLifetimeString != null )
         {
@@ -178,13 +179,13 @@ public final class NativeAuthenticationServiceImpl
 
             if ( passwordLifetime != null ) { _passwordLifetimeMillis = passwordLifetime; }
             else
-            { _badlyFormattedPasswordProperty = Property.AUTHENTICATION_NATIVE_PASSWORD_LIFETIME; }
+            { _badlyFormattedPasswordProperty = PropertyHelper.AUTHENTICATION_NATIVE_PASSWORD_LIFETIME; }
         }
 
         String  expirationThresholdString = PropertyUtil.getPropertyFromSet
             (
              properties,
-             Property.AUTHENTICATION_PASSWORD_EXPIRATION_THRESHOLD
+             PropertyHelper.AUTHENTICATION_PASSWORD_EXPIRATION_THRESHOLD
              );
         if ( expirationThresholdString != null )
         {
@@ -192,7 +193,7 @@ public final class NativeAuthenticationServiceImpl
 
             if ( expirationThreshold != null ) { _passwordExpirationThreshold = expirationThreshold; }
             else
-            { _badlyFormattedPasswordProperty = Property.AUTHENTICATION_PASSWORD_EXPIRATION_THRESHOLD; }
+            { _badlyFormattedPasswordProperty = PropertyHelper.AUTHENTICATION_PASSWORD_EXPIRATION_THRESHOLD; }
         }
         
     }
@@ -589,7 +590,7 @@ public final class NativeAuthenticationServiceImpl
                     throw SQLWarningFactory.newSQLWarning( SQLState.DBO_PASSWORD_EXPIRES_SOON, databaseName );
                 }
                 
-                long    daysRemaining = remainingLifetime / Property.MILLISECONDS_IN_DAY;
+                long    daysRemaining = remainingLifetime / PropertyHelper.MILLISECONDS_IN_DAY;
                 throw SQLWarningFactory.newSQLWarning
                     ( SQLState.PASSWORD_EXPIRES_SOON, Long.toString( daysRemaining ), databaseName );
             }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/SpecificAuthenticationServiceImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/authentication/SpecificAuthenticationServiceImpl.java
@@ -32,6 +32,7 @@
 package com.splicemachine.db.impl.jdbc.authentication;
 
 import com.splicemachine.db.iapi.reference.Property;
+import com.splicemachine.db.iapi.reference.PropertyHelper;
 import com.splicemachine.db.iapi.reference.SQLState;
 
 import com.splicemachine.db.iapi.error.StandardException;
@@ -90,9 +91,9 @@ public class SpecificAuthenticationServiceImpl
 			  (!specificAuthenticationScheme.isEmpty()) &&
 
 			  (!((StringUtil.SQLEqualsIgnoreCase(specificAuthenticationScheme,
-					  Property.AUTHENTICATION_PROVIDER_BUILTIN)) ||
-			  (specificAuthenticationScheme.equalsIgnoreCase(Property.AUTHENTICATION_PROVIDER_LDAP))     ||
-					  (specificAuthenticationScheme.equalsIgnoreCase(Property.AUTHENTICATION_PROVIDER_KERBEROS))
+					  PropertyHelper.AUTHENTICATION_PROVIDER_BUILTIN)) ||
+			  (specificAuthenticationScheme.equalsIgnoreCase(PropertyHelper.AUTHENTICATION_PROVIDER_LDAP))     ||
+					  (specificAuthenticationScheme.equalsIgnoreCase(PropertyHelper.AUTHENTICATION_PROVIDER_KERBEROS))
 
 			  )));
 	}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -409,11 +409,11 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
                 //is either UCS_BASIC or TERRITORY_BASED. If none provided, 
                 //then we will take it to be the default which is UCS_BASIC.
                 userDefinedCollation=startParams.getProperty(
-                        Attribute.COLLATION,Property.UCS_BASIC_COLLATION);
+                        Attribute.COLLATION, PropertyHelper.UCS_BASIC_COLLATION);
                 bootingTC.setProperty(Property.COLLATION,userDefinedCollation,true);
             }else{
                 userDefinedCollation=startParams.getProperty(
-                        Property.COLLATION,Property.UCS_BASIC_COLLATION);
+                        Property.COLLATION, PropertyHelper.UCS_BASIC_COLLATION);
             }
 
             //Initialize the collation type of user schemas by looking at
@@ -492,7 +492,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
                 // Set default hash algorithm used to protect passwords stored
                 // in the database for BUILTIN and NATIVE authentication.
                 bootingTC.setProperty(
-                        Property.AUTHENTICATION_BUILTIN_ALGORITHM,
+                        PropertyHelper.AUTHENTICATION_BUILTIN_ALGORITHM,
                         findDefaultBuiltinAlgorithm(),
                         false);
             }else{
@@ -579,11 +579,11 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
     private String findDefaultBuiltinAlgorithm(){
         try{
             // First check for the preferred default, and return it if present
-            MessageDigest.getInstance(Property.AUTHENTICATION_BUILTIN_ALGORITHM_DEFAULT);
-            return Property.AUTHENTICATION_BUILTIN_ALGORITHM_DEFAULT;
+            MessageDigest.getInstance(PropertyHelper.AUTHENTICATION_BUILTIN_ALGORITHM_DEFAULT);
+            return PropertyHelper.AUTHENTICATION_BUILTIN_ALGORITHM_DEFAULT;
         }catch(NoSuchAlgorithmException nsae){
             // Couldn't find the preferred algorithm, so use the fallback
-            return Property.AUTHENTICATION_BUILTIN_ALGORITHM_FALLBACK;
+            return PropertyHelper.AUTHENTICATION_BUILTIN_ALGORITHM_FALLBACK;
         }
     }
 
@@ -728,7 +728,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
         if(!supportConfigurableHash){
             return null;
         }else{
-            String algorithm=(String)PropertyUtil.getPropertyFromSet(props,Property.AUTHENTICATION_BUILTIN_ALGORITHM);
+            String algorithm=(String)PropertyUtil.getPropertyFromSet(props, PropertyHelper.AUTHENTICATION_BUILTIN_ALGORITHM);
 
             if(algorithm==null){
                 return null;
@@ -743,8 +743,8 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
                     salt=generateRandomSalt(props);
                     iterations=getIntProperty(
                             props,
-                            Property.AUTHENTICATION_BUILTIN_ITERATIONS,
-                            Property.AUTHENTICATION_BUILTIN_ITERATIONS_DEFAULT,
+                            PropertyHelper.AUTHENTICATION_BUILTIN_ITERATIONS,
+                            PropertyHelper.AUTHENTICATION_BUILTIN_ITERATIONS_DEFAULT,
                             1,Integer.MAX_VALUE);
                 }
             }
@@ -763,8 +763,8 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
      */
     private byte[] generateRandomSalt(Dictionary props){
         int saltLength=getIntProperty(props,
-                Property.AUTHENTICATION_BUILTIN_SALT_LENGTH,
-                Property.AUTHENTICATION_BUILTIN_SALT_LENGTH_DEFAULT,
+                PropertyHelper.AUTHENTICATION_BUILTIN_SALT_LENGTH,
+                PropertyHelper.AUTHENTICATION_BUILTIN_SALT_LENGTH_DEFAULT,
                 0,Integer.MAX_VALUE);
 
         SecureRandom random=new SecureRandom();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateIndexNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateIndexNode.java
@@ -34,6 +34,7 @@ package com.splicemachine.db.impl.sql.compile;
 import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.Property;
+import com.splicemachine.db.iapi.reference.PropertyHelper;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.loader.GeneratedClass;
@@ -450,7 +451,7 @@ public class CreateIndexNode extends DDLStatementNode
 
                 properties.put(
                     Property.PAGE_SIZE_PARAMETER,
-                    Property.PAGE_SIZE_DEFAULT_LONG);
+                    PropertyHelper.PAGE_SIZE_DEFAULT_LONG);
 
             }
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateTableNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateTableNode.java
@@ -33,6 +33,7 @@ package com.splicemachine.db.impl.sql.compile;
 
 import com.splicemachine.db.iapi.error.ExceptionSeverity;
 import com.splicemachine.db.iapi.reference.Property;
+import com.splicemachine.db.iapi.reference.PropertyHelper;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.reference.Limits;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
@@ -678,7 +679,7 @@ public class CreateTableNode extends DDLStatementNode
 
                 properties.put(
                     Property.PAGE_SIZE_PARAMETER,
-                    Property.PAGE_SIZE_DEFAULT_LONG);
+                    PropertyHelper.PAGE_SIZE_DEFAULT_LONG);
             }
         }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableElementList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableElementList.java
@@ -35,6 +35,7 @@ import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.catalog.types.DefaultInfoImpl;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.Property;
+import com.splicemachine.db.iapi.reference.PropertyHelper;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.services.property.PropertyUtil;
@@ -1347,7 +1348,7 @@ public class TableElementList extends QueryTreeNodeVector {
         {
             result.put(
                     Property.PAGE_SIZE_PARAMETER,
-                    Property.PAGE_SIZE_DEFAULT_LONG);
+                    PropertyHelper.PAGE_SIZE_DEFAULT_LONG);
         }
         return result;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericAuthorizer.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericAuthorizer.java
@@ -34,6 +34,7 @@ package com.splicemachine.db.impl.sql.conn;
 import com.splicemachine.db.catalog.types.RoutineAliasInfo;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.Property;
+import com.splicemachine.db.iapi.reference.PropertyHelper;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.property.PersistentSet;
 import com.splicemachine.db.iapi.services.property.PropertyUtil;
@@ -255,11 +256,11 @@ public class GenericAuthorizer implements Authorizer {
                                     Property.DEFAULT_CONNECTION_MODE_PROPERTY);
         if (modeS == null)
             return FULL_ACCESS;
-        else if(StringUtil.SQLEqualsIgnoreCase(modeS, Property.NO_ACCESS))
+        else if(StringUtil.SQLEqualsIgnoreCase(modeS, PropertyHelper.NO_ACCESS))
             return NO_ACCESS;
-        else if(StringUtil.SQLEqualsIgnoreCase(modeS, Property.READ_ONLY_ACCESS))
+        else if(StringUtil.SQLEqualsIgnoreCase(modeS, PropertyHelper.READ_ONLY_ACCESS))
             return READ_ACCESS;
-        else if(StringUtil.SQLEqualsIgnoreCase(modeS, Property.FULL_ACCESS))
+        else if(StringUtil.SQLEqualsIgnoreCase(modeS, PropertyHelper.FULL_ACCESS))
             return FULL_ACCESS;
         else
         {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionFactory.java
@@ -353,9 +353,9 @@ public class GenericLanguageConnectionFactory
         else if (key.equals(Property.DEFAULT_CONNECTION_MODE_PROPERTY))
         {
             String value_s = (String)value;
-            if (!StringUtil.SQLEqualsIgnoreCase(value_s, Property.NO_ACCESS) &&
-                !StringUtil.SQLEqualsIgnoreCase(value_s, Property.READ_ONLY_ACCESS) &&
-                !StringUtil.SQLEqualsIgnoreCase(value_s, Property.FULL_ACCESS))
+            if (!StringUtil.SQLEqualsIgnoreCase(value_s, PropertyHelper.NO_ACCESS) &&
+                !StringUtil.SQLEqualsIgnoreCase(value_s, PropertyHelper.READ_ONLY_ACCESS) &&
+                !StringUtil.SQLEqualsIgnoreCase(value_s, PropertyHelper.FULL_ACCESS))
                 throw StandardException.newException(SQLState.AUTH_INVALID_AUTHORIZATION_PROPERTY, key, value_s);
 
             return true;

--- a/db-engine/src/main/java/com/splicemachine/utils/DbEngineUtils.java
+++ b/db-engine/src/main/java/com/splicemachine/utils/DbEngineUtils.java
@@ -2,16 +2,15 @@ package com.splicemachine.utils;
 
 public class DbEngineUtils {
 
-    public static String getJavaRegexpFilterFromAsterixFilter(String asterixFilter)
+    public static String getJavaRegexpFilterFromAsteriskFilter(String asteriskFilter)
     {
-        String filter = asterixFilter;
+        String filter = asteriskFilter;
+        filter = filter.replace("\\", "\\\\");
         String toEscape[] = {"<", "(", "[", "{", "^", "-", "=", "$", "!", "|", "]", "}", ")", "+", ".", ">"};
         for(String s : toEscape) {
-            filter = filter.replaceAll("\\" + s, "\\\\" + s);
+            filter = filter.replace(s, "\\" + s);
         }
-        filter.replaceAll("\\\\", "\\\\\\\\");
-
-        filter = filter.replaceAll("\\*", ".*");
-        return filter.replaceAll("\\?", ".");
+        filter = filter.replace("*", ".*");
+        return filter.replace("?", ".");
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/utils/DbEngineUtils.java
+++ b/db-engine/src/main/java/com/splicemachine/utils/DbEngineUtils.java
@@ -1,0 +1,17 @@
+package com.splicemachine.utils;
+
+public class DbEngineUtils {
+
+    public static String getJavaRegexpFilterFromAsterixFilter(String asterixFilter)
+    {
+        String filter = asterixFilter;
+        String toEscape[] = {"<", "(", "[", "{", "^", "-", "=", "$", "!", "|", "]", "}", ")", "+", ".", ">"};
+        for(String s : toEscape) {
+            filter = filter.replaceAll("\\" + s, "\\\\" + s);
+        }
+        filter.replaceAll("\\\\", "\\\\\\\\");
+
+        filter = filter.replaceAll("\\*", ".*");
+        return filter.replaceAll("\\?", ".");
+    }
+}

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -58,7 +58,7 @@ public interface Property {
      * Property that holds the client   IP Address
      *
      */
-    public static final String IP_ADDRESS = "ip_address";
+    String IP_ADDRESS = "ip_address";
 
     /**
      * Name of the file that contains system wide properties. Has to be located
@@ -117,7 +117,6 @@ public interface Property {
      Takes precendence over db.stream.error.method.
      Takes precendence over db.stream.error.field
      */
-
     String ERRORLOG_FILE_PROPERTY = "derby.stream.error.file";
 
     /**
@@ -188,83 +187,9 @@ public interface Property {
      */
     String DELETE_ON_CREATE = "derby.__deleteOnCreate";
 
-    /**
-     db.database.forceDatabaseLock
-     <BR>
-     Derby attempts to prevent two instances of Derby from booting
-     the same database with the use of a file called db.lck inside the
-     database directory.
-
-     On some platforms, Derby can successfully prevent a second
-     instance of Derby from booting the database, and thus prevents
-     corruption. If this is the case, you will see an SQLException like the
-     following:
-
-     ERROR XJ040: Failed to start database 'toursDB', see the next exception
-     for details.
-     ERROR XSDB6: Another instance of Derby may have already booted the
-     database C:\databases\toursDB.
-
-     The error is also written to the information log.
-
-     On other platforms, Derby issues a warning message if an instance
-     of Derby attempts to boot a database that may already have a
-     running instance of Derby attached to it.
-     However, it does not prevent the second instance from booting, and thus
-     potentially corrupting, the database.
-
-     If a warning message has been issued, corruption may already have
-     occurred.
-
-
-     The warning message looks like this:
-
-     WARNING: Derby (instance 80000000-00d2-3265-de92-000a0a0a0200) is
-     attempting to boot the database /export/home/sky/wombat even though
-     Derby (instance 80000000-00d2-3265-8abf-000a0a0a0200) may still be
-     active. Only one instance of Derby
-     should boot a database at a time. Severe and non-recoverable corruption
-     can result and may have already occurred.
-
-     The warning is also written to the information log.
-
-     This warning is primarily a Technical Support aid to determine the
-     cause of corruption. However, if you see this warning, your best
-     choice is to close the connection and exit the JVM. This minimizes the
-     risk of a corruption. Close all instances of Derby, then restart
-     one instance of Derby and shut down the database properly so that
-     the db.lck file can be removed. The warning message continues to appear
-     until a proper shutdown of the Derby system can delete the db.lck
-     file.
-
-     If the "derby.database.forceDatabaseLock" property is set to true
-     then this default behavior is altered on systems where Derby cannot
-     prevent this dual booting.  If the to true, then if the platform does
-     not provide the ability for Derby to guarantee no double boot, and
-     if Derby finds a db.lck file when it boots, it will throw an
-     exception (TODO - mikem - add what exception), leave the db.lck file
-     in place and not boot the system.  At this point the system will not
-     boot until the db.lck file is removed by hand.  Note that this
-     situation can arise even when 2 VM's are not accessing the same
-     Derby system.  Also note that if the db.lck file is removed by
-     hand while a VM is still accessing a db.database, then there
-     is no way for Derby to prevent a second VM from starting up and
-     possibly corrupting the database.  In this situation no warning
-     message will be logged to the error log.
-
-     To disable the default behavior of the db.lck file set property as
-     follows:
-
-     db.database.forceDatabaseLock=true
-
-     */
-    String FORCE_DATABASE_LOCK = "derby.database.forceDatabaseLock";
-
-
     /*
      ** db.locks.* and related properties
      */
-
     String LOCKS_INTRO = "derby.locks.";
 
     /**
@@ -281,11 +206,6 @@ public interface Property {
      The default value for LOCKS_ESCALATION_THRESHOLD
      */
     int DEFAULT_LOCKS_ESCALATION_THRESHOLD = 5000;
-
-    /**
-     The minimum value for LOCKS_ESCALATION_THRESHOLD
-     */
-    int MIN_LOCKS_ESCALATION_THRESHOLD = 100;
 
     /**
      Configuration parameter for deadlock timeouts, set in seconds.
@@ -391,11 +311,6 @@ public interface Property {
     String PAGE_SIZE_PARAMETER = "derby.storage.pageSize";
 
     /**
-     * The default page size to use for tables that contain a long column.
-     **/
-    String PAGE_SIZE_DEFAULT_LONG = "32768";
-
-    /**
      * The bump threshold for pages sizes for create tables
      * If the approximate column sizes of a table is greater than this
      * threshold, the page size for the tbl is bumped to PAGE_SIZE_DEFAULT_LONG
@@ -492,28 +407,6 @@ public interface Property {
             "derby.system.durability";
 
     /**
-     * This is a value supported for db.system.durability
-     * When db.system.durability=test, the storage system does not
-     * force syncs and the system may not recover. It is also possible that
-     * the database might be in an inconsistent state
-     * @see #DURABILITY_PROPERTY
-     */
-    String DURABILITY_TESTMODE_NO_SYNC = "test";
-
-    /**
-     * db.storage.fileSyncTransactionLog
-     * <p>
-     * When set, the store system will use sync() call on the log at 
-     * commit instead of doing  a write sync on all writes to  the log;
-     * even if the write sync mode (rws) is supported in the JVM.
-     * <p>
-     *
-     **/
-    String FILESYNC_TRANSACTION_LOG =
-            "derby.storage.fileSyncTransactionLog";
-
-
-    /**
      *	db.storage.logArchiveMode
      *<BR>
      *used to identify whether the log is being archived for the database or not.
@@ -528,17 +421,6 @@ public interface Property {
      */
     String LOG_ARCHIVE_MODE = "derby.storage.logArchiveMode";
 
-
-    /**
-     *	db.storage.logDeviceWhenBackedUp
-     *<BR>
-     *  This property indicates the logDevice location(path) when the backup was
-     *  taken, used to restore the log to the same location while restoring from
-     *  backup.
-     *<P>
-     *<B>INTERNAL USE ONLY</B>
-     */
-    String LOG_DEVICE_AT_BACKUP = "derby.storage.logDeviceWhenBackedUp";
 
     /**
      * derby.module.modulename
@@ -845,14 +727,6 @@ public interface Property {
     double STORAGE_AUTO_INDEX_STATS_DEBUG_LNDIFF_THRESHOLD_DEFAULT = 1.0;
 
     /**
-     * Specifies the size of the work unit queue in the index statistics update
-     * daemon.
-     */
-    String STORAGE_AUTO_INDEX_STATS_DEBUG_QUEUE_SIZE =
-            "derby.storage.indexStats.debug.queueSize";
-    int STORAGE_AUTO_INDEX_STATS_DEBUG_QUEUE_SIZE_DEFAULT = 20;
-
-    /**
      * Specifies whether to revert to 10.8 behavior and keep disposable stats.
      */
     String STORAGE_AUTO_INDEX_STATS_DEBUG_KEEP_DISPOSABLE_STATS =
@@ -906,10 +780,6 @@ public interface Property {
     String
             DEFAULT_CONNECTION_MODE_PROPERTY = "derby.database.defaultConnectionMode";
 
-    String NO_ACCESS = "NOACCESS";
-    String READ_ONLY_ACCESS = "READONLYACCESS";
-    String FULL_ACCESS = "FULLACCESS";
-
     /**
      * List of users with read-only connection level authorization.
      */
@@ -938,97 +808,6 @@ public interface Property {
 
     // These are the different built-in providers Derby supports
 
-    String AUTHENTICATION_PROVIDER_NATIVE =
-            "NATIVE:";
-
-    String AUTHENTICATION_PROVIDER_BUILTIN =
-            "BUILTIN";
-
-    String AUTHENTICATION_PROVIDER_LDAP =
-            "LDAP";
-
-    String AUTHENTICATION_PROVIDER_KERBEROS =
-            "KERBEROS";
-    String AUTHENTICATION_SERVER_PARAMETER =
-            "derby.authentication.server";
-
-    // this suffix on the NATIVE authentication provider means that
-    // database operations should be authenticated locally
-    String AUTHENTICATION_PROVIDER_LOCAL_SUFFIX =
-            ":LOCAL";
-
-    // when local native authentication is enabled, we store this value for db.authentication.provider
-    String AUTHENTICATION_PROVIDER_NATIVE_LOCAL =
-            AUTHENTICATION_PROVIDER_NATIVE + AUTHENTICATION_PROVIDER_LOCAL_SUFFIX;
-
-    // Property to force the creation of the native credentials database.
-    // Generally, this is only done at the time of the creation of the whole Splice/Derby database.
-    // In this particular instance, there are Splice beta customers with AnA disabled and they want to
-    // switch to using native AnA.  So we allow a manual override here.  See DB-2088 for more details.
-    String AUTHENTICATION_NATIVE_CREATE_CREDENTIALS_DATABASE =
-            "derby.authentication.native.create.credentials.database";
-
-    // lifetime (in milliseconds) of a NATIVE password. if <= 0, then the password never expires
-    String AUTHENTICATION_NATIVE_PASSWORD_LIFETIME =
-            "derby.authentication.native.passwordLifetimeMillis";
-
-    // default lifetime (in milliseconds) of a NATIVE password. FOREVER
-    long MILLISECONDS_IN_DAY = 1000L * 60L * 60L * 24L;
-    long AUTHENTICATION_NATIVE_PASSWORD_LIFETIME_DEFAULT = 0L;
-
-    // threshhold for raising a warning that a password is about to expire.
-    // raise a warning if the remaining password lifetime is less than this proportion of the max lifetime.
-    String  AUTHENTICATION_PASSWORD_EXPIRATION_THRESHOLD =
-            "derby.authentication.native.passwordLifetimeThreshold";
-    double  AUTHENTICATION_PASSWORD_EXPIRATION_THRESHOLD_DEFAULT = 0.125;
-
-
-    /**
-     * Property that specifies the name of the hash algorithm to use with
-     * the configurable hash authentication scheme.
-     */
-    String AUTHENTICATION_BUILTIN_ALGORITHM =
-            "derby.authentication.builtin.algorithm";
-
-    /**
-     * Default value for db.authentication.builtin.algorithm when creating
-     * a new database.
-     */
-    String AUTHENTICATION_BUILTIN_ALGORITHM_DEFAULT =
-            "SHA-256";
-
-    /**
-     * Alternative default value for db.authentication.builtin.algorithm if
-     * {@link #AUTHENTICATION_BUILTIN_ALGORITHM_DEFAULT} is not available at
-     * database creation time.
-     */
-    String AUTHENTICATION_BUILTIN_ALGORITHM_FALLBACK =
-            "SHA-1";
-
-    /**
-     * Property that specifies the number of bytes with random salt to use
-     * when hashing credentials using the configurable hash authentication
-     * scheme.
-     */
-    String AUTHENTICATION_BUILTIN_SALT_LENGTH =
-            "derby.authentication.builtin.saltLength";
-
-    /**
-     * The default value for db.authentication.builtin.saltLength.
-     */
-    int AUTHENTICATION_BUILTIN_SALT_LENGTH_DEFAULT = 16;
-
-    /**
-     * Property that specifies the number of times to apply the hash
-     * function in the configurable hash authentication scheme.
-     */
-    String AUTHENTICATION_BUILTIN_ITERATIONS =
-            "derby.authentication.builtin.iterations";
-
-    /**
-     * Default value for db.authentication.builtin.iterations.
-     */
-    int AUTHENTICATION_BUILTIN_ITERATIONS_DEFAULT = 1000;
 
     /*
      ** Log
@@ -1048,29 +827,6 @@ public interface Property {
      Property name for specifying log archival location
      */
     String LOG_ARCHIVAL_DIRECTORY = "derby.storage.logArchive";
-
-    /**
-     Property name for specifying log Buffer Size
-     */
-    String LOG_BUFFER_SIZE = "derby.storage.logBufferSize";
-
-
-    /*
-     ** Replication
-     */
-
-    /** Property name for specifying the size of the replication log buffers */
-    String REPLICATION_LOG_BUFFER_SIZE= "derby.replication.logBufferSize";
-
-    /** Property name for specifying the minimum log shipping interval*/
-    String REPLICATION_MIN_SHIPPING_INTERVAL = "derby.replication.minLogShippingInterval";
-
-    /** Property name for specifying the maximum log shipping interval*/
-    String REPLICATION_MAX_SHIPPING_INTERVAL = "derby.replication.maxLogShippingInterval";
-
-    /** Property name for specifying whether or not replication messages are
-     * written to the log*/
-    String REPLICATION_VERBOSE = "derby.replication.verbose";
 
     /*
      ** Upgrade
@@ -1105,10 +861,6 @@ public interface Property {
      <B>INTERNAL USE ONLY</B>
      */
     String DELETE_ROOT_ON_ERROR  = PROPERTY_RUNTIME_PREFIX  + "deleteRootOnError";
-
-    String HTTP_DB_FILE_OFFSET = "db2j.http.file.offset";
-    String HTTP_DB_FILE_LENGTH = "db2j.http.file.length";
-    String HTTP_DB_FILE_NAME =   "db2j.http.file.name";
 
     /**
      * db.drda.startNetworkServer
@@ -1220,74 +972,6 @@ public interface Property {
     String SERVICE_LOCALE = "derby.serviceLocale";
 
     String COLLATION = "derby.database.collation";
-    // These are the six possible values for collation type if the collation
-    // derivation is not NONE. If collation derivation is NONE, then collation
-    // type should be ignored. The TERRITORY_BASED collation uses the default
-    // collator strength while the four with a colon uses a specific strength.
-    String UCS_BASIC_COLLATION =
-            "UCS_BASIC";
-    String TERRITORY_BASED_COLLATION =
-            "TERRITORY_BASED";
-    String TERRITORY_BASED_PRIMARY_COLLATION =
-            "TERRITORY_BASED:PRIMARY";
-    String TERRITORY_BASED_SECONDARY_COLLATION =
-            "TERRITORY_BASED:SECONDARY";
-    String TERRITORY_BASED_TERTIARY_COLLATION =
-            "TERRITORY_BASED:TERTIARY";
-    String TERRITORY_BASED_IDENTICAL_COLLATION =
-            "TERRITORY_BASED:IDENTICAL";
-    // Define a static string for collation derivation NONE
-    String COLLATION_NONE =
-            "NONE";
-
-    /**
-     * db2j.storage.dataNotSyncedAtCheckPoint
-     * <p>
-     * When set, the store system will not force a sync() call on the
-     * containers during a checkpoint.
-     * <p>
-     * An internal debug system only flag.  The recovery system will not
-     * work properly if this flag is enabled, it is provided to do performance
-     * debugging to see whether the system is I/O bound based on checkpoint
-     * synchronous I/O.
-     * <p>
-     *
-     **/
-    String STORAGE_DATA_NOT_SYNCED_AT_CHECKPOINT =
-            "db2j.storage.dataNotSyncedAtCheckPoint";
-
-    /**
-     * db2j.storage.dataNotSyncedAtAllocation
-     * <p>
-     * When set, the store system will not force a sync() call on the
-     * containers when pages are allocated.
-     * <p>
-     * An internal debug system only flag.  The recovery system will not
-     * work properly if this flag is enabled, it is provided to do performance
-     * debugging to see whether the system is I/O bound based on page allocation
-     * synchronous I/O.
-     * <p>
-     *
-     **/
-    String STORAGE_DATA_NOT_SYNCED_AT_ALLOCATION =
-            "db2j.storage.dataNotSyncedAtAllocation";
-
-    /**
-     * db2j.storage.logNotSynced
-     * <p>
-     * When set, the store system will not force a sync() call on the log at 
-     * commit.
-     * <p>
-     * An internal debug system only flag.  The recovery system will not
-     * work properly if this flag is enabled, it is provided to do performance
-     * debugging to see whether the system is I/O bound based on log file
-     * synchronous I/O.
-     * <p>
-     *
-     **/
-    String STORAGE_LOG_NOT_SYNCED =
-            "db2j.storage.logNotSynced";
-
 
     /**
      * db.storage.useDefaultFilePermissions = {false,true}

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/PropertyHelper.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/PropertyHelper.java
@@ -1,0 +1,122 @@
+package com.splicemachine.db.iapi.reference;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+import java.util.TreeSet;
+
+public class PropertyHelper {
+    // These are the six possible values for collation type if the collation
+    // derivation is not NONE. If collation derivation is NONE, then collation
+    // type should be ignored. The TERRITORY_BASED collation uses the default
+    // collator strength while the four with a colon uses a specific strength.
+    public static final String UCS_BASIC_COLLATION =
+            "UCS_BASIC";
+    public static final String TERRITORY_BASED_COLLATION =
+            "TERRITORY_BASED";
+    public static final String TERRITORY_BASED_PRIMARY_COLLATION =
+            "TERRITORY_BASED:PRIMARY";
+    public static final String TERRITORY_BASED_SECONDARY_COLLATION =
+            "TERRITORY_BASED:SECONDARY";
+    public static final String TERRITORY_BASED_TERTIARY_COLLATION =
+            "TERRITORY_BASED:TERTIARY";
+    public static final String TERRITORY_BASED_IDENTICAL_COLLATION =
+            "TERRITORY_BASED:IDENTICAL";
+    // Define a static string for collation derivation NONE
+    public static final String COLLATION_NONE =
+            "NONE";
+    /**
+     * The default page size to use for tables that contain a long column.
+     **/
+    public static final String PAGE_SIZE_DEFAULT_LONG = "32768";
+    public static final String AUTHENTICATION_PROVIDER_NATIVE =
+            "NATIVE:";
+    public static final String AUTHENTICATION_PROVIDER_BUILTIN =
+            "BUILTIN";
+    public static final String AUTHENTICATION_PROVIDER_LDAP =
+            "LDAP";
+    public static final String AUTHENTICATION_PROVIDER_KERBEROS =
+            "KERBEROS";
+    public static final String AUTHENTICATION_SERVER_PARAMETER =
+            "derby.authentication.server";
+    // this suffix on the NATIVE authentication provider means that
+    // database operations should be authenticated locally
+    public static final String AUTHENTICATION_PROVIDER_LOCAL_SUFFIX =
+            ":LOCAL";
+    // when local native authentication is enabled, we store this value for db.authentication.provider
+    public static final String AUTHENTICATION_PROVIDER_NATIVE_LOCAL =
+            AUTHENTICATION_PROVIDER_NATIVE + AUTHENTICATION_PROVIDER_LOCAL_SUFFIX;
+    // Property to force the creation of the native credentials database.
+    // Generally, this is only done at the time of the creation of the whole Splice/Derby database.
+    // In this particular instance, there are Splice beta customers with AnA disabled and they want to
+    // switch to using native AnA.  So we allow a manual override here.  See DB-2088 for more details.
+    public static final String AUTHENTICATION_NATIVE_CREATE_CREDENTIALS_DATABASE =
+            "derby.authentication.native.create.credentials.database";
+    // lifetime (in milliseconds) of a NATIVE password. if <= 0, then the password never expires
+    public static final String AUTHENTICATION_NATIVE_PASSWORD_LIFETIME =
+            "derby.authentication.native.passwordLifetimeMillis";
+    // default lifetime (in milliseconds) of a NATIVE password. FOREVER
+    public static final long MILLISECONDS_IN_DAY = 1000L * 60L * 60L * 24L;
+    public static final long AUTHENTICATION_NATIVE_PASSWORD_LIFETIME_DEFAULT = 0L;
+    // threshhold for raising a warning that a password is about to expire.
+    // raise a warning if the remaining password lifetime is less than this proportion of the max lifetime.
+    public static final String  AUTHENTICATION_PASSWORD_EXPIRATION_THRESHOLD =
+            "derby.authentication.native.passwordLifetimeThreshold";
+    public static final double  AUTHENTICATION_PASSWORD_EXPIRATION_THRESHOLD_DEFAULT = 0.125;
+    /**
+     * Property that specifies the name of the hash algorithm to use with
+     * the configurable hash authentication scheme.
+     */
+    public static final String AUTHENTICATION_BUILTIN_ALGORITHM =
+            "derby.authentication.builtin.algorithm";
+    /**
+     * Default value for db.authentication.builtin.algorithm when creating
+     * a new database.
+     */
+    public static final String AUTHENTICATION_BUILTIN_ALGORITHM_DEFAULT =
+            "SHA-256";
+    /**
+     * Alternative default value for db.authentication.builtin.algorithm if
+     * {@link #AUTHENTICATION_BUILTIN_ALGORITHM_DEFAULT} is not available at
+     * database creation time.
+     */
+    public static final String AUTHENTICATION_BUILTIN_ALGORITHM_FALLBACK =
+            "SHA-1";
+    /**
+     * Property that specifies the number of bytes with random salt to use
+     * when hashing credentials using the configurable hash authentication
+     * scheme.
+     */
+    public static final String AUTHENTICATION_BUILTIN_SALT_LENGTH =
+            "derby.authentication.builtin.saltLength";
+    /**
+     * The default value for db.authentication.builtin.saltLength.
+     */
+    public static final int AUTHENTICATION_BUILTIN_SALT_LENGTH_DEFAULT = 16;
+    /**
+     * Property that specifies the number of times to apply the hash
+     * function in the configurable hash authentication scheme.
+     */
+    public static final String AUTHENTICATION_BUILTIN_ITERATIONS =
+            "derby.authentication.builtin.iterations";
+    /**
+     * Default value for db.authentication.builtin.iterations.
+     */
+    public static final int AUTHENTICATION_BUILTIN_ITERATIONS_DEFAULT = 1000;
+    public static final String NO_ACCESS = "NOACCESS";
+    public static final String READ_ONLY_ACCESS = "READONLYACCESS";
+    public static final String FULL_ACCESS = "FULLACCESS";
+
+    public static Set<String> getAllProperties() {
+        Set<String> propertyList = new TreeSet<>();
+        // get configuration fields from class com.splicemachine.db.iapi.reference.Property
+        for (Field field : com.splicemachine.db.iapi.reference.Property.class.getFields()) {
+            try {
+                if(field.getType().equals(String.class))
+                    propertyList.add( ((String)field.get(null)) );
+            } catch (IllegalAccessException e) {
+                // continue
+            }
+        }
+        return propertyList;
+    }
+}

--- a/hbase_sql/src/test/java/com/splicemachine/derby/utils/SqlshellIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/utils/SqlshellIT.java
@@ -8,7 +8,6 @@ import com.splicemachine.db.impl.tools.ij.ijCommands;
 import com.splicemachine.derby.test.framework.SpliceNetConnection;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import org.apache.commons.io.IOUtils;
 import org.junit.*;
 

--- a/hbase_sql/src/test/java/com/splicemachine/derby/utils/SqlshellIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/utils/SqlshellIT.java
@@ -8,6 +8,7 @@ import com.splicemachine.db.impl.tools.ij.ijCommands;
 import com.splicemachine.derby.test.framework.SpliceNetConnection;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.*;
 

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/AuthenticationConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/AuthenticationConfiguration.java
@@ -14,7 +14,7 @@
 
 package com.splicemachine.access.configuration;
 
-import com.splicemachine.db.iapi.reference.Property;
+import com.splicemachine.db.iapi.reference.PropertyHelper;
 
 /**
  * @author Scott Fines
@@ -108,7 +108,7 @@ public class AuthenticationConfiguration implements ConfigurationDefault {
             builder.authorizationScheme = System.getProperty(AUTHORIZATION_SCHEME);
         else
             builder.authorizationScheme = configurationSource.getString(AUTHORIZATION_SCHEME, DEFAULT_AUTHORIZATION_SCHEME);
-        if (builder.authentication.equals(Property.AUTHENTICATION_PROVIDER_LDAP)) {
+        if (builder.authentication.equals(PropertyHelper.AUTHENTICATION_PROVIDER_LDAP)) {
             builder.authenticationLdapServer = configurationSource.getString(AUTHENTICATION_LDAP_SERVER, DEFAULT_AUTHENTICATION_LDAP_SERVER);
             builder.authenticationLdapSearchauthdn = configurationSource.getString(AUTHENTICATION_LDAP_SEARCHAUTHDN, DEFAULT_AUTHENTICATION_LDAP_SEARCHAUTHDN);
             builder.authenticationLdapSearchauthpw = configurationSource.getString(AUTHENTICATION_LDAP_SEARCHAUTH_PASSWORD, DEFAULT_AUTHENTICATION_LDAP_SEARCHAUTHPW);

--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SConfigurationImpl.java
@@ -1185,9 +1185,14 @@ public final class SConfigurationImpl implements SConfiguration {
             }
             config.put(field.getName(), (value == null ? "null" : value));
         }
-        for (Map.Entry<String,String> hadoopEntry : getConfigSource().prefixMatch(null).entrySet()) {
-            String value = hadoopEntry.getValue();
-            config.put(hadoopEntry.getKey(), (value == null ? "null" : value));
+        try {
+            for (Map.Entry<String, String> hadoopEntry : getConfigSource().prefixMatch(null).entrySet()) {
+                String value = hadoopEntry.getValue();
+                config.put(hadoopEntry.getKey(), (value == null ? "null" : value));
+            }
+        } catch(sun.reflect.generics.reflectiveObjects.NotImplementedException e) {
+            // on mem platform we can't access this
+            LOG.info("can't access SConfigurationImpl.getConfigSource. Is this Mem Platform?");
         }
         return config;
     }

--- a/splice_ck/src/main/java/com/splicemachine/ck/command/TListCommand.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/command/TListCommand.java
@@ -17,9 +17,11 @@ package com.splicemachine.ck.command;
 import com.splicemachine.ck.HBaseInspector;
 import com.splicemachine.ck.Utils;
 import com.splicemachine.ck.command.common.CommonOptions;
+import com.splicemachine.utils.DbEngineUtils;
 import picocli.CommandLine;
 
 import java.util.concurrent.Callable;
+
 
 @CommandLine.Command(name = "tlist", description = "list SpliceMachine tables (similar to systables)" )
 public class TListCommand extends CommonOptions implements Callable<Integer>
@@ -27,23 +29,11 @@ public class TListCommand extends CommonOptions implements Callable<Integer>
     @CommandLine.Parameters(index = "0", description = "a filter applied on schemaname.tablename. supported is * or ?, e.g. *SYS????S",
             defaultValue = "") String filter;
 
-    public static String getJavaRegexpFilterFromAsterixFilter(String asterixFilter)
-    {
-        String filter = asterixFilter;
-        String toEscape[] = {"<", "(", "[", "{", "\\", "^", "-", "=", "$", "!", "|", "]", "}", ")", "+", ".", ">"};
-            for(String s : toEscape) {
-                filter = filter.replaceAll("\\" + s, "\\" + s);
-            }
-
-        filter = filter.replaceAll("\\*", ".*");
-        return filter.replaceAll("\\?", ".");
-    }
-
     @Override
     public Integer call() throws Exception {
         HBaseInspector hbaseInspector = new HBaseInspector(Utils.constructConfig(zkq, port));
 
-        String javaFilter = getJavaRegexpFilterFromAsterixFilter(filter);
+        String javaFilter = DbEngineUtils.getJavaRegexpFilterFromAsterixFilter(filter);
         System.out.println(hbaseInspector.listTables(javaFilter.toUpperCase()));
         return 0;
     }

--- a/splice_ck/src/main/java/com/splicemachine/ck/command/TListCommand.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/command/TListCommand.java
@@ -33,7 +33,7 @@ public class TListCommand extends CommonOptions implements Callable<Integer>
     public Integer call() throws Exception {
         HBaseInspector hbaseInspector = new HBaseInspector(Utils.constructConfig(zkq, port));
 
-        String javaFilter = DbEngineUtils.getJavaRegexpFilterFromAsterixFilter(filter);
+        String javaFilter = DbEngineUtils.getJavaRegexpFilterFromAsteriskFilter(filter);
         System.out.println(hbaseInspector.listTables(javaFilter.toUpperCase()));
         return 0;
     }

--- a/splice_machine/src/main/java/com/splicemachine/authentication/JNDIAuthenticationService.java
+++ b/splice_machine/src/main/java/com/splicemachine/authentication/JNDIAuthenticationService.java
@@ -113,10 +113,6 @@ public class JNDIAuthenticationService
 		// authentication scheme for this service
 		UserAuthenticator aJNDIAuthscheme;
 
-		String authenticationProvider = PropertyUtil.getPropertyFromSet(
-				properties,
-				Property.AUTHENTICATION_PROVIDER_PARAMETER);
-
 		// we're dealing with LDAP
 		aJNDIAuthscheme = ManagerLoader.load().getAuthenticationManager(this, properties);
 		this.setAuthenticationService(aJNDIAuthscheme);

--- a/splice_machine/src/main/java/com/splicemachine/authentication/JNDIAuthenticationService.java
+++ b/splice_machine/src/main/java/com/splicemachine/authentication/JNDIAuthenticationService.java
@@ -16,6 +16,7 @@ package com.splicemachine.authentication;
 
 import com.splicemachine.db.iapi.reference.Property;
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.PropertyHelper;
 import com.splicemachine.db.iapi.services.property.PropertyUtil;
 
 import com.splicemachine.db.authentication.UserAuthenticator;
@@ -77,9 +78,9 @@ public class JNDIAuthenticationService
 
 		return (authenticationProvider != null) &&
 				(StringUtil.SQLEqualsIgnoreCase(authenticationProvider,
-						Property.AUTHENTICATION_PROVIDER_LDAP) ||
+						PropertyHelper.AUTHENTICATION_PROVIDER_LDAP) ||
 				StringUtil.SQLEqualsIgnoreCase(authenticationProvider,
-						Property.AUTHENTICATION_PROVIDER_KERBEROS));
+						PropertyHelper.AUTHENTICATION_PROVIDER_KERBEROS));
 
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
@@ -21,6 +21,7 @@ import com.splicemachine.db.iapi.ast.ISpliceVisitor;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.jdbc.AuthenticationService;
 import com.splicemachine.db.iapi.reference.Property;
+import com.splicemachine.db.iapi.reference.PropertyHelper;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.context.Context;
 import com.splicemachine.db.iapi.services.context.ContextManager;
@@ -203,7 +204,7 @@ public class SpliceDatabase extends BasicDatabase{
     protected void configureAuthentication(){
         SConfiguration configuration =SIDriver.driver().getConfiguration();
         if(configuration.authenticationNativeCreateCredentialsDatabase()) {
-            System.setProperty(Property.AUTHENTICATION_NATIVE_CREATE_CREDENTIALS_DATABASE,Boolean.toString(true));
+            System.setProperty(PropertyHelper.AUTHENTICATION_NATIVE_CREATE_CREDENTIALS_DATABASE,Boolean.toString(true));
         }
 
         String authTypeString=configuration.getAuthentication();
@@ -246,7 +247,7 @@ public class SpliceDatabase extends BasicDatabase{
         System.setProperty("derby.connection.requireAuthentication","true");
         System.setProperty("derby.database.sqlAuthorization","true");
         SpliceLogUtils.info(LOG,"using Kerberos to authorize Splice Machine");
-        System.setProperty("derby.authentication.provider", Property.AUTHENTICATION_PROVIDER_KERBEROS);
+        System.setProperty("derby.authentication.provider", PropertyHelper.AUTHENTICATION_PROVIDER_KERBEROS);
     }
 
     private void configureLDAPAuth(SConfiguration config){
@@ -263,7 +264,7 @@ public class SpliceDatabase extends BasicDatabase{
                 authenticationLDAPSearchAuthDN,
                 authenticationLDAPSearchBase,
                 authenticationLDAPSearchFilter);
-        System.setProperty("derby.authentication.provider", Property.AUTHENTICATION_PROVIDER_LDAP);
+        System.setProperty("derby.authentication.provider", PropertyHelper.AUTHENTICATION_PROVIDER_LDAP);
         System.setProperty("derby.authentication.ldap.searchAuthDN",authenticationLDAPSearchAuthDN);
         System.setProperty("derby.authentication.ldap.searchAuthPW",authenticationLDAPSearchAuthPW);
         System.setProperty("derby.authentication.ldap.searchBase",authenticationLDAPSearchBase);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -1086,6 +1086,19 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .build());
 
         /*
+         * Procedure to get all database properties
+         */
+        procedures.add(Procedure.newBuilder().name("SYSCS_GET_GLOBAL_DATABASE_PROPERTIES")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .modifiesSql() // restrict execution
+                .returnType(null).isDeterministic(false)
+                .varchar("FILTER", Limits.DB2_VARCHAR_MAXWIDTH)
+                .arg("validate", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
+                .build());
+
+        /*
          * Procedure to enable splice enterprise version
          */
         procedures.add(Procedure.newBuilder().name("SYSCS_ENABLE_ENTERPRISE")

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -1077,7 +1077,7 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
          */
         procedures.add(Procedure.newBuilder().name("SYSCS_SET_GLOBAL_DATABASE_PROPERTY")
                 .numOutputParams(0)
-                .numResultSets(0)
+                .numResultSets(1)
                 .ownerClass(SpliceAdmin.class.getCanonicalName())
                 .modifiesSql() // restrict execution
                 .returnType(null).isDeterministic(false)

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -246,7 +246,7 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .integer("mode")            // 0 = fetch all, 1 = fetch only props where value not same on all servers
                 .numOutputParams(0)
                 .numResultSets(1)
-                .sqlControl(RoutineAliasInfo.NO_SQL)
+                .modifiesSql() // restrict execution
                 .ownerClass(SpliceAdmin.class.getCanonicalName())
                 .build();
         procedures.add(getRegionServerConfig);
@@ -872,7 +872,7 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .numResultSets(0)
                 .varchar("loggerName", 128)
                 .varchar("loggerLevel", 128)
-                .sqlControl(RoutineAliasInfo.NO_SQL)
+                .modifiesSql() // restriction execution
                 .ownerClass(SpliceAdmin.class.getCanonicalName())
                 .build();
         procedures.add(setLoggerLevel);
@@ -882,7 +882,7 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .numResultSets(0)
                 .varchar("loggerName", 128)
                 .varchar("loggerLevel", 128)
-                .sqlControl(RoutineAliasInfo.NO_SQL)
+                .modifiesSql() // restriction execution
                 .ownerClass(SpliceAdmin.class.getCanonicalName())
                 .build();
         procedures.add(setLoggerLevelLocal);
@@ -1067,7 +1067,8 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .numOutputParams(0)
                 .numResultSets(1)
                 .ownerClass(SpliceAdmin.class.getCanonicalName())
-                .sqlControl(RoutineAliasInfo.READS_SQL_DATA).returnType(null).isDeterministic(false)
+                .modifiesSql()
+                .returnType(null).isDeterministic(false)
                 .catalog("KEY")
                 .build());
 
@@ -1078,7 +1079,8 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .numOutputParams(0)
                 .numResultSets(0)
                 .ownerClass(SpliceAdmin.class.getCanonicalName())
-                .sqlControl(RoutineAliasInfo.MODIFIES_SQL_DATA).returnType(null).isDeterministic(false)
+                .modifiesSql() // restrict execution
+                .returnType(null).isDeterministic(false)
                 .catalog("KEY")
                 .varchar("VALUE", Limits.DB2_VARCHAR_MAXWIDTH)
                 .build());
@@ -1173,7 +1175,8 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .numOutputParams(0)
                 .numResultSets(0)
                 .ownerClass(SpliceAdmin.class.getCanonicalName())
-                .sqlControl(RoutineAliasInfo.NO_SQL).returnType(null).isDeterministic(false)
+                .modifiesSql() // restriction execution
+                .returnType(null).isDeterministic(false)
                 .build());
 
         procedures.add(Procedure.newBuilder().name("SYSCS_BACKUP_TABLE")

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/PropertyConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/PropertyConglomerate.java
@@ -18,6 +18,7 @@ import com.splicemachine.concurrent.Clock;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.Attribute;
 import com.splicemachine.db.iapi.reference.Property;
+import com.splicemachine.db.iapi.reference.PropertyHelper;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.io.Formatable;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
@@ -108,7 +109,7 @@ public class PropertyConglomerate {
             serviceProperties.put(Property.LOCKS_ESCALATION_THRESHOLD, "500");
             serviceProperties.put(Property.DATABASE_PROPERTIES_ONLY, "false");
             serviceProperties.put(Property.DEFAULT_CONNECTION_MODE_PROPERTY, "fullAccess");
-            serviceProperties.put(Property.AUTHENTICATION_BUILTIN_ALGORITHM, Property.AUTHENTICATION_BUILTIN_ALGORITHM_DEFAULT);
+            serviceProperties.put(PropertyHelper.AUTHENTICATION_BUILTIN_ALGORITHM, PropertyHelper.AUTHENTICATION_BUILTIN_ALGORITHM_DEFAULT);
             serviceProperties.put(Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED, "false");
             for (Object key: serviceProperties.keySet()) {
                 propertyManager.addProperty((String)key,serviceProperties.getProperty((String)key));

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/ResultHelper.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/ResultHelper.java
@@ -80,10 +80,14 @@ class ResultHelper {
     }
 
     public int numColumns() {
-        return columnDescriptors.size();
+        return columns.size();
     }
 
     public ResultColumnDescriptor[] getColumnDescriptorsArray() {
+        List<GenericColumnDescriptor> columnDescriptors = new ArrayList<>();
+        for( Column column : columns ) {
+            columnDescriptors.add(column.getGenericColumnDescriptor());
+        }
         return columnDescriptors.toArray(new ResultColumnDescriptor[columnDescriptors.size()]);
     }
 
@@ -117,33 +121,44 @@ class ResultHelper {
     class Column {
         public int index;
         boolean set = false;
+        String name;
+        int length;
 
         public void finishRow() {
             if( !set ) init();
             set = false;
         }
 
+        GenericColumnDescriptor getGenericColumnDescriptor() {
+            return new GenericColumnDescriptor(name, getDataTypeDescriptor());
+        }
+        DataTypeDescriptor getDataTypeDescriptor() { throw new RuntimeException("not implemented"); }
+
         void add(String name, int length)
         {
-            columnDescriptors.add( new GenericColumnDescriptor(name, create(length)) );
-            index = columnDescriptors.size();
+            this.name = name;
+            this.length = length;
             columns.add(this);
+            index = columns.size();
         }
 
         void init() { throw new RuntimeException("not implemented"); }
-
-        public DataTypeDescriptor create(int length) { throw new RuntimeException("not implemented"); }
     }
 
     class VarcharColumn extends Column {
+        int maxLength = 0;
+
         @Override
-        public DataTypeDescriptor create(int length)
-        {
-            return DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, length);
+        DataTypeDescriptor getDataTypeDescriptor() {
+            maxLength = Math.max(maxLength, name.length());
+            return DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR,
+                    length < 0 ? maxLength : length );
         }
+
         public void set(String value) {
             assert row != null;
             row.setColumn(index, new SQLVarchar(value));
+            maxLength = Math.max(maxLength, value == null ? 4 : value.length());
             set = true;
         }
         @Override
@@ -153,8 +168,7 @@ class ResultHelper {
     }
     class BigintColumn extends Column {
         @Override
-        public DataTypeDescriptor create(int length)
-        {
+        DataTypeDescriptor getDataTypeDescriptor() {
             return DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BIGINT, length);
         }
         public void set(long value) {
@@ -169,9 +183,7 @@ class ResultHelper {
     }
 
     class TimestampColumn extends Column {
-        @Override
-        public DataTypeDescriptor create(int length)
-        {
+        DataTypeDescriptor getDataTypeDescriptor() {
             return DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.TIMESTAMP, length);
         }
         public void set(org.joda.time.DateTime value) throws StandardException {
@@ -189,6 +201,5 @@ class ResultHelper {
     }
     private List<ExecRow> rows = new ArrayList<>();
     private List<Column> columns = new ArrayList<>();
-    private List<GenericColumnDescriptor> columnDescriptors = new ArrayList<>();
     private ExecRow row;
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
@@ -85,7 +85,6 @@ import splice.com.google.common.net.HostAndPort;
 import javax.management.MalformedObjectNameException;
 import javax.management.remote.JMXConnector;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.net.URISyntaxException;
 import java.security.SecureRandom;
 import java.sql.*;
@@ -1340,7 +1339,7 @@ public class SpliceAdmin extends BaseAdminProcedures{
         ResultHelper.VarcharColumn colValue    = resultHelper.addVarchar("VALUE", -1);
         ResultHelper.VarcharColumn colInfo     = resultHelper.addVarchar("INFO", 50);
         if( filter != null ) {
-            filter = DbEngineUtils.getJavaRegexpFilterFromAsterixFilter(filter);
+            filter = DbEngineUtils.getJavaRegexpFilterFromAsteriskFilter(filter);
         }
 
         for(String property : PropertyHelper.getAllProperties()) {

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
@@ -108,12 +108,12 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
     public static void createDataSet() throws Exception {
         createData(spliceClassWatcher.getOrCreateConnection(), spliceSchemaWatcher.toString());
         spliceClassWatcher.executeUpdate("call syscs_util.INVALIDATE_GLOBAL_DICTIONARY_CACHE()");
-        spliceClassWatcher.executeUpdate("call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', true)");
+        spliceClassWatcher.execute("call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', true)");
     }
 
     @AfterClass
     public static void exitDB2CompatibilityMode() throws Exception {
-        spliceClassWatcher.executeUpdate("call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', null)");
+        spliceClassWatcher.execute("call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', null)");
         spliceClassWatcher.executeUpdate("call syscs_util.INVALIDATE_GLOBAL_DICTIONARY_CACHE()");
     }
 
@@ -294,7 +294,7 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
     @Test
     public void testInvalidateStoredStatements() throws Exception {
         // Turn off DB2 varchar compatibility mode.
-        methodWatcher.executeUpdate("call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', null)");
+        methodWatcher.execute("call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', null)");
         methodWatcher.executeUpdate("delete from t11");
         methodWatcher.executeUpdate("create trigger trig1\n" +
                                     "after insert on t1\n" +
@@ -306,7 +306,7 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
         methodWatcher.executeUpdate("insert into t1 values (1, 'a     ')");
 
         // Turn on DB2 varchar compatibility mode.
-        methodWatcher.executeUpdate("call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', true)");
+        methodWatcher.execute("call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', true)");
 
         // The following statement should cause all triggers to be recompiled
         // the next time they are fired.
@@ -334,7 +334,7 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
         testQuery(sqlText, expected, methodWatcher);
         methodWatcher.executeUpdate("drop trigger trig1");
         methodWatcher.executeUpdate("delete from t11");
-        methodWatcher.executeUpdate("call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', null)");
+        methodWatcher.execute("call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', null)");
 
         // Delete the rows we created so we don't impact other tests.
         methodWatcher.executeUpdate("delete from t1 where b = 'a     '");
@@ -342,7 +342,7 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
 		methodWatcher.executeUpdate("insert into t11 select * from t1");
 
         // Restore the flag setting to the value when this test started.
-        methodWatcher.executeUpdate("call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', true)");
+        methodWatcher.execute("call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', true)");
     }
 
     @Test

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsImportIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/load/HdfsImportIT.java
@@ -2127,7 +2127,7 @@ public class HdfsImportIT extends SpliceUnitTest {
 
     public static void setPreserveLineEndings(Connection conn, Boolean preserve) throws Exception {
         try( Statement s = conn.createStatement()) {
-            s.executeUpdate("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( " +
+            s.execute("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( " +
                     "'" + Property.PRESERVE_LINE_ENDINGS + "', '" + preserve + "' )");
         }
     }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/catalog/SqlJJarIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/catalog/SqlJJarIT.java
@@ -194,8 +194,7 @@ public class SqlJJarIT extends SpliceUnitTest {
         Assert.assertEquals("Incorrect return code or result count returned!", 0, rc);
 
         // Add the jar file into the global DB class path.
-        rc = methodWatcher.executeUpdate(String.format(CALL_SET_GLOBAL_CLASSPATH_FORMAT_STRING, JAR_FILE_SQL_NAME));
-        Assert.assertEquals("Incorrect return code or result count returned!", 0, rc);
+        methodWatcher.execute(String.format(CALL_SET_GLOBAL_CLASSPATH_FORMAT_STRING, JAR_FILE_SQL_NAME));
 
         // Select from the user defined VTI
         rs = methodWatcher.executeQuery(SELECT_FROM_VTI_STRING);
@@ -245,8 +244,7 @@ public class SqlJJarIT extends SpliceUnitTest {
         Assert.assertEquals("Global database CLASSPATH is incorrect!", JAR_FILE_SQL_NAME, dbClassPath);
 
         // Remove the jar file from the global DB class path.
-        rc = methodWatcher.executeUpdate(CALL_SET_GLOBAL_CLASSPATH_TO_DEFAULT);
-        Assert.assertEquals("Incorrect return code or result count returned!", 0, rc);
+        methodWatcher.execute(CALL_SET_GLOBAL_CLASSPATH_TO_DEFAULT);
 
         // Remove the jar file from the DB.
         rc = methodWatcher.executeUpdate(String.format(CALL_REMOVE_JAR_FORMAT_STRING, JAR_FILE_SQL_NAME));

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/NumericTypesToStringTypesConversionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/NumericTypesToStringTypesConversionIT.java
@@ -71,7 +71,7 @@ public class NumericTypesToStringTypesConversionIT extends SpliceUnitTest {
             default:
                 assert false;
         }
-        methodWatcher.executeUpdate(String.format("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'splice.function.floatingPointNotation', '%s' )", notationStr));
+        methodWatcher.execute(String.format("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'splice.function.floatingPointNotation', '%s' )", notationStr));
     }
 
     private static final String queryTemplate = "select cast(%s as %s(%d)), cast(%s as %s(%d)), %s(%s), %s(%s) from test";

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimestampIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TimestampIT.java
@@ -887,7 +887,7 @@ public class TimestampIT extends SpliceUnitTest {
     }
 
     private void withFormat(String format) throws Exception {
-        methodWatcher.executeUpdate(String.format("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'splice.function.timestampFormat', '%s' )", format));
+        methodWatcher.execute(String.format("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'splice.function.timestampFormat', '%s' )", format));
     }
 
     private void shouldEqual(String inputTimestamp, String expectedTimestamp) throws SQLException {
@@ -942,10 +942,10 @@ public class TimestampIT extends SpliceUnitTest {
         for(int i=0; i<100; i++)
         {
             boolean bOK;
-            methodWatcher.executeUpdate("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'splice.function.currentTimestampPrecision', '1' )");
+            methodWatcher.execute("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'splice.function.currentTimestampPrecision', '1' )");
             bOK = "2020-12-06 21:50:13.1".length()
                     == methodWatcher.executeGetString( "values current timestamp", 1 ).length();
-            methodWatcher.executeUpdate("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'splice.function.currentTimestampPrecision', '9' )");
+            methodWatcher.execute("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'splice.function.currentTimestampPrecision', '9' )");
             bOK = bOK && "2020-12-06 21:50:13.123456789".length()
                     == methodWatcher.executeGetString( "values current timestamp", 1 ).length();
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
@@ -1069,14 +1069,12 @@ public class SpliceUnitTest {
         return count;
     }
 
-    /// execute sql query 'sqlText' and expect an exception of certain state being thrown
-    public static void sqlExpectException(SpliceWatcher methodWatcher, String sqlText, String expectedState, boolean update)
-    {
-        try {
+    public static void sqlExpectException(Connection conn, String sqlText, String expectedState, boolean update) {
+        try ( Statement s = conn.createStatement() ){
             if( update )
-                methodWatcher.executeUpdate(sqlText);
+                s.executeUpdate(sqlText);
             else {
-                ResultSet rs = methodWatcher.executeQuery(sqlText);
+                ResultSet rs = s.executeQuery(sqlText);
                 rs.close();
             }
             Assert.fail("Exception not thrown for " + sqlText);
@@ -1086,6 +1084,12 @@ public class SpliceUnitTest {
         } catch (Exception e) {
             Assert.assertEquals("Wrong Exception for " + sqlText + ". " + e, expectedState, e.getClass().getName());
         }
+    }
+
+    /// execute sql query 'sqlText' and expect an exception of certain state being thrown
+    public static void sqlExpectException(SpliceWatcher methodWatcher, String sqlText, String expectedState, boolean update)
+    {
+        sqlExpectException( methodWatcher.getOrCreateConnection(), sqlText, expectedState, update );
     }
 
     public static void assertThrows(Runnable r, String expectedExceptionStr) {

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceAdminIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceAdminIT.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.shared.common.reference.SQLState;
 import com.splicemachine.derby.test.framework.*;
 import com.splicemachine.test_dao.TableDAO;
@@ -614,12 +613,5 @@ public class SpliceAdminIT extends SpliceUnitTest {
         }
     }
 
-    @Test
-    public void testGetJavaRegexpFilterFromAsterixFilter() {
-        Assert.assertEquals( DbEngineUtils.getJavaRegexpFilterFromAsterixFilter("Hello*World"), "Hello.*World");
-        Assert.assertEquals( DbEngineUtils.getJavaRegexpFilterFromAsterixFilter("Hello?World"), "Hello.World");
-        Assert.assertEquals( DbEngineUtils.getJavaRegexpFilterFromAsterixFilter(
-                "With things-to-(escape)"),
-                "With things\\-to\\-\\(escape\\)");
-    }
+
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/StatisticsAdminIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/StatisticsAdminIT.java
@@ -895,7 +895,7 @@ public class StatisticsAdminIT extends SpliceUnitTest {
         /* 1. t3 has an index ind_t3_1 on (a3, e3) */
 
         /* 2. set the database property splice.database.collectIndexStatsOnly to true */
-        methodWatcher4.executeUpdate("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY('derby.database.collectIndexStatsOnly', 'true')");
+        methodWatcher4.execute("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY('derby.database.collectIndexStatsOnly', 'true')");
 
         /* 3. confirm the setting */
         String expected = "1  |\n" +
@@ -925,7 +925,7 @@ public class StatisticsAdminIT extends SpliceUnitTest {
         rs.close();
 
         /* 6. change the property to default */
-        methodWatcher4.executeUpdate("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY('derby.database.collectIndexStatsOnly', 'false')");
+        methodWatcher4.execute("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY('derby.database.collectIndexStatsOnly', 'false')");
 
         /* 7. confirm the setting */
         expected = "1   |\n" +

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/StringUtilsTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/StringUtilsTest.java
@@ -16,6 +16,7 @@ package com.splicemachine.derby.utils;
 
 import com.splicemachine.db.impl.ast.StringUtils;
 import com.splicemachine.si.testenv.ArchitectureIndependent;
+import com.splicemachine.utils.DbEngineUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -83,5 +84,17 @@ public class StringUtilsTest {
         String test = "\\u0009hello goodbye";
         String result = StringUtils.parseControlCharacters(test);
         Assert.assertEquals("\thello goodbye",result);
+    }
+
+    @Test
+    public void testGetJavaRegexpFilterFromAsteriskFilter() {
+        Assert.assertEquals( "Hello.*World.*", DbEngineUtils.getJavaRegexpFilterFromAsteriskFilter("Hello*World*") );
+        Assert.assertEquals( "H.llo.World", DbEngineUtils.getJavaRegexpFilterFromAsteriskFilter("H?llo?World") );
+        Assert.assertEquals( "With things\\-to\\-\\(escape\\)",
+                DbEngineUtils.getJavaRegexpFilterFromAsteriskFilter(
+                "With things-to-(escape)"));
+        Assert.assertEquals( "With \\\\backslash\\\\ and dot\\.",
+                DbEngineUtils.getJavaRegexpFilterFromAsteriskFilter(
+                        "With \\backslash\\ and dot."));
     }
 }


### PR DESCRIPTION
# Description

- DB-10968 SYSCS_SET_GLOBAL_DATABASE_PROPERTY should check existence of properties
- DB-11156 restrict execution of SYSCS_GET_REGION_SERVER_CONFIG_INFO to admin only

# Motivation DB-11156

SYSCS_GET_REGION_SERVER_CONFIG_INFO shows internal server information. Before this fix, every user could call it, after it, only admins.

# How to test DB-11156

```
-- create a simple (non-admin) user
CALL SYSCS_UTIL.SYSCS_CREATE_USER('fred', 'fredpassword');

-- connect as Fred
connect 'jdbc:splice://localhost:1527/splicedb;user=fred;password=fredpassword';

call SYSCS_UTIL.SYSCS_GET_REGION_SERVER_CONFIG_INFO(null, 0);
-- this should not be possible, as this prints internal server configuration which should not be accessible 
```
# Motivation DB-10968

When calling `SYSCS_SET_GLOBAL_DATABASE_PROPERTY` we don't give feedback if that property is even valid, so e.g. if the user does something like

```
splice> call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'not.existing.property', true);
Statement executed.
ELAPSED TIME = 991 milliseconds
```

The output doesn't show that we didn't set a meaningful property, so making small errors like using `splice.db2.VARCHAR.compatible` or `db2.varchar.compatible` instead of `splice.db2.varchar.compatible` will not report any warnings.

# How to test DB-10968

new code will report a warning when setting a not-known property:

```
splice> call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'db2.varchar.compatible', true);
name                |value                                                                                                                                                                               
------------------------------------------------------------------------------
KEY                 |db2.varchar.compatible                                                                                                                                                              
NEW VALUE           |true                                                                                                                                                                                
PREVIOUS VALUE      |NULL                                                                                                                                                                                
                    |                                                                                                                                                                                    
!!! WARNING !!!     |Database Property 'db2.varchar.compatible' seems to be unknown!                                                                                                                     

5 rows selected
```

For correct properties, it will show the previous value:

```
ELAPSED TIME = 31 milliseconds
splice> call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'splice.db2.varchar.compatible', true);
name                |value                                                                                                                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
KEY                 |splice.db2.varchar.compatible                                                                                                                                                       
NEW VALUE           |true                                                                                                                                                                                
PREVIOUS VALUE      |NULL                                                                                                                                                                                

3 rows selected
ELAPSED TIME = 29 milliseconds
```