### PR TITLE
Add parameter, fix archiving and regex

### DIFF
--- a/pipelines/spliceengine-PR/Jenkinsfile
+++ b/pipelines/spliceengine-PR/Jenkinsfile
@@ -110,7 +110,7 @@ node('spliceengine'){
         throw any
 
     } finally {
-        archiveArtifacts artifacts: '**,spliceengine/platform_it/target/*.log, spliceengine/target/platform_it/*log.*, spliceengine/platform_it/*.log, spliceengine/platform_it/*log.*, spliceengine/platform_it/target/SpliceTestYarnPlatform/**/*, spliceengine/mem_sql/target/*.log', allowEmptyArchive: true
+        archiveArtifacts artifacts: 'spliceengine/platform_it/target/*.log, spliceengine/target/platform_it/*log.*, spliceengine/platform_it/*.log, spliceengine/platform_it/*log.*, spliceengine/platform_it/target/SpliceTestYarnPlatform/**/*, spliceengine/mem_sql/target/*.log', allowEmptyArchive: true
         // success or failure, always send notifications
         notifyBuild(currentBuild.result)
     }

--- a/pipelines/spliceengine-branch/Jenkinsfile
+++ b/pipelines/spliceengine-branch/Jenkinsfile
@@ -142,7 +142,7 @@ node(node_name){
         throw any
 
     } finally {
-        archiveArtifacts artifacts: '**,spliceengine/platform_it/target/*.log, spliceengine/target/platform_it/*log.*, spliceengine/platform_it/*.log, spliceengine/platform_it/*log.*, spliceengine/platform_it/target/SpliceTestYarnPlatform/**/*, spliceengine/mem_sql/target/*.log', allowEmptyArchive: true
+        archiveArtifacts artifacts: 'spliceengine/platform_it/target/*.log, spliceengine/target/platform_it/*log.*, spliceengine/platform_it/*.log, spliceengine/platform_it/*log.*, spliceengine/platform_it/target/SpliceTestYarnPlatform/**/*, spliceengine/mem_sql/target/*.log', allowEmptyArchive: true
         // success or failure, always send notifications
         notifyBuild(currentBuild.result)
     }

--- a/pipelines/spliceengine-branch/Jenkinsfile
+++ b/pipelines/spliceengine-branch/Jenkinsfile
@@ -45,11 +45,26 @@ properties([
                     'mem'
                     ], 
                 description: ''
+                ),
+        choice(name: 'DEBUG', 
+                choices: [
+                    'false',
+                    'true'
+                    ], 
+                description: 'Create an on-demand instance to allow for debugging issues'
                 )
     ]),
 ])
 
-node('spliceengine'){
+def node_name = ""
+
+if (env.DEBUG == 'true') {
+    node_name = "spliceengine-debug"
+} else {
+    node_name = "spliceengine"
+}
+
+node(node_name){
     def artifact_values  = [
         [$class: 'VaultSecret', path: "secret/aws/jenkins/colo_jenkins", secretValues: [
             [$class: 'VaultSecretValue', envVar: 'ARTIFACT_USER', vaultKey: 'user'],

--- a/pipelines/spliceengine-jdbc/Jenkinsfile
+++ b/pipelines/spliceengine-jdbc/Jenkinsfile
@@ -62,9 +62,9 @@ node('splice-standalone'){
                 // Run Maven on a Unix agent.
                 dir('spliceengine'){
                     sh '''
-                    export SRCVER="$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version 2>&1 | egrep -v '(^\[|Download(ed|ing):)' | grep '^[0-9]' | head -1)"
+                    export SRCVER="$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version 2>&1 | egrep -v '(^[|Download(ed|ing):)' | grep '^[0-9]' | head -1)"
                     cd db-client/target/
-                    export JAR="$(ls | grep ".jar" | grep -v "original" | grep -v "sources" | grep -v "\-SNAPSHOT")"
+                    export JAR="$(ls | grep ".jar" | grep -v "original" | grep -v "sources" | grep -v "-SNAPSHOT")"
                     if [ ! -z "$JAR" ]; then
                         aws s3 cp $JAR s3://splice-releases/$SRCVER/cluster/jdbc-driver/ --acl public-read
                     fi

--- a/pipelines/spliceengine-platform/Jenkinsfile
+++ b/pipelines/spliceengine-platform/Jenkinsfile
@@ -85,7 +85,7 @@ def generateStage(platform,slackResponse) {
 }
 
 
-node('splice-standalone'){
+node('micro-spliceengine'){
     try{
         stage("Initiate Parallel Stages"){
                 parallel parallelStagesMap
@@ -100,7 +100,7 @@ node('splice-standalone'){
         currentBuild.result = "FAILED"
         throw any
     } finally {
-        archiveArtifacts artifacts: '**,spliceengine/platform_it/target/*.log, spliceengine/target/platform_it/*log.*, spliceengine/platform_it/*.log, spliceengine/platform_it/*log.*, spliceengine/platform_it/target/SpliceTestYarnPlatform/**/*, spliceengine/mem_sql/target/*.log', allowEmptyArchive: true
+        archiveArtifacts artifacts: 'spliceengine/platform_it/target/*.log, spliceengine/target/platform_it/*log.*, spliceengine/platform_it/*.log, spliceengine/platform_it/*log.*, spliceengine/platform_it/target/SpliceTestYarnPlatform/**/*, spliceengine/mem_sql/target/*.log', allowEmptyArchive: true
         slackSend(channel: slackResponse.threadId, message: "$JOB_NAME job status: $currentBuild.result $BUILD_URL")
         // success or failure, always send notifications
         notifyBuild(currentBuild.result)


### PR DESCRIPTION
Create a debugging node option for spliceengine-branch. 

-  Creates a non-spot instanced node that can be ssh'd into and debugged for issues. The ordinary standalone spot instances is under an internal VPC and will randomly get killed if the spot capacity is low (Possibly won't stay up long)

Switch spliceengine-platform pod to small ec2 node. 

- The spliceengine-platform flyweight pod currently dies after about an hour of idle time. The platform_it's take about 3ish hours to complete currently. While the tests still run, the flyweight job is killed, so even if the platform_it's all complete, the overall job will fail.

Remove ** from spliceengine-PR and spliceengine-platform

- There is not enough space in the disk to archive the entire workspace on jenkins master, since all job workspace are being pushed onto it. It will not scale effectively if the entire workspace is saved. 

Fix the jenkins job regex. 

- The `\` is not accepted by the job.