### PR TITLE
DB-11252 Fix JoinConditionVisitor childParentMap for VALUES clauses with subqueries.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/JoinConditionVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/JoinConditionVisitor.java
@@ -104,6 +104,12 @@ public class JoinConditionVisitor extends AbstractSpliceVisitor {
     }
 
     @Override
+    public RowResultSetNode visit(RowResultSetNode node) throws StandardException {
+        initializeMap(node);
+        return node;
+    }
+
+    @Override
     public JoinNode visit(JoinNode j) throws StandardException {
         if (LOG.isDebugEnabled())
             LOG.debug(String.format("visit joinNode=%s",j));


### PR DESCRIPTION
Fixes VALUES clause queries or triggers that use multiple joins and/or subqueries, e.g.

> CREATE TRIGGER FeatureTable_History_UPDATE_PREHISTORIC
> AFTER UPDATE ON FeatureTable
> REFERENCING OLD_TABLE AS OLDW NEW_TABLE AS NEWW
> FOR EACH STATEMENT
> WHEN (
>      (NOT EXISTS (SELECT 1 FROM FeatureTable_History H,NEWW N WHERE H.ENTITY_KEY=N.ENTITY_KEY AND N.LAST_UPDATE_TS >= H.ASOF_TS AND N.LAST_UPDATE_TS < H.UNTIL_TS))
>      AND
>      (EXISTS (SELECT 1 FROM OLDW,NEWW WHERE OLDW.ENTITY_KEY=NEWW.ENTITY_KEY AND OLDW.LAST_UPDATE_TS < NEWW.LAST_UPDATE_TS))
> )
> ...

The WHEN clause is converted to a VALUES clause internally.  Since the JoinConditionVisitor doesn't scan the entire RowResultSetNode tree for ResultColumns, an incomplete joinChainMap may be built leading to some column references not being found in the map, causing the statement to error out.