### PR TITLE
DB-9898-wip-storage-id joint effort with Arnaud to fix the issue.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/catalog/IndexDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/IndexDescriptor.java
@@ -71,6 +71,8 @@ public interface IndexDescriptor
 	 */
 	int[]	baseColumnPositions();
 
+	int[] baseColumnStoragePositions();
+
 	/**
      * Returns the postion of a column.
      * <p>
@@ -123,13 +125,6 @@ public interface IndexDescriptor
 	 * supported.
 	 */
 	boolean			isDescending(Integer keyColumnPosition);
-
-	/**
-	 * set the baseColumnPositions field of the index descriptor.  This
-	 * is for updating the field in operations such as "alter table drop
-	 * column" where baseColumnPositions is changed.
-	 */
-	void     setBaseColumnPositions(int[] baseColumnPositions);
 
 	/**
 	 * set the isAscending field of the index descriptor.  This

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ColumnDescriptorList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ColumnDescriptorList.java
@@ -91,14 +91,26 @@ public class ColumnDescriptorList extends ArrayList<ColumnDescriptor>
     /**
      * Get the column descriptor
      *
-     * @param tableID the table id (ignored)
+     * @param tableID the table id
      * @param columnID the column id
      *
-     * @return the column descriptor if found
+     * @return the column descriptor if found, otherwise null.
      */ 
     public ColumnDescriptor getColumnDescriptor(UUID tableID, int columnID) {
         ColumnDescriptor returnValue = get(columnID-1);
         return (returnValue !=null && tableID.equals(returnValue.getReferencingUUID()))?returnValue:null;
+    }
+
+    /**
+     * Get the column descriptor using its storage ID
+     *
+     * @param tableID the table id
+     * @param columnStorageId the column storage id, this number is a monotonically-increasing number given each time a
+     * new column is added to the table.
+     * @return the column descriptor if found, otherwise null.
+     */
+    public ColumnDescriptor getColumnDescriptorByStorageId(UUID tableId, int columnStorageId) {
+        return stream().filter(cd -> cd != null && cd.getStoragePosition() == columnStorageId && cd.getReferencingUUID().equals(tableId)).findFirst().orElse(null);
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/IndexRowGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/IndexRowGenerator.java
@@ -69,38 +69,38 @@ public class IndexRowGenerator implements IndexDescriptor, Formatable
 
     /**
      * Constructor for an IndexRowGeneratorImpl
-     * 
-     * @param indexType		The type of index
-     * @param isUnique		True means the index is unique
-     * @param isUniqueWithDuplicateNulls means the index is almost unique
-     *                              i.e. unique only for non null keys
-     * @param baseColumnPositions	An array of column positions in the base
-     * 								table.  Each index column corresponds to a
-     * 								column position in the base table.
-     * @param isAscending	An array of booleans telling asc/desc on each
-     * 						column.
-     * @param numberOfOrderedColumns	In the future, it will be possible
-     * 									to store non-ordered columns in an
-     * 									index.  These will be useful for
-     * 									covered queries.
-     */
+     *  @param indexType        The type of index
+     * @param isUnique        True means the index is unique
+	 * @param isUniqueWithDuplicateNulls means the index is almost unique
+ *                              i.e. unique only for non null keys
+	 * @param baseColumnPositions    An array of column positions in the base
+* 								table.  Each index column corresponds to a
+* 								column position in the base table.
+	 * @param baseColumnStoragePositions
+	 * @param isAscending    An array of booleans telling asc/desc on each
+	 * 						column.
+	 * @param numberOfOrderedColumns    In the future, it will be possible
+ * 									to store non-ordered columns in an
+ * 									index.  These will be useful for
+	 */
     public IndexRowGenerator(String indexType,
-                             boolean isUnique,
-                             boolean isUniqueWithDuplicateNulls,
-                             int[] baseColumnPositions,
-                             boolean[] isAscending,
-                             int numberOfOrderedColumns,
-                             boolean excludeNulls,
-                             boolean excludeDefaults)
+							 boolean isUnique,
+							 boolean isUniqueWithDuplicateNulls,
+							 int[] baseColumnPositions,
+							 int[] baseColumnStoragePositions,
+							 boolean[] isAscending,
+							 int numberOfOrderedColumns,
+							 boolean excludeNulls,
+							 boolean excludeDefaults)
     {
         id = new IndexDescriptorImpl(indexType,
-                                    isUnique,
-                                    isUniqueWithDuplicateNulls,
-                                    baseColumnPositions,
-                                    isAscending,
-                                    numberOfOrderedColumns,
-                                    excludeNulls,
-                                    excludeDefaults);
+									 isUnique,
+									 isUniqueWithDuplicateNulls,
+									 baseColumnPositions,
+									 baseColumnStoragePositions,
+									 isAscending,
+									 numberOfOrderedColumns,
+									 excludeNulls, excludeDefaults);
 
         if (SanityManager.DEBUG)
         {
@@ -109,10 +109,11 @@ public class IndexRowGenerator implements IndexDescriptor, Formatable
         }
     }
 
-    public IndexRowGenerator(String indexType,
+ public IndexRowGenerator(String indexType,
                              boolean isUnique,
                              boolean isUniqueWithDuplicateNulls,
                              int[] baseColumnPositions,
+                             int[] baseColumnStoragePositions,
                              DataTypeDescriptor[] indexColumnTypes,
                              boolean[] isAscending,
                              int numberOfOrderedColumns,
@@ -126,6 +127,7 @@ public class IndexRowGenerator implements IndexDescriptor, Formatable
                                     isUnique,
                                     isUniqueWithDuplicateNulls,
                                     baseColumnPositions,
+                                    baseColumnStoragePositions,
                                     indexColumnTypes,
                                     isAscending,
                                     numberOfOrderedColumns,
@@ -422,7 +424,12 @@ public class IndexRowGenerator implements IndexDescriptor, Formatable
 		return id.baseColumnPositions();
 	}
 
-	/** @see IndexDescriptor#getKeyColumnPosition */
+    @Override
+    public int[] baseColumnStoragePositions() {
+        return id.baseColumnStoragePositions();
+    }
+
+    /** @see IndexDescriptor#getKeyColumnPosition */
 	public int getKeyColumnPosition(int heapColumnPosition) throws StandardException
 	{
 		return id.getKeyColumnPosition(heapColumnPosition);
@@ -468,12 +475,6 @@ public class IndexRowGenerator implements IndexDescriptor, Formatable
 	public boolean[]		isAscending()
 	{
 		return id.isAscending();
-	}
-
-	/** @see IndexDescriptor#setBaseColumnPositions */
-	public void		setBaseColumnPositions(int[] baseColumnPositions)
-	{
-		id.setBaseColumnPositions(baseColumnPositions);
 	}
 
 	/** @see IndexDescriptor#setIsAscending */

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableDescriptor.java
@@ -1203,6 +1203,10 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
         return columnDescriptorList.getColumnDescriptor(oid,columnNumber);
     }
 
+    public ColumnDescriptor getColumnDescriptorByStorageId(int storageId) {
+        return columnDescriptorList.getColumnDescriptorByStorageId(oid, storageId);
+    }
+
     /**
      * Gets a ConglomerateDescriptor[] to loop through all the conglomerate descriptors
      * for the table.
@@ -1498,13 +1502,35 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
         return tableType == LOCAL_TEMPORARY_TABLE_TYPE;
     }
 
-        /*
-         * Get an int[] mapping the column position of the indexed columns in the main table
-         * to it's location in the index table. The values are placed in the provided baseColumnPositions array,
-         * and the highest baseColumnPosition is returned.
-         */
+    private interface IntProviderOperation {
+        int getInt(ColumnDescriptor cd);
+    }
+
+    /**
+     * Get an int[] mapping the column position of the indexed columns in the main table
+     * to it's location in the index table. The values are placed in the provided baseColumnPositions array,
+     * and the highest baseColumnPosition is returned.
+     */
     public int getBaseColumnPositions(LanguageConnectionContext lcc,
                                        int[] baseColumnPositions, String[] columnNames) throws StandardException {
+        return getBaseColumnPositions(lcc, baseColumnPositions, columnNames, ColumnDescriptor::getPosition);
+    }
+
+    /**
+     * Get an int[] mapping the column position of the indexed columns in the main table
+     * to it's storage location in the indexed table. The values are placed in the provided baseColumnStoragePositions array,
+     * and the highest baseColumnStoragePosition is returned.
+     */
+    public int getBaseColumnStoragePositions(LanguageConnectionContext lcc,
+                                      int[] baseColumnStoragePositions, String[] columnNames) throws StandardException {
+        return getBaseColumnPositions(lcc, baseColumnStoragePositions, columnNames, ColumnDescriptor::getStoragePosition);
+    }
+
+    private int getBaseColumnPositions(LanguageConnectionContext lcc,
+                                      int[] baseColumnPositions,
+                                       String[] columnNames,
+                                       IntProviderOperation intProvider
+                                      ) throws StandardException {
         int maxBaseColumnPosition = Integer.MIN_VALUE;
         ClassFactory cf = lcc.getLanguageConnectionFactory().getClassFactory();
         for (int i = 0; i < columnNames.length; i++) {
@@ -1539,13 +1565,14 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
                 throw StandardException.newException(SQLState.LANG_COLUMN_NOT_ORDERABLE_DURING_EXECUTION, typeId.getSQLTypeName());
 
             // Remember the position in the base table of each column
-            baseColumnPositions[i] = columnDescriptor.getPosition();
+            baseColumnPositions[i] = intProvider.getInt(columnDescriptor);
 
             if (maxBaseColumnPosition < baseColumnPositions[i])
                 maxBaseColumnPosition = baseColumnPositions[i];
         }
         return maxBaseColumnPosition;
     }
+
 
     public DataValueDescriptor getDefaultValue(int columnNumber) {
         return getColumnDescriptor(columnNumber).getDefaultValue();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -7278,26 +7278,30 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
         return conglomerateDescriptor;
     }
 
-    public void initSystemIndexVariables(TabInfoImpl ti,int indexNumber) throws StandardException{
-        int numCols=ti.getIndexColumnCount(indexNumber);
-        int[] baseColumnPositions=new int[numCols];
+    public void initSystemIndexVariables(TabInfoImpl ti,int indexNumber) throws StandardException {
+        int numCols = ti.getIndexColumnCount(indexNumber);
+        int[] baseColumnPositions = new int[numCols];
 
-        for(int colCtr=0;colCtr<numCols;colCtr++){
-            baseColumnPositions[colCtr]=ti.getBaseColumnPosition(indexNumber,colCtr);
+        for (int colCtr = 0; colCtr < numCols; colCtr++) {
+            baseColumnPositions[colCtr] = ti.getBaseColumnPosition(indexNumber, colCtr);
         }
 
-        int baseColumnLength=baseColumnPositions.length;
-        boolean[] isAscending=new boolean[baseColumnLength];
-        for(int i=0;i<baseColumnLength;i++)
-            isAscending[i]=true;
+        int baseColumnLength = baseColumnPositions.length;
+        boolean[] isAscending = new boolean[baseColumnLength];
+        for (int i = 0; i < baseColumnLength; i++)
+            isAscending[i] = true;
 
+        /* system tables don't drop columns so positions / storage positions are always in-sync.*/
+        int[] baseColumnStoragePositions = baseColumnPositions;
 
-        boolean isUnique=ti.isIndexUnique(indexNumber);
+        boolean isUnique = ti.isIndexUnique(indexNumber);
         //Splice is always higher than 10.4
-        IndexRowGenerator irg=new IndexRowGenerator("DENSE",isUnique,false,baseColumnPositions,isAscending,baseColumnLength,false,false);
+        IndexRowGenerator irg = new IndexRowGenerator("DENSE", isUnique, false,
+                                                      baseColumnPositions, baseColumnStoragePositions, isAscending,
+                                                      baseColumnLength, false, false);
 
         // For now, assume that all index columns are ordered columns
-        ti.setIndexRowGenerator(indexNumber,irg);
+        ti.setIndexRowGenerator(indexNumber, irg);
     }
 
     /**

--- a/platform_it/pom.xml
+++ b/platform_it/pom.xml
@@ -1074,6 +1074,7 @@
                                 <argument>-Dderby.language.updateSystemProcs=false</argument>
                                 <!-- Setting the logStatementText option to true enables logging of all statements. -->
                                 <argument>-Dderby.infolog.append=true</argument>
+                                <argument>-Dderby.debug.true=DumpClassFile</argument>
                                 <argument>com.splicemachine.test.SpliceTestPlatform</argument>
                                 <argument>file://${project.build.directory}/</argument>
                                 <argument>60000</argument>

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLUtils.java
@@ -254,24 +254,12 @@ public class DDLUtils {
         return scan;
     }
 
-    public static int[] getMainColToIndexPosMap(int[] indexColsToMainColMap, BitSet indexedCols) {
-        int[] mainColToIndexPosMap = new int[(int) indexedCols.length()];
-        for (int i = 0 ; i < indexedCols.length(); ++i) {
-            mainColToIndexPosMap[i] = -1;
+    public static BitSet asBitSet(int[] inputArray) {
+        BitSet result = new BitSet();
+        for (int item : inputArray) {
+            result.set(item - 1);
         }
-        for (int indexCol = 0; indexCol < indexColsToMainColMap.length; indexCol++) {
-            int mainCol = indexColsToMainColMap[indexCol];
-            mainColToIndexPosMap[mainCol - 1] = indexCol;
-        }
-        return mainColToIndexPosMap;
-    }
-
-    public static BitSet getIndexedCols(int[] indexColsToMainColMap) {
-        BitSet indexedCols = new BitSet();
-        for (int indexCol : indexColsToMainColMap) {
-            indexedCols.set(indexCol - 1);
-        }
-        return indexedCols;
+        return result;
     }
 
     public static byte[] getIndexConglomBytes(long indexConglomerate) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SpliceCreateTableOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/SpliceCreateTableOperation.java
@@ -32,6 +32,7 @@ import com.splicemachine.db.shared.common.reference.SQLState;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Properties;
 
 /**
@@ -189,29 +190,29 @@ public class SpliceCreateTableOperation extends CreateTableConstantOperation {
 		}
 	}
 
-	@Override
-	protected ConglomerateDescriptor getTableConglomerateDescriptor(TableDescriptor td, long conglomId, SchemaDescriptor sd, DataDescriptorGenerator ddg) throws StandardException {
-        /*
-         * If there is a PrimaryKey Constraint, build an IndexRowGenerator that returns the Primary Keys,
-         * otherwise, do whatever Derby does by default
-         */
-		if(constraintActions ==null)
-			return super.getTableConglomerateDescriptor(td,conglomId,sd,ddg);
+    @Override
+    protected ConglomerateDescriptor getTableConglomerateDescriptor(TableDescriptor td, long conglomId, SchemaDescriptor sd, DataDescriptorGenerator ddg) throws StandardException {
+		/*
+		 * If there is a PrimaryKey Constraint, build an IndexRowGenerator that returns the Primary Keys,
+		 * otherwise, do whatever Derby does by default
+		 */
+		if (constraintActions == null)
+			return super.getTableConglomerateDescriptor(td, conglomId, sd, ddg);
 
-		for(ConstraintConstantOperation constantAction:constraintActions){
-			if(constantAction.getConstraintType()== DataDictionary.PRIMARYKEY_CONSTRAINT){
-				int [] pkColumns = ((CreateConstraintConstantOperation)constantAction).genColumnPositions(td, true);
+		for (ConstraintConstantOperation constantAction : constraintActions) {
+			if (constantAction.getConstraintType() == DataDictionary.PRIMARYKEY_CONSTRAINT) {
+				int[] pkColumns = ((CreateConstraintConstantOperation) constantAction).genColumnPositions(td, true);
+				int[] pkStorageColumns = ((CreateConstraintConstantOperation) constantAction).genColumnStoragePositions(td, true);
 				boolean[] ascending = new boolean[pkColumns.length];
-				for(int i=0;i<ascending.length;i++){
-					ascending[i] = true;
-				}
+				Arrays.fill(ascending, true);
 
-				IndexDescriptor descriptor = new IndexDescriptorImpl("PRIMARYKEY",true,false,pkColumns,ascending,pkColumns.length,false,false);
+				IndexDescriptor descriptor = new IndexDescriptorImpl("PRIMARYKEY", true, false, pkColumns,
+																	 pkStorageColumns, ascending, pkColumns.length, false, false);
 				IndexRowGenerator irg = new IndexRowGenerator(descriptor);
-				return ddg.newConglomerateDescriptor(conglomId,null,false,irg,false,null,td.getUUID(),sd.getUUID());
+				return ddg.newConglomerateDescriptor(conglomId, null, false, irg, false, null, td.getUUID(), sd.getUUID());
 			}
 		}
-		return super.getTableConglomerateDescriptor(td,conglomId,sd,ddg);
+		return super.getTableConglomerateDescriptor(td, conglomId, sd, ddg);
 	}
 
 	public String getScopeName() {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceConglomerate.java
@@ -184,11 +184,6 @@ public abstract class SpliceConglomerate extends GenericConglomerate implements 
         return columnOrdering;
     }
 
-    @SuppressFBWarnings(value = "EI_EXPOSE_REP2",justification = "Intentional")
-    public void setColumnOrdering(int[] columnOrdering){
-        this.columnOrdering=columnOrdering;
-    }
-
     public abstract int getBaseMemoryUsage();
 
     public abstract void writeExternal(ObjectOutput out) throws IOException;

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/BulkDeleteRowIndexGenerationFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/BulkDeleteRowIndexGenerationFunction.java
@@ -121,11 +121,11 @@ public class BulkDeleteRowIndexGenerationFunction extends RowAndIndexGenerator {
     /**
      * Strip off all non-index columns from a main table row
      */
-    private ExecRow getIndexRow(IndexTransformFunction indexTransformFunction, ExecRow execRow) throws StandardException {
-        List<Integer> indexColToMainCol = indexTransformFunction.getIndexColsToMainColMapList();
+    private ExecRow getIndexRow(final IndexTransformFunction indexTransformFunction, ExecRow execRow) throws StandardException {
+        int indexColCount = indexTransformFunction.getIndexColsToMainColMapList().size();
         Long conglom = indexTransformFunction.getIndexConglomerateId();
         int[] indexColToScanRowMap = indexColMap.get(conglom);
-        ExecRow row = new ValueRow(indexColToMainCol.size());
+        ExecRow row = new ValueRow(indexColCount);
         int col = 1;
         for (Integer n : indexColToScanRowMap) {
             row.setColumn(col, execRow.getColumn(n+1));

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/IndexWriteHandler.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/IndexWriteHandler.java
@@ -45,7 +45,7 @@ public class IndexWriteHandler extends RoutingWriteHandler{
         super(transformer.getIndexConglomBytes(),keepState);
         this.expectedWrites = expectedWrites;
         this.transformer = transformer;
-        this.indexedColumns = transformer.gitIndexedCols();
+        this.indexedColumns = transformer.getIndexColPositions();
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/protobuf/ProtoUtil.java
+++ b/splice_machine/src/main/java/com/splicemachine/protobuf/ProtoUtil.java
@@ -310,7 +310,7 @@ public class ProtoUtil {
             builder = builder.addDescColumns(!ascColumns[i]);
         }
 
-        int[] backingArray=indexDescriptor.baseColumnPositions();
+        int[] backingArray=indexDescriptor.baseColumnStoragePositions();
         for(int i=0;i<backingArray.length;i++){
             builder = builder.addIndexColsToMainColMap(backingArray[i]);
         }


### PR DESCRIPTION
- what we're trying to do so far is to consistently use the storage position
  of a column instead of the column DDL position.
- to do this we changed the semantics of the PB's Index.indexColsToMainColMap
  to refer to the storage number.
- we also started with changing the semantics of Table.columnOrdering since
  that one is also used by the PK, since PK is an index that is sensitive to
  drop columns, it must operate with storage numbers instead of relative
  numbers.
- this is not easy and requires substantial change in the codebase.
- we leave this effort until we have more bandwidtch to proceed with it.