### PR TITLE
DB-11256 Session property minPlanTimeout

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -165,6 +165,12 @@ public interface LanguageConnectionContext extends Context {
     int getTableLimitForExhaustiveSearch();
 
     /**
+     * Get value of minPlanTimeout
+     * @return value of minPlanTimeout
+     */
+    long getMinPlanTimeout();
+
+    /**
      * get the lock escalation threshold to use with this connection.
      */
     int getLockEscalationThreshold();

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/SessionProperties.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/SessionProperties.java
@@ -54,7 +54,8 @@ public interface SessionProperties {
         SPARK_RESULT_STREAMING_BATCH_SIZE(10),
         TABLELIMITFOREXHAUSTIVESEARCH(11),
         DISABLE_NLJ_PREDICATE_PUSH_DOWN(12),
-        USE_NATIVE_SPARK(13);
+        USE_NATIVE_SPARK(13),
+        MINPLANTIMEOUT(14);
 
         public static final int COUNT = PROPERTYNAME.values().length;
 
@@ -88,7 +89,7 @@ public interface SessionProperties {
             property = SessionProperties.PROPERTYNAME.valueOf(propertyNameString);
         } catch (IllegalArgumentException e) {
             throw StandardException.newException(SQLState.LANG_INVALID_SESSION_PROPERTY,propertyNameString,
-                    "useOLAP, useSpark (deprecated), defaultSelectivityFactor, skipStats, olapQueue, recursiveQueryIterationLimit, tableLimitForExhaustiveSearch");
+                    "useOLAP, useSpark (deprecated), defaultSelectivityFactor, skipStats, olapQueue, recursiveQueryIterationLimit, tableLimitForExhaustiveSearch, minPlanTimeout");
         }
 
         String valString = pair.getSecond();
@@ -134,10 +135,11 @@ public interface SessionProperties {
                     throw StandardException.newException(SQLState.LANG_INVALID_SESSION_PROPERTY_VALUE, valString, "value should be a positive integer or null");
                 break;
             case SNAPSHOT_TIMESTAMP:
-                long timestamp;
+            case MINPLANTIMEOUT:
+                long longValue;
                 try {
-                    timestamp = Long.parseLong(valString);
-                    if (timestamp <= 0)
+                    longValue = Long.parseLong(valString);
+                    if (longValue <= 0)
                         throw StandardException.newException(SQLState.LANG_INVALID_SESSION_PROPERTY_VALUE, valString, "value should be a positive long");
                 } catch (NumberFormatException parseIntE) {
                     throw StandardException.newException(SQLState.LANG_INVALID_SESSION_PROPERTY_VALUE, valString, "value should be a positive long");

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/TransactionResourceImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/TransactionResourceImpl.java
@@ -140,6 +140,7 @@ public final class TransactionResourceImpl
     private SparkExecutionType useNativeSpark;
     private boolean skipStats;
     private double defaultSelectivityFactor;
+    private long minPlanTimeout = -1;
     private String ipAddress;
     private String defaultSchema;
     // set these up after constructor, called by EmbedConnection
@@ -203,6 +204,18 @@ public final class TransactionResourceImpl
                         SQLState.LANG_INVALID_SELECTIVITY);
         } else
             defaultSelectivityFactor = -1d;
+
+        String minPlanTimeoutString = info.getProperty(Property.CONNECTION_MIN_PLAN_TIMEOUT, null);
+        if (minPlanTimeoutString != null) {
+            try {
+                minPlanTimeout = Long.parseLong(minPlanTimeoutString);
+            } catch (Exception parseLongE) {
+                throw new SQLException(StandardException.newException(SQLState.LANG_INVALID_MIN_PLAN_TIMEOUT, minPlanTimeoutString).getMessage(), SQLState.LANG_INVALID_SELECTIVITY);
+            }
+            if (minPlanTimeout < 0l)
+                throw new SQLException(StandardException.newException(SQLState.LANG_INVALID_MIN_PLAN_TIMEOUT, minPlanTimeoutString).getMessage(),
+                        SQLState.LANG_INVALID_SELECTIVITY);
+        }
 
         // make a new context manager for this TransactionResource
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
@@ -187,6 +187,9 @@ public class OptimizerImpl implements Optimizer{
 
     private static final int NANOS_TO_MILLIS = 1000000;
     private boolean forSpark = false;
+    private final long minPlanTimeout;
+    private final long maxPlanTimeout;
+    boolean foundCompleteJoinPlan = false;
 
     protected OptimizerImpl(OptimizableList optimizableList,
                             OptimizablePredicateList predicateList,
@@ -200,6 +203,10 @@ public class OptimizerImpl implements Optimizer{
                             RequiredRowOrdering requiredRowOrdering,
                             int numTablesInQuery) throws StandardException{
         assert optimizableList!=null: "optimizableList is not expected to be null";
+
+        minPlanTimeout = getSessionMinPlanTimeout() >= 0 ?
+                         getSessionMinPlanTimeout() : getMinTimeout();
+        maxPlanTimeout = Long.max(getMaxTimeout(), minPlanTimeout);
 
         outermostCostEstimate=getNewCostEstimate(0.0d,1.0d,1.0d);
 
@@ -1126,6 +1133,8 @@ public class OptimizerImpl implements Optimizer{
             tracer().trace(OptimizerFlag.INFEASIBLE_JOIN,0,0,0.0,optimizable.getCurrentAccessPath().getJoinStrategy());
             return;
         }
+        if (joinPosition == numOptimizables-1 && !foundCompleteJoinPlan)
+            foundCompleteJoinPlan = true;
 
         /* Cost the optimizable at the current join position */
         optimizable.optimizeIt(this, predicateList, outerCost, currentRowOrdering);
@@ -2514,6 +2523,15 @@ public class OptimizerImpl implements Optimizer{
         return optimizable.estimateCost(predList, cd, outerCost,this, currentRowOrdering);
     }
 
+    private long getSessionMinPlanTimeout() {
+        LanguageConnectionContext lcc =
+            (LanguageConnectionContext) ContextService.
+                getContextOrNull(LanguageConnectionContext.CONTEXT_ID);
+        if (lcc == null)
+            return -1;
+        return lcc.getMinPlanTimeout();
+    }
+
     private boolean checkTimeout(){
         /*
          * Check whether or not optimization time as timed out
@@ -2529,17 +2547,22 @@ public class OptimizerImpl implements Optimizer{
         if(noTimeout) return false;
         if(timeExceeded || numOptimizables<=optimizableList.getTableLimitForExhaustiveSearch()) return timeExceeded;
 
+        // Must at least find one complete join plan, otherwise
+        // the query will not run at all.
+        if (!foundCompleteJoinPlan)
+            return false;
+
         // All of the following are assumed to be in milliseconds,
         // even if originally derived from a different unit:
         // currentTime, timeOptimizationStarted, timeLimit, getMinTimeout(), getMaxTimeout()
 
         long searchDuration = System.currentTimeMillis() - timeOptimizationStarted;
 
-        if (searchDuration > timeLimit && searchDuration > getMinTimeout()) {
+        if (searchDuration > timeLimit && searchDuration > minPlanTimeout) {
             // We've exceeded the best time seen so far to process a permutation
             timeExceeded = true;
             tracer().trace(OptimizerFlag.BEST_TIME_EXCEEDED, 0, 0, searchDuration);
-        } else if (searchDuration > getMaxTimeout()) {
+        } else if (searchDuration > maxPlanTimeout) {
             // We've exceeded max time allowed to process a permutation
             timeExceeded = true;
             tracer().trace(OptimizerFlag.MAX_TIME_EXCEEDED, 0, 0, searchDuration);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -461,6 +461,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             setSessionFromConnectionProperty(connectionProperties, Property.CONNECTION_SNAPSHOT, SessionProperties.PROPERTYNAME.SNAPSHOT_TIMESTAMP);
             setSessionFromConnectionProperty(connectionProperties, Property.OLAP_PARALLEL_PARTITIONS, SessionProperties.PROPERTYNAME.OLAPPARALLELPARTITIONS);
             setSessionFromConnectionProperty(connectionProperties, Property.OLAP_SHUFFLE_PARTITIONS, SessionProperties.PROPERTYNAME.OLAPSHUFFLEPARTITIONS);
+            setSessionFromConnectionProperty(connectionProperties, Property.CONNECTION_MIN_PLAN_TIMEOUT, SessionProperties.PROPERTYNAME.MINPLANTIMEOUT);
 
             String disableAdvancedTC = connectionProperties.getProperty(Property.CONNECTION_DISABLE_TC_PUSHED_DOWN_INTO_VIEWS);
             if (disableAdvancedTC != null && disableAdvancedTC.equalsIgnoreCase("true")) {
@@ -664,6 +665,16 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         if (tableLimit != null)
             return tableLimit;
         return tableLimitForExhaustiveSearch;
+    }
+
+    @Override
+    public long getMinPlanTimeout() {
+        Long minPlanTimeout = (Long) sessionProperties.getProperty(
+                SessionProperties.PROPERTYNAME.MINPLANTIMEOUT);
+        if (minPlanTimeout != null)
+            return minPlanTimeout;
+        else
+            return -1;
     }
 
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/SessionPropertiesImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/SessionPropertiesImpl.java
@@ -104,6 +104,10 @@ public class SessionPropertiesImpl implements SessionProperties {
                 boolean useNativeSpark = Boolean.parseBoolean(valString);
                 properties[USE_NATIVE_SPARK.getId()] = useNativeSpark;
                 break;
+            case MINPLANTIMEOUT:
+                long minPlanTimeout = Long.parseLong(valString);
+                properties[MINPLANTIMEOUT.getId()] = minPlanTimeout;
+                break;
             default:
                 assert false;
         }

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1505,6 +1505,11 @@ public interface Property {
     String CONNECTION_DEFAULT_SELECTIVITY_FACTOR = "defaultSelectivityFactor";
 
     /**
+     * minPlanTimeout for this connection
+     */
+    String CONNECTION_MIN_PLAN_TIMEOUT = "minPlanTimeout";
+
+    /**
      * Default Olap queue name for this connection
      */
     String CONNECTION_OLAP_QUEUE = "olapQueue";

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -1031,7 +1031,7 @@ public interface SQLState {
     String LANG_INVALID_FORCED_INDEX2                                      = "42Y48";
     String LANG_DUPLICATE_PROPERTY                                         = "42Y49";
     String LANG_BOTH_FORCE_INDEX_AND_CONSTRAINT_SPECIFIED                  = "42Y50";
-    //    String LANG_INVALID_FORCED_INDEX4                                = "42Y51";
+    String LANG_INVALID_MIN_PLAN_TIMEOUT                                   = "42Y51";
     String LANG_INVALID_FORCED_SKIPSTATS                                   = "42Y52";
     String LANG_INVALID_SPLITS                                             = "42Y53";
     String LANG_INVALID_SELECTIVITY                                        = "42Y54";

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -2682,7 +2682,11 @@ Guide.
                 <text>Properties list for table '{0}' may contain values for index or for constraint but not both.</text>
                 <arg>tableName</arg>
             </msg>
-
+            <msg>
+                <name>42Y51</name>
+                <text>The hint minPlanTimeout should be non-negative long and does not support '{0}'.</text>
+                <arg>tableName</arg>
+            </msg>
             <msg>
                 <name>42Y52</name>
                 <text>The hint skipStats needs (true/false) and does not support '{0}'.</text>

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SessionPropertyIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SessionPropertyIT.java
@@ -43,11 +43,16 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
 
 import static com.splicemachine.test_tools.Rows.row;
 import static com.splicemachine.test_tools.Rows.rows;
+import static java.lang.System.currentTimeMillis;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -321,5 +326,40 @@ public class SessionPropertyIT extends SpliceUnitTest {
                     query,contains,level,actualString);
             Assert.assertTrue(failMessage,actualString.contains(contains));
         }
+    }
+
+    @Test
+    public void TestMinPlanTimeout() throws Exception {
+        TestConnection conn = methodWatcher.createConnection();
+        String testQuery = "explain select * from t1 a, t1 b, t1 c, t1 d, t1 e, t1 f, t1 g, t1 h, t1 i, t1 j " +
+            "where a.a1 = b.a1 and b.a1 = c.a1 and c.a1 = d.a1 and d.a1 = e.a1 and e.a1 = f.a1 and f.a1 = g.a1 and g.a1 = h.a1 and h.a1 = i.a1 and i.a1 = j.a1";
+
+        long startTime = System.currentTimeMillis();
+        conn.execute("set session_property minPlanTimeout=1");
+        try (ResultSet rs = conn.query(testQuery)) { }
+        long endTime = System.currentTimeMillis();
+        Assert.assertTrue("Expected query planning to take less than 5 seconds", (endTime - startTime) < 5000);
+        conn.execute("set session_property minPlanTimeout=5000");
+        startTime = System.currentTimeMillis();
+        try (ResultSet rs = conn.query(testQuery)) { }
+        endTime = System.currentTimeMillis();
+        Assert.assertTrue("Expected query planning to take more than 5 seconds", (endTime - startTime) > 5000);
+        conn.close();
+
+        // "jdbc:splice://localhost:1527/splicedb;create=true;user=splice;password=admin;minPlanTimeout=3000";
+        conn = methodWatcher.connectionBuilder().minPlanTimeout(3000).build();
+        startTime = System.currentTimeMillis();
+        try (ResultSet rs = conn.query(testQuery)) { }
+        endTime = System.currentTimeMillis();
+        Assert.assertTrue("Expected query planning to take more than 3 seconds", (endTime - startTime) > 3000);
+        conn.execute("set session_property minPlanTimeout=1");
+        startTime = System.currentTimeMillis();
+        try (ResultSet rs = conn.query(testQuery)) { }
+        endTime = System.currentTimeMillis();
+        Assert.assertTrue("Expected query planning to take less than 3 seconds", (endTime - startTime) < 3000);
+
+        List<String> expectedErrors =
+           Arrays.asList("Invalid session property value '-1' specified, 'value should be a positive long' is expected. ");
+        testUpdateFail("set session_property minPlanTimeout=-1", expectedErrors, methodWatcher);
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceNetConnection.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceNetConnection.java
@@ -135,6 +135,7 @@ public class SpliceNetConnection {
         private String ssl;
         private String useOLAP;
         private String useNativeSpark;
+        private String minPlanTimeout;
 
         @Override
         public ConnectionBuilder clone() throws CloneNotSupportedException {
@@ -185,6 +186,10 @@ public class SpliceNetConnection {
             this.useNativeSpark = Boolean.toString(useNativeSpark);
             return this;
         }
+        public ConnectionBuilder minPlanTimeout(long minPlanTimeout) {
+            this.minPlanTimeout = Long.toString(minPlanTimeout);
+            return this;
+        }
 
         public Connection build() throws SQLException {
             Properties info = new Properties();
@@ -202,6 +207,8 @@ public class SpliceNetConnection {
                 info.put("useOLAP", useOLAP != null ? useOLAP : jdbcUseOLAP);
             if (useNativeSpark != null)
                 info.put("useNativeSpark", useNativeSpark);
+            if (minPlanTimeout != null)
+                info.put("minPlanTimeout", minPlanTimeout);
             StringBuilder url = new StringBuilder();
             if (host != null || port != null) {
                 url.append(URL_PREFIX);

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
@@ -126,6 +126,10 @@ public class SpliceWatcher extends TestWatcher implements AutoCloseable {
             delegate.useNativeSpark(useNativeSpark);
             return this;
         }
+        public ConnectionBuilder minPlanTimeout(long minPlanTimeout) {
+            delegate.minPlanTimeout(minPlanTimeout);
+            return this;
+        }
 
         /**
          * Always creates a new connection, replacing this class's reference to the current connection, if any.


### PR DESCRIPTION
Adds support for:
> set session_property minPlanTimeout=5000;

or
> connect ‘jdbc:splice://localhost:1527/splicedb;user=splice;password=admin;minPlanTimeout=3000’;

To allow queries at least the specified number of milliseconds in join planning.