### PR TITLE
DB-11118 Add DB2-like RTRIM functionality

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLChar.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLChar.java
@@ -2821,6 +2821,45 @@ public class SQLChar
         return source.substring(start, end + 1);
     }
 
+    private String db2TrimInternal(int trimType, String trimString, String source)
+    {
+        if (source == null) {
+            return null;
+        }
+
+        int len = source.length();
+        int start = 0;
+        if (trimType == LEADING || trimType == BOTH)
+        {
+            for (; start < len; start++)
+                if (trimString.charAt(start) != source.charAt(start))
+                    break;
+        }
+
+        if (start == len)
+            return "";
+
+        int end = len - 1;
+        int trimEnd = trimString.length() - 1;
+        if (trimEnd > end) {
+            trimString = trimString.substring(0, len);
+            trimEnd = end;
+        }
+        int origTrimEnd = trimEnd;
+        if (trimType == TRAILING || trimType == BOTH)
+        {
+            for (; end >= 0 && trimEnd >= 0; end--,
+                                             trimEnd = trimEnd == 0 ?
+                                               origTrimEnd : trimEnd - 1)
+                if (trimString.charAt(trimEnd) != source.charAt(end))
+                    break;
+        }
+        if (end == -1)
+            return "";
+
+        return source.substring(start, end + 1);
+    }
+
     /**
      * @param trimType  Type of trim (LEADING, TRAILING, or BOTH)
      * @param trimChar  Character to trim from this SQLChar (may be null)
@@ -2857,6 +2896,29 @@ public class SQLChar
         char trimCharacter = trimChar.getString().charAt(0);
 
         result.setValue(trimInternal(trimType, trimCharacter, getString()));
+        return result;
+    }
+
+    // The same as ansiTrim, but allow longer trim strings than one character.
+    public StringDataValue db2Trim(
+    int             trimType,
+    StringDataValue trimString,
+    StringDataValue result)
+            throws StandardException
+    {
+
+        if (result == null)
+        {
+            result = getNewVarchar();
+        }
+
+        if (trimString == null || trimString.getString() == null)
+        {
+            result.setToNull();
+            return result;
+        }
+
+        result.setValue(db2TrimInternal(trimType, trimString.getString(), getString()));
         return result;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/StringDataValue.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/StringDataValue.java
@@ -174,6 +174,13 @@ public interface StringDataValue extends ConcatableDataValue
 			StringDataValue result)
 		throws StandardException;
 
+	// Same as ansiTrim, but allow a trimString longer than a single character.
+	StringDataValue db2Trim(
+			int trimType,
+			StringDataValue trimString,
+			StringDataValue result)
+		throws StandardException;
+
 	/**
 	 * Convert the string to upper case.
 	 *

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLGrammarImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLGrammarImpl.java
@@ -750,6 +750,13 @@ class SQLGrammarImpl {
     ValueNode getTrimOperatorNode(Integer trimSpec, ValueNode trimChar,
                                           ValueNode trimSource, ContextManager cm) throws StandardException
     {
+        return getTrimOperatorNode(trimSpec, trimChar, trimSource, false, cm);
+    }
+
+    ValueNode getTrimOperatorNode(Integer trimSpec, ValueNode trimChar,
+                                  ValueNode trimSource, boolean forDB2RTrim,
+                                  ContextManager cm) throws StandardException
+    {
         if (trimChar == null)
         {
             trimChar = (CharConstantNode) nodeFactory.getNode(
@@ -757,12 +764,13 @@ class SQLGrammarImpl {
                     " ",
                     getContextManager());
         }
+        final int trimType = forDB2RTrim ? TernaryOperatorNode.DB2RTRIM : TernaryOperatorNode.TRIM;
         return new TernaryOperatorNode(
                 C_NodeTypes.TRIM_OPERATOR_NODE,
                 trimSource, // receiver
                 trimChar,   // leftOperand.
                 null, // right
-                ReuseFactory.getInteger(TernaryOperatorNode.TRIM),
+                ReuseFactory.getInteger(trimType),
                 trimSpec,
                 cm == null ? getContextManager() : cm);
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
@@ -91,8 +91,9 @@ public class TernaryOperatorNode extends OperatorNode
     public static final int RIGHT = 7;
     public static final int LEFT = 8;
     public static final int SPLIT_PART = 9;
-    static final String[] TernaryOperators = {"trim", "LOCATE", "substring", "like", "TIMESTAMPADD", "TIMESTAMPDIFF", "replace", "right", "left", "split_part"};
-    static final String[] TernaryMethodNames = {"ansiTrim", "locate", "substring", "like", "timestampAdd", "timestampDiff", "replace", "right", "left", "split_part"};
+    public static final int DB2RTRIM = 10;
+    static final String[] TernaryOperators = {"trim", "LOCATE", "substring", "like", "TIMESTAMPADD", "TIMESTAMPDIFF", "replace", "right", "left", "split_part", "trim"};
+    static final String[] TernaryMethodNames = {"ansiTrim", "locate", "substring", "like", "timestampAdd", "timestampDiff", "replace", "right", "left", "split_part", "db2Trim"};
 
     static final String[] TernaryResultType = {
             ClassName.StringDataValue,
@@ -102,6 +103,7 @@ public class TernaryOperatorNode extends OperatorNode
             ClassName.DateTimeDataValue,
             ClassName.NumberDataValue,
             ClassName.ConcatableDataValue,
+            ClassName.StringDataValue,
             ClassName.StringDataValue,
             ClassName.StringDataValue,
             ClassName.StringDataValue
@@ -116,7 +118,8 @@ public class TernaryOperatorNode extends OperatorNode
             {ClassName.ConcatableDataValue, ClassName.StringDataValue, ClassName.StringDataValue}, // replace{}
             {ClassName.StringDataValue, ClassName.NumberDataValue, ClassName.NumberDataValue}, // right
             {ClassName.StringDataValue, ClassName.NumberDataValue, ClassName.NumberDataValue}, // left
-            {ClassName.StringDataValue, ClassName.StringDataValue, ClassName.NumberDataValue} // split_part
+            {ClassName.StringDataValue, ClassName.StringDataValue, ClassName.NumberDataValue}, // split_part
+            {ClassName.StringDataValue, ClassName.StringDataValue, "java.lang.Integer"} // DB2 rtrim
     };
 
     public TernaryOperatorNode() {}
@@ -241,7 +244,7 @@ public class TernaryOperatorNode extends OperatorNode
         {
             rightOperand = rightOperand.bindExpression(fromList, subqueryList,  aggregateVector);
         }
-        if (operatorType == TRIM)
+        if (operatorType == TRIM || operatorType == DB2RTRIM)
             trimBind();
         else if (operatorType == LOCATE)
             locateBind();
@@ -342,7 +345,7 @@ public class TernaryOperatorNode extends OperatorNode
         LocalField field = acb.newFieldDeclaration(Modifier.PRIVATE, resultInterfaceType);
 
         receiver.generateExpression(acb, mb);
-        if (operatorType == TRIM)
+        if (operatorType == TRIM || operatorType == DB2RTRIM)
         {
             mb.push(trimType);
             leftOperand.generateExpression(acb, mb);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -2024,7 +2024,6 @@ TOKEN [IGNORE_CASE] :
 |    <RANK: "rank">
 |    <ROLE: "role">
 |    <ROWNUMBER: "row_number">
-|    <RTRIM: "rtrim">
 |    <SUBSTR:    "substr">
 |    <XML:    "xml">
 |    <TEXT:    "text">
@@ -2102,6 +2101,7 @@ TOKEN [IGNORE_CASE] :
 |    <RETURNING: "returning">
 |   <RR: "rr">
 |   <RS: "rs">
+|    <RTRIM: "rtrim">
 |   <SAMPLE: "sample">
 |    <SEQUENCE: "sequence">
 |    <SEQUENTIAL: "sequential">
@@ -7123,11 +7123,12 @@ trimFunction() throws StandardException :
     ValueNode    source;
     Integer        trimType;
     ValueNode    ansiTrimNode;
+    ValueNode    trimString = null;
 }
 {
-    trimType = trimType() <LEFT_PAREN> source = additiveExpression(null,0) <RIGHT_PAREN>
+    trimType = trimType() <LEFT_PAREN> source = additiveExpression(null,0) [<COMMA> trimString = additiveExpression(null,0) ] <RIGHT_PAREN>
     {
-        return getTrimOperatorNode(trimType, null, source, null);
+        return getTrimOperatorNode(trimType, trimString, source, trimString != null, null);
     }
 |
     <TRIM> ansiTrimNode = ansiTrim()
@@ -17478,6 +17479,7 @@ nonReservedKeyword()  :
     |    tok = <ROWNUMBER>
     |   tok = <RR>
     |   tok = <RS>
+    |   tok = <RTRIM>
     |   tok = <SAMPLE>
     |    tok = <SBCS>
     |    tok = <SCALE>

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -1692,6 +1692,14 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                             .varchar("ARG1", Limits.DB2_VARCHAR_MAXWIDTH)
                             .varchar("ARG2", Limits.DB2_VARCHAR_MAXWIDTH)
                             .build(),
+                    Procedure.newBuilder().name("RTRIM")
+                            .numOutputParams(0)
+                            .numResultSets(0)
+                            .sqlControl(RoutineAliasInfo.NO_SQL)
+                            .returnType(DataTypeDescriptor.getCatalogType(Types.VARCHAR, Limits.DB2_VARCHAR_MAXWIDTH))
+                            .isDeterministic(true).ownerClass(SpliceStringFunctions.class.getCanonicalName())
+                            .varchar("S", Limits.DB2_VARCHAR_MAXWIDTH)
+                            .build(),
                     Procedure.newBuilder().name("REGEXP_LIKE")
                             .numOutputParams(0)
                             .numResultSets(0)

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceStringFunctions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceStringFunctions.java
@@ -40,6 +40,7 @@ import splice.com.google.common.cache.LoadingCache;
 
 public class SpliceStringFunctions {
 
+    public static final String TRAILING_WHITESPACE_REGEXP = "\\s+$";
     /**
      * Implements logic for the SQL function INSTR.
      * 
@@ -109,6 +110,22 @@ public class SpliceStringFunctions {
 			return (s != null) ? patternCache.get(regexp).matcher(s).matches() : false;
 	    } catch (ExecutionException e) {
 	        throw new RuntimeException(String.format("Unable to fetch Pattern for regexp [%s]", regexp), e);
+	    }
+    }
+
+    /**
+     * Implements logic for the SQL function RTRIM.
+     *
+     * @param s string to be trimmed.
+     *
+     * @return The input string s, with trailing whitespaces removed.
+     */
+    public static String RTRIM(String s)
+    {
+    	try {
+			return (s != null) ? patternCache.get(TRAILING_WHITESPACE_REGEXP).matcher(s).replaceAll("") : null;
+	    } catch (ExecutionException e) {
+	        throw new RuntimeException(String.format("Unable to fetch Pattern for regexp [%s]", TRAILING_WHITESPACE_REGEXP), e);
 	    }
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
@@ -395,7 +395,7 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
 
 	    // Use a join so we can test native spark execution.
 	    try (ResultSet rs = methodWatcher.executeQuery(
-	            "SELECT RTRIM(a.a,a.b), a.c from " + tableWatcherK + " a --splice-properties useSpark=" + useSpark +
+	            "SELECT RTRIM(a.a,a.b), a.c from " + tableWatcherK + " a --splice-properties joinStrategy=nestedloop,useSpark=" + useSpark +
                     "\n, " + tableWatcherK + " b where a.a = b.a and a.b = b.b")) {
 
             while (rs.next()) {
@@ -405,7 +405,7 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
                 count++;
             }
         }
-	    Assert.assertEquals("Incorrect row count", 11, count);
+	    Assert.assertEquals("Incorrect row count", 13, count);
     }
 
     @Test

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
@@ -85,6 +85,11 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
     // Table for long string concatenate testing.
     private static final SpliceTableWatcher tableWatcherJ = new SpliceTableWatcher(
             "J", schemaWatcher.schemaName, "(a double)");
+
+    // Table for RTRIM testing.
+    private static final SpliceTableWatcher tableWatcherK = new SpliceTableWatcher(
+            "K", schemaWatcher.schemaName, "(a varchar(10), b varchar(20), c varchar(10))");
+
     @ClassRule
     public static TestRule chain = RuleChain.outerRule(classWatcher)
             .around(schemaWatcher)
@@ -98,207 +103,263 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
             .around(tableWatcherH)
             .around(tableWatcherI)
             .around(tableWatcherJ)
+            .around(tableWatcherK)
             .around(new SpliceDataWatcher() {
                 @Override
                 protected void starting(Description description) {
                     try{
-                        PreparedStatement ps;
-
-                        ps = classWatcher.prepareStatement(
-                                "insert into " + tableWatcherA + " (a, b, c) values (?, ?, ?)");
-                        ps.setInt   (1, 2); // row 1
-                        ps.setString(2, "aaa");
-                        ps.setString(3, "aaa");
-                        ps.execute();
-                        ps.setInt   (1, 3);
-                        ps.setObject(2, "bbb");
-                        ps.setString(3, "bbb");
-                        ps.execute();
-                        ps.setInt   (1, 4);
-                        ps.setObject(2, null);
-                        ps.setString(3, null);
-                        ps.execute();
+                        try (PreparedStatement ps = classWatcher.prepareStatement(
+                                "insert into " + tableWatcherA + " (a, b, c) values (?, ?, ?)")) {
+                            ps.setInt   (1, 2); // row 1
+                            ps.setString(2, "aaa");
+                            ps.setString(3, "aaa");
+                            ps.execute();
+                            ps.setInt   (1, 3);
+                            ps.setObject(2, "bbb");
+                            ps.setString(3, "bbb");
+                            ps.execute();
+                            ps.setInt   (1, 4);
+                            ps.setObject(2, null);
+                            ps.setString(3, null);
+                            ps.execute();
+                        }
 
                         // Each of the following inserted rows represents an individual test,
                         // including expected result (column 'd'), for less test code in the
                         // testInstr methods.
 
-                        ps = classWatcher.prepareStatement(
-                            "insert into " + tableWatcherB + " (a, b, c, d) values (?, ?, ?, ?)");
-                        ps.setInt   (1, 1); // row 1
-                        ps.setObject(2, "Fred Flintstone");
-                        ps.setString(3, "Flint");
-                        ps.setInt   (4, 6);
-                        ps.execute();
+                        try (PreparedStatement ps = classWatcher.prepareStatement(
+                            "insert into " + tableWatcherB + " (a, b, c, d) values (?, ?, ?, ?)")) {
+                            ps.setInt(1, 1); // row 1
+                            ps.setObject(2, "Fred Flintstone");
+                            ps.setString(3, "Flint");
+                            ps.setInt(4, 6);
+                            ps.execute();
 
-                        ps.setInt   (1, 2);
-                        ps.setObject(2, "Fred Flintstone");
-                        ps.setString(3, "Fred");
-                        ps.setInt   (4, 1);
-                        ps.execute();
+                            ps.setInt(1, 2);
+                            ps.setObject(2, "Fred Flintstone");
+                            ps.setString(3, "Fred");
+                            ps.setInt(4, 1);
+                            ps.execute();
 
-                        ps.setInt   (1, 3);
-                        ps.setObject(2, "Fred Flintstone");
-                        ps.setString(3, " F");
-                        ps.setInt   (4, 5);
-                        ps.execute();
+                            ps.setInt(1, 3);
+                            ps.setObject(2, "Fred Flintstone");
+                            ps.setString(3, " F");
+                            ps.setInt(4, 5);
+                            ps.execute();
 
-                        ps.setInt   (1, 4);
-                        ps.setObject(2, "Fred Flintstone");
-                        ps.setString(3, "Flintstone");
-                        ps.setInt   (4, 6);
-                        ps.execute();
+                            ps.setInt(1, 4);
+                            ps.setObject(2, "Fred Flintstone");
+                            ps.setString(3, "Flintstone");
+                            ps.setInt(4, 6);
+                            ps.execute();
 
-                        ps.setInt   (1, 5);
-                        ps.setObject(2, "Fred Flintstone");
-                        ps.setString(3, "stoner");
-                        ps.setInt   (4, 0);
-                        ps.execute();
+                            ps.setInt(1, 5);
+                            ps.setObject(2, "Fred Flintstone");
+                            ps.setString(3, "stoner");
+                            ps.setInt(4, 0);
+                            ps.execute();
 
-                        ps.setInt   (1, 6);
-                        ps.setObject(2, "Barney Rubble");
-                        ps.setString(3, "Wilma");
-                        ps.setInt   (4, 0);
-                        ps.execute();
+                            ps.setInt(1, 6);
+                            ps.setObject(2, "Barney Rubble");
+                            ps.setString(3, "Wilma");
+                            ps.setInt(4, 0);
+                            ps.execute();
 
-                        ps.setInt   (1, 7);
-                        ps.setObject(2, "Bam Bam");
-                        ps.setString(3, "Bam Bam Bam");
-                        ps.setInt   (4, 0);
-                        ps.execute();
+                            ps.setInt(1, 7);
+                            ps.setObject(2, "Bam Bam");
+                            ps.setString(3, "Bam Bam Bam");
+                            ps.setInt(4, 0);
+                            ps.execute();
 
-                        ps.setInt   (1, 8);
-                        ps.setObject(2, "Betty");
-                        ps.setString(3, "");
-                        ps.setInt   (4, 0);
-                        ps.execute();
+                            ps.setInt(1, 8);
+                            ps.setObject(2, "Betty");
+                            ps.setString(3, "");
+                            ps.setInt(4, 0);
+                            ps.execute();
 
-                        ps.setInt   (1, 9);
-                        ps.setObject(2, null);
-                        ps.setString(3, null);
-                        ps.setInt   (4, 0);
-                        ps.execute();
+                            ps.setInt(1, 9);
+                            ps.setObject(2, null);
+                            ps.setString(3, null);
+                            ps.setInt(4, 0);
+                            ps.execute();
+                        }
+                        try (PreparedStatement ps = classWatcher.prepareStatement(
+                                "insert into " + tableWatcherC + " (a, b) values (?, ?)")) {
+                            ps.setObject(1, "freDdy kruGeR");
+                            ps.setString(2, "Freddy Kruger");
+                            ps.execute();
+                        }
+                        try (PreparedStatement ps = classWatcher.prepareStatement(
+                                "insert into " + tableWatcherD + " (a, b, c) values (?, ?, ?)")) {
+                            ps.setString(1, "AAA");
+                            ps.setString(2, "BBB");
+                            ps.setString(3, "AAABBB");
+                            ps.execute();
 
-                        ps = classWatcher.prepareStatement(
-                                "insert into " + tableWatcherC + " (a, b) values (?, ?)");
-                        ps.setObject(1, "freDdy kruGeR");
-                        ps.setString(2, "Freddy Kruger");
-                        ps.execute();
+                            ps.setString(1, "");
+                            ps.setString(2, "BBB");
+                            ps.setString(3, "BBB");
+                            ps.execute();
 
-                        ps = classWatcher.prepareStatement(
-                                "insert into " + tableWatcherD + " (a, b, c) values (?, ?, ?)");
-                        ps.setString(1, "AAA");
-                        ps.setString(2, "BBB");
-                        ps.setString(3, "AAABBB");
-                        ps.execute();
+                            ps.setString(1, "AAA");
+                            ps.setString(2, "");
+                            ps.setString(3, "AAA");
+                            ps.execute();
 
-                        ps.setString(1, "");
-                        ps.setString(2, "BBB");
-                        ps.setString(3, "BBB");
-                        ps.execute();
+                            ps.setString(1, "");
+                            ps.setString(2, "");
+                            ps.setString(3, "");
+                            ps.execute();
 
-                        ps.setString(1, "AAA");
-                        ps.setString(2, "");
-                        ps.setString(3, "AAA");
-                        ps.execute();
+                            ps.setString(1, null);
+                            ps.setString(2, "BBB");
+                            ps.setString(3, null);
+                            ps.execute();
 
-                        ps.setString(1, "");
-                        ps.setString(2, "");
-                        ps.setString(3, "");
-                        ps.execute();
+                            ps.setString(1, "AAA");
+                            ps.setString(2, null);
+                            ps.setString(3, null);
+                            ps.execute();
+                        }
+                        try (PreparedStatement ps = classWatcher.prepareStatement(
+                                "insert into " + tableWatcherE + " (a, b) values (?, ?)")) {
+                            ps.setInt(1, 0);
+                            ps.setString(2, "\u0000");
+                            ps.execute();
 
-                        ps.setString(1, null);
-                        ps.setString(2, "BBB");
-                        ps.setString(3, null);
-                        ps.execute();
+                            ps.setInt(1, 255);
+                            ps.setString(2, "ÿ");
+                            ps.execute();
 
-                        ps.setString(1, "AAA");
-                        ps.setString(2, null);
-                        ps.setString(3, null);
-                        ps.execute();
+                            ps.setInt(1, 256);
+                            ps.setString(2, "\u0000");
+                            ps.execute();
 
-                        ps = classWatcher.prepareStatement(
-                                "insert into " + tableWatcherE + " (a, b) values (?, ?)");
-                        ps.setInt(1, 0);
-                        ps.setString(2, "\u0000");
-                        ps.execute();
+                            ps.setInt(1, 65);
+                            ps.setString(2, "A");
+                            ps.execute();
 
-                        ps.setInt(1, 255);
-                        ps.setString(2, "ÿ");
-                        ps.execute();
+                            ps.setInt(1, 97);
+                            ps.setString(2, "a");
+                            ps.execute();
 
-                        ps.setInt(1, 256);
-                        ps.setString(2, "\u0000");
-                        ps.execute();
+                            ps.setInt(1, 321);
+                            ps.setString(2, "A");
+                            ps.execute();
+                        }
+                        try (PreparedStatement ps = classWatcher.prepareStatement(
+                                "insert into " + tableWatcherF+ " (a, b) values (?, ?)")) {
+                            ps.setInt(1, 1111567890);
+                            ps.setString(2, "1111");
+                            ps.execute();
 
-                        ps.setInt(1, 65);
-                        ps.setString(2, "A");
-                        ps.execute();
+                            ps.setInt(1, 1234567890);
+                            ps.setString(2, "1234");
+                            ps.execute();
 
-                        ps.setInt(1, 97);
-                        ps.setString(2, "a");
-                        ps.execute();
+                            ps.setNull(1, 4);
+                            ps.setNull(2, 1);
+                            ps.execute();
+                        }
+                        try (PreparedStatement ps = classWatcher.prepareStatement(
+                                "insert into " + tableWatcherG+ " (a, b) values (?, ?)")) {
+                            ps.setString(1, "12345678901234567890");
+                            ps.setString(2, "12345678901234567890");
+                            ps.execute();
+                            ps.setString(1, "21345678901234567890");
+                            ps.setString(2, "21345678901234567890");
+                            ps.execute();
+                        }
+                        try (PreparedStatement ps = classWatcher.prepareStatement(
+                                "insert into " + tableWatcherH+ " (a, b, c) values (?, ?, ?)")) {
+                            ps.setFloat(1, 0.123456789f);
+                            ps.setFloat(2, 0.123456789f);
+                            ps.setDouble(3, 1234567890.0123456789);
+                            ps.execute();
+                        }
+                        try (PreparedStatement ps = classWatcher.prepareStatement(
+                                "insert into " + tableWatcherI+ " (a, b) values (?, ?)")) {
+                            ps.setInt(1, 1);
+                            ps.setString(2, "a");
+                            ps.execute();
+                            ps.setInt(1, 1);
+                            ps.setString(2, "b");
+                            ps.execute();
+                            ps.setInt(1, 2);
+                            ps.setString(2, "c");
+                            ps.execute();
+                            ps.setInt(1, 2);
+                            ps.setString(2, "d");
+                            ps.execute();
+                            ps.setInt(1, 2);
+                            ps.setString(2, "e");
+                            ps.execute();
+                            ps.setInt(1, 2);
+                            ps.setString(2, "c");
+                            ps.execute();
+                        }
+                        try (PreparedStatement ps = classWatcher.prepareStatement(
+                                "insert into " + tableWatcherJ+ " (a) values (?)")) {
+                            ps.setDouble(1, 12.3);
+                            ps.execute();
+                        }
 
-                        ps.setInt(1, 321);
-                        ps.setString(2, "A");
-                        ps.execute();
-
-                        ps = classWatcher.prepareStatement(
-                                "insert into " + tableWatcherF+ " (a, b) values (?, ?)");
-                        ps.setInt(1, 1111567890);
-                        ps.setString(2, "1111");
-                        ps.execute();
-
-                        ps.setInt(1, 1234567890);
-                        ps.setString(2, "1234");
-                        ps.execute();
-
-                        ps.setNull(1, 4);
-                        ps.setNull(2, 1);
-                        ps.execute();
-
-                        ps = classWatcher.prepareStatement(
-                                "insert into " + tableWatcherG+ " (a, b) values (?, ?)");
-                        ps.setString(1,"12345678901234567890");
-                        ps.setString(2,"12345678901234567890");
-                        ps.execute();
-                        ps.setString(1,"21345678901234567890");
-                        ps.setString(2,"21345678901234567890");
-                        ps.execute();
-
-                        ps = classWatcher.prepareStatement(
-                                "insert into " + tableWatcherH+ " (a, b, c) values (?, ?, ?)");
-                        ps.setFloat(1,0.123456789f);
-                        ps.setFloat(2,0.123456789f);
-                        ps.setDouble(3,1234567890.0123456789);
-                        ps.execute();
-
-                        ps = classWatcher.prepareStatement(
-                                "insert into " + tableWatcherI+ " (a, b) values (?, ?)");
-                        ps.setInt(1,1);
-                        ps.setString(2,"a");
-                        ps.execute();
-                        ps.setInt(1,1);
-                        ps.setString(2,"b");
-                        ps.execute();
-                        ps.setInt(1,2);
-                        ps.setString(2,"c");
-                        ps.execute();
-                        ps.setInt(1,2);
-                        ps.setString(2,"d");
-                        ps.execute();
-                        ps.setInt(1,2);
-                        ps.setString(2,"e");
-                        ps.execute();
-                        ps.setInt(1,2);
-                        ps.setString(2,"c");
-                        ps.execute();
-
-                        ps = classWatcher.prepareStatement(
-                                "insert into " + tableWatcherJ+ " (a) values (?)");
-                        ps.setDouble(1,12.3);
-                        ps.execute();
-
+                        try (PreparedStatement ps = classWatcher.prepareStatement(
+                                "insert into " + tableWatcherK + " (a, b, c) values (?, ?, ?)")) {
+                            ps.setString(1, "aaa");
+                            ps.setString(2, "aaa");
+                            ps.setString(3, "");
+                            ps.execute();
+                            ps.setString(1, "Zicam");
+                            ps.setString(2, "Mycam");
+                            ps.setString(3, "Zi");
+                            ps.execute();
+                            ps.setString(1, "CVS");
+                            ps.setString(2, "s");
+                            ps.setString(3, "CVS");
+                            ps.execute();
+                            ps.setString(1, "aaa\t");
+                            ps.setString(2, "aaa");
+                            ps.setString(3, "aaa\t");
+                            ps.execute();
+                            ps.setString(1, "abc");
+                            ps.setString(2, "abcabcabc");
+                            ps.setString(3, "");
+                            ps.execute();
+                            ps.setString(1, "abc");
+                            ps.setString(2, "ac");
+                            ps.setString(3, "ab");
+                            ps.execute();
+                            ps.setString(1, "abc ");
+                            ps.setString(2, "abc");
+                            ps.setString(3, "abc ");
+                            ps.execute();
+                            ps.setString(1, " ab c");
+                            ps.setString(2, " ab cabcabc");
+                            ps.setString(3, "");
+                            ps.execute();
+                            ps.setString(1, "abcabc");
+                            ps.setString(2, "abc");
+                            ps.setString(3, "");
+                            ps.execute();
+                            ps.setString(1, "\t\t\t\t\t\t");
+                            ps.setString(2, "\t\t");
+                            ps.setString(3, "");
+                            ps.execute();
+                            ps.setString(1, "\t\t\t \t\t\t");
+                            ps.setString(2, "\t\t");
+                            ps.setString(3, "\t\t\t ");
+                            ps.execute();
+                            ps.setString(1, "abc\t\t\t  \t");
+                            ps.setString(2, " \t");
+                            ps.setString(3, "abc\t\t\t ");
+                            ps.execute();
+                            ps.setString(1, "abc g  ");
+                            ps.setString(2, " ");
+                            ps.setString(3, "abc g");
+                            ps.execute();
+                        }
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     } finally {
@@ -314,66 +375,130 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
         int count = 0;
 	    String sCell1 = null;
 	    String sCell2 = null;
-	    ResultSet rs;
 
-	    rs = methodWatcher.executeQuery("SELECT INSTR(b, c), d from " + tableWatcherB);
-	    count = 0;
-	    while (rs.next()) {
-    		sCell1 = rs.getString(1);
-            sCell2 = rs.getString(2);
-            Assert.assertEquals("Wrong result value", sCell1, sCell2);
-            count++;
-	    }
-	    Assert.assertEquals("Incorrect row count", 9, count);
+	    try (ResultSet rs = methodWatcher.executeQuery("SELECT INSTR(b, c), d from " + tableWatcherB)) {
+            count = 0;
+            while (rs.next()) {
+                sCell1 = rs.getString(1);
+                sCell2 = rs.getString(2);
+                Assert.assertEquals("Wrong result value", sCell1, sCell2);
+                count++;
+            }
+            Assert.assertEquals("Incorrect row count", 9, count);
+        }
+    }
+
+    private void runRTrimTests(boolean useSpark) throws Exception {
+	    String sCell1 = null;
+	    String sCell2 = null;
+        int count = 0;
+
+	    // Use a join so we can test native spark execution.
+	    try (ResultSet rs = methodWatcher.executeQuery(
+	            "SELECT RTRIM(a.a,a.b), a.c from " + tableWatcherK + " a --splice-properties useSpark=" + useSpark +
+                    "\n, " + tableWatcherK + " b where a.a = b.a and a.b = b.b")) {
+
+            while (rs.next()) {
+                sCell1 = rs.getString(1);
+                sCell2 = rs.getString(2);
+                Assert.assertEquals("Wrong result value", sCell2, sCell1);
+                count++;
+            }
+        }
+	    Assert.assertEquals("Incorrect row count", 11, count);
+    }
+
+    @Test
+    public void testRtrimFunction() throws Exception {
+        runRTrimTests(false);
+        runRTrimTests(true);
+    }
+
+    private void runRTrimSysFunTests(boolean useSpark, String expected) throws Exception {
+	    String sCell1 = null;
+	    String sCell2 = null;
+        int count = 0;
+
+	    // Use a join so we can test native spark execution.
+	    String sqlText = "SELECT SYSFUN.RTRIM(a.a) from " + tableWatcherK + " a --splice-properties useSpark=" + useSpark +
+                    "\n, " + tableWatcherK + " b where a.a = b.a and a.b = b.b";
+
+        testQuery(sqlText, expected, methodWatcher);
+    }
+
+    @Test
+    public void testRtrimSysFun() throws Exception {
+        String sqlText = "select '-'|| repeat(b, 3) || '-' from A order by 1";
+
+        String expected =
+                "1   |\n" +
+                "--------\n" +
+                "       |\n" +
+                "       |\n" +
+                "  CVS  |\n" +
+                " Zicam |\n" +
+                "  aaa  |\n" +
+                "  aaa  |\n" +
+                " ab c  |\n" +
+                "  abc  |\n" +
+                "  abc  |\n" +
+                "  abc  |\n" +
+                "  abc  |\n" +
+                " abc g |\n" +
+                "abcabc |";
+
+        runRTrimSysFunTests(false, expected);
+        runRTrimSysFunTests(true, expected);
     }
 
     @Test
     public void testInitcapFunction() throws Exception {
 	    String sCell1 = null;
 	    String sCell2 = null;
-	    ResultSet rs;
-	    
-	    rs = methodWatcher.executeQuery("SELECT INITCAP(a), b from " + tableWatcherC);
-	    while (rs.next()) {
-    		sCell1 = rs.getString(1);
-            sCell2 = rs.getString(2);
-            Assert.assertEquals("Wrong result value", sCell2, sCell1);
-	    }
+
+	    try (ResultSet rs = methodWatcher.executeQuery("SELECT INITCAP(a), b from " + tableWatcherC)) {
+            while (rs.next()) {
+                sCell1 = rs.getString(1);
+                sCell2 = rs.getString(2);
+                Assert.assertEquals("Wrong result value", sCell2, sCell1);
+            }
+        }
     }
 
     @Test
     public void testConcatFunction() throws Exception {
 	    String sCell1 = null;
 	    String sCell2 = null;
-	    ResultSet rs;
-	    
-	    rs = methodWatcher.executeQuery("SELECT CONCAT(a, b), c from " + tableWatcherD);
-	    while (rs.next()) {
-    		sCell1 = rs.getString(1);
-            sCell2 = rs.getString(2);
-            Assert.assertEquals("Wrong result value", sCell2, sCell1);
-	    }
+
+	    try (ResultSet rs = methodWatcher.executeQuery("SELECT CONCAT(a, b), c from " + tableWatcherD)) {
+            while (rs.next()) {
+                sCell1 = rs.getString(1);
+                sCell2 = rs.getString(2);
+                Assert.assertEquals("Wrong result value", sCell2, sCell1);
+            }
+        }
     }
 
     @Test
     public void testConcatAliasFunction() throws Exception {
 	    String sCell1 = null;
 	    String sCell2 = null;
-	    ResultSet rs;
 
-	    rs = methodWatcher.executeQuery("SELECT a CONCAT b, c from " + tableWatcherD);
-	    while (rs.next()) {
-            sCell1 = rs.getString(1);
-            sCell2 = rs.getString(2);
-            Assert.assertEquals("Wrong result value", sCell2, sCell1);
-	    }
+	    try (ResultSet rs = methodWatcher.executeQuery("SELECT a CONCAT b, c from " + tableWatcherD)) {
+            while (rs.next()) {
+                sCell1 = rs.getString(1);
+                sCell2 = rs.getString(2);
+                Assert.assertEquals("Wrong result value", sCell2, sCell1);
+            }
+        }
     }
 
     @Test
     public void testReges() throws Exception {
-        ResultSet rs = methodWatcher.executeQuery("select count(*) from d where REGEXP_LIKE(a, 'aa*')");
-        rs.next();
-        Assert.assertEquals(3, rs.getInt(1));
+        try (ResultSet rs = methodWatcher.executeQuery("select count(*) from d where REGEXP_LIKE(a, 'aa*')")) {
+            rs.next();
+            Assert.assertEquals(3, rs.getInt(1));
+        }
     }
 
     @Test


### PR DESCRIPTION
Adds support for:
1. System function SYSFUN.RTRIM, which trims all trailing whitespaces off a string expression, e.g.

> values(sysfun.rtrim('abc   ') || sysfun.rtrim('abc   '));
> 1                                                                                                                                                                                                                                                               
> //----------------------------------------------------------------
> abcabc     
                                
2. An extra parameter to the RTRIM operator/function which supports stripping multiple occurrences of a trim string from the end of an expression, e.g.

> values (rtrim('abcdefdef','def'));
> 1        
> //---------
> abc      
