### PR TITLE
DB-11278 More join planning time for triggers and hinted joinStrategy

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizer.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizer.java
@@ -407,4 +407,6 @@ public interface Optimizer{
     public void setForSpark(boolean forSpark);
 
     public boolean isForSpark();
+
+    int getJoinPosition();
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizer.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizer.java
@@ -300,6 +300,15 @@ public interface Optimizer{
     void setJoinType(int joinType);
 
     /**
+     *
+     * Retrieve the join type of the outer optimizable, if any.
+     * A value of zero means there is no outer optimizable.
+     *
+     */
+
+    int getJoinType();
+
+    /**
      * Get the number of join strategies supported by this optimizer.
      */
     int getNumberOfJoinStrategies();

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -1518,4 +1518,12 @@ public interface LanguageConnectionContext extends Context {
 
     void setupSparkSQLUtils(SparkSQLUtils sparkSQLUtils);
 
+    boolean hasJoinStrategyHint();
+
+    void setHasJoinStrategyHint(boolean newValue);
+
+    boolean compilingStoredPreparedStatement();
+
+    void setCompilingStoredPreparedStatement(boolean newValue);
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SPSDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SPSDescriptor.java
@@ -287,6 +287,7 @@ public class SPSDescriptor extends TupleDescriptor implements UniqueSQLObjectDes
         Statement stmt = lcf.getStatement(dd.getSchemaDescriptor(compSchemaId, null), text, true, lcc);
 
         try {
+            lcc.setCompilingStoredPreparedStatement(true);
             preparedStatement = (ExecPreparedStatement) stmt.prepareStorable(
                     lcc,
                     preparedStatement,
@@ -294,6 +295,7 @@ public class SPSDescriptor extends TupleDescriptor implements UniqueSQLObjectDes
                     getSchemaDescriptor(),
                     type == SPS_TYPE_TRIGGER);
         } finally {
+            lcc.setCompilingStoredPreparedStatement(false);
             if (triggerTable != null) {
                 lcc.popTriggerTable(triggerTable);
             }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -851,6 +851,7 @@ public class GenericStatement implements Statement{
             throw e;
         }  finally{ // for block introduced by pushCompilerContext()
             lcc.resetDB2VarcharCompatibilityMode();
+            lcc.setHasJoinStrategyHint(false);
             if (boundAndOptimizedStatement == null)
                 lcc.popCompilerContext(cc);
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -721,6 +721,7 @@ public class FromBaseTable extends FromTable {
                     }
                     break;
                 case "joinstrategy":
+                    getLanguageConnectionContext().setHasJoinStrategyHint(true);
                     userSpecifiedJoinStrategy=StringUtil.SQLToUpperCase(value);
                     if (userSpecifiedJoinStrategy.equals("CROSS")) {
                         dataSetProcessorType = dataSetProcessorType.combine(DataSetProcessorType.FORCED_OLAP);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
@@ -49,6 +49,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.*;
 
+import static com.splicemachine.db.impl.sql.compile.JoinNode.INNERJOIN;
+
 /**
  * A FromTable represents a table in the FROM clause of a DML statement.
  * It can be either a base table, a subquery or a project restrict.
@@ -201,6 +203,14 @@ public abstract class FromTable extends ResultSetNode implements Optimizable{
         return getCostEstimate();
     }
 
+    // To be used only in the midst of join planning,
+    // to indicate if this optimizable is being costed
+    // as a single-table scan.
+    private boolean isSingleTableScan(Optimizer optimizer) {
+        return optimizer.getJoinPosition() == 0   &&
+               optimizer.getJoinType() < INNERJOIN;
+    }
+
     @Override
     public boolean nextAccessPath(Optimizer optimizer,
                                   OptimizablePredicateList predList,
@@ -239,20 +249,22 @@ public abstract class FromTable extends ResultSetNode implements Optimizable{
             ap.setHintedJoinStrategy(false);
 
             // Do not waste time by planning single-table queries, or the
-            // first by itself.
-            // A join is always:
+            // first table of a join alone, with anything other than nested
+            // loop join.
+            // When outermostCostEstimate.joinType is not set,
+            // A join always consists of:
             //     innerTable = joinPosition
             //     outerTable = joinPosition - 1
-            // When joinPosition is zero, we are not planning a join,
+            // When joinPosition is zero, and outermostCostEstimate has no set
+            // join type, we are not planning a join,
             // but a single-table scan, so only consider nested loop
-            // join in that case (which is always what ends up getting
+            // join in that case (which is what ends up getting
             // picked for single-table scan anyways).
-            if (joinStrategyNumber == 0 || optimizer.getJoinPosition() != 0) {
+            if (joinStrategyNumber == 0 || !isSingleTableScan(optimizer)) {
+
                 /* Step through the join strategies. */
                 ap.setJoinStrategy(optimizer.getJoinStrategy(joinStrategyNumber));
-
                 joinStrategyNumber++;
-
                 found = true;
 
                 optimizer.tracer().trace(OptimizerFlag.CONSIDERING_JOIN_STRATEGY, tableNumber, 0, 0.0, ap.getJoinStrategy(),

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
@@ -2745,4 +2745,7 @@ public class OptimizerImpl implements Optimizer{
         return currentRowOrdering;
     }
 
+    public int getJoinPosition() {
+        return joinPosition;
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
@@ -1413,6 +1413,8 @@ public class OptimizerImpl implements Optimizer{
      */
     @Override public void setJoinType(int joinType){ outermostCostEstimate.setJoinType(joinType); }
 
+    @Override public int getJoinType(){ return outermostCostEstimate.getJoinType(); }
+
     @Override
     public int tableLockThreshold(){ return tableLockThreshold; }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -359,6 +359,8 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     private Object sparkContext = null;
     private int applicationJarsHashCode = 0;
     private SparkSQLUtils sparkSQLUtils;
+    private boolean hasJoinStrategyHint;
+    private boolean compilingStoredPreparedStatement;
 
     /* constructor */
     public GenericLanguageConnectionContext(
@@ -4137,5 +4139,25 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     @Override
     public void setupSparkSQLUtils(SparkSQLUtils sparkSQLUtils) {
         this.sparkSQLUtils = sparkSQLUtils;
+    }
+
+    @Override
+    public boolean hasJoinStrategyHint() {
+        return hasJoinStrategyHint;
+    }
+
+    @Override
+    public void setHasJoinStrategyHint(boolean newValue) {
+        hasJoinStrategyHint = newValue;
+    }
+
+    @Override
+    public boolean compilingStoredPreparedStatement() {
+        return compilingStoredPreparedStatement;
+    }
+
+    @Override
+    public void setCompilingStoredPreparedStatement(boolean newValue) {
+        compilingStoredPreparedStatement = newValue;
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
@@ -23,6 +23,8 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 
 import java.sql.*;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 
 import static com.splicemachine.test_tools.Rows.row;
@@ -637,13 +639,36 @@ public class ExplainPlanIT extends SpliceUnitTest  {
         }
     }
 
-    @Ignore("DB-11278")
     @Test
     public void testJoinStrategyHintOnTargetTable() throws Exception {
         String query ="explain update t4 --splice-properties joinStrategy=nestedloop\n" +
                              "set (a4,b4) = (select 1,1 from t1 where c1 = a4)";
 
         rowContainsQuery(3, query, "NestedLoopJoin", methodWatcher);
+    }
+
+    @Test
+    public void testTriggerWithManyJoinsUsesMoreThan10msInQueryPlanner() throws Exception {
+        methodWatcher.execute("CREATE TRIGGER MyTrig\n" +
+            "BEFORE INSERT ON T4\n" +
+            "FOR EACH STATEMENT\n" +
+            "WHEN (EXISTS (SELECT 1 FROM t4 a, t4 b, t4 c, t4 d, t4 e, t4 f, t4 g, t4 h, t4 i, t4 j " +
+            "WHERE a.a4 = b.a4 and b.a4=c.a4 and c.a4 = d.a4 and d.a4 = e.a4 and e.a4 = f.a4 and" +
+                  " f.a4 = g.a4 and g.a4 = h.a4 and h.a4 = i.a4 and i.a4 = j.a4))\n" +
+            "SIGNAL SQLSTATE '12345' ('No inserts allowed')\n");
+
+        long startTime = System.currentTimeMillis();
+        String query ="insert into t4 values (20,20,20)";
+
+        List<String> expectedErrors =
+           Arrays.asList("Application raised error or warning with diagnostic text: \"No inserts allowed\"");
+        methodWatcher.execute("CALL SYSCS_UTIL.SYSCS_INVALIDATE_STORED_STATEMENTS()");
+        methodWatcher.execute("CALL SYSCS_UTIL.SYSCS_EMPTY_GLOBAL_STATEMENT_CACHE()");
+        testUpdateFail(query, expectedErrors, methodWatcher);
+        long endTime = System.currentTimeMillis();
+        long runTime = (endTime - startTime);
+        Assert.assertTrue("Expected query planning to take more than 10 ms.  Actual time: " + runTime + " milliseconds", runTime > 10);
+        methodWatcher.execute("DROP TRIGGER MyTrig");
     }
 
     @Test

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
@@ -400,6 +400,11 @@ public class SpliceUnitTest {
         return Double.parseDouble(m1.group().substring("scannedRows=".length()));
     }
 
+    protected void runQuery(String sqlText, SpliceWatcher methodWatcher) throws Exception {
+        try (ResultSet rs = methodWatcher.executeQuery(sqlText)) {
+        }
+    }
+
     protected void testQuery(String sqlText, String expected, SpliceWatcher methodWatcher) throws Exception {
         try (ResultSet rs = methodWatcher.executeQuery(sqlText)) {
             assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toString(rs));


### PR DESCRIPTION
This Jira replaces the problematic prepared statement check of DB-10773 with the following:

1. A check if a stored prepared statement is currently being compiled.  If so, the join planning time limit lower bound is set to 10 ms.
2. A check if a joinStrategy hint is present in the SQL.  If so, the join planning time limit lower bound is set to 2 ms.

Also fixed as part of this Jira:

1. A bug in DB-11256, where the max timeout setting when using Level2OptimizerImpl is set to zero, which could cause queries to time out too early and use a suboptimal join plan.
2. The join planner is updated to only consider nested loop join when planning a single table.  Nested loop join is a special "join strategy" which also knows how to handle single-table access paths.  The planner should never pick a "join strategy" other than nested loop join when costing a single table, so the planner is updated to avoid considering the other join strategies.

See [DB-11278](https://splicemachine.atlassian.net/browse/DB-11278)