### PR TITLE
DB-11296 fix upgrades from 1985 to 1996

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -76,6 +76,10 @@ public class SpliceCatalogUpgradeScripts{
         this.tc=tc;
 
         scripts = new ArrayList<>();
+        // DB-11296: UpgradeConglomerateTable has to be executed first, because it adds a system table
+        // CONGLOMERATE_SI_TABLE_NAME that is from then on needed to create tables, e.g.
+        // in UpgradeScriptToAddSysNaturalNumbersTable. If UpgradeConglomerateTable is at the end,
+        // these upgrades would fail
         addUpgradeScript(baseVersion4, 1996, new UpgradeConglomerateTable(sdd, tc));
 
         addUpgradeScript(baseVersion1, 1901, new UpgradeScriptToRemoveUnusedBackupTables(sdd,tc));

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -76,6 +76,8 @@ public class SpliceCatalogUpgradeScripts{
         this.tc=tc;
 
         scripts = new ArrayList<>();
+        addUpgradeScript(baseVersion4, 1996, new UpgradeConglomerateTable(sdd, tc));
+
         addUpgradeScript(baseVersion1, 1901, new UpgradeScriptToRemoveUnusedBackupTables(sdd,tc));
         addUpgradeScript(baseVersion1, 1909, new UpgradeScriptForReplication(sdd, tc));
         addUpgradeScript(baseVersion1, 1917, new UpgradeScriptForMultiTenancy(sdd,tc));
@@ -105,7 +107,7 @@ public class SpliceCatalogUpgradeScripts{
         addUpgradeScript(baseVersion4, 1992, new UpgradeScriptForTablePriorities(sdd, tc));
         addUpgradeScript(baseVersion4, 1993, new UpgradeScriptToAddSysIndexesViewInSYSIBMAndUpdateIndexColUseViewInSYSCAT(sdd, tc));
         addUpgradeScript(baseVersion4, 1996, new UpgradeScriptToAddReferencesViewInSYSCAT(sdd, tc));
-        addUpgradeScript(baseVersion4, 1996, new UpgradeConglomerateTable(sdd, tc));
+
         // remember to add your script to SpliceCatalogUpgradeScriptsTest too, otherwise test fails
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
@@ -31,8 +31,10 @@ public class SpliceCatalogUpgradeScriptsTest {
     String s2 = "VERSION4.1989: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToAddIndexColUseViewInSYSCAT\n" +
             "VERSION4.1992: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptForTablePriorities\n" +
             "VERSION4.1993: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToAddSysIndexesViewInSYSIBMAndUpdateIndexColUseViewInSYSCAT\n" +
-            "VERSION4.1996: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToAddReferencesViewInSYSCAT\n" +
-            "VERSION4.1996: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeConglomerateTable\n";
+            "VERSION4.1996: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToAddReferencesViewInSYSCAT\n";
+
+    // see DB-11296, UpgradeConglomerateTable must run before other upgrade scripts
+    String s3 = "VERSION4.1996: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeConglomerateTable\n";
     // add more scripts here
 
     private String replaceVersions(String s) {
@@ -49,7 +51,7 @@ public class SpliceCatalogUpgradeScriptsTest {
         Splice_DD_Version version = new Splice_DD_Version(null, 3,1,0, 1933);
         List<SpliceCatalogUpgradeScripts.VersionAndUpgrade> list =
                 SpliceCatalogUpgradeScripts.getScriptsToUpgrade(s.getScripts(), version);
-        Assert.assertEquals(replaceVersions(s1 + s2), getUpgradeScriptsToStr(list));
+        Assert.assertEquals(replaceVersions(s3 + s1 + s2), getUpgradeScriptsToStr(list));
     }
 
     @Test
@@ -59,7 +61,7 @@ public class SpliceCatalogUpgradeScriptsTest {
         Splice_DD_Version version = new Splice_DD_Version(null, 3,2,0, 1987);
         List<SpliceCatalogUpgradeScripts.VersionAndUpgrade> list =
                 SpliceCatalogUpgradeScripts.getScriptsToUpgrade(s.getScripts(), version);
-        Assert.assertEquals(replaceVersions(s2), getUpgradeScriptsToStr(list));
+        Assert.assertEquals(replaceVersions(s3 + s2), getUpgradeScriptsToStr(list));
     }
 
     @Test


### PR DESCRIPTION
# Description

DB-8897 introduced a system table with conglomerate `SPLICE_CONGLOMERATE_SI`, and also an upgrade script `UpgradeConglomerateTable` to create this table. This table is used when other tables are created. However, that means it is are also used in some other upgrade scripts, specifically `UpgradeScriptToAddSysNaturalNumbersTable` from 1985. Since `UpgradeScriptToAddSysNaturalNumbersTable` runs before `UpgradeConglomerateTable`, this would fail.

Solution is to move `UpgradeConglomerateTable` script before `UpgradeScriptToAddSysNaturalNumbersTable` script.

# How to test
See also DB-11134 for some scripts.

Basic idea:
PROFILE=cdh6.3.0,core

1. create a "snapshot" of a standalone 1980 cluster:
a. `git checkout tags/3.1.0.1980`
b. `./start-splice-cluster -p${PROFILE}`
c. `./start-splice-cluster -k` # stop cluster
d. `mkdir my_snapshot && cp -r platform_it/target/hbase platform_it/target/zookeeper  my_snapshot`

2. get current version
a. `git checkout origin/master` # or other version
b. `mvn -T 16 clean install -P${PROFILE} -DskipTests=true` # or other profiles

3. start standalone with "snapshot"
a. `cd platform_it && git clean -dfx && cd ..` # clean up platform_it
b. `mkdir platform_it/target && cp my_snapshot/* platform_it/target/.`
c. `./start-splice-cluster -b`

4. check platform_it/splice.log for log messages containing `SpliceCatalogUpgradeScripts`.
