### PR TITLE
add missing splice_ck modules to hdp profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+ <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright (c) 2012 - 2020 Splice Machine, Inc.
   ~
@@ -910,6 +910,7 @@
                 <module>hbase_sql</module>
                 <module>platform_it</module>
                 <module>spark_sql</module>
+                <module>splice_ck</module>
                 <module>splice_spark</module>
                 <module>scala_util</module>
                 <module>assembly</module>
@@ -942,6 +943,7 @@
                 <module>hbase_sql</module>
                 <module>platform_it</module>
                 <module>spark_sql</module>
+                <module>splice_ck</module>
                 <module>splice_spark</module>
                 <module>scala_util</module>
                 <module>assembly</module>
@@ -974,6 +976,7 @@
                 <module>hbase_sql</module>
                 <module>platform_it</module>
                 <module>spark_sql</module>
+                <module>splice_ck</module>
                 <module>splice_spark</module>
                 <module>scala_util</module>
                 <module>assembly</module>
@@ -1006,6 +1009,7 @@
                 <module>hbase_sql</module>
                 <module>platform_it</module>
                 <module>spark_sql</module>
+                <module>splice_ck</module>
                 <module>splice_spark</module>
                 <module>scala_util</module>
                 <module>assembly</module>


### PR DESCRIPTION
# Short Description
Add the missing splice_ck modules to the hdp profiles

# Long Description
The jenkins build will fail at the end of the assembly module since it is looking for the splice_ck artifacts, which were never built since they were included in the list of required modules to be built in the hdp profile. 

# How to test
Running a maven build should succeed successfully after the module is added
`mvn clean install -Pcore,hdp2.6.3 -DskipTests -Denv=hdp2.6.3`
You should also see the splice_ck module in the list of completed modules built
`[INFO] splice_ck .......................................... SUCCESS [  3.108 s]`