### PR TITLE
DB-10756 CREATE ALIAS - Write conflict detected

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -8148,82 +8148,15 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
     }
 
     /**
-     * Returns a unique system generated name of the form SQLyymmddhhmmssxxn
-     * yy - year, mm - month, dd - day of month, hh - hour, mm - minute, ss - second,
-     * xx - the first 2 digits of millisec because we don't have enough space to keep the exact millisec value,
-     * n - number between 0-9
-     * <p/>
-     * The number at the end is to handle more than one system generated name request came at the same time.
-     * In that case, the timestamp will remain the same, we will just increment n at the end of the name.
-     * <p/>
-     * Following is how we get around the problem of more than 10 system generated name requestes at the same time:
-     * When the database boots up, we start a counter with value -1 for the last digit in the generated name.
-     * We also keep the time in millisec to keep track of when the last system name was generated. At the
-     * boot time, it will be default to 0L. In addition, we have a calendar object for the time in millisec
-     * That calendar object is used to fetch yy, mm, dd, etc for the string SQLyymmddhhmmssxxn
-     * <p/>
-     * When the first request for the system generated name comes, time of last system generated name will be less than
-     * the current time. We initialize the counter to 0, set the time of last system generated name to the
-     * current time truncated off to lower 10ms time. The first name request is the only time we know for sure the
-     * time of last system generated name will be less than the current time. After this first request, the next request
-     * could be at any time. We go through the following algorithm for every generated name request.
-     * <p/>
-     * First check if the current time(truncated off to lower 10ms) is greater than the timestamp for last system generated name
-     * <p/>
-     * If yes, then we change the timestamp for system generated name to the current timestamp and reset the counter to 0
-     * and generate the name using the current timestamp and 0 as the number at the end of the generated name.
-     * <p/>
-     * If no, then it means this request for generated name has come at the same time as last one.
-     * Or it may come at a time less than the last generated name request. This could be because of seasonal time change
-     * or somebody manually changing the time on the computer. In any case,
-     * if the counter is less than 10(meaning this is not yet our 11th request for generated name at a given time),
-     * we use that in the generated name. But if the counter has reached 10(which means, this is the 11th name request
-     * at the same time), then we increment the system generated name timestamp by 10ms and reset the counter to 0
-     * (notice, at this point, the timestamp for system generated names is not in sync with the real current time, but we
-     * need to have this mechanism to get around the problem of more than 10 generated name requests at a same physical time).
+     * Returns a unique system generated name of the form SQL[UUID]. The uniqueness must be guaranteed across all region servers.
+     * com.splicemachine.db.iapi.services.uuid.UUIDFactory is used to generate an unique ID.
      *
      * @return system generated unique name
      */
     @Override
     public String getSystemSQLName(){
-        StringBuilder generatedSystemSQLName=new StringBuilder("SQL");
-        synchronized(this){
-            //get the current timestamp
-            long timeNow=(System.currentTimeMillis()/10L)*10L;
-
-            //if the current timestamp is greater than last constraint name generation time, then we reset the counter and
-            //record the new timestamp
-            if(timeNow>timeForLastSystemSQLName){
-                systemSQLNameNumber=0;
-                calendarForLastSystemSQLName.setTimeInMillis(timeNow);
-                timeForLastSystemSQLName=timeNow;
-            }else{
-                //the request has come at the same time as the last generated name request
-                //or it has come at a time less than the time the last generated name request. This can happen
-                //because of seasonal time change or manual update of computer time.
-
-                //get the number that was last used for the last digit of generated name and increment it by 1.
-                systemSQLNameNumber++;
-                if(systemSQLNameNumber==10){ //we have already generated 10 names at the last system generated timestamp value
-                    //so reset the counter
-                    systemSQLNameNumber=0;
-                    timeForLastSystemSQLName=timeForLastSystemSQLName+10L;
-                    //increment the timestamp for system generated names by 10ms
-                    calendarForLastSystemSQLName.setTimeInMillis(timeForLastSystemSQLName);
-                }
-            }
-
-            generatedSystemSQLName.append(twoDigits(calendarForLastSystemSQLName.get(Calendar.YEAR)));
-            //have to add 1 to the month value returned because the method give 0-January, 1-February and so on and so forth
-            generatedSystemSQLName.append(twoDigits(calendarForLastSystemSQLName.get(Calendar.MONTH)+1));
-            generatedSystemSQLName.append(twoDigits(calendarForLastSystemSQLName.get(Calendar.DAY_OF_MONTH)));
-            generatedSystemSQLName.append(twoDigits(calendarForLastSystemSQLName.get(Calendar.HOUR_OF_DAY)));
-            generatedSystemSQLName.append(twoDigits(calendarForLastSystemSQLName.get(Calendar.MINUTE)));
-            generatedSystemSQLName.append(twoDigits(calendarForLastSystemSQLName.get(Calendar.SECOND)));
-            //because we don't have enough space to store the entire millisec value, just store the higher 2 digits.
-            generatedSystemSQLName.append(twoDigits(calendarForLastSystemSQLName.get(Calendar.MILLISECOND)/10));
-            generatedSystemSQLName.append(systemSQLNameNumber);
-        }
+        StringBuilder generatedSystemSQLName = new StringBuilder("SQL");
+        generatedSystemSQLName.append(uuidFactory.createUUID().toString());
         return generatedSystemSQLName.toString();
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -8156,7 +8156,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
     @Override
     public String getSystemSQLName(){
         StringBuilder generatedSystemSQLName = new StringBuilder("SQL");
-        generatedSystemSQLName.append(uuidFactory.createUUID().toString());
+        generatedSystemSQLName.append(uuidFactory.createUUID().toString().toUpperCase().replaceAll("-",""));
         return generatedSystemSQLName.toString();
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/ShowCreateTableIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/ShowCreateTableIT.java
@@ -56,6 +56,7 @@ import java.util.stream.Stream;
  */
 public class ShowCreateTableIT extends SpliceUnitTest
 {
+    private static final String SYSTEM_SQL_NAME_PATTERN = "\\bSQL[0-9a-f]{8}\\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\\b[0-9a-f]{12}\\b";
     private static final String SCHEMA = ShowCreateTableIT.class.getSimpleName().toUpperCase();
     private static final SpliceWatcher classWatcher = new SpliceWatcher(SCHEMA);
 
@@ -141,7 +142,7 @@ public class ShowCreateTableIT extends SpliceUnitTest
         ResultSet rs = methodWatcher.executeQuery("call syscs_util.SHOW_CREATE_TABLE('SHOWCREATETABLEIT','T1')");
         rs.next();
         String ddl = rs.getString(1);
-        Pattern pattern = Pattern.compile("SQL\\d+");
+        Pattern pattern = Pattern.compile(SYSTEM_SQL_NAME_PATTERN);
         Matcher m1 = pattern.matcher(ddl);
         String csName = null;
         while (m1.find())
@@ -160,7 +161,7 @@ public class ShowCreateTableIT extends SpliceUnitTest
         ResultSet rs = methodWatcher.executeQuery("call syscs_util.SHOW_CREATE_TABLE('SHOWCREATETABLEIT','T2')");
         rs.next();
         String ddl = rs.getString(1);
-        Pattern pattern = Pattern.compile("SQL\\d+");
+        Pattern pattern = Pattern.compile(SYSTEM_SQL_NAME_PATTERN);
         Matcher m1 = pattern.matcher(ddl);
         String csName = null;
         while (m1.find())
@@ -177,7 +178,7 @@ public class ShowCreateTableIT extends SpliceUnitTest
         ResultSet rs = methodWatcher.executeQuery("call syscs_util.SHOW_CREATE_TABLE('SHOWCREATETABLEIT','T9')");
         rs.next();
         String ddl = rs.getString(1);
-        Pattern pattern = Pattern.compile("SQL\\d+");
+        Pattern pattern = Pattern.compile(SYSTEM_SQL_NAME_PATTERN);
         Matcher m1 = pattern.matcher(ddl);
         String csName = null;
         while (m1.find())
@@ -255,7 +256,7 @@ public class ShowCreateTableIT extends SpliceUnitTest
         ResultSet rs = methodWatcher.executeQuery("call syscs_util.SHOW_CREATE_TABLE('SHOWCREATETABLEIT','T6')");
         rs.next();
         String ddl = rs.getString(1);
-        Pattern pattern = Pattern.compile("SQL\\d+");
+        Pattern pattern = Pattern.compile(SYSTEM_SQL_NAME_PATTERN);
         Matcher m1 = pattern.matcher(ddl);
         String csName = null;
         while (m1.find())

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/ShowCreateTableIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/ShowCreateTableIT.java
@@ -56,7 +56,7 @@ import java.util.stream.Stream;
  */
 public class ShowCreateTableIT extends SpliceUnitTest
 {
-    private static final String SYSTEM_SQL_NAME_PATTERN = "\\bSQL[0-9a-f]{8}\\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\\b[0-9a-f]{12}\\b";
+    public static final String SYSTEM_SQL_NAME_PATTERN = "\\bSQL[0-9A-F]{32}\\b";
     private static final String SCHEMA = ShowCreateTableIT.class.getSimpleName().toUpperCase();
     private static final SpliceWatcher classWatcher = new SpliceWatcher(SCHEMA);
 


### PR DESCRIPTION
# Description

While doing 8 streams of  "create alias" at the same time (to speed up schema_create), all on different tables, there are write conflicts such as:
During ERROR SE014: Write Conflict detected between transactions 97147649 and 97147393.

The conflict happened when two txns were writing to unique index SYSALIASES_INDEX3(SCHEMAID, SPECIFICNAME).

The two create alias DDL were executed from different region servers, and got same specificname, which were generated according to timestamp and total number of generated SQL names. DataDictionaryImpl.getSystemSQLName() is guaranteed to be unique for a single server, but not cluster-wise. 

# How to test

Scripts to create tables and aliases are attached in https://splicemachine.atlassian.net/browse/DB-10756. It should be tested on the cluster with more than 2 region servers. "create alias" statements have to be executed from multiple processes. For example, I could reproduce the issue in k8s environment, executed 8 given scripts from 8 sqlshells in parallel:

```
run '/tmp/create_table_TEST02.parallel_aa';
run '/tmp/create_table_TEST02.parallel_ab';
run '/tmp/create_table_TEST02.parallel_ac';
run '/tmp/create_table_TEST02.parallel_ad';
run '/tmp/create_table_TEST02.parallel_ae';
run '/tmp/create_table_TEST02.parallel_af';
run '/tmp/create_table_TEST02.parallel_ag';
run '/tmp/create_table_TEST02.parallel_ah';

run '/tmp/create_alias_TEST02.parallel_aa';
run '/tmp/create_alias_TEST02.parallel_ab';
run '/tmp/create_alias_TEST02.parallel_ac';
run '/tmp/create_alias_TEST02.parallel_ad';
run '/tmp/create_alias_TEST02.parallel_ae';
run '/tmp/create_alias_TEST02.parallel_af';
run '/tmp/create_alias_TEST02.parallel_ag';
run '/tmp/create_alias_TEST02.parallel_ah';
```