### PR TITLE
DB-11312 Make the FROM clause of a DELETE statement optional.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -3316,7 +3316,7 @@ deleteBody() throws StandardException :
         return getDeleteNode(fromTable, tableName, whereClause, null, parameterList);
     }
 |
-    <FROM> tableName = qualifiedName(Limits.MAX_IDENTIFIER_LENGTH)
+    [<FROM>] tableName = qualifiedName(Limits.MAX_IDENTIFIER_LENGTH)
         [
             LOOKAHEAD
             ( { (getToken(1).kind != EOF) && (getToken(1).kind != RIGHT_PAREN) &&

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DeleteOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DeleteOperationIT.java
@@ -94,6 +94,12 @@ public class DeleteOperationIT extends SpliceUnitTest {
                 .withInsert("insert into b values(?)")
                 .withRows(rows(row(2), row(3)))
                 .create();
+
+        new TableCreator(connection)
+                .withCreate("create table c(i int)")
+                .withInsert("insert into c values(?)")
+                .withRows(rows(row(2), row(3)))
+                .create();
     }
 
     @Rule
@@ -186,5 +192,18 @@ public class DeleteOperationIT extends SpliceUnitTest {
         ResultSet rs = methodWatcher.executeQuery("select count(*) from a");
         rs.next();
         Assert.assertEquals(0, rs.getInt(1));
+    }
+
+    @Test
+    public void testNoFromClause() throws Exception {
+        methodWatcher.execute("delete c where i=2");
+        String expected = "I |\n" +
+                        "----\n" +
+                        " 3 |";
+        testQuery("select * from c", expected, methodWatcher);
+
+        expected = "";
+        methodWatcher.execute("delete c where i in (select i from b)");
+        testQuery("select * from c", expected, methodWatcher);
     }
 }


### PR DESCRIPTION
This makes the FROM keyword in a DELETE FROM _tableName_  statement optional.
These statements are recognized as being identical:
DELETE T1;
DELETE FROM T1;