### PR TITLE
DB-11266 Fix trigger concurrency issues.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
@@ -112,7 +112,7 @@ public class DataDictionaryCache {
          */
         int tdCacheSize = getCacheSize(startParams, Property.LANG_TD_CACHE_SIZE,
                 Property.LANG_TD_CACHE_SIZE_DEFAULT);
-        int stmtCacheSize = getCacheSize(startParams, Property.LANG_SPS_CACHE_SIZE,
+        int spsCacheSize = getCacheSize(startParams, Property.LANG_SPS_CACHE_SIZE,
                 Property.LANG_SPS_CACHE_SIZE_DEFAULT);
         int seqgenCacheSize = getCacheSize(startParams, Property.LANG_SEQGEN_CACHE_SIZE,
                 Property.LANG_SEQGEN_CACHE_SIZE_DEFAULT);
@@ -162,9 +162,9 @@ public class DataDictionaryCache {
         };
         oidTdCache = new ManagedCache<>(CacheBuilder.newBuilder().recordStats().maximumSize(tdCacheSize).build(), tdCacheSize);
         nameTdCache = new ManagedCache<>(CacheBuilder.newBuilder().maximumSize(tdCacheSize).build(), tdCacheSize);
-        if(stmtCacheSize>0){
-            spsNameCache = new ManagedCache<>(CacheBuilder.newBuilder().recordStats().maximumSize(stmtCacheSize).removalListener(dependentInvalidator).build(), stmtCacheSize);
-            storedPreparedStatementCache = new ManagedCache<>(CacheBuilder.newBuilder().recordStats().maximumSize(stmtCacheSize).removalListener(dependentInvalidator).build(), stmtCacheSize);
+        if(spsCacheSize>0){
+            spsNameCache = new ManagedCache<>(CacheBuilder.newBuilder().recordStats().maximumSize(spsCacheSize).removalListener(dependentInvalidator).build(), spsCacheSize);
+            storedPreparedStatementCache = new ManagedCache<>(CacheBuilder.newBuilder().recordStats().maximumSize(spsCacheSize).removalListener(dependentInvalidator).build(), spsCacheSize);
         }
         sequenceGeneratorCache=new ManagedCache<>(CacheBuilder.newBuilder().recordStats().maximumSize(seqgenCacheSize).build(), seqgenCacheSize);
         partitionStatisticsCache = new ManagedCache<>(CacheBuilder.newBuilder().recordStats()

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -632,7 +632,7 @@ public interface Property {
      * Externally visible.
      */
     String	LANG_SPS_CACHE_SIZE = "derby.language.spsCacheSize";
-    int		LANG_SPS_CACHE_SIZE_DEFAULT =32;
+    int		LANG_SPS_CACHE_SIZE_DEFAULT =256;
 
     /**
      * The size of the sequence generator cache

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TriggerHandler.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TriggerHandler.java
@@ -393,8 +393,18 @@ public class TriggerHandler {
                 f.get(); // bubble up any exceptions
             }
         }
-        for (Future<Void> f : futures) {
-            f.get(); // bubble up any exceptions
+        try {
+            for (Future<Void> f : futures) {
+                f.get(); // bubble up any exceptions
+            }
+        }
+        catch (ExecutionException e) {
+            // Need to cancel the running futures so no further
+            // exceptions are hit.
+            for (Future<Void> f : futures) {
+                f.cancel(true);
+            }
+            throw e;
         }
         pendingAfterRows.clear();
     }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
@@ -793,13 +793,15 @@ public class ExplainPlanIT extends SpliceUnitTest  {
 
     @Test
     public void testPlanPrinterBugDB11341() throws Exception {
-        String planPrinterLevel;
-        planPrinterLevel = methodWatcher.query("call syscs_util.syscs_get_logger_level('com.splicemachine.db.impl.ast.PlanPrinter')");
-        try {
-            methodWatcher.execute("call syscs_util.syscs_set_logger_level('com.splicemachine.db.impl.ast.PlanPrinter','DEBUG')");
-            methodWatcher.executeQuery("SELECT 1 FROM ( SELECT 1 FROM sysibm.sysdummy1 ORDER BY 1 )"); // Failed before DB-11341
-        } finally {
-            methodWatcher.execute(format("call syscs_util.syscs_set_logger_level('com.splicemachine.db.impl.ast.PlanPrinter', '%s')", planPrinterLevel));
+        try (ResultSet rs = methodWatcher.executeQuery("call syscs_util.syscs_get_logger_level('com.splicemachine.db.impl.ast.PlanPrinter')")) {
+            rs.next();
+            String planPrinterLevel = rs.getString(1);
+            try {
+                methodWatcher.execute("call syscs_util.syscs_set_logger_level('com.splicemachine.db.impl.ast.PlanPrinter','DEBUG')");
+                methodWatcher.executeQuery("SELECT 1 FROM ( SELECT 1 FROM sysibm.sysdummy1 ORDER BY 1 )"); // Failed before DB-11341
+            } finally {
+                methodWatcher.execute(format("call syscs_util.syscs_set_logger_level('com.splicemachine.db.impl.ast.PlanPrinter', '%s')", planPrinterLevel));
+            }
         }
     }
 }

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/AbstractTxn.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/AbstractTxn.java
@@ -25,6 +25,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -35,7 +36,7 @@ public abstract class AbstractTxn extends AbstractTxnView implements Txn {
 
     private AtomicLong counter;
     protected LongHashSet rolledback = new LongHashSet();
-    protected Set<Txn> children = new HashSet<>();
+    protected Set<Txn> children = ConcurrentHashMap.newKeySet();
     protected Txn parentReference;
     private boolean subtransactionsAllowed = true;
 


### PR DESCRIPTION
Fixes issues with concurrent row triggers:

1. Aborts other running trigger threads when one thread errors out, so the main thread doesn't try to clean up resources actively being used by running triggers.
2. Increase the size of the stored prepared statement cache, to decrease likelihood two threads are trying to recompile the same trigger simultaneously.
3. Use a ConcurrentHashMap-backed HashSet for the "children" Set of transactions in AbstractTxn, to avoid ConcurrentModificationException errors.

Part 3 will alleviate customer issues in the interim until DB-10276 is complete.  In that Jira I'm working on an issue where the LanguageConnectionContext used to get the transaction to elevate when compiling a trigger may sometimes be the wrong one (is gotten from the ContextService instead of the Activation).  DB-10276 will remove the use of the ConcurrentHashMap in AbstractTxn.