### PR TITLE
DB-11401 allow querying VTI without specifying the schema.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataTypeDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataTypeDescriptor.java
@@ -1787,9 +1787,5 @@ public class DataTypeDescriptor implements Formatable{
         return typeId.getStructField(columnName, getPrecision(), getScale(), childStructField);
 
     }
-
-    public TypeDescriptorImpl getTypeDescriptor() {
-        return typeDescriptor;
-    }
 }
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataTypeDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataTypeDescriptor.java
@@ -1787,5 +1787,9 @@ public class DataTypeDescriptor implements Formatable{
         return typeId.getStructField(columnName, getPrecision(), getScale(), childStructField);
 
     }
+
+    public TypeDescriptorImpl getTypeDescriptor() {
+        return typeDescriptor;
+    }
 }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
@@ -257,7 +257,13 @@ public class FromVTI extends FromTable implements VTIEnvironment {
          * in the expanded list.
          */
         this.exposedName = (TableName) exposedTableName;
-        this.typeDescriptor = (TypeDescriptor) typeDescriptor;
+        if(typeDescriptor != null) {
+            this.typeDescriptor = (TypeDescriptor) typeDescriptor;
+        } else {
+            if(invocation instanceof NewInvocationNode) {
+                this.typeDescriptor = ((NewInvocationNode)invocation).getTypeDescriptor();
+            }
+        }
     }
 
     // Optimizable interface

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NewInvocationNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NewInvocationNode.java
@@ -31,42 +31,29 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
+import com.splicemachine.db.catalog.TypeDescriptor;
 import com.splicemachine.db.catalog.types.TypeDescriptorImpl;
-import com.splicemachine.db.iapi.services.loader.ClassInspector;
-
-import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
-import com.splicemachine.db.iapi.services.compiler.LocalField;
-
-
-import com.splicemachine.db.iapi.services.sanity.SanityManager;
-
 import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.iapi.services.i18n.MessageService;
-
-import com.splicemachine.db.iapi.sql.ResultSet;
-import com.splicemachine.db.iapi.sql.compile.DataSetProcessorType;
-import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
-
 import com.splicemachine.db.iapi.reference.SQLState;
-
+import com.splicemachine.db.iapi.services.compiler.LocalField;
+import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.i18n.MessageService;
+import com.splicemachine.db.iapi.services.loader.ClassInspector;
+import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.util.JBitSet;
-
-import com.splicemachine.db.catalog.TypeDescriptor;
 import com.splicemachine.db.vti.CompileTimeSchema;
 
-import javax.el.MethodNotFoundException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static java.sql.ResultSetMetaData.columnNullable;

--- a/db-engine/src/main/java/com/splicemachine/db/vti/CompileTimeSchema.java
+++ b/db-engine/src/main/java/com/splicemachine/db/vti/CompileTimeSchema.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.db.vti;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+/**
+ * This interface provides information whether a VTI has a compile-time result set, if a VTI has
+ * such a result set then query compilation is able to infer the schema of the result set of the
+ * VTI even if the user did not specify it explicitly in the query.
+ *
+ * Example
+ * =======
+ * Here is an example that assumes we have a VTI called com.splicemachine.db.vti.XYZ which has a
+ * result set of type (varchar(20), timestamp) and accepts a varchar(12) parameter, running such
+ * query:
+ *
+ *  `select * from new com.splicemachine.db.vti.XYZ('foo')`
+ *
+ * works as expected provided that XYZ implements this interface.
+ *
+ * How does it work?
+ * =================
+ *
+ * directly after parsing and building `FromVTI` node we check if `tableProperties` (i.e. user-
+ * defined schema) is defined, if not, then we use reflection to examine the invoked VTI, in this
+ * example it would be com.splicemachine.db.vti.XYZ, then we invoke `schemaKnownAtCompileTime` to see
+ * if the VTI has a static compile-time schema, if so, we retrieve it by calling `getMetaData` and
+ * we perform some transformation before we proceed with binding and optimization.
+ *
+ * How to use it?
+ * ==============
+ *
+ * If your VTI returns a fixed-type result set, you should override the default implementation of
+ * these methods and provide information about your schema, that's all, not implementing this interface
+ * is also fine, it just means that the user will always have to provide the schema explicitly when
+ * invoking your VTI, so it makes sense to leave the method untouched e.g. if the result set returned
+ * from your VTI is dynamic.
+ *
+ * @note the column names in your schemas should be uniquely defined.
+ */
+public interface CompileTimeSchema {
+
+    static ResultSetMetaData getMetaData() throws SQLException {
+        throw new SQLException("not supported");
+    }
+
+    static boolean schemaKnownAtCompileTime() {
+        return false;
+    }
+
+}

--- a/db-engine/src/main/java/com/splicemachine/db/vti/CompileTimeSchema.java
+++ b/db-engine/src/main/java/com/splicemachine/db/vti/CompileTimeSchema.java
@@ -13,13 +13,17 @@
 
 package com.splicemachine.db.vti;
 
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-
 /**
- * This interface provides information whether a VTI has a compile-time result set, if a VTI has
+ * This marker interface provides information whether a VTI has a compile-time result set, if a VTI has
  * such a result set then query compilation is able to infer the schema of the result set of the
  * VTI even if the user did not specify it explicitly in the query.
+ *
+ * If you implement this interface, you must implement the following static method in your class:
+ *
+ * static ResultSetMetaData getMetaData() throws SQLException
+ *    this method returns the ResultSetMetaData of the VTI's ResultSet
+ * @note the column names in your schemas should be uniquely defined.
+ * See implementation example below to get an idea on how to implement this method
  *
  * Example
  * =======
@@ -49,16 +53,32 @@ import java.sql.SQLException;
  * invoking your VTI, so it makes sense to leave the method untouched e.g. if the result set returned
  * from your VTI is dynamic.
  *
+ * Implementation Example
+ * ======================
+ *
+ * Let us assume we have a VTI that returns a ResultSet comprising two columns: VARCHAR(2), and INTEGER,
+ * it implements this marker interface and provides and implementation of getMetaData() method:
+ * <pre>
+ * {@code
+ * class MyVTI implements CompileTimeSchema {
+ *
+ *    static ResultSetMetaData getMetaData() throws SQLException {
+ *         return metadata;
+ *     }
+ *
+ *     private static final ResultColumnDescriptor[] columnInfo = {
+ *        EmbedResultSetMetaData.getResultColumnDescriptor("Column1", Types.VARCHAR, false, 128),
+ *        EmbedResultSetMetaData.getResultColumnDescriptor("Column2", Types.INTEGER, false)
+ *     };
+ *
+ *     private static final ResultSetMetaData metadata = new EmbedResultSetMetaData(columnInfo);
+ *
+ *     // rest of implementation
+ * }
+ * }
+ * </pre>
+ *
+ *
  * @note the column names in your schemas should be uniquely defined.
  */
-public interface CompileTimeSchema {
-
-    static ResultSetMetaData getMetaData() throws SQLException {
-        throw new SQLException("not supported");
-    }
-
-    static boolean schemaKnownAtCompileTime() {
-        return false;
-    }
-
-}
+public interface CompileTimeSchema {}

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -1148,7 +1148,7 @@ public interface SQLState {
     String LANG_SHARE_ROW           = "42Z88.U";
 
     // MORE GENERIC LANGUAGE STUFF
-    // String LANG_UPDATABLE_VTI_BAD_GETRESULTSETCONCURRENCY          = "42Z89";
+    String LANG_VTI_DOES_NO_COMPILE_TIME_SCHEMA           = "42Z89";
     String LANG_UPDATABLE_VTI_NON_UPDATABLE_RS            = "42Z90";
     String LANG_SUBQUERY                                  = "42Z91";
     String LANG_REPEATABLE_READ                           = "42Z92";

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -3089,6 +3089,12 @@ Guide.
             </msg>
 
             <msg>
+                <name>42Z89</name>
+                <text>VTI '{0}' does not does not implement compile-time schema</text>
+                <arg>vti</arg>
+            </msg>
+
+            <msg>
                 <name>42Z90</name>
                 <text>Class '{0}' does not return an updatable ResultSet.</text>
                 <arg>className</arg>

--- a/hbase_sql/src/main/java/com/splicemachine/derby/vti/KafkaVTI.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/vti/KafkaVTI.java
@@ -80,10 +80,6 @@ public class KafkaVTI implements DatasetProvider, VTICosting{
         return false;
     }
 
-    public ResultSetMetaData getMetaData() throws SQLException {
-        throw new SQLException("not supported");
-    }
-
     @Override
     public OperationContext getOperationContext() {
         return operationContext;

--- a/hbase_sql/src/main/java/com/splicemachine/derby/vti/KafkaVTI.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/vti/KafkaVTI.java
@@ -80,7 +80,6 @@ public class KafkaVTI implements DatasetProvider, VTICosting{
         return false;
     }
 
-    @Override
     public ResultSetMetaData getMetaData() throws SQLException {
         throw new SQLException("not supported");
     }

--- a/hbase_sql/src/main/java/com/splicemachine/derby/vti/SpliceDatasetVTI.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/vti/SpliceDatasetVTI.java
@@ -67,11 +67,6 @@ public class SpliceDatasetVTI implements DatasetProvider, VTICosting {
     }
 
     @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
-throw new UnsupportedOperationException();
-    }
-
-    @Override
     public OperationContext getOperationContext() {
         return operationContext;
     }

--- a/hbase_sql/src/main/java/com/splicemachine/derby/vti/SpliceRDDVTI.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/vti/SpliceRDDVTI.java
@@ -51,11 +51,6 @@ public class SpliceRDDVTI implements DatasetProvider, VTICosting {
     }
 
     @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public OperationContext getOperationContext() {
         return operationContext;
     }

--- a/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMHiveRecordWriter.java
+++ b/hbase_sql/src/main/java/com/splicemachine/mrio/api/hive/SMHiveRecordWriter.java
@@ -34,6 +34,7 @@ import com.splicemachine.si.api.txn.Txn;
 import com.splicemachine.si.api.txn.TxnView;
 import com.splicemachine.si.impl.txn.ActiveWriteTxn;
 import com.splicemachine.utils.SpliceLogUtils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.collections.iterators.SingletonIterator;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.serde2.SerDeException;
@@ -47,7 +48,7 @@ import org.apache.log4j.Logger;
 
 public class SMHiveRecordWriter implements RecordWriter<RowLocationWritable, ExecRowWritable> {
 
-    protected static Logger LOG = Logger.getLogger(RecordWriter.class);
+    protected static final Logger LOG = Logger.getLogger(RecordWriter.class);
 	protected Configuration conf;
     protected TxnView parentTxn;
     protected SMSQLUtil util;
@@ -126,6 +127,7 @@ public class SMHiveRecordWriter implements RecordWriter<RowLocationWritable, Exe
         return new ControlDataSet(new SingletonIterator(value.get()));
     }
 
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", justification = "tableName could be null again after calling conf.get")
     private void init() {
         if (LOG.isTraceEnabled())
             SpliceLogUtils.trace(LOG, "setConf conf=%s", conf);

--- a/splice_machine/src/main/java/com/splicemachine/derby/catalog/TriggerNewTransitionRows.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/catalog/TriggerNewTransitionRows.java
@@ -317,8 +317,9 @@ public class TriggerNewTransitionRows
 
 		return resultSet;
 	}
-    
-    public ResultSetMetaData getMetaData() throws SQLException
+
+	@Override
+    public ResultSetMetaData getRuntimeMetaData() throws SQLException
     {
         if (resultSet != null)
             return resultSet.getMetaData();

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SchemaFilterVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SchemaFilterVTI.java
@@ -11,6 +11,7 @@ import com.splicemachine.db.iapi.types.SQLVarchar;
 import com.splicemachine.db.impl.jdbc.EmbedResultSetMetaData;
 import com.splicemachine.db.impl.sql.catalog.DataDictionaryImpl;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
+import com.splicemachine.db.vti.CompileTimeSchema;
 import com.splicemachine.db.vti.VTICosting;
 import com.splicemachine.db.vti.VTIEnvironment;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
@@ -25,7 +26,7 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SchemaFilterVTI implements DatasetProvider, VTICosting {
+public class SchemaFilterVTI implements DatasetProvider, VTICosting, CompileTimeSchema {
     private OperationContext operationContext;
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SchemaFilterVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SchemaFilterVTI.java
@@ -68,9 +68,12 @@ public class SchemaFilterVTI implements DatasetProvider, VTICosting {
         return dsp.createDataSet(items.iterator());
     }
 
-    @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
+    public static ResultSetMetaData getMetaData() throws SQLException {
         return metadata;
+    }
+
+    public static boolean schemaKnownAtCompileTime() {
+        return true;
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceAllRolesVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceAllRolesVTI.java
@@ -99,9 +99,12 @@ public class SpliceAllRolesVTI implements DatasetProvider, VTICosting {
         return false;
     }
 
-    @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
+    public static ResultSetMetaData getMetaData() throws SQLException {
         return metadata;
+    }
+
+    public static boolean schemaKnownAtCompileTime() {
+        return true;
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceAllRolesVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceAllRolesVTI.java
@@ -11,6 +11,7 @@ import com.splicemachine.db.iapi.types.SQLVarchar;
 import com.splicemachine.db.impl.jdbc.EmbedResultSetMetaData;
 import com.splicemachine.db.impl.sql.catalog.DataDictionaryImpl;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
+import com.splicemachine.db.vti.CompileTimeSchema;
 import com.splicemachine.db.vti.VTICosting;
 import com.splicemachine.db.vti.VTIEnvironment;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
@@ -30,7 +31,7 @@ import java.util.Map;
 /**
  * Created by yxia on 4/25/19.
  */
-public class SpliceAllRolesVTI implements DatasetProvider, VTICosting {
+public class SpliceAllRolesVTI implements DatasetProvider, VTICosting, CompileTimeSchema {
     protected OperationContext operationContext;
 
     public SpliceAllRolesVTI () {

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceFileVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceFileVTI.java
@@ -263,11 +263,6 @@ public class SpliceFileVTI implements DatasetProvider, VTICosting {
     }
 
     @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
-        throw new SQLException("not supported");
-    }
-
-    @Override
     public OperationContext getOperationContext() {
         return operationContext;
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceGroupUserVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceGroupUserVTI.java
@@ -8,6 +8,7 @@ import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.SQLVarchar;
 import com.splicemachine.db.impl.jdbc.EmbedResultSetMetaData;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
+import com.splicemachine.db.vti.CompileTimeSchema;
 import com.splicemachine.db.vti.VTICosting;
 import com.splicemachine.db.vti.VTIEnvironment;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
@@ -25,7 +26,7 @@ import java.util.List;
 /**
  * Created by yxia on 4/25/19.
  */
-public class SpliceGroupUserVTI implements DatasetProvider, VTICosting {
+public class SpliceGroupUserVTI implements DatasetProvider, VTICosting, CompileTimeSchema {
     protected OperationContext operationContext;
     public static final int INCLUDINGSELFANDPUBLIC = 1;
     public static final int ADMINONLY = 2;

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceGroupUserVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceGroupUserVTI.java
@@ -101,9 +101,12 @@ public class SpliceGroupUserVTI implements DatasetProvider, VTICosting {
         return false;
     }
 
-    @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
+    public static ResultSetMetaData getMetaData() throws SQLException {
         return metadata;
+    }
+
+    public static boolean schemaKnownAtCompileTime() {
+        return true;
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceIteratorVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceIteratorVTI.java
@@ -50,11 +50,6 @@ public class SpliceIteratorVTI implements DatasetProvider, VTICosting {
     }
 
     @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
-        throw new SQLException("not supported");
-    }
-
-    @Override
     public OperationContext getOperationContext() {
         return operationContext;
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceIteratorVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceIteratorVTI.java
@@ -32,7 +32,6 @@ import java.sql.SQLException;
  */
 public class SpliceIteratorVTI implements DatasetProvider, VTICosting {
 
-    private OperationContext operationContext;
     private DataSet dataSet;
 
     public DataSet<ExecRow> getDataSet(SpliceOperation op, DataSetProcessor dsp, ExecRow execRow) throws StandardException {
@@ -51,7 +50,7 @@ public class SpliceIteratorVTI implements DatasetProvider, VTICosting {
 
     @Override
     public OperationContext getOperationContext() {
-        return operationContext;
+        return null;
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceJDBCVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceJDBCVTI.java
@@ -89,7 +89,7 @@ public class SpliceJDBCVTI implements DatasetProvider, VTICosting {
     }
 
     @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
+    public ResultSetMetaData getRuntimeMetaData() throws SQLException {
         Connection connection = DriverManager.getConnection(connectionUrl);
         PreparedStatement ps;
         try {

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceJDBCVTI.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/SpliceJDBCVTI.java
@@ -90,14 +90,9 @@ public class SpliceJDBCVTI implements DatasetProvider, VTICosting {
 
     @Override
     public ResultSetMetaData getRuntimeMetaData() throws SQLException {
-        Connection connection = DriverManager.getConnection(connectionUrl);
-        PreparedStatement ps;
-        try {
-            ps = connection.prepareStatement(sql != null ? sql : "select * from " + schemaName + "." + tableName);
+        try(Connection connection = DriverManager.getConnection(connectionUrl);
+            PreparedStatement ps = connection.prepareStatement(sql != null ? sql : "select * from " + schemaName + "." + tableName)) {
             return ps.getMetaData();
-        } finally {
-            if (connection!=null)
-                connection.close();
         }
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/iapi/DatasetProvider.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/iapi/DatasetProvider.java
@@ -16,6 +16,7 @@ package com.splicemachine.derby.vti.iapi;
 
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
+import com.splicemachine.db.vti.CompileTimeSchema;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
@@ -27,7 +28,7 @@ import java.sql.SQLException;
 /**
  * Created by jleach on 10/7/15.
  */
-public interface DatasetProvider {
+public interface DatasetProvider extends CompileTimeSchema {
     /**
      *
      * Processing pipeline supporting in memory and spark datasets.
@@ -40,12 +41,11 @@ public interface DatasetProvider {
      DataSet<ExecRow> getDataSet(SpliceOperation op, DataSetProcessor dsp,ExecRow execRow) throws StandardException;
 
     /**
-     *
-     * Dynamic MetaData used to dynamically bind a function.
-     *
-     * @return
+     * @return dynamic MetaData used to dynamically bind a function.
      */
-    ResultSetMetaData getMetaData() throws SQLException;
+    default ResultSetMetaData getRuntimeMetaData() throws SQLException {
+        throw new SQLException("not supported");
+    }
 
     OperationContext getOperationContext();
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/vti/iapi/DatasetProvider.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/vti/iapi/DatasetProvider.java
@@ -28,7 +28,7 @@ import java.sql.SQLException;
 /**
  * Created by jleach on 10/7/15.
  */
-public interface DatasetProvider extends CompileTimeSchema {
+public interface DatasetProvider {
     /**
      *
      * Processing pipeline supporting in memory and spark datasets.

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/VTIOperationIT.java
@@ -343,4 +343,24 @@ public class VTIOperationIT extends SpliceUnitTest {
         testQuery(sqlText, expected, spliceClassWatcher);
     }
 
+    @Test
+    public void testQueryingVTIWithoutExplicitSchema() throws Exception {
+        ResultSet rs = spliceClassWatcher.executeQuery("select * From new com.splicemachine.derby.vti.SpliceAllRolesVTI() x");
+        int count = 0;
+        while (rs.next()) {
+            count++;
+        }
+        Assert.assertTrue(count > 0);
+    }
+
+    @Test
+    public void testQueryingVTIWithExplicitSchema() throws Exception {
+        ResultSet rs = spliceClassWatcher.executeQuery("select * From new com.splicemachine.derby.vti.SpliceAllRolesVTI() x(y varchar(12))");
+        int count = 0;
+        while (rs.next()) {
+            count++;
+        }
+        Assert.assertTrue(count > 0);
+    }
+
 }

--- a/sqlj-it-procs/src/main/java/org/splicetest/sqlj/PropertiesFileVTI.java
+++ b/sqlj-it-procs/src/main/java/org/splicetest/sqlj/PropertiesFileVTI.java
@@ -24,6 +24,7 @@ import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.SQLVarchar;
 import com.splicemachine.db.impl.jdbc.EmbedResultSetMetaData;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
+import com.splicemachine.db.vti.CompileTimeSchema;
 import com.splicemachine.db.vti.VTICosting;
 import com.splicemachine.db.vti.VTIEnvironment;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
@@ -43,7 +44,7 @@ import java.util.Properties;
  * @author erindriggers
  *
  */
-public class PropertiesFileVTI  implements DatasetProvider, VTICosting{
+public class PropertiesFileVTI  implements DatasetProvider, VTICosting, CompileTimeSchema {
 
     private String fileName;
     

--- a/sqlj-it-procs/src/main/java/org/splicetest/sqlj/PropertiesFileVTI.java
+++ b/sqlj-it-procs/src/main/java/org/splicetest/sqlj/PropertiesFileVTI.java
@@ -105,9 +105,12 @@ public class PropertiesFileVTI  implements DatasetProvider, VTICosting{
         return false;
     }
 
-    @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
+    public static ResultSetMetaData getMetaData() throws SQLException {
         return metadata;
+    }
+
+    public static boolean schemaKnownAtCompileTime() {
+        return true;
     }
 
     @Override


### PR DESCRIPTION
In this PR we allow querying a VTI without explicitly specifying the output result set provided the VTI class implements the newly introduced interface `CompileTimeSchema`.

The rationale behind this PR is that we want to be able to introduce a monitoring table-valued function called `MON_GET_CONNECTION`, which, [similar to DB2](https://www.ibm.com/support/knowledgecenter/SSEPGG_11.5.0/com.ibm.db2.luw.sql.rtn.doc/doc/r0053938.html), has hundreds of columns, VTIs provide a way to implement table-valued functions as [documented in Derby](https://db.apache.org/derby/docs/10.11/publishedapi/org/apache/derby/vti/package-summary.html), however with this limitation (having to explicitly specify the output schema) it becomes very difficult to expose `MON_GET_CONNECTION` as a table-valued function.

As a practical example, there is a VTI in SpliceMachine called `SpliceAllRolesVTI`, previously we were able to query it like this:

`select * From new com.splicemachine.derby.vti.SpliceAllRolesVTI() x(y varchar(12))`

removing the schema `(y varchar(12))` gives an error 42X81 'A query expression must return at least one column', with this PR this becomes possible (since we adapt `SpliceAllRolesVTI` such that it implements the interface `CompileTimeSchema`:

```
select * From new com.splicemachine.derby.vti.SpliceAllRolesVTI() x;
ROLENAME
----------
PUBLIC
SPLICE
```

To get more details on how this is implemented please have a look at the documentation of `CompileTimeSchema`, there we provide some details about how and when to use it.