### PR TITLE
DB-10276 Row trigger performance improvements on Spark

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/Activation.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/Activation.java
@@ -653,4 +653,8 @@ public interface Activation extends Dependent, AutoCloseable
     boolean isSubStatement();
 
     void setSubStatement(boolean newValue);
+
+    boolean isRowTrigger();
+
+    void setIsRowTrigger(boolean newValue);
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
@@ -766,4 +766,8 @@ public interface CompilerContext extends Context
     void setVarcharDB2CompatibilityMode(boolean newValue);
 
     boolean getVarcharDB2CompatibilityMode();
+
+    boolean compilingTrigger();
+
+    void setCompilingTrigger(boolean newVal);
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -44,6 +44,7 @@ import com.splicemachine.db.iapi.sql.PreparedStatement;
 import com.splicemachine.db.iapi.sql.compile.*;
 import com.splicemachine.db.iapi.sql.depend.Provider;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
+import com.splicemachine.db.iapi.sql.dictionary.SPSDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.sql.execute.ConstantAction;
@@ -52,7 +53,9 @@ import com.splicemachine.db.iapi.sql.execute.ExecPreparedStatement;
 import com.splicemachine.db.iapi.sql.execute.ExecutionStmtValidator;
 import com.splicemachine.db.iapi.store.access.AccessFactory;
 import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.db.iapi.store.access.conglomerate.Conglomerate;
 import com.splicemachine.db.iapi.types.DataValueFactory;
+import com.splicemachine.db.impl.sql.catalog.ManagedCache;
 import com.splicemachine.db.impl.sql.compile.CharTypeCompiler;
 import com.splicemachine.db.impl.sql.execute.TriggerExecutionContext;
 import com.splicemachine.db.impl.sql.execute.TriggerExecutionStack;
@@ -1525,5 +1528,16 @@ public interface LanguageConnectionContext extends Context {
     boolean compilingStoredPreparedStatement();
 
     void setCompilingStoredPreparedStatement(boolean newValue);
+
+    void setupLocalSPSCache(boolean fromSparkExecution,
+                            SPSDescriptor fromTableDmlSpsDescriptor) throws StandardException;
+
+    ManagedCache<UUID, SPSDescriptor> getLocalSpsCache();
+
+    List<String> getDefaultRoles();
+
+    SchemaDescriptor getInitialDefaultSchemaDescriptor();
+
+    long getActiveStateTxId();
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionFactory.java
@@ -31,6 +31,7 @@
 
 package com.splicemachine.db.iapi.sql.conn;
 
+import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.db.InternalDatabase;
 
 import com.splicemachine.db.iapi.services.authorization.AuthorizationFactory;
@@ -38,6 +39,8 @@ import com.splicemachine.db.iapi.services.property.PropertyFactory;
 
 import com.splicemachine.db.iapi.sql.compile.*;
 
+import com.splicemachine.db.iapi.sql.dictionary.SPSDescriptor;
+import com.splicemachine.db.iapi.store.access.conglomerate.Conglomerate;
 import com.splicemachine.db.iapi.types.DataValueFactory;
 import com.splicemachine.db.iapi.sql.execute.ExecutionFactory;
 import com.splicemachine.db.iapi.sql.Statement;
@@ -50,6 +53,7 @@ import com.splicemachine.db.iapi.services.loader.ClassFactory;
 import com.splicemachine.db.iapi.sql.LanguageFactory;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
 import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.db.impl.sql.catalog.ManagedCache;
 import com.splicemachine.db.impl.sql.misc.CommentStripper;
 
 import java.util.List;
@@ -123,6 +127,10 @@ public interface LanguageConnectionFactory {
 								 double defaultSelectivityFactor,
 								 String ipAddress,
 								 String defaultSchema,
+                                 ManagedCache<UUID, SPSDescriptor> spsCache,
+                                 List<String> defaultRoles,
+                                 SchemaDescriptor initialDefaultSchemaDescriptor,
+								 long driverTxnId,
 								 Properties sessionProperties)
 
 		throws StandardException;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SPSDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/SPSDescriptor.java
@@ -34,7 +34,6 @@ package com.splicemachine.db.iapi.sql.dictionary;
 import com.splicemachine.db.catalog.Dependable;
 import com.splicemachine.db.catalog.DependableFinder;
 import com.splicemachine.db.catalog.UUID;
-import com.splicemachine.db.catalog.types.TypeDescriptorImpl;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.context.ContextManager;
@@ -52,10 +51,8 @@ import com.splicemachine.db.iapi.sql.depend.DependencyManager;
 import com.splicemachine.db.iapi.sql.depend.Dependent;
 import com.splicemachine.db.iapi.sql.depend.Provider;
 import com.splicemachine.db.iapi.sql.execute.ExecPreparedStatement;
-import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
-import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.impl.sql.GenericStorablePreparedStatement;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -101,6 +98,7 @@ public class SPSDescriptor extends TupleDescriptor implements UniqueSQLObjectDes
     private String text;
     private String usingText;
     private UUID uuid;
+    private UUID suuid;
 
     private boolean valid;
     private ExecPreparedStatement preparedStatement;
@@ -183,6 +181,7 @@ public class SPSDescriptor extends TupleDescriptor implements UniqueSQLObjectDes
         }
         this.name = name;
         this.uuid = uuid;
+        this.suuid = suuid;
         this.type = type;
         this.text = text;
         this.usingText = usingText;
@@ -193,6 +192,31 @@ public class SPSDescriptor extends TupleDescriptor implements UniqueSQLObjectDes
         this.compSchemaId = compSchemaUUID;
         this.initiallyCompilable = initiallyCompilable;
     }
+
+    public final synchronized SPSDescriptor shallowClone() throws StandardException {
+        SPSDescriptor copy =
+            new SPSDescriptor(dataDictionary,
+                name,
+                uuid,
+                suuid,
+                compSchemaId,
+                type,
+                valid,
+                text,
+                usingText,
+                compileTime,
+                preparedStatement,
+                initiallyCompilable);
+
+        copy.setParams(getParams());
+        copy.setParameterDefaults(getParameterDefaults());
+        copy.setLookedUpParams(getLookedUpParams());
+        copy.setFinalTableConglomID(getFinalTableConglomID());
+        return copy;
+    }
+
+    public void setLookedUpParams(boolean lookedUpParams) { this.lookedUpParams = lookedUpParams; }
+    public boolean getLookedUpParams() { return lookedUpParams; }
 
     /**
      * FOR TRIGGERS ONLY
@@ -518,7 +542,7 @@ public class SPSDescriptor extends TupleDescriptor implements UniqueSQLObjectDes
      * @return the preparedStatement
      */
     public final ExecPreparedStatement getPreparedStatement() throws StandardException {
-        return getPreparedStatement(true);
+        return getPreparedStatement(true, null);
     }
 
     /**
@@ -530,16 +554,22 @@ public class SPSDescriptor extends TupleDescriptor implements UniqueSQLObjectDes
      * @param recompIfInvalid if false, never recompile even
      *                        if statement is invalid
      */
-    public final synchronized ExecPreparedStatement getPreparedStatement(boolean recompIfInvalid) throws StandardException {
+    public final synchronized ExecPreparedStatement getPreparedStatement(boolean recompIfInvalid,
+                                                                         LanguageConnectionContext activationLCC) throws StandardException {
 
         /*  Recompile if we are invalid, we don't have a prepared statement, or the statements activation
          *  has been cleared and cannot be reconstituted.*/
         if (recompIfInvalid && (!valid || (preparedStatement == null))) {
-            ContextManager cm = ContextService.getFactory().getCurrentContextManager();
 
-            /* Find the language connection context.  Get it each time in case a connection is dropped. */
-            LanguageConnectionContext lcc = (LanguageConnectionContext)
-                    cm.getContext(LanguageConnectionContext.CONTEXT_ID);
+            /*  Find the language connection context from the ContextService
+             *  only if the one to use was not specified by the caller.
+             *  For concurrent triggers we want to use the lcc created
+             *  for the proper thread.
+             **/
+            LanguageConnectionContext lcc = activationLCC != null ? activationLCC :
+                (LanguageConnectionContext)
+                    ContextService.getFactory().getCurrentContextManager().
+                           getContext(LanguageConnectionContext.CONTEXT_ID);
 
             if (!lcc.getDataDictionary().isReadOnlyUpgrade()) {
 
@@ -1012,6 +1042,7 @@ public class SPSDescriptor extends TupleDescriptor implements UniqueSQLObjectDes
         writeNullableString(text, out);
         writeNullableString(usingText, out);
         out.writeObject(uuid);
+        out.writeObject(suuid);
         out.writeBoolean(valid);
         boolean writePreparedStatement = (preparedStatement instanceof GenericStorablePreparedStatement);
         out.writeBoolean(writePreparedStatement);
@@ -1049,6 +1080,7 @@ public class SPSDescriptor extends TupleDescriptor implements UniqueSQLObjectDes
         text = readNullableString(in);
         usingText = readNullableString(in);
         uuid = (UUID) in.readObject();
+        suuid = (UUID) in.readObject();
         valid = in.readBoolean();
         boolean readPreparedStatement = in.readBoolean();
         if (readPreparedStatement)

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TriggerDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TriggerDescriptor.java
@@ -299,8 +299,7 @@ public class TriggerDescriptor extends TupleDescriptor implements UniqueSQLObjec
         return getSPS(lcc, activation, index);
     }
 
-    private boolean
-    olapStatementIntializingOnRegionServer(Activation activation) {
+    private boolean olapStatementIntializingOnRegionServer(Activation activation) {
         return activation.datasetProcessorType().isOlap() &&
                isDRDAConnThread();
     }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TriggerDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TriggerDescriptor.java
@@ -368,10 +368,11 @@ public class TriggerDescriptor extends TupleDescriptor implements UniqueSQLObjec
         if (sps == null) {
             sps = dd.getSPSDescriptor(spsId);
         }
+        assert sps != null : "sps should not be null";
+
         boolean wasValid = sps.isValid();
         boolean needsSpecialRecompile = !sps.isValid() && isRow && usesReferencingClause;
 
-        assert sps != null : "sps should not be null";
 
         // lcc.commitNestedTransaction();
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TupleDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TupleDescriptor.java
@@ -33,9 +33,7 @@ package com.splicemachine.db.iapi.sql.dictionary;
 
 import com.splicemachine.db.catalog.DependableFinder;
 import com.splicemachine.db.catalog.UUID;
-import com.splicemachine.db.iapi.services.context.ContextService;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
-import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 
 /**
  * This is the superclass of all Descriptors. Users of DataDictionary should use
@@ -73,12 +71,6 @@ public class TupleDescriptor
 	}
 
 	public DataDictionary getDataDictionary() {
-		if (dataDictionary == null) {
-			LanguageConnectionContext lcc =
-				(LanguageConnectionContext) ContextService.getContext(LanguageConnectionContext.CONTEXT_ID);
-			if (lcc != null)
-                dataDictionary = lcc.getDataDictionary();
-		}
 		return dataDictionary;
 	}
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TupleDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TupleDescriptor.java
@@ -33,7 +33,9 @@ package com.splicemachine.db.iapi.sql.dictionary;
 
 import com.splicemachine.db.catalog.DependableFinder;
 import com.splicemachine.db.catalog.UUID;
+import com.splicemachine.db.iapi.services.context.ContextService;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 
 /**
  * This is the superclass of all Descriptors. Users of DataDictionary should use
@@ -71,6 +73,12 @@ public class TupleDescriptor
 	}
 
 	public DataDictionary getDataDictionary() {
+		if (dataDictionary == null) {
+			LanguageConnectionContext lcc =
+				(LanguageConnectionContext) ContextService.getContext(LanguageConnectionContext.CONTEXT_ID);
+			if (lcc != null)
+                dataDictionary = lcc.getDataDictionary();
+		}
 		return dataDictionary;
 	}
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/TransactionController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/TransactionController.java
@@ -36,7 +36,6 @@ import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.services.io.Storable;
 import com.splicemachine.db.iapi.services.locks.CompatibilitySpace;
 import com.splicemachine.db.iapi.services.property.PersistentSet;
-import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.store.access.conglomerate.Conglomerate;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/TransactionController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/TransactionController.java
@@ -36,6 +36,7 @@ import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.services.io.Storable;
 import com.splicemachine.db.iapi.services.locks.CompatibilitySpace;
 import com.splicemachine.db.iapi.services.property.PersistentSet;
+import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.store.access.conglomerate.Conglomerate;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/db/BasicDatabase.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/db/BasicDatabase.java
@@ -304,7 +304,8 @@ public class BasicDatabase implements ModuleControl, ModuleSupportable, Property
         // push a database shutdown context
         // we also need to push a language connection context.
         LanguageConnectionContext lctx = lcf.newLanguageConnectionContext(cm, tc, lf, this, user, groupuserlist, drdaID, dbname,
-                rdbIntTkn, type, sparkExecutionType, skipStats, defaultSelectivityFactor, ipAddress, defaultSchema, sessionProperties);
+                rdbIntTkn, type, sparkExecutionType, skipStats, defaultSelectivityFactor, ipAddress, defaultSchema,
+                null, null, null, -1, sessionProperties);
 
         // push the context that defines our class factory
         pushClassFactoryContext(cm, lcf.getClassFactory());

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnectionMaker2.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnectionMaker2.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2012 - 2021 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.tools;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import com.splicemachine.db.jdbc.EmbeddedDriver;
+
+
+/**
+ * Provides connections for internal use.
+ */
+public final class EmbedConnectionMaker2 {
+
+    private static final String JDBC_URL = String.format("jdbc:splice:splicedb;user=splice;password=admin");
+
+    private final EmbeddedDriver driver = new EmbeddedDriver();
+
+    /**
+     * Connection for internal use. Connects as 'splice' without using a password.
+     */
+//    @Override
+    public Connection createNew(Properties dbProperties) throws SQLException {
+        return createNew(JDBC_URL, dbProperties);
+    }
+
+    /**
+     * Creates a Connection to the DB specified by jdbcString using dbProperties.
+     * 
+     * @param jdbcString
+     * @param dbProperties
+     * @return
+     * @throws SQLException
+     */
+    public Connection createNew(String jdbcString, Properties dbProperties) throws SQLException {
+        return driver.connect(jdbcString, dbProperties);
+    }
+}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericActivationHolder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericActivationHolder.java
@@ -38,11 +38,13 @@ import com.splicemachine.db.iapi.sql.compile.DataSetProcessorType;
 import com.splicemachine.db.iapi.sql.compile.SparkExecutionType;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.conn.SQLSessionContext;
+import com.splicemachine.db.iapi.store.access.conglomerate.Conglomerate;
 import com.splicemachine.db.iapi.types.DataValueFactory;
 import com.splicemachine.db.iapi.sql.execute.ExecPreparedStatement;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.sql.execute.ExecutionFactory;
 import com.splicemachine.db.iapi.sql.execute.ConstantAction;
+import com.splicemachine.db.impl.sql.catalog.ManagedCache;
 import com.splicemachine.db.impl.sql.execute.BaseActivation;
 import com.splicemachine.db.iapi.sql.depend.Provider;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
@@ -103,6 +105,7 @@ final public class GenericActivationHolder implements Activation
     private final LanguageConnectionContext lcc;
 
     private boolean isSubStatement = false;
+    private boolean isRowTrigger = false;
 
     /**
      * Constructor for an ActivationHolder
@@ -872,8 +875,17 @@ final public class GenericActivationHolder implements Activation
 	public boolean isSubStatement() { return isSubStatement; }
 
 	@Override
-        public void setSubStatement(boolean newValue) {
+    public void setSubStatement(boolean newValue) {
 	    isSubStatement = newValue;
 	    ac.setSubStatement(newValue);
+	}
+
+	@Override
+	public boolean isRowTrigger() { return isRowTrigger; }
+
+	@Override
+    public void setIsRowTrigger(boolean newValue) {
+	    isRowTrigger = newValue;
+	    ac.setIsRowTrigger(newValue);
 	}
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -418,7 +418,7 @@ public class GenericStatement implements Statement{
                 preparedStmt.setActivationClass(null);
             }
         }
-
+        CompilerContext cc = null;
         try{
             /*
             ** For stored prepared statements, we want all
@@ -440,7 +440,6 @@ public class GenericStatement implements Statement{
             ** get the CompilerContext to make the createDependency()
             ** call a noop.
             */
-            CompilerContext cc = null;
             if (boundAndOptimizedStatement != null)
                 cc = boundAndOptimizedStatement.getCompilerContext();
             else {
@@ -481,6 +480,8 @@ public class GenericStatement implements Statement{
                 setSSQFlatteningForUpdateDisabled(lcc, cc);
                 setVarcharDB2CompatibilityMode(lcc, cc);
             }
+            if (internalSQL)
+                cc.setCompilingTrigger(true);
             fourPhasePrepare(lcc,paramDefaults,timestamps,foundInCache,cc,boundAndOptimizedStatement);
         }catch(StandardException se){
             if(foundInCache)
@@ -500,6 +501,8 @@ public class GenericStatement implements Statement{
                 TriggerReferencingStruct.isFromTableStatement.get().setValue(true);
             else
                 TriggerReferencingStruct.isFromTableStatement.get().setValue(false);
+            if (cc != null)
+                cc.setCompilingTrigger(false);
         }
 
         lcc.commitNestedTransaction();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
@@ -359,19 +359,35 @@ public class DataDictionaryCache {
         storedPreparedStatementCache.invalidateAll();
     }
 
+    private long getDriverTaskTxnId() {
+        LanguageConnectionContext lcc =
+            (LanguageConnectionContext)ContextService.getCurrentContextManager().
+                                getContext(LanguageConnectionContext.CONTEXT_ID);
+        if (lcc == null)
+            return -1;
+        return lcc.getActiveStateTxId();
+    }
+
+    private Conglomerate txnAwareConglomerateCacheFind(Long conglomId) throws StandardException {
+        if (dd.useTxnAwareCache()) {
+            long txnId = getDriverTaskTxnId();
+            if (txnId == -1)
+                return null;
+            return txnAwareConglomerateCacheFind(new Pair(txnId,conglomId));
+        }
+        return null;
+    }
+
     public Conglomerate conglomerateCacheFind(TransactionController xactMgr,Long conglomId) throws StandardException {
         if (!dd.canReadCache(xactMgr) && conglomId>=DataDictionary.FIRST_USER_TABLE_NUMBER) {
             // Use cache even if dd says we can't as long as it's a system table (conglomID is < FIRST_USER_TABLE_NUMBER)
-            if (dd.useTxnAwareCache()) {
-                long txnId = xactMgr.getActiveStateTxId();
-                if (txnId == -1)
-                    return null;
-                return txnAwareConglomerateCacheFind(new Pair(txnId,conglomId));
-            }
-            return null;
+            Conglomerate conglomerate = txnAwareConglomerateCacheFind(conglomId);
+            if (conglomerate != null)
+                return conglomerate;
         }
         if (LOG.isDebugEnabled())
             LOG.debug("conglomerateCacheFind " + conglomId);
+
         return conglomerateCache.getIfPresent(conglomId);
     }
 
@@ -382,7 +398,7 @@ public class DataDictionaryCache {
     public void conglomerateCacheAdd(Long conglomId, Conglomerate conglomerate,TransactionController xactMgr) throws StandardException {
         if (!dd.canWriteCache(xactMgr)) {
             if (dd.useTxnAwareCache()) {
-                long txnId = xactMgr.getActiveStateTxId();
+                long txnId = getDriverTaskTxnId();
                 if (txnId == -1)
                     return;
                 txnAwareConglomerateCacheAdd(new Pair(txnId, conglomId), conglomerate);
@@ -416,7 +432,6 @@ public class DataDictionaryCache {
             LOG.debug("conglomerateCacheRemove " + conglomId);
         conglomerateCache.invalidate(conglomId);
     }
-
 
     public SchemaDescriptor schemaCacheFind(String schemaName) throws StandardException {
         if (!dd.canReadCache(null))

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -3243,8 +3243,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
         sps = dataDictionaryCache.storedPreparedStatementCacheFind(uuid);
         if (sps!=null)
             return sps;
-        if (sps == null)
-            sps=getSPSDescriptorIndex2Scan(uuid.toString());
+        sps=getSPSDescriptorIndex2Scan(uuid.toString());
         dataDictionaryCache.storedPreparedStatementCacheAdd(sps);
         return sps;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -3241,9 +3241,10 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
         /* Make sure that non-core info is initialized */
         getNonCoreTI(SYSSTATEMENTS_CATALOG_NUM);
         sps = dataDictionaryCache.storedPreparedStatementCacheFind(uuid);
-        if(sps!=null)
-                return sps;
-        sps=getSPSDescriptorIndex2Scan(uuid.toString());
+        if (sps!=null)
+            return sps;
+        if (sps == null)
+            sps=getSPSDescriptorIndex2Scan(uuid.toString());
         dataDictionaryCache.storedPreparedStatementCacheAdd(sps);
         return sps;
     }
@@ -3613,7 +3614,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
     public void recompileInvalidSPSPlans(LanguageConnectionContext lcc) throws StandardException{
         for(Object o : getAllSPSDescriptors()){
             SPSDescriptor spsd=(SPSDescriptor)o;
-            spsd.getPreparedStatement(true);
+            spsd.getPreparedStatement(true, lcc);
         }
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/GenericManagedCacheIFace.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/GenericManagedCacheIFace.java
@@ -13,6 +13,10 @@
  */
 package com.splicemachine.db.impl.sql.catalog;
 
+import splice.com.google.common.cache.Cache;
+
+import java.util.Map;
+
 /**
  *
  * A second IFace for functions needed generic K and V values. JMX will not allow for types such as K and V
@@ -21,6 +25,8 @@ package com.splicemachine.db.impl.sql.catalog;
 
 public interface GenericManagedCacheIFace <K, V> {
     void put(K var1, V var2);
+    void putAll(ManagedCache<? extends K, ? extends V> var1);
     V getIfPresent(K k);
     void invalidate(K k);
+    Cache<K, V> getManagedCache();
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/ManagedCache.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/ManagedCache.java
@@ -48,8 +48,10 @@ public class ManagedCache<K, V> implements ManagedCacheMBean, GenericManagedCach
     @Override public long getRequestCount(){ return managedCache.stats().requestCount(); }
     @Override public void invalidateAll(){ managedCache.invalidateAll(); }
     @Override public void put(K var1, V var2){ managedCache.put(var1, var2); }
+    @Override public void putAll(ManagedCache<? extends K, ? extends V> var1) { managedCache.putAll(var1.getManagedCache().asMap()); }
     @Override public V getIfPresent(K k) { return managedCache.getIfPresent(k);}
     @Override public void invalidate(K k) { managedCache.invalidate(k);}
+    @Override public Cache<K, V> getManagedCache() { return managedCache; }
 
     @Override
     public void writeExternal(ObjectOutput out) throws IOException {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSSTATEMENTSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSSTATEMENTSRowFactory.java
@@ -171,7 +171,7 @@ public class SYSSTATEMENTSRowFactory extends CatalogRowFactory
 			time = spsDescriptor.getCompileTime();
 			typeStr = spsDescriptor.getTypeAsString();
 			initiallyCompilable = spsDescriptor.initiallyCompilable();
-			preparedStatement = spsDescriptor.getPreparedStatement(compileMe);
+			preparedStatement = spsDescriptor.getPreparedStatement(compileMe, null);
 			compUuidStr = (spsDescriptor.getCompSchemaId() != null)?
 					spsDescriptor.getCompSchemaId().toString():null;
 			usingText = spsDescriptor.getUsingText();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/TotalManagedCache.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/TotalManagedCache.java
@@ -19,6 +19,7 @@ import splice.com.google.common.cache.Cache;
 import java.beans.ConstructorProperties;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 public class TotalManagedCache<K, V> implements ManagedCacheMBean, GenericManagedCacheIFace<K, V> {
 
@@ -67,6 +68,7 @@ public class TotalManagedCache<K, V> implements ManagedCacheMBean, GenericManage
             mc.invalidateAll();
         }
     }
+    @Override public void putAll(ManagedCache<? extends K, ? extends V> var1) { throw new UnsupportedOperationException(); }
     @Override public void put(K var1, V var2){
         throw new UnsupportedOperationException();
     }
@@ -76,5 +78,6 @@ public class TotalManagedCache<K, V> implements ManagedCacheMBean, GenericManage
     @Override public void invalidate(K k) {
         throw new UnsupportedOperationException();
     }
+    @Override public Cache<K, V> getManagedCache() { throw new UnsupportedOperationException(); }
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
@@ -61,6 +61,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.SQLWarning;
 import java.util.*;
 
+import static com.splicemachine.db.iapi.sql.compile.DataSetProcessorType.*;
+
 /**
  *
  * CompilerContextImpl, implementation of CompilerContext.
@@ -134,7 +136,7 @@ public class CompilerContextImpl extends ContextImpl
         initRequiredPriv();
         defaultSchemaStack = null;
         referencedSequences = null;
-        dataSetProcessorType = DataSetProcessorType.DEFAULT_OLTP;
+        dataSetProcessorType = DEFAULT_OLTP;
         sparkExecutionType = SparkExecutionType.UNSPECIFIED;
         skipStatsTableList.clear();
         selectivityEstimationIncludingSkewedDefault = false;
@@ -1245,7 +1247,8 @@ public class CompilerContextImpl extends ContextImpl
     private HashMap requiredUsagePrivileges;
     private HashMap requiredRolePrivileges;
     private HashMap referencedSequences;
-    private DataSetProcessorType dataSetProcessorType = DataSetProcessorType.DEFAULT_OLTP;
+    private DataSetProcessorType dataSetProcessorType = DEFAULT_OLTP;
+    private boolean compilingTrigger = false;
 
     public SparkExecutionType getSparkExecutionType() {
         return sparkExecutionType;
@@ -1264,6 +1267,14 @@ public class CompilerContextImpl extends ContextImpl
 
     @Override
     public DataSetProcessorType getDataSetProcessorType() {
+        if (compilingTrigger) {
+            // Session hints should not affect how stored trigger
+            // code is executed, because we do not recompile triggers
+            // when a query with a different session hint is issued.
+            if (dataSetProcessorType == SESSION_HINTED_OLAP ||
+                dataSetProcessorType == SESSION_HINTED_OLTP)
+                return DEFAULT_OLTP;
+        }
         return dataSetProcessorType;
     }
 
@@ -1276,4 +1287,15 @@ public class CompilerContextImpl extends ContextImpl
     public Vector<Integer> getSkipStatsTableList() {
         return skipStatsTableList;
     }
+
+    @Override
+    public boolean compilingTrigger() {
+        return compilingTrigger;
+    }
+
+    @Override
+    public void setCompilingTrigger(boolean newVal) {
+        compilingTrigger = newVal;
+    }
+
 } // end of class CompilerContextImpl

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLModStatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLModStatementNode.java
@@ -49,6 +49,7 @@ import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.impl.sql.execute.FKInfo;
 import com.splicemachine.db.impl.sql.execute.TriggerInfo;
+import com.splicemachine.db.impl.sql.execute.TriggerInfo2;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -860,7 +861,7 @@ abstract class DMLModStatementNode extends DMLStatementNode
     {
         if ((triggerList != null) && (!triggerList.isEmpty()))
         {
-            triggerInfo = new TriggerInfo(td, changedCols, triggerList);
+            triggerInfo = new TriggerInfo2(td, changedCols, triggerList);
         }
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -628,12 +628,15 @@ public class FromBaseTable extends FromTable {
         skipStats = skipStatsObj != null && skipStatsObj;
         Double defaultSelectivityFactorObj = (Double)getLanguageConnectionContext().getSessionProperties().getProperty(SessionProperties.PROPERTYNAME.DEFAULTSELECTIVITYFACTOR);
         defaultSelectivityFactor = defaultSelectivityFactorObj==null?-1d: defaultSelectivityFactorObj;
-        Boolean useSparkObj = (Boolean)getLanguageConnectionContext().getSessionProperties().getProperty(SessionProperties.PROPERTYNAME.USEOLAP);
+        boolean isCompilingTrigger = getCompilerContext().compilingTrigger();
+        Boolean useSparkObj = isCompilingTrigger ? null :
+            (Boolean)getLanguageConnectionContext().getSessionProperties().getProperty(SessionProperties.PROPERTYNAME.USEOLAP);
         if (useSparkObj != null)
             dataSetProcessorType = dataSetProcessorType.combine(useSparkObj ?
                     DataSetProcessorType.SESSION_HINTED_OLAP :
                     DataSetProcessorType.SESSION_HINTED_OLTP);
-        Boolean useNativeSparkObj = (Boolean)getLanguageConnectionContext().getSessionProperties().getProperty(SessionProperties.PROPERTYNAME.USE_NATIVE_SPARK);
+        Boolean useNativeSparkObj = isCompilingTrigger ? null :
+            (Boolean)getLanguageConnectionContext().getSessionProperties().getProperty(SessionProperties.PROPERTYNAME.USE_NATIVE_SPARK);
         if (useNativeSparkObj != null)
             sparkExecutionType = sparkExecutionType.combine(useNativeSparkObj ?
                     SparkExecutionType.SESSION_HINTED_NATIVE :

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
@@ -540,8 +540,7 @@ public class FromVTI extends FromTable implements VTIEnvironment {
     getNewTriggerExecutionContext(LanguageConnectionContext lcc, String statementText, TriggerInfo triggerInfo, UUID tableId,
                                   String targetTableName, FormatableBitSet heapList, SPSDescriptor fromTableDmlSpsDescriptor)  throws StandardException {
         GenericExecutionFactory executionFactory = (GenericExecutionFactory) lcc.getLanguageConnectionFactory().getExecutionFactory();
-        TriggerExecutionContext tec = executionFactory.getTriggerExecutionContext(
-              (ConnectionContext) lcc.getContextManager().getContext(ConnectionContext.CONTEXT_ID),
+        TriggerExecutionContext tec = executionFactory.getTriggerExecutionContext(lcc,
               statementText, triggerInfo.getColumnIds(), triggerInfo.getColumnNames(),
               tableId, targetTableName, null, heapList, false, fromTableDmlSpsDescriptor);
 
@@ -626,7 +625,7 @@ public class FromVTI extends FromTable implements VTIEnvironment {
         GenericDescriptorList<TriggerDescriptor> triggerList = new GenericDescriptorList<>();
         triggerList.add(triggerd);
 
-        TriggerInfo triggerInfo = new TriggerInfo(targetTableDescriptor, null, triggerList);
+        TriggerInfo triggerInfo = new TriggerInfo2(targetTableDescriptor, null, triggerList);
         // A special location to hold the temporary trigger descriptor
         // so we don't muck around with the dictionary cache.
         TriggerReferencingStruct.fromTableTriggerDescriptor.set(triggerd);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
@@ -3566,6 +3566,10 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                                         MethodBuilder mb,
                                         Optimizable optTable,
                                         boolean absolute) throws StandardException{
+        if (size() == 0) {
+            mb.pushNull("java.lang.String");
+            return;
+        }
         ExpressionClassBuilder acb=(ExpressionClassBuilder)acbi;
 
         String retvalType=ClassName.Qualifier+"[][]";

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -452,7 +452,9 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             int value = valueString == null ? 0 : Integer.parseInt(valueString);
             if (value > 0)
                 tableLimitForExhaustiveSearch = value;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
+            throw e;
+        }  catch (Exception e) {
             // no op, use default value 6
         }
 
@@ -461,6 +463,8 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
                 PropertyUtil.getCachedDatabaseProperty(this, Property.DISABLE_NLJ_PREIDCATE_PUSH_DOWN);
             if (nljPredPushDownString != null)
                 nljPredicatePushDownDisabled = Boolean.valueOf(nljPredPushDownString);
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
             // no op, use default value 6
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -67,6 +67,7 @@ import com.splicemachine.db.iapi.util.StringUtil;
 import com.splicemachine.db.impl.db.BasicDatabase;
 import com.splicemachine.db.impl.sql.GenericStatement;
 import com.splicemachine.db.impl.sql.GenericStorablePreparedStatement;
+import com.splicemachine.db.impl.sql.catalog.ManagedCache;
 import com.splicemachine.db.impl.sql.compile.CharTypeCompiler;
 import com.splicemachine.db.impl.sql.compile.CompilerContextImpl;
 import com.splicemachine.db.impl.sql.execute.*;
@@ -75,6 +76,7 @@ import com.splicemachine.utils.SparkSQLUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import splice.com.google.common.cache.CacheBuilder;
 
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
@@ -90,10 +92,12 @@ import static com.splicemachine.db.iapi.reference.Property.MATCHING_STATEMENT_CA
  * <p/>
  * The generic impl does not provide statement caching.
  */
-public class GenericLanguageConnectionContext extends ContextImpl implements LanguageConnectionContext{
+public class GenericLanguageConnectionContext extends ContextImpl implements LanguageConnectionContext {
 
     private final Logger stmtLogger = Logger.getLogger("splice-derby.statement");
-    private static Logger LOG=Logger.getLogger(GenericLanguageConnectionContext.class);
+    private static Logger LOG = Logger.getLogger(GenericLanguageConnectionContext.class);
+    private static final int LOCAL_MANAGED_CACHE_MAX_SIZE = 256;
+
 
     private static final ThreadLocal<String> badFile = new ThreadLocal<String>() {
         @Override
@@ -116,16 +120,16 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         }
     };
     // make sure these are not zeros
-    private final static int NON_XA=0;
-    private final static int XA_ONE_PHASE=1;
-    private final static int XA_TWO_PHASE=2;
+    private final static int NON_XA = 0;
+    private final static int XA_ONE_PHASE = 1;
+    private final static int XA_TWO_PHASE = 2;
 
     /*
         fields
      */
 
     private final ArrayList<Activation> acts;
-    private volatile boolean unusedActs=false;
+    private volatile boolean unusedActs = false;
     /**
      * The maximum size of acts since the last time it was trimmed. Used to
      * determine whether acts should be trimmed to reclaim space.
@@ -140,7 +144,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     //The currentSavepointLevel is used to provide the rollback behavior of 
     //temporary tables.  At any point, this variable has the total number of 
     //savepoints defined for the transaction.
-    private int currentSavepointLevel=0;
+    private int currentSavepointLevel = 0;
 
     protected long nextCursorId;
 
@@ -159,6 +163,9 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     private String rdbIntTkn;
 
     private Object lastQueryTree; // for debugging
+    private ManagedCache<UUID, SPSDescriptor> spsCache = null;
+    private SPSDescriptor createTriggerSPSDescriptor;
+    private long activeStateTxId = -1;
 
     /**
      * The transaction to use within this language connection context.  It may
@@ -176,7 +183,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * with a nested transaction context.
      *
      */
-    private final List<TransactionController> nestedTransactions=new LinkedList<>();
+    private final List<TransactionController> nestedTransactions = new LinkedList<>();
 
     /**
      * If non-null indicates that a read-only nested
@@ -206,7 +213,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     protected OptimizerFactory of;
     protected LanguageConnectionFactory connFactory;
 
-    /* 
+    /*
      * A statement context is "pushed" and "popped" at the beginning and
      * end of every statement so that only that statement is cleaned up
      * on a Statement Exception.  As a performance optimization, we only push
@@ -215,12 +222,12 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * invocation, though we still push and pop it as needed.  All other
      * statement contexts will allocated and pushed and popped on demand.
      */
-    private final StatementContext[] statementContexts=new StatementContext[2];
+    private final StatementContext[] statementContexts = new StatementContext[2];
     private int statementDepth;
-    private int outermostTrigger=-1;
+    private int outermostTrigger = -1;
 
     protected Authorizer authorizer;
-    protected String userName=null; //The name the user connects with.
+    protected String userName = null; //The name the user connects with.
     protected List<String> groupuserlist = null; // name of ldap user group
 
     //May still be quoted.
@@ -240,7 +247,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * Used to hold the computed value of the initial default schema,
      * cf logic in initDefaultSchemaDescriptor.
      */
-    private SchemaDescriptor cachedInitialDefaultSchemaDescr=null;
+    private SchemaDescriptor cachedInitialDefaultSchemaDescr = null;
 
     /**
      * Used to hold the defaultRoles
@@ -248,10 +255,10 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     private List<String> defaultRoles = null;
 
     // RESOLVE - How do we want to set the default.
-    private int defaultIsolationLevel=ExecutionContext.READ_COMMITTED_ISOLATION_LEVEL;
-    protected int isolationLevel=defaultIsolationLevel;
+    private int defaultIsolationLevel = ExecutionContext.READ_COMMITTED_ISOLATION_LEVEL;
+    protected int isolationLevel = defaultIsolationLevel;
 
-    private boolean isolationLevelExplicitlySet=false;
+    private boolean isolationLevelExplicitlySet = false;
     // Isolation level can be changed using JDBC api Connection.setTransactionIsolation
     // or it can be changed using SQL "set current isolation = NEWLEVEL".
     // 
@@ -267,12 +274,12 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     // then BrokeredConnection's isolation level state will be brought upto date
     // with Real Connection's isolation level and this flag will be set to false
     // after that.
-    private boolean isolationLevelSetUsingSQLorJDBC=false;
+    private boolean isolationLevelSetUsingSQLorJDBC = false;
 
     // isolation level to when preparing statements.
     // if unspecified, the statement won't be prepared with a specific 
     // scan isolationlevel
-    protected int prepareIsolationLevel=ExecutionContext.UNSPECIFIED_ISOLATION_LEVEL;
+    protected int prepareIsolationLevel = ExecutionContext.UNSPECIFIED_ISOLATION_LEVEL;
 
     // Whether or not to write executing statement info to db2j.log
     private boolean logStatementText;
@@ -335,7 +342,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     /**
      * If in restore mode, statements can't be executed
      */
-    private boolean restoreMode=false;
+    private boolean restoreMode = false;
 
     /**
      * Allows fallback to distributed mode when we read too many rows on control mode
@@ -364,45 +371,55 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
 
     /* constructor */
     public GenericLanguageConnectionContext(
-            ContextManager cm,
-            TransactionController tranCtrl,
-            LanguageFactory lf,
-            LanguageConnectionFactory lcf,
-            InternalDatabase db,
-            String userName,
-            List<String> groupuserlist,
-            int instanceNumber,
-            String drdaID,
-            String dbname,
-            String rdbIntTkn,
-            DataSetProcessorType type,
-            SparkExecutionType sparkExecutionType,
-            boolean skipStats,
-            double defaultSelectivityFactor,
-            String ipAddress,
-            String defaultSchema,
-            Properties connectionProperties
-    ) throws StandardException{
-        super(cm,ContextId.LANG_CONNECTION);
-        acts=new ArrayList<>();
-        tran=tranCtrl;
+        ContextManager cm,
+        TransactionController tranCtrl,
+        LanguageFactory lf,
+        LanguageConnectionFactory lcf,
+        InternalDatabase db,
+        String userName,
+        List<String> groupuserlist,
+        int instanceNumber,
+        String drdaID,
+        String dbname,
+        String rdbIntTkn,
+        DataSetProcessorType type,
+        SparkExecutionType sparkExecutionType,
+        boolean skipStats,
+        double defaultSelectivityFactor,
+        String ipAddress,
+        String defaultSchema,
+        ManagedCache<UUID, SPSDescriptor> spsCache,
+        List<String> defaultRoles,
+        SchemaDescriptor initialDefaultSchemaDescriptor,
+        long driverTxnId,
+        Properties connectionProperties
+    ) throws StandardException {
+        super(cm, ContextId.LANG_CONNECTION);
+        acts = new ArrayList<>();
+        tran = tranCtrl;
         this.type = type;
         this.sparkExecutionType = sparkExecutionType;
         this.ipAddress = ipAddress;
-        dataFactory=lcf.getDataValueFactory();
-        tcf=lcf.getTypeCompilerFactory();
-        of=lcf.getOptimizerFactory();
-        langFactory=lf;
-        connFactory=lcf;
-        this.db=db;
-        this.userName=userName;
-        this.groupuserlist=groupuserlist;
-        this.instanceNumber=instanceNumber;
-        this.drdaID=drdaID;
-        this.dbname=dbname;
-        this.rdbIntTkn=rdbIntTkn;
+        dataFactory = lcf.getDataValueFactory();
+        tcf = lcf.getTypeCompilerFactory();
+        of = lcf.getOptimizerFactory();
+        langFactory = lf;
+        connFactory = lcf;
+        this.db = db;
+        this.userName = userName;
+        this.groupuserlist = groupuserlist;
+        this.instanceNumber = instanceNumber;
+        this.drdaID = drdaID;
+        this.dbname = dbname;
+        this.rdbIntTkn = rdbIntTkn;
         this.commentStripper = lcf.newCommentStripper();
         this.defaultSchema = defaultSchema;
+        this.spsCache = spsCache;
+        this.activeStateTxId = driverTxnId;
+        this.defaultRoles = defaultRoles;
+        this.cachedInitialDefaultSchemaDescr = initialDefaultSchemaDescriptor;
+        if (initialDefaultSchemaDescriptor != null)
+            initialDefaultSchemaDescriptor.setDataDictionary(getDataDictionary());
 
         if (defaultSchema != null) {
             if (defaultSchema.charAt(0) == '"') {
@@ -416,8 +433,8 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
 
         /* Find out whether or not to log info on executing statements to error log
          */
-        String logStatementProperty=PropertyUtil.getCachedDatabaseProperty(this,"derby.language.logStatementText");
-        logStatementText=logStatementProperty == null || Boolean.valueOf(logStatementProperty);
+        String logStatementProperty = PropertyUtil.getCachedDatabaseProperty(this, "derby.language.logStatementText");
+        logStatementText = logStatementProperty == null || Boolean.valueOf(logStatementProperty);
         // log statements by default
         if (!logStatementText) {
             stmtLogger.setLevel(Level.OFF);
@@ -425,14 +442,14 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
 
         String maxStatementLogLenStr = PropertyUtil.getCachedDatabaseProperty(this, "derby.language.maxStatementLogLen");
         maxStatementLogLen = maxStatementLogLenStr == null ? -1 : Integer.parseInt
-                (maxStatementLogLenStr);
+            (maxStatementLogLenStr);
 
-        String logQueryPlanProperty=PropertyUtil.getCachedDatabaseProperty(this,"derby.language.logQueryPlan");
-        logQueryPlan=Boolean.valueOf(logQueryPlanProperty);
+        String logQueryPlanProperty = PropertyUtil.getCachedDatabaseProperty(this, "derby.language.logQueryPlan");
+        logQueryPlan = Boolean.valueOf(logQueryPlanProperty);
 
         try {
             String valueString = PropertyUtil.getCachedDatabaseProperty(this, "derby.language.tableLimitForExhaustiveSearch");
-            int value = Integer.parseInt(valueString);
+            int value = valueString == null ? 0 : Integer.parseInt(valueString);
             if (value > 0)
                 tableLimitForExhaustiveSearch = value;
         } catch (Exception e) {
@@ -441,17 +458,17 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
 
         try {
             String nljPredPushDownString =
-                    PropertyUtil.getCachedDatabaseProperty(this, Property.DISABLE_NLJ_PREIDCATE_PUSH_DOWN);
+                PropertyUtil.getCachedDatabaseProperty(this, Property.DISABLE_NLJ_PREIDCATE_PUSH_DOWN);
             if (nljPredPushDownString != null)
                 nljPredicatePushDownDisabled = Boolean.valueOf(nljPredPushDownString);
         } catch (Exception e) {
             // no op, use default value 6
         }
 
-        lockEscalationThreshold=Property.DEFAULT_LOCKS_ESCALATION_THRESHOLD;
-        stmtValidators=new ArrayList<>();
-        triggerTables=new ArrayList<>();
-        limiter=ControlExecutionLimiter.NO_OP;
+        lockEscalationThreshold = Property.DEFAULT_LOCKS_ESCALATION_THRESHOLD;
+        stmtValidators = new ArrayList<>();
+        triggerTables = new ArrayList<>();
+        limiter = ControlExecutionLimiter.NO_OP;
         sessionProperties = new SessionPropertiesImpl();
         // transfer setting of skipStats and defaultSelectivityFactor from jdbc connnection string to sessionProperties
         if (skipStats)
@@ -475,7 +492,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             setSessionFromConnectionProperty(connectionProperties, Property.SPARK_RESULT_STREAMING_BATCH_SIZE, SessionProperties.PROPERTYNAME.SPARK_RESULT_STREAMING_BATCH_SIZE);
             String disableNestedLoopJoinPredicatePushDown = connectionProperties.getProperty(Property.CONNECTION_DISABLE_NLJ_PREDICATE_PUSH_DOWN);
             if (disableNestedLoopJoinPredicatePushDown != null &&
-                    disableNestedLoopJoinPredicatePushDown.equalsIgnoreCase("true")) {
+                disableNestedLoopJoinPredicatePushDown.equalsIgnoreCase("true")) {
                 this.sessionProperties.setProperty(SessionProperties.PROPERTYNAME.DISABLE_NLJ_PREDICATE_PUSH_DOWN, "TRUE".toString());
             }
         }
@@ -508,33 +525,34 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * executing with definer's rights), the sessionUser is constant in a
      * session.
      */
-    private String sessionUser=null;
+    private String sessionUser = null;
 
     @Override
-    public void initialize() throws StandardException{
-        interruptedException=null;
-        sessionUser=IdUtil.getUserAuthorizationId(userName);
+    public void initialize() throws StandardException {
+        interruptedException = null;
+        sessionUser = IdUtil.getUserAuthorizationId(userName);
         /*
-        ** Set the authorization id.  User shouldn't
-        ** be null or else we are going to blow up trying
-        ** to create a schema for this user.
-        */
-        if(SanityManager.DEBUG){
-            if(getSessionUserId()==null){
-                SanityManager.THROWASSERT("User name is null,"+
-                        " check the connection manager to make sure it is set"+
-                        " reasonably");
+         ** Set the authorization id.  User shouldn't
+         ** be null or else we are going to blow up trying
+         ** to create a schema for this user.
+         */
+        if (SanityManager.DEBUG) {
+            if (getSessionUserId() == null) {
+                SanityManager.THROWASSERT("User name is null," +
+                    " check the connection manager to make sure it is set" +
+                    " reasonably");
             }
         }
-        referencedColumnMap=new WeakHashMap<>();
-        defaultRoles = initDefaultRoleSet();
-        SchemaDescriptor sd=initDefaultSchemaDescriptor();
+        referencedColumnMap = new WeakHashMap<>();
+        if (defaultRoles == null)
+            defaultRoles = initDefaultRoleSet();
+        SchemaDescriptor sd = initDefaultSchemaDescriptor();
         /*
          * It is possible for Splice's startup sequence to end up in this code on the same thread
          * as a connection. When this happens, we need to ensure that we do not destroy the schema
          * set by the user by default (if such a schema is set already).
          */
-        if(getDefaultSchema()==null)
+        if (getDefaultSchema() == null)
             setDefaultSchema(sd);
     }
 
@@ -542,24 +560,24 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * Initialize the LCC without the extraneous SQL Calls.
      */
     @Override
-    public void initializeSplice(String sessionUser,SchemaDescriptor defaultSchemaDescriptor) throws StandardException{
-        interruptedException=null;
-        this.sessionUser=sessionUser;
+    public void initializeSplice(String sessionUser, SchemaDescriptor defaultSchemaDescriptor) throws StandardException {
+        interruptedException = null;
+        this.sessionUser = sessionUser;
 
-            /*
-            ** Set the authorization id.  User shouldn't
-            ** be null or else we are going to blow up trying
-            ** to create a schema for this user.
-            */
-        if(SanityManager.DEBUG){
-            if(getSessionUserId()==null){
-                SanityManager.THROWASSERT("User name is null,"+
-                        " check the connection manager to make sure it is set"+
-                        " reasonably");
+        /*
+         ** Set the authorization id.  User shouldn't
+         ** be null or else we are going to blow up trying
+         ** to create a schema for this user.
+         */
+        if (SanityManager.DEBUG) {
+            if (getSessionUserId() == null) {
+                SanityManager.THROWASSERT("User name is null," +
+                    " check the connection manager to make sure it is set" +
+                    " reasonably");
             }
         }
         setDefaultSchema(defaultSchemaDescriptor);
-        referencedColumnMap=new WeakHashMap<>();
+        referencedColumnMap = new WeakHashMap<>();
     }
 
 
@@ -569,34 +587,34 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @return computed initial default schema value for this session
      * @throws StandardException
      */
-    protected SchemaDescriptor initDefaultSchemaDescriptor() throws StandardException{
+    protected SchemaDescriptor initDefaultSchemaDescriptor() throws StandardException {
         /*
-        ** - If the database supports schemas and a schema with the
-        ** same name as the user's name exists (has been created using
-        ** create schema already) the database will set the users
-        ** default schema to the the schema with the same name as the
-        ** user.
-        ** - Else Set the default schema to SPLICE.
-        */
-        if(cachedInitialDefaultSchemaDescr==null){
-            DataDictionary dd=getDataDictionary();
+         ** - If the database supports schemas and a schema with the
+         ** same name as the user's name exists (has been created using
+         ** create schema already) the database will set the users
+         ** default schema to the the schema with the same name as the
+         ** user.
+         ** - Else Set the default schema to SPLICE.
+         */
+        if (cachedInitialDefaultSchemaDescr == null) {
+            DataDictionary dd = getDataDictionary();
             SchemaDescriptor sd;
             if (defaultSchema != null) {
                 sd = dd.getSchemaDescriptor(defaultSchema, getTransactionCompile(), true);
             } else {
                 sd = dd.getSchemaDescriptor(
-                        getSessionUserId(), getTransactionCompile(), false);
+                    getSessionUserId(), getTransactionCompile(), false);
             }
-            if(sd==null){
-                sd=new SchemaDescriptor(
-                        dd,
-                        getSessionUserId(),
-                        getSessionUserId(),
-                        null,
-                        false);
+            if (sd == null) {
+                sd = new SchemaDescriptor(
+                    dd,
+                    getSessionUserId(),
+                    getSessionUserId(),
+                    null,
+                    false);
             }
 
-            cachedInitialDefaultSchemaDescr=sd;
+            cachedInitialDefaultSchemaDescr = sd;
         }
         return cachedInitialDefaultSchemaDescr;
     }
@@ -607,20 +625,20 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @return computed initial default roles for this session
      * @throws StandardException
      */
-    protected List<String> initDefaultRoleSet() throws StandardException{
-        if(defaultRoles==null){
-            DataDictionary dd=getDataDictionary();
+    protected List<String> initDefaultRoleSet() throws StandardException {
+        if (defaultRoles == null) {
+            DataDictionary dd = getDataDictionary();
             defaultRoles = new ArrayList<>();
-            List<String>  userRoles =
-                    dd.getDefaultRoles(getSessionUserId(),getTransactionCompile());
+            List<String> userRoles =
+                dd.getDefaultRoles(getSessionUserId(), getTransactionCompile());
             defaultRoles.addAll(userRoles);
             List<String> publicRoles =
-                    dd.getDefaultRoles("PUBLIC", getTransactionCompile());
+                dd.getDefaultRoles("PUBLIC", getTransactionCompile());
             defaultRoles.addAll(publicRoles);
             if (groupuserlist != null) {
                 for (String groupuser : groupuserlist) {
                     List<String> groupRoles =
-                            dd.getDefaultRoles(groupuser, getTransactionCompile());
+                        dd.getDefaultRoles(groupuser, getTransactionCompile());
                     defaultRoles.addAll(groupRoles);
                 }
             }
@@ -629,15 +647,16 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         return defaultRoles;
     }
 
-    private List<String> getDefaultRoles() {
+    public List<String> getDefaultRoles() {
         return defaultRoles;
     }
+
     /**
      * Get the computed value for the initial default schema.
      *
      * @return the schema descriptor of the computed initial default schema
      */
-    private SchemaDescriptor getInitialDefaultSchemaDescriptor(){
+    public SchemaDescriptor getInitialDefaultSchemaDescriptor() {
         return cachedInitialDefaultSchemaDescr;
     }
 
@@ -647,24 +666,24 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     //
 
     @Override
-    public boolean getLogStatementText(){
+    public boolean getLogStatementText() {
         return logStatementText;
     }
 
     @Override
-    public void setLogStatementText(boolean logStatementText){
-        this.logStatementText=logStatementText;
+    public void setLogStatementText(boolean logStatementText) {
+        this.logStatementText = logStatementText;
     }
 
     @Override
-    public boolean getLogQueryPlan(){
+    public boolean getLogQueryPlan() {
         return logQueryPlan;
     }
 
     @Override
     public int getTableLimitForExhaustiveSearch() {
         Integer tableLimit = (Integer) sessionProperties.getProperty(
-                SessionProperties.PROPERTYNAME.TABLELIMITFOREXHAUSTIVESEARCH);
+            SessionProperties.PROPERTYNAME.TABLELIMITFOREXHAUSTIVESEARCH);
         if (tableLimit != null)
             return tableLimit;
         return tableLimitForExhaustiveSearch;
@@ -673,7 +692,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     @Override
     public long getMinPlanTimeout() {
         Long minPlanTimeout = (Long) sessionProperties.getProperty(
-                SessionProperties.PROPERTYNAME.MINPLANTIMEOUT);
+            SessionProperties.PROPERTYNAME.MINPLANTIMEOUT);
         if (minPlanTimeout != null)
             return minPlanTimeout;
         else
@@ -681,7 +700,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     }
 
     @Override
-    public boolean usesSqlAuthorization(){
+    public boolean usesSqlAuthorization() {
         return getDataDictionary().usesSqlAuthorization();
     }
 
@@ -689,7 +708,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * get the lock escalation threshold.
      */
     @Override
-    public int getLockEscalationThreshold(){
+    public int getLockEscalationThreshold() {
         return lockEscalationThreshold;
     }
 
@@ -698,45 +717,45 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      */
     @Override
     public void addActivation(Activation a)
-            throws StandardException{
+        throws StandardException {
         acts.add(a);
 
-        if(acts.size()>maxActsSize){
-            maxActsSize=acts.size();
+        if (acts.size() > maxActsSize) {
+            maxActsSize = acts.size();
         }
     }
 
     @Override
-    public void closeUnusedActivations() throws StandardException{
+    public void closeUnusedActivations() throws StandardException {
         // DERBY-418. Activations which are marked unused,
         // are closed here. Activations Vector is iterated 
         // to identify and close unused activations, only if 
         // unusedActs flag is set to true and if the total 
         // size exceeds 20.
-        if((unusedActs) && (acts.size()>20)){
-            unusedActs=false;
+        if ((unusedActs) && (acts.size() > 20)) {
+            unusedActs = false;
 
-            for(int i=acts.size()-1;i>=0;i--){
+            for (int i = acts.size() - 1; i >= 0; i--) {
 
                 // it maybe the case that a Activation's reset() ends up
                 // closing one or more activation leaving our index beyond
                 // the end of the array
-                if(i>=acts.size())
+                if (i >= acts.size())
                     continue;
 
-                Activation a1=acts.get(i);
-                if(!a1.isInUse()){
+                Activation a1 = acts.get(i);
+                if (!a1.isInUse()) {
                     a1.close();
                 }
             }
         }
 
-        if(SanityManager.DEBUG){
+        if (SanityManager.DEBUG) {
 
-            if(SanityManager.DEBUG_ON("memoryLeakTrace")){
+            if (SanityManager.DEBUG_ON("memoryLeakTrace")) {
 
-                if(acts.size()>20)
-                    System.out.println("memoryLeakTrace:GenericLanguageContext:activations "+acts.size());
+                if (acts.size() > 20)
+                    System.out.println("memoryLeakTrace:GenericLanguageContext:activations " + acts.size());
             }
         }
     }
@@ -744,67 +763,67 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     /**
      * Make a note that some activations are marked unused
      */
-    public void notifyUnusedActivation(){
-        unusedActs=true;
+    public void notifyUnusedActivation() {
+        unusedActs = true;
     }
 
     @Override
-    public boolean checkIfAnyDeclaredGlobalTempTablesForThisConnection(){
-        return (allDeclaredGlobalTempTables!=null);
+    public boolean checkIfAnyDeclaredGlobalTempTablesForThisConnection() {
+        return (allDeclaredGlobalTempTables != null);
     }
 
     @Override
-    public void addDeclaredGlobalTempTable(TableDescriptor td) throws StandardException{
+    public void addDeclaredGlobalTempTable(TableDescriptor td) throws StandardException {
 
-        if(findDeclaredGlobalTempTable(td.getName())!=null){
+        if (findDeclaredGlobalTempTable(td.getName()) != null) {
             //if table already declared, throw an exception
             throw StandardException.newException(
-                    SQLState.LANG_OBJECT_ALREADY_EXISTS_IN_OBJECT,
-                    "Temporary table",
-                    td.getName(),
-                    "Schema",
-                    td.getSchemaName());
+                SQLState.LANG_OBJECT_ALREADY_EXISTS_IN_OBJECT,
+                "Temporary table",
+                td.getName(),
+                "Schema",
+                td.getSchemaName());
         }
 
         //save all the information about temp table in this special class
-        TempTableInfo tempTableInfo=
-                new TempTableInfo(td,currentSavepointLevel);
+        TempTableInfo tempTableInfo =
+            new TempTableInfo(td, currentSavepointLevel);
 
         // Rather than exist in a catalog, a simple array is kept of the 
         // tables currently active in the transaction.
 
-        if(allDeclaredGlobalTempTables==null)
-            allDeclaredGlobalTempTables=new ArrayList<>();
+        if (allDeclaredGlobalTempTables == null)
+            allDeclaredGlobalTempTables = new ArrayList<>();
 
         allDeclaredGlobalTempTables.add(tempTableInfo);
     }
 
     @Override
-    public boolean dropDeclaredGlobalTempTable(TableDescriptor td){
-        TempTableInfo tempTableInfo=findDeclaredGlobalTempTable(td.getName());
+    public boolean dropDeclaredGlobalTempTable(TableDescriptor td) {
+        TempTableInfo tempTableInfo = findDeclaredGlobalTempTable(td.getName());
 
-        if(tempTableInfo!=null){
-            if(SanityManager.DEBUG){
-                if(tempTableInfo.getDeclaredInSavepointLevel()>currentSavepointLevel){
+        if (tempTableInfo != null) {
+            if (SanityManager.DEBUG) {
+                if (tempTableInfo.getDeclaredInSavepointLevel() > currentSavepointLevel) {
                     SanityManager.THROWASSERT(
-                            "declared in savepoint level ("+
-                                    tempTableInfo.getDeclaredInSavepointLevel()+
-                                    ") can not be higher than current savepoint level ("+
-                                    currentSavepointLevel+
-                                    ").");
+                        "declared in savepoint level (" +
+                            tempTableInfo.getDeclaredInSavepointLevel() +
+                            ") can not be higher than current savepoint level (" +
+                            currentSavepointLevel +
+                            ").");
                 }
             }
 
             // check if the table was declared in the current unit of work.
-            if(tempTableInfo.getDeclaredInSavepointLevel()==currentSavepointLevel){
+            if (tempTableInfo.getDeclaredInSavepointLevel() == currentSavepointLevel) {
                 // since the table was declared in this unit of work, the drop 
                 // table method should remove it from the valid list of temp 
                 // table for this unit of work
                 allDeclaredGlobalTempTables.remove(allDeclaredGlobalTempTables.indexOf(tempTableInfo));
 
-                if(allDeclaredGlobalTempTables.isEmpty())
-                    allDeclaredGlobalTempTables=null;
-            }else{
+                if (allDeclaredGlobalTempTables.isEmpty())
+                    allDeclaredGlobalTempTables = null;
+            } else {
                 // since the table was not declared in this unit of work, the
                 // drop table method will just mark the table as dropped
                 // in the current unit of work. This information will be used 
@@ -814,7 +833,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             }
 
             return true;
-        }else{
+        } else {
             return false;
         }
     }
@@ -844,8 +863,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             if (Integer.parseInt(tableName.substring(lastIdx + 1)) == getInstanceNumber())
                 return true;
             return false;
-        }
-        catch (NumberFormatException e) {
+        } catch (NumberFormatException e) {
             throw StandardException.newException(SQLState.LANG_INVALID_INTERNAL_TEMP_TABLE_NAME, tableName);
         }
     }
@@ -857,23 +875,23 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * savepoint level, then we should change them to the current savepoint
      * level
      */
-    private void tempTablesReleaseSavepointLevels(){
+    private void tempTablesReleaseSavepointLevels() {
         // unlike rollback, here we check for dropped in / declared in / 
         // modified in savepoint levels > current savepoint level only.
         // This is because the temp tables with their savepoint levels same as 
         // currentSavepointLevel have correct value assigned to them and
         // do not need to be changed and hence no need to check for >=
 
-        for(TempTableInfo tempTableInfo : allDeclaredGlobalTempTables){
-            if(tempTableInfo.getDroppedInSavepointLevel()>currentSavepointLevel){
+        for (TempTableInfo tempTableInfo : allDeclaredGlobalTempTables) {
+            if (tempTableInfo.getDroppedInSavepointLevel() > currentSavepointLevel) {
                 tempTableInfo.setDroppedInSavepointLevel(currentSavepointLevel);
             }
 
-            if(tempTableInfo.getDeclaredInSavepointLevel()>currentSavepointLevel){
+            if (tempTableInfo.getDeclaredInSavepointLevel() > currentSavepointLevel) {
                 tempTableInfo.setDeclaredInSavepointLevel(currentSavepointLevel);
             }
 
-            if(tempTableInfo.getModifiedInSavepointLevel()>currentSavepointLevel){
+            if (tempTableInfo.getModifiedInSavepointLevel() > currentSavepointLevel) {
                 tempTableInfo.setModifiedInSavepointLevel(currentSavepointLevel);
             }
         }
@@ -896,19 +914,19 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      *                          temp tables at commit time.
      * @throws StandardException Standard exception policy.
      **/
-    private void tempTablesAndCommit(boolean in_xa_transaction) throws StandardException{
+    private void tempTablesAndCommit(boolean in_xa_transaction) throws StandardException {
         // loop through all declared global temporary tables and determine
         // what to do at commit time based on if they were dropped during
         // the current savepoint level.
-        for(int i=allDeclaredGlobalTempTables.size()-1;i>=0;i--){
-            TempTableInfo tempTableInfo=allDeclaredGlobalTempTables.get(i);
+        for (int i = allDeclaredGlobalTempTables.size() - 1; i >= 0; i--) {
+            TempTableInfo tempTableInfo = allDeclaredGlobalTempTables.get(i);
 
-            if(tempTableInfo.getDroppedInSavepointLevel()!=-1){
+            if (tempTableInfo.getDroppedInSavepointLevel() != -1) {
                 // this means table was dropped in this unit of work and hence 
                 // should be removed from valid list of temp tables
 
                 allDeclaredGlobalTempTables.remove(i);
-            }else{
+            } else {
                 //this table was not dropped in this unit of work, hence set 
                 //its declaredInSavepointLevel as -1 and also mark it as not 
                 //modified 
@@ -929,31 +947,31 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         // the transaction until loop below finds one it needs to 
         // process.
 
-        for(TempTableInfo allDeclaredGlobalTempTable : allDeclaredGlobalTempTables){
-            TableDescriptor td=allDeclaredGlobalTempTable.getTableDescriptor();
-            if(!td.isOnCommitDeleteRows()){
+        for (TempTableInfo allDeclaredGlobalTempTable : allDeclaredGlobalTempTables) {
+            TableDescriptor td = allDeclaredGlobalTempTable.getTableDescriptor();
+            if (!td.isOnCommitDeleteRows()) {
                 // do nothing for temp table with ON COMMIT PRESERVE ROWS
-            }else if(!checkIfAnyActivationHasHoldCursor(td.getName())){
+            } else if (!checkIfAnyActivationHasHoldCursor(td.getName())) {
                 // temp tables with ON COMMIT DELETE ROWS and 
                 // no open held cursors
                 getDataDictionary().getDependencyManager().invalidateFor(
-                        td,DependencyManager.DROP_TABLE,this);
+                    td, DependencyManager.DROP_TABLE, this);
 
-                if(!in_xa_transaction){
+                if (!in_xa_transaction) {
                     // delay physical cleanup to after the commit for XA
                     // transactions.   In XA the transaction is likely in
                     // prepare state at this point and physical changes to
                     // store are not allowed until after the commit.
                     // Do the work here for non-XA so that fast path does
                     // have to do the 2 commits that the XA path will.
-                    cleanupTempTableOnCommitOrRollback(td,true);
+                    cleanupTempTableOnCommitOrRollback(td, true);
                 }
             }
         }
     }
 
-    private void tempTablesXApostCommit() throws StandardException{
-        TransactionController tc=getTransactionExecute();
+    private void tempTablesXApostCommit() throws StandardException {
+        TransactionController tc = getTransactionExecute();
 
         // at commit time for an XA transaction drop all temporary tables.
         // A transaction context may not be maintained from one
@@ -962,9 +980,9 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         // tables again.  To provide consistent behavior in embedded vs
         // network server, consistently remove temp tables at XA commit
         // transaction boundary.
-        for(int i=0;i<allDeclaredGlobalTempTables.size();i++){
+        for (int i = 0; i < allDeclaredGlobalTempTables.size(); i++) {
             // remove all temp tables from this context.
-            TableDescriptor td=allDeclaredGlobalTempTables.get(i).getTableDescriptor();
+            TableDescriptor td = allDeclaredGlobalTempTables.get(i).getTableDescriptor();
 
             //remove the conglomerate created for this temp table
             tc.dropConglomerate(td.getHeapConglomerateId());
@@ -978,11 +996,11 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
 
     /*Reset the connection before it is returned (indirectly) by a PooledConnection object. See EmbeddedConnection. */
     @Override
-    public void resetFromPool() throws StandardException{
-        interruptedException=null;
+    public void resetFromPool() throws StandardException {
+        interruptedException = null;
 
         // Reset IDENTITY_VAL_LOCAL
-        identityNotNull=false;
+        identityNotNull = false;
 
         // drop all temp tables.
         dropAllDeclaredGlobalTempTables();
@@ -996,7 +1014,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         // Reset the current user
         getCurrentSQLSessionContext().setUser(getSessionUserId());
 
-        referencedColumnMap=new WeakHashMap<>();
+        referencedColumnMap = new WeakHashMap<>();
 
         sessionProperties.resetAll();
 
@@ -1009,12 +1027,12 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     // debug methods
 
     @Override
-    public void setLastQueryTree(Object queryTree){
-        lastQueryTree=queryTree;
+    public void setLastQueryTree(Object queryTree) {
+        lastQueryTree = queryTree;
     }
 
     @Override
-    public Object getLastQueryTree(){
+    public Object getLastQueryTree() {
         return lastQueryTree;
     }
 
@@ -1026,51 +1044,51 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * connection are dropped before a new connection handle is issued on that
      * same physical database connection.
      */
-    private void dropAllDeclaredGlobalTempTables() throws StandardException{
-        if(allDeclaredGlobalTempTables==null)
+    private void dropAllDeclaredGlobalTempTables() throws StandardException {
+        if (allDeclaredGlobalTempTables == null)
             return;
 
-        StandardException topLevelStandardException=null;
+        StandardException topLevelStandardException = null;
 
-        GenericExecutionFactory execFactory=(GenericExecutionFactory)getLanguageConnectionFactory().getExecutionFactory();
-        GenericConstantActionFactory constantActionFactory=execFactory.getConstantActionFactory();
+        GenericExecutionFactory execFactory = (GenericExecutionFactory) getLanguageConnectionFactory().getExecutionFactory();
+        GenericConstantActionFactory constantActionFactory = execFactory.getConstantActionFactory();
 
         // collect all the exceptions we might receive while dropping the
         // temporary tables and throw them as one chained exception at the end.
-        int i=0;
-        for(TempTableInfo tempTableInfo : allDeclaredGlobalTempTables){
-            try{
+        int i = 0;
+        for (TempTableInfo tempTableInfo : allDeclaredGlobalTempTables) {
+            try {
 
-                TableDescriptor td=tempTableInfo.getTableDescriptor();
+                TableDescriptor td = tempTableInfo.getTableDescriptor();
 
-                if(tempTableInfo.getDroppedInSavepointLevel()!=-1){
+                if (tempTableInfo.getDroppedInSavepointLevel() != -1) {
                     // this means table was dropped in this unit of work and hence
                     // should be removed from valid list of temp tables
 
                     allDeclaredGlobalTempTables.remove(i);
-                }else{
+                } else {
 
                     // Drop the temp table via normal drop table action
-                    ConstantAction action=constantActionFactory.getDropTableConstantAction(td.getQualifiedName(),
-                            td.getName(),
-                            td.getSchemaDescriptor(),
-                            td.getHeapConglomerateId(),
-                            td.getUUID(),StatementType.DROP_CASCADE);
+                    ConstantAction action = constantActionFactory.getDropTableConstantAction(td.getQualifiedName(),
+                        td.getName(),
+                        td.getSchemaDescriptor(),
+                        td.getHeapConglomerateId(),
+                        td.getUUID(), StatementType.DROP_CASCADE);
 
-                    action.executeConstantAction(new DropTableActivation(this,td));
+                    action.executeConstantAction(new DropTableActivation(this, td));
                 }
-            }catch(StandardException e){
-                if(topLevelStandardException==null){
+            } catch (StandardException e) {
+                if (topLevelStandardException == null) {
                     // always keep the first exception unchanged
-                    topLevelStandardException=e;
-                }else{
-                    try{
+                    topLevelStandardException = e;
+                } else {
+                    try {
                         // Try to create a chain of exceptions. If successful,
                         // the current exception is the top-level exception,
                         // and the previous exception the cause of it.
                         e.initCause(topLevelStandardException);
-                        topLevelStandardException=e;
-                    }catch(IllegalStateException ise){
+                        topLevelStandardException = e;
+                    } catch (IllegalStateException ise) {
                         // initCause() has already been called on e. We don't
                         // expect this to happen, but if it happens, just skip
                         // the current exception from the chain. This is safe
@@ -1081,24 +1099,24 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             ++i;
         }
 
-        allDeclaredGlobalTempTables=null;
-        try{
+        allDeclaredGlobalTempTables = null;
+        try {
             internalCommit(true);
-        }catch(StandardException e){
+        } catch (StandardException e) {
             // do the same chaining as above
-            if(topLevelStandardException==null){
-                topLevelStandardException=e;
-            }else{
-                try{
+            if (topLevelStandardException == null) {
+                topLevelStandardException = e;
+            } else {
+                try {
                     e.initCause(topLevelStandardException);
-                    topLevelStandardException=e;
-                }catch(IllegalStateException ise){
+                    topLevelStandardException = e;
+                } catch (IllegalStateException ise) {
                     /* ignore */
                 }
             }
         }
 
-        if(topLevelStandardException!=null)
+        if (topLevelStandardException != null)
             throw topLevelStandardException;
     }
 
@@ -1111,9 +1129,9 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * Note: I'm assuming, because this class extends BaseActivation, it will properly serialize and
      * work across region servers.
      */
-    private static class DropTableActivation extends BaseActivation{
+    private static class DropTableActivation extends BaseActivation {
 
-        public DropTableActivation(LanguageConnectionContext lcc,TableDescriptor td) throws StandardException{
+        public DropTableActivation(LanguageConnectionContext lcc, TableDescriptor td) throws StandardException {
             // Just pass the only pertinent info to BaseActivation
             super();
             initFromContext(lcc);
@@ -1121,39 +1139,39 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         }
 
         @Override
-        protected int getExecutionCount(){
+        protected int getExecutionCount() {
             return 0;
         }
 
         @Override
-        protected void setExecutionCount(int newValue){
+        protected void setExecutionCount(int newValue) {
         }
 
         @Override
-        protected Vector getRowCountCheckVector(){
+        protected Vector getRowCountCheckVector() {
             return null;
         }
 
         @Override
-        protected void setRowCountCheckVector(Vector newValue){
+        protected void setRowCountCheckVector(Vector newValue) {
         }
 
         @Override
-        protected int getStalePlanCheckInterval(){
+        protected int getStalePlanCheckInterval() {
             return 0;
         }
 
         @Override
-        protected void setStalePlanCheckInterval(int newValue){
+        protected void setStalePlanCheckInterval(int newValue) {
         }
 
         @Override
-        public ResultSet execute() throws StandardException{
+        public ResultSet execute() throws StandardException {
             return null;
         }
 
         @Override
-        public void postConstructor() throws StandardException{
+        public void postConstructor() throws StandardException {
         }
 
         @Override
@@ -1173,19 +1191,19 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * 4)If an existing temp table was modified in the UOW, then get rid of
      * all the rows from the table.
      */
-    private void tempTablesAndRollback() throws StandardException{
-        for(int i=allDeclaredGlobalTempTables.size()-1;i>=0;i--){
-            TempTableInfo tempTableInfo=allDeclaredGlobalTempTables.get(i);
+    private void tempTablesAndRollback() throws StandardException {
+        for (int i = allDeclaredGlobalTempTables.size() - 1; i >= 0; i--) {
+            TempTableInfo tempTableInfo = allDeclaredGlobalTempTables.get(i);
 
-            if(tempTableInfo.getDeclaredInSavepointLevel()>=
-                    currentSavepointLevel){
-                if(tempTableInfo.getDroppedInSavepointLevel()==-1){
+            if (tempTableInfo.getDeclaredInSavepointLevel() >=
+                currentSavepointLevel) {
+                if (tempTableInfo.getDroppedInSavepointLevel() == -1) {
                     // the table was declared but not dropped in the unit of 
                     // work getting rolled back and hence we will remove it 
                     // from valid list of temporary tables and drop the 
                     // conglomerate associated with it
 
-                    TableDescriptor td=tempTableInfo.getTableDescriptor();
+                    TableDescriptor td = tempTableInfo.getTableDescriptor();
                     invalidateDroppedTempTable(td);
 
                     //remove the conglomerate created for this temp table
@@ -1194,21 +1212,21 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
                     //remove it from the list of temp tables
                     allDeclaredGlobalTempTables.remove(i);
 
-                }else if(tempTableInfo.getDroppedInSavepointLevel()>=
-                        currentSavepointLevel){
+                } else if (tempTableInfo.getDroppedInSavepointLevel() >=
+                    currentSavepointLevel) {
                     // the table was declared and dropped in the unit of work 
                     // getting rolled back
                     allDeclaredGlobalTempTables.remove(i);
                 }
-            }else if(tempTableInfo.getDroppedInSavepointLevel()>=
-                    currentSavepointLevel){
+            } else if (tempTableInfo.getDroppedInSavepointLevel() >=
+                currentSavepointLevel) {
                 // this means the table was declared in an earlier savepoint 
                 // unit / transaction and then dropped in current UOW 
 
                 // restore the old definition of temp table because drop is 
                 // being rolledback
-                TableDescriptor td=tempTableInfo.getTableDescriptor();
-                td=cleanupTempTableOnCommitOrRollback(td,false);
+                TableDescriptor td = tempTableInfo.getTableDescriptor();
+                td = cleanupTempTableOnCommitOrRollback(td, false);
 
                 // In order to store the old conglomerate information for the 
                 // temp table, we need to replace the existing table descriptor
@@ -1221,10 +1239,10 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
                 // because the table data has been deleted as part of the 
                 // current rollback
                 tempTableInfo.setModifiedInSavepointLevel(-1);
-                allDeclaredGlobalTempTables.set(i,tempTableInfo);
+                allDeclaredGlobalTempTables.set(i, tempTableInfo);
 
-            }else if(tempTableInfo.getModifiedInSavepointLevel()>=
-                    currentSavepointLevel){
+            } else if (tempTableInfo.getModifiedInSavepointLevel() >=
+                currentSavepointLevel) {
                 // this means the table was declared in an earlier savepoint 
                 // unit / transaction and modified in current UOW
 
@@ -1232,7 +1250,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
                 // because the table data will be deleted as part of the 
                 // current rollback
                 tempTableInfo.setModifiedInSavepointLevel(-1);
-                TableDescriptor td=tempTableInfo.getTableDescriptor();
+                TableDescriptor td = tempTableInfo.getTableDescriptor();
 
                 invalidateDroppedTempTable(td);
             }
@@ -1241,17 +1259,17 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             // unit/transaction and not modified
         }
 
-        if(allDeclaredGlobalTempTables.isEmpty()){
-            allDeclaredGlobalTempTables=null;
+        if (allDeclaredGlobalTempTables.isEmpty()) {
+            allDeclaredGlobalTempTables = null;
         }
     }
 
     /**
      * Invalidate a dropped temp table
      */
-    private void invalidateDroppedTempTable(TableDescriptor td) throws StandardException{
-        getDataDictionary().getDependencyManager().invalidateFor(td,DependencyManager.DROP_TABLE,this);
-        cleanupTempTableOnCommitOrRollback(td,true);
+    private void invalidateDroppedTempTable(TableDescriptor td) throws StandardException {
+        getDataDictionary().getDependencyManager().invalidateFor(td, DependencyManager.DROP_TABLE, this);
+        cleanupTempTableOnCommitOrRollback(td, true);
     }
 
     /**
@@ -1269,21 +1287,21 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      *                  getting changed
      * @param td        New table descriptor for the temporary table
      */
-    private void replaceDeclaredGlobalTempTable(String tableName,TableDescriptor td){
-        TempTableInfo tempTableInfo=findDeclaredGlobalTempTable(tableName);
+    private void replaceDeclaredGlobalTempTable(String tableName, TableDescriptor td) {
+        TempTableInfo tempTableInfo = findDeclaredGlobalTempTable(tableName);
         tempTableInfo.setDroppedInSavepointLevel(-1);
         tempTableInfo.setDeclaredInSavepointLevel(-1);
         tempTableInfo.setTableDescriptor(td);
 
-        allDeclaredGlobalTempTables.set(allDeclaredGlobalTempTables.indexOf(tempTableInfo),tempTableInfo);
+        allDeclaredGlobalTempTables.set(allDeclaredGlobalTempTables.indexOf(tempTableInfo), tempTableInfo);
     }
 
     /**
      * @see LanguageConnectionContext#getTableDescriptorForTempTable
      */
-    public TableDescriptor getTableDescriptorForTempTable(String tableName){
-        TempTableInfo tempTableInfo=findDeclaredGlobalTempTable(tableName);
-        if(tempTableInfo==null)
+    public TableDescriptor getTableDescriptorForTempTable(String tableName) {
+        TempTableInfo tempTableInfo = findDeclaredGlobalTempTable(tableName);
+        if (tempTableInfo == null)
             return null;
         else
             return tempTableInfo.getTableDescriptor();
@@ -1295,20 +1313,20 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @param tableName look for this table name in the saved list
      * @return data structure defining the temporary table if found. Else, return null
      */
-    private TempTableInfo findDeclaredGlobalTempTable(String tableName){
-        if(allDeclaredGlobalTempTables==null)
+    private TempTableInfo findDeclaredGlobalTempTable(String tableName) {
+        if (allDeclaredGlobalTempTables == null)
             return null;
 
-        for(TempTableInfo allDeclaredGlobalTempTable : allDeclaredGlobalTempTables){
-            if(allDeclaredGlobalTempTable.matches(tableName))
+        for (TempTableInfo allDeclaredGlobalTempTable : allDeclaredGlobalTempTables) {
+            if (allDeclaredGlobalTempTable.matches(tableName))
                 return allDeclaredGlobalTempTable;
         }
         return null;
     }
 
     @Override
-    public void markTempTableAsModifiedInUnitOfWork(String tableName){
-        TempTableInfo tempTableInfo=findDeclaredGlobalTempTable(tableName);
+    public void markTempTableAsModifiedInUnitOfWork(String tableName) {
+        TempTableInfo tempTableInfo = findDeclaredGlobalTempTable(tableName);
         tempTableInfo.setModifiedInSavepointLevel(currentSavepointLevel);
     }
 
@@ -1316,46 +1334,46 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     public PreparedStatement prepareInternalStatement(SchemaDescriptor compilationSchema,
                                                       String sqlText,
                                                       boolean isForReadOnly,
-                                                      boolean forMetaData) throws StandardException{
-        if(restoreMode){
+                                                      boolean forMetaData) throws StandardException {
+        if (restoreMode) {
             throw StandardException.newException(
-                    SQLState.CONNECTION_RESET_ON_RESTORE_MODE);
+                SQLState.CONNECTION_RESET_ON_RESTORE_MODE);
         }
-        if(forMetaData){
+        if (forMetaData) {
             //DERBY-2946
             //Make sure that metadata queries always run with SYS as
             //compilation schema. This will make sure that the collation
             //type of character string constants will be UCS_BASIC which
             //is also the collation of character string columns belonging
             //to system tables.
-            compilationSchema=getDataDictionary().getSystemSchemaDescriptor();
+            compilationSchema = getDataDictionary().getSystemSchemaDescriptor();
         }
-        return connFactory.getStatement(compilationSchema,sqlText,isForReadOnly, this).prepare(this,forMetaData);
+        return connFactory.getStatement(compilationSchema, sqlText, isForReadOnly, this).prepare(this, forMetaData);
     }
 
 
     @Override
-    public PreparedStatement prepareInternalStatement(String sqlText) throws StandardException{
-        if(restoreMode){
+    public PreparedStatement prepareInternalStatement(String sqlText) throws StandardException {
+        if (restoreMode) {
             throw StandardException.newException(SQLState.CONNECTION_RESET_ON_RESTORE_MODE);
         }
-        return connFactory.getStatement(getDefaultSchema(),sqlText,true, this).prepare(this);
+        return connFactory.getStatement(getDefaultSchema(), sqlText, true, this).prepare(this);
     }
 
     /**
      * Remove the activation to those known about by this connection.
      */
     @Override
-    public void removeActivation(Activation a){
-        if(SanityManager.DEBUG){
-            SanityManager.ASSERT(a.isClosed(),"Activation is not closed");
+    public void removeActivation(Activation a) {
+        if (SanityManager.DEBUG) {
+            SanityManager.ASSERT(a.isClosed(), "Activation is not closed");
         }
 
         acts.remove(a);
 
-        if(maxActsSize>20 && (maxActsSize>2*acts.size())){
+        if (maxActsSize > 20 && (maxActsSize > 2 * acts.size())) {
             acts.trimToSize();
-            maxActsSize=acts.size();
+            maxActsSize = acts.size();
         }
     }
 
@@ -1367,7 +1385,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * the next commit/rollback).
      */
     @Override
-    public int getActivationCount(){
+    public int getActivationCount() {
         return acts.size();
     }
 
@@ -1379,19 +1397,19 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @return the activation for the given cursor, null if none was found.
      */
     @Override
-    public CursorActivation lookupCursorActivation(String cursorName){
+    public CursorActivation lookupCursorActivation(String cursorName) {
 
-        int size=acts.size();
-        if(size>0){
-            int cursorHash=cursorName.hashCode();
+        int size = acts.size();
+        if (size > 0) {
+            int cursorHash = cursorName.hashCode();
 
-            for(Activation a : acts){
-                if(!a.isInUse()){
+            for (Activation a : acts) {
+                if (!a.isInUse()) {
                     continue;
                 }
 
 
-                String executingCursorName=a.getCursorName();
+                String executingCursorName = a.getCursorName();
 
                 // If the executing cursor has no name, or if the hash code of
                 // its name is different from the one we're looking for, it
@@ -1404,22 +1422,22 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
                 // determine that the names don't match. Even if the hash codes
                 // are equal, we still need to call equals() to verify that the
                 // two names actually are equal.
-                if(executingCursorName==null || executingCursorName.hashCode()!=cursorHash){
+                if (executingCursorName == null || executingCursorName.hashCode() != cursorHash) {
                     continue;
                 }
 
-                if(cursorName.equals(executingCursorName)){
+                if (cursorName.equals(executingCursorName)) {
 
-                    ResultSet rs=a.getResultSet();
-                    if(rs==null)
+                    ResultSet rs = a.getResultSet();
+                    if (rs == null)
                         continue;
 
                     // if the result set is closed, the the cursor doesn't exist
-                    if(rs.isClosed()){
+                    if (rs.isClosed()) {
                         continue;
                     }
 
-                    return (CursorActivation)a;
+                    return (CursorActivation) a;
                 }
             }
         }
@@ -1437,7 +1455,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @param statement Statement to remove
      * @throws StandardException thrown if lookup goes wrong.
      */
-    public void removeStatement(GenericStatement statement) throws StandardException{
+    public void removeStatement(GenericStatement statement) throws StandardException {
         getDataDictionary().getDataDictionaryCache().statementCacheRemove(statement);
     }
 
@@ -1449,22 +1467,22 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * if none was found.
      * @throws StandardException thrown if lookup goes wrong.
      */
-    public PreparedStatement lookupStatement(GenericStatement statement) throws StandardException{
+    public PreparedStatement lookupStatement(GenericStatement statement) throws StandardException {
         GenericStorablePreparedStatement ps = getDataDictionary().getDataDictionaryCache().statementCacheFind(statement);
-        if (ps==null) {
+        if (ps == null) {
             ps = new GenericStorablePreparedStatement(statement);
-            getDataDictionary().getDataDictionaryCache().statementCacheAdd(statement,ps);
+            getDataDictionary().getDataDictionaryCache().statementCacheAdd(statement, ps);
         }
-        synchronized(ps){
-            if(ps.upToDate()){
-                GeneratedClass ac=ps.getActivationClass();
+        synchronized (ps) {
+            if (ps.upToDate()) {
+                GeneratedClass ac = ps.getActivationClass();
 
                 // Check to see if the statement was prepared before some change
                 // in the class loading set. If this is the case then force it to be invalid
-                int currentClasses=getLanguageConnectionFactory().getClassFactory().getClassLoaderVersion();
+                int currentClasses = getLanguageConnectionFactory().getClassFactory().getClassLoaderVersion();
 
-                if(ac.getClassLoaderVersion()!=currentClasses){
-                    ps.makeInvalid(DependencyManager.INTERNAL_RECOMPILE_REQUEST,this);
+                if (ac.getClassLoaderVersion() != currentClasses) {
+                    ps.makeInvalid(DependencyManager.INTERNAL_RECOMPILE_REQUEST, this);
                 }
 
                 // note that the PreparedStatement is not kept in the cache. This is because
@@ -1480,22 +1498,22 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     }
 
     /* Get a connection unique system generated name for a cursor. */
-    public String getUniqueCursorName(){
-        return getNameString("SQLCUR",nextCursorId++);
+    public String getUniqueCursorName() {
+        return getNameString("SQLCUR", nextCursorId++);
     }
 
     /* Get a connection unique system generated name for an unnamed savepoint. */
     @Override
-    public String getUniqueSavepointName(){
-        return getNameString("SAVEPT",nextSavepointId++);
+    public String getUniqueSavepointName() {
+        return getNameString("SAVEPT", nextSavepointId++);
     }
 
     /**
      * Get a connection unique system generated id for an unnamed savepoint.
      */
     @Override
-    public int getUniqueSavepointID(){
-        return nextSavepointId-1;
+    public int getUniqueSavepointID() {
+        return nextSavepointId - 1;
     }
 
     /**
@@ -1505,11 +1523,11 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @param number The number to append for uniqueness
      * @return A unique String for a statement name.
      */
-    private String getNameString(String prefix,long number){
-        if(sb!=null){
+    private String getNameString(String prefix, long number) {
+        if (sb != null) {
             sb.setLength(0);
-        }else{
-            sb=new StringBuffer();
+        } else {
+            sb = new StringBuffer();
         }
         sb.append(prefix).append(number);
 
@@ -1524,8 +1542,8 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @throws StandardException thrown on failure
      */
     @Override
-    public void internalCommit(boolean commitStore) throws StandardException{
-        doCommit(commitStore,true,NON_XA,false);
+    public void internalCommit(boolean commitStore) throws StandardException {
+        doCommit(commitStore, true, NON_XA, false);
     }
 
     /**
@@ -1537,8 +1555,8 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @throws StandardException thrown on failure
      */
     @Override
-    public void userCommit() throws StandardException{
-        doCommit(true,true,NON_XA,true);
+    public void userCommit() throws StandardException {
+        doCommit(true, true, NON_XA, true);
     }
 
 
@@ -1557,8 +1575,8 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @throws StandardException thrown on failure
      */
     @Override
-    public final void internalCommitNoSync(int commitflag) throws StandardException{
-        doCommit(true,false,commitflag,false);
+    public final void internalCommitNoSync(int commitflag) throws StandardException {
+        doCommit(true, false, commitflag, false);
     }
 
     /**
@@ -1569,12 +1587,12 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      *                 prepared state.
      */
     @Override
-    public final void xaCommit(boolean onePhase) throws StandardException{
+    public final void xaCommit(boolean onePhase) throws StandardException {
         // further overload internalCommit to make it understand 2 phase commit
         doCommit(true /* commit store */,
-                true /* sync */,
-                onePhase?XA_ONE_PHASE:XA_TWO_PHASE,
-                true);
+            true /* sync */,
+            onePhase ? XA_ONE_PHASE : XA_TWO_PHASE,
+            true);
     }
 
 
@@ -1618,15 +1636,15 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
                             boolean sync,
                             int commitflag,
                             boolean requestedByUser)
-            throws StandardException{
-        StatementContext statementContext=getStatementContext();
+        throws StandardException {
+        StatementContext statementContext = getStatementContext();
 
-        if(requestedByUser &&
-                (statementContext!=null) &&
-                statementContext.inUse() &&
-                statementContext.isAtomic()){
+        if (requestedByUser &&
+            (statementContext != null) &&
+            statementContext.inUse() &&
+            statementContext.isAtomic()) {
             throw StandardException.newException(
-                    SQLState.LANG_NO_COMMIT_IN_NESTED_CONNECTION);
+                SQLState.LANG_NO_COMMIT_IN_NESTED_CONNECTION);
         }
 
         logCommit();
@@ -1634,43 +1652,43 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         endTransactionActivationHandling(false);
 
         // Do clean up work required for temporary tables at commit time.  
-        if(allDeclaredGlobalTempTables!=null){
-            tempTablesAndCommit(commitflag!=NON_XA);
+        if (allDeclaredGlobalTempTables != null) {
+            tempTablesAndCommit(commitflag != NON_XA);
         }
 
         //reset the current savepoint level for the connection to 0 at the end 
         //of commit work for temp tables
-        currentSavepointLevel=0;
+        currentSavepointLevel = 0;
 
         // now commit the Store transaction
-        TransactionController tc=getTransactionExecute();
+        TransactionController tc = getTransactionExecute();
 
         // Check that any nested transaction has been destoyed
         // before a commit.
-        if(SanityManager.DEBUG){
-            if(readOnlyNestedTransaction!=null){
+        if (SanityManager.DEBUG) {
+            if (readOnlyNestedTransaction != null) {
                 SanityManager.THROWASSERT("Nested transaction active!");
             }
         }
 
-        if(tc!=null && commitStore){
-            if(sync){
-                if(commitflag==NON_XA){
+        if (tc != null && commitStore) {
+            if (sync) {
+                if (commitflag == NON_XA) {
                     // regular commit
                     tc.commit();
-                }else{
+                } else {
                     // This may be a xa_commit, check overloaded commitflag.
 
-                    if(SanityManager.DEBUG)
-                        SanityManager.ASSERT(commitflag==XA_ONE_PHASE ||
-                                        commitflag==XA_TWO_PHASE,
-                                "invalid commit flag");
+                    if (SanityManager.DEBUG)
+                        SanityManager.ASSERT(commitflag == XA_ONE_PHASE ||
+                                commitflag == XA_TWO_PHASE,
+                            "invalid commit flag");
 
-                    ((XATransactionController)tc).xa_commit(
-                            commitflag==XA_ONE_PHASE);
+                    ((XATransactionController) tc).xa_commit(
+                        commitflag == XA_ONE_PHASE);
 
                 }
-            }else{
+            } else {
                 tc.commitNoSync(commitflag);
             }
 
@@ -1680,8 +1698,8 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             resetSavepoints();
 
             // Do post commit XA temp table cleanup if necessary.
-            if((allDeclaredGlobalTempTables!=null) &&
-                    (commitflag!=NON_XA)){
+            if ((allDeclaredGlobalTempTables != null) &&
+                (commitflag != NON_XA)) {
                 tempTablesXApostCommit();
             }
         }
@@ -1701,46 +1719,46 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * temp table (because the drop on it is being rolled back).
      */
     private TableDescriptor cleanupTempTableOnCommitOrRollback(TableDescriptor td,
-                                                               boolean dropAndRedeclare) throws StandardException{
+                                                               boolean dropAndRedeclare) throws StandardException {
         // need to upgrade txn to write
         getDataDictionary().startWriting(this);
-        TransactionController tc=getTransactionExecute();
+        TransactionController tc = getTransactionExecute();
 
         //create new conglomerate with same properties as the old conglomerate 
         //and same row template as the old conglomerate
-        long conglomId=
-                tc.createConglomerate(td.getTableType() == TableDescriptor.EXTERNAL_TYPE,
-                        "heap", // we're requesting a heap conglomerate
-                        td.getEmptyExecRow().getRowArray(), // row template
-                        null, //column sort order - not required for heap
-                        td.getColumnCollationIds(),  // same ids as old conglomerate
-                        null, // properties
-                        (TransactionController.IS_TEMPORARY|
-                                TransactionController.IS_KEPT), Conglomerate.Priority.NORMAL);
+        long conglomId =
+            tc.createConglomerate(td.getTableType() == TableDescriptor.EXTERNAL_TYPE,
+                "heap", // we're requesting a heap conglomerate
+                td.getEmptyExecRow().getRowArray(), // row template
+                null, //column sort order - not required for heap
+                td.getColumnCollationIds(),  // same ids as old conglomerate
+                null, // properties
+                (TransactionController.IS_TEMPORARY |
+                    TransactionController.IS_KEPT), Conglomerate.Priority.NORMAL);
 
-        long cid=td.getHeapConglomerateId();
+        long cid = td.getHeapConglomerateId();
 
         //remove the old conglomerate descriptor from the table descriptor
-        ConglomerateDescriptor cgd=td.getConglomerateDescriptor(cid);
+        ConglomerateDescriptor cgd = td.getConglomerateDescriptor(cid);
         td.getConglomerateDescriptorList().dropConglomerateDescriptorByUUID(
-                cgd.getUUID());
+            cgd.getUUID());
 
         //add the new conglomerate descriptor to the table descriptor
-        cgd=getDataDictionary().getDataDescriptorGenerator().newConglomerateDescriptor(conglomId,null,false,null,false,null,td.getUUID(),
-                td.getSchemaDescriptor().getUUID());
-        ConglomerateDescriptorList conglomList=
-                td.getConglomerateDescriptorList();
+        cgd = getDataDictionary().getDataDescriptorGenerator().newConglomerateDescriptor(conglomId, null, false, null, false, null, td.getUUID(),
+            td.getSchemaDescriptor().getUUID());
+        ConglomerateDescriptorList conglomList =
+            td.getConglomerateDescriptorList();
         conglomList.add(cgd);
 
         //reset the heap conglomerate number in table descriptor to -1 so it 
         //will be refetched next time with the new value
         td.resetHeapConglomNumber();
 
-        if(dropAndRedeclare){
+        if (dropAndRedeclare) {
             //remove the old conglomerate from the system
             tc.dropConglomerate(cid);
 
-            replaceDeclaredGlobalTempTable(td.getName(),td);
+            replaceDeclaredGlobalTempTable(td.getName(), td);
         }
 
         return (td);
@@ -1772,8 +1790,8 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @throws StandardException thrown on failure
      */
     @Override
-    public void internalRollback() throws StandardException{
-        doRollback(false /* non-xa */,false);
+    public void internalRollback() throws StandardException {
+        doRollback(false /* non-xa */, false);
     }
 
     /**
@@ -1783,16 +1801,16 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * sure that users aren't doing anything bad.
      */
     @Override
-    public void userRollback() throws StandardException{
-        doRollback(false /* non-xa */,true);
+    public void userRollback() throws StandardException {
+        doRollback(false /* non-xa */, true);
     }
 
     /**
      * Same as userRollback() except rolls back a distrubuted transaction.
      */
     @Override
-    public void xaRollback() throws StandardException{
-        doRollback(true /* xa */,true);
+    public void xaRollback() throws StandardException {
+        doRollback(true /* xa */, true);
     }
 
     /**
@@ -1816,12 +1834,12 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @param requestedByUser true if requested by user
      * @throws StandardException thrown on failure
      */
-    private void doRollback(boolean xa,boolean requestedByUser) throws StandardException{
-        StatementContext statementContext=getStatementContext();
-        if(requestedByUser &&
-                (statementContext!=null) &&
-                statementContext.inUse() &&
-                statementContext.isAtomic()){
+    private void doRollback(boolean xa, boolean requestedByUser) throws StandardException {
+        StatementContext statementContext = getStatementContext();
+        if (requestedByUser &&
+            (statementContext != null) &&
+            statementContext.inUse() &&
+            statementContext.isAtomic()) {
             throw StandardException.newException(SQLState.LANG_NO_ROLLBACK_IN_NESTED_CONNECTION);
         }
 
@@ -1829,24 +1847,24 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
 
         endTransactionActivationHandling(true);
 
-        currentSavepointLevel=0; //reset the current savepoint level for the connection to 0 at the beginning of rollback work for temp tables
-        if(allDeclaredGlobalTempTables!=null)
+        currentSavepointLevel = 0; //reset the current savepoint level for the connection to 0 at the beginning of rollback work for temp tables
+        if (allDeclaredGlobalTempTables != null)
             tempTablesAndRollback();
 
         // If a nested transaction is active then
         // ensure it is destroyed before working
         // with the user transaction.
-        if(readOnlyNestedTransaction!=null){
+        if (readOnlyNestedTransaction != null) {
             readOnlyNestedTransaction.destroy();
-            readOnlyNestedTransaction=null;
-            queryNestingDepth=0;
+            readOnlyNestedTransaction = null;
+            queryNestingDepth = 0;
         }
 
         // now rollback the Store transaction
-        TransactionController tc=getTransactionExecute();
-        if(tc!=null){
-            if(xa)
-                ((XATransactionController)tc).xa_rollback();
+        TransactionController tc = getTransactionExecute();
+        if (tc != null) {
+            if (xa)
+                ((XATransactionController) tc).xa_rollback();
             else
                 tc.abort();
 
@@ -1865,11 +1883,11 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      *
      * @throws StandardException thrown if something goes wrong
      */
-    private void resetSavepoints() throws StandardException{
-        final ContextManager cm=getContextManager();
-        final List<Context> stmts=cm.getContextStack(ContextId.LANG_STATEMENT);
-        for(Context stmt : stmts){
-            ((StatementContext)stmt).resetSavePoint();
+    private void resetSavepoints() throws StandardException {
+        final ContextManager cm = getContextManager();
+        final List<Context> stmts = cm.getContextStack(ContextId.LANG_STATEMENT);
+        for (Context stmt : stmts) {
+            ((StatementContext) stmt).resetSavePoint();
         }
     }
 
@@ -1887,26 +1905,26 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @throws StandardException thrown if something goes wrong
      */
     @Override
-    public void internalRollbackToSavepoint(String savepointName,boolean refreshStyle,Object kindOfSavepoint)
-            throws StandardException{
+    public void internalRollbackToSavepoint(String savepointName, boolean refreshStyle, Object kindOfSavepoint)
+        throws StandardException {
         // now rollback the Store transaction to the savepoint
-        TransactionController tc=getTransactionExecute();
-        if(tc!=null){
+        TransactionController tc = getTransactionExecute();
+        if (tc != null) {
             boolean closeConglomerates;
 
-            if(refreshStyle){
-                closeConglomerates=true;
+            if (refreshStyle) {
+                closeConglomerates = true;
                 // bug 5145 - don't forget to close the activations while rolling
                 // back to a savepoint
                 endTransactionActivationHandling(true);
-            }else{
-                closeConglomerates=false;
+            } else {
+                closeConglomerates = false;
             }
 
-            currentSavepointLevel=tc.rollbackToSavePoint(savepointName,closeConglomerates,kindOfSavepoint);
+            currentSavepointLevel = tc.rollbackToSavePoint(savepointName, closeConglomerates, kindOfSavepoint);
         }
 
-        if(tc!=null && refreshStyle && allDeclaredGlobalTempTables!=null)
+        if (tc != null && refreshStyle && allDeclaredGlobalTempTables != null)
             tempTablesAndRollback();
     }
 
@@ -1920,12 +1938,12 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      *                        A JDBC Savepoint object value for kindOfSavepoint would mean it is JDBC savepoint
      */
     @Override
-    public void releaseSavePoint(String savepointName,Object kindOfSavepoint) throws StandardException{
-        TransactionController tc=getTransactionExecute();
-        if(tc!=null){
-            currentSavepointLevel=tc.releaseSavePoint(savepointName,kindOfSavepoint);
+    public void releaseSavePoint(String savepointName, Object kindOfSavepoint) throws StandardException {
+        TransactionController tc = getTransactionExecute();
+        if (tc != null) {
+            currentSavepointLevel = tc.releaseSavePoint(savepointName, kindOfSavepoint);
             //after a release of a savepoint, we need to go through our temp tables list.
-            if(allDeclaredGlobalTempTables!=null)
+            if (allDeclaredGlobalTempTables != null)
                 tempTablesReleaseSavepointLevels();
         }
     }
@@ -1941,10 +1959,10 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @throws StandardException thrown if something goes wrong
      */
     @Override
-    public void languageSetSavePoint(String savepointName,Object kindOfSavepoint) throws StandardException{
-        TransactionController tc=getTransactionExecute();
-        if(tc!=null){
-            currentSavepointLevel=tc.setSavePoint(savepointName,kindOfSavepoint);
+    public void languageSetSavePoint(String savepointName, Object kindOfSavepoint) throws StandardException {
+        TransactionController tc = getTransactionExecute();
+        if (tc != null) {
+            currentSavepointLevel = tc.setSavePoint(savepointName, kindOfSavepoint);
         }
     }
 
@@ -1954,34 +1972,34 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * track of how many times we have tried to start a NUT.
      */
     @Override
-    public void beginNestedTransaction(boolean readOnly) throws StandardException{
+    public void beginNestedTransaction(boolean readOnly) throws StandardException {
         // DERBY-2490 incremental rework, currently this is only called
         // with read-only true. Future changes will have this
         // method support read-write nested transactions as well
         // instead of callers using the startNestedUserTransaction
         // directly on tran.
-        if(SanityManager.DEBUG){
+        if (SanityManager.DEBUG) {
             // if called for update transactions, compile would start using
             // non-readonly xacts for compile.  For now, throw an error if
             // someone tries to use this call to make non readonly transaction.
             SanityManager.ASSERT(
-                    readOnly,
-                    "Routine not yet coded to support non-readonly transactions.");
+                readOnly,
+                "Routine not yet coded to support non-readonly transactions.");
         }
 
-        if(readOnlyNestedTransaction==null)
-            readOnlyNestedTransaction=
-                    getTransactionExecute().startNestedUserTransaction(readOnly,true);
+        if (readOnlyNestedTransaction == null)
+            readOnlyNestedTransaction =
+                getTransactionExecute().startNestedUserTransaction(readOnly, true);
 
         queryNestingDepth++;
     }
 
     @Override
-    public void commitNestedTransaction() throws StandardException{
-        if(--queryNestingDepth==0){
+    public void commitNestedTransaction() throws StandardException {
+        if (--queryNestingDepth == 0) {
             readOnlyNestedTransaction.commit();
             readOnlyNestedTransaction.destroy();
-            readOnlyNestedTransaction=null;
+            readOnlyNestedTransaction = null;
         }
     }
 
@@ -1991,44 +2009,46 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * transaction.
      */
     @Override
-    public TransactionController getTransactionCompile(){
-        return (readOnlyNestedTransaction!=null)?readOnlyNestedTransaction:tran;
+    public TransactionController getTransactionCompile() {
+        return (readOnlyNestedTransaction != null) ? readOnlyNestedTransaction : tran;
     }
 
     @Override
-    public TransactionController getTransactionExecute(){
-        return nestedTransactions.isEmpty()?tran:nestedTransactions.get(0);
+    public TransactionController getTransactionExecute() {
+        return nestedTransactions.isEmpty() ? tran : nestedTransactions.get(0);
     }
 
     @Override
-    public void pushNestedTransaction(TransactionController nestedTransaction){
-        nestedTransactions.add(0,nestedTransaction);
+    public void pushNestedTransaction(TransactionController nestedTransaction) {
+        nestedTransactions.add(0, nestedTransaction);
     }
 
     @Override
-    public TransactionController popNestedTransaction(){
+    public TransactionController popNestedTransaction() {
         return nestedTransactions.remove(0);
     }
 
     @Override
-    public boolean hasNestedTransaction() { return !nestedTransactions.isEmpty(); }
+    public boolean hasNestedTransaction() {
+        return !nestedTransactions.isEmpty();
+    }
 
     /**
      * Get the data value factory to use with this language connection context.
      */
     @Override
-    public DataValueFactory getDataValueFactory(){
+    public DataValueFactory getDataValueFactory() {
         return dataFactory;
     }
 
     /* Get the language factory to use with this language connection context. */
     @Override
-    public LanguageFactory getLanguageFactory(){
+    public LanguageFactory getLanguageFactory() {
         return langFactory;
     }
 
     @Override
-    public OptimizerFactory getOptimizerFactory(){
+    public OptimizerFactory getOptimizerFactory() {
         return of;
     }
 
@@ -2036,7 +2056,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * Get the language connection factory to use with this language connection context.
      */
     @Override
-    public LanguageConnectionFactory getLanguageConnectionFactory(){
+    public LanguageConnectionFactory getLanguageConnectionFactory() {
         return connFactory;
     }
 
@@ -2046,10 +2066,10 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @param tableName look for any activations referencing this table name
      * @return boolean  false if found no activations
      */
-    private boolean checkIfAnyActivationHasHoldCursor(String tableName) throws StandardException{
-        for(int i=acts.size()-1;i>=0;i--){
-            Activation a=acts.get(i);
-            if(a.checkIfThisActivationHasHoldCursor(tableName))
+    private boolean checkIfAnyActivationHasHoldCursor(String tableName) throws StandardException {
+        for (int i = acts.size() - 1; i >= 0; i--) {
+            Activation a = acts.get(i);
+            if (a.checkIfThisActivationHasHoldCursor(tableName))
                 return true;
         }
         return false;
@@ -2068,36 +2088,36 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      */
     @SuppressFBWarnings(value = "DM_GC", justification = "Intentional")
     @Override
-    public boolean verifyAllHeldResultSetsAreClosed() throws StandardException{
-        boolean seenOpenResultSets=false;
+    public boolean verifyAllHeldResultSetsAreClosed() throws StandardException {
+        boolean seenOpenResultSets = false;
 
         /* For every activation */
-        for(int i=acts.size()-1;i>=0;i--){
+        for (int i = acts.size() - 1; i >= 0; i--) {
 
-            Activation a=acts.get(i);
+            Activation a = acts.get(i);
 
-            if(SanityManager.DEBUG){
-                SanityManager.ASSERT(a instanceof CursorActivation,"a is not a CursorActivation");
+            if (SanityManager.DEBUG) {
+                SanityManager.ASSERT(a instanceof CursorActivation, "a is not a CursorActivation");
             }
 
-            if(!a.isInUse()){
+            if (!a.isInUse()) {
                 continue;
             }
 
-            if(!a.getResultSetHoldability()){
+            if (!a.getResultSetHoldability()) {
                 continue;
             }
 
-            ResultSet rs=a.getResultSet();
+            ResultSet rs = a.getResultSet();
 
             /* is there an open result set? */
-            if((rs!=null) && !rs.isClosed() && rs.returnsRows()){
-                seenOpenResultSets=true;
+            if ((rs != null) && !rs.isClosed() && rs.returnsRows()) {
+                seenOpenResultSets = true;
                 break;
             }
         }
 
-        if(!seenOpenResultSets)
+        if (!seenOpenResultSets)
             return (true);
 
         // There may be open ResultSet's that are yet to be garbage collected
@@ -2106,26 +2126,26 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         System.runFinalization();
 
         /* For every activation */
-        for(int i=acts.size()-1;i>=0;i--){
+        for (int i = acts.size() - 1; i >= 0; i--) {
 
-            Activation a=acts.get(i);
+            Activation a = acts.get(i);
 
-            if(SanityManager.DEBUG){
-                SanityManager.ASSERT(a instanceof CursorActivation,"a is not a CursorActivation");
+            if (SanityManager.DEBUG) {
+                SanityManager.ASSERT(a instanceof CursorActivation, "a is not a CursorActivation");
             }
 
-            if(!a.isInUse()){
+            if (!a.isInUse()) {
                 continue;
             }
 
-            if(!a.getResultSetHoldability()){
+            if (!a.getResultSetHoldability()) {
                 continue;
             }
 
-            ResultSet rs=a.getResultSet();
+            ResultSet rs = a.getResultSet();
 
             /* is there an open held result set? */
-            if((rs!=null) && !rs.isClosed() && rs.returnsRows()){
+            if ((rs != null) && !rs.isClosed() && rs.returnsRows()) {
                 return (false);
             }
         }
@@ -2143,43 +2163,43 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      */
     @SuppressFBWarnings(value = "DM_GC", justification = "Intentional")
     @Override
-    public boolean verifyNoOpenResultSets(PreparedStatement pStmt,Provider provider,int action)
-            throws StandardException{
+    public boolean verifyNoOpenResultSets(PreparedStatement pStmt, Provider provider, int action)
+        throws StandardException {
         /*
-        ** It is not a problem to create an index when there is an open
-        ** result set, since it doesn't invalidate the access path that was
-        ** chosen for the result set.
-        */
-        boolean seenOpenResultSets=false;
+         ** It is not a problem to create an index when there is an open
+         ** result set, since it doesn't invalidate the access path that was
+         ** chosen for the result set.
+         */
+        boolean seenOpenResultSets = false;
 
         /* For every activation */
 
         // synchronize on acts as other threads may be closing activations
         // in this list, thus invalidating the Enumeration
-        for(int i=acts.size()-1;i>=0;i--){
+        for (int i = acts.size() - 1; i >= 0; i--) {
 
-            Activation a=acts.get(i);
+            Activation a = acts.get(i);
 
-            if(!a.isInUse()){
+            if (!a.isInUse()) {
                 continue;
             }
-            
+
             /* for this prepared statement */
-            if(pStmt==a.getPreparedStatement()){
-                ResultSet rs=a.getResultSet();
+            if (pStmt == a.getPreparedStatement()) {
+                ResultSet rs = a.getResultSet();
 
                 /* is there an open result set? */
-                if(rs!=null && !rs.isClosed()){
-                    if(!rs.returnsRows())
+                if (rs != null && !rs.isClosed()) {
+                    if (!rs.returnsRows())
                         continue;
-                    seenOpenResultSets=true;
+                    seenOpenResultSets = true;
                     break;
                 }
 
             }
         }
 
-        if(!seenOpenResultSets)
+        if (!seenOpenResultSets)
             return false;
 
         // There may be open ResultSet's that are yet to be garbage collected
@@ -2190,26 +2210,26 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         /* For every activation */
         // synchronize on acts as other threads may be closing activations
         // in this list, thus invalidating the Enumeration
-        for(int i=acts.size()-1;i>=0;i--){
+        for (int i = acts.size() - 1; i >= 0; i--) {
 
-            Activation a=acts.get(i);
+            Activation a = acts.get(i);
 
-            if(!a.isInUse()){
+            if (!a.isInUse()) {
                 continue;
             }
 
             /* for this prepared statement */
-            if(pStmt==a.getPreparedStatement()){
-                ResultSet rs=a.getResultSet();
+            if (pStmt == a.getPreparedStatement()) {
+                ResultSet rs = a.getResultSet();
 
                 /* is there an open result set? */
-                if(rs!=null && !rs.isClosed()){
-                    if((provider!=null) && rs.returnsRows()){
-                        DependencyManager dmgr=getDataDictionary().getDependencyManager();
+                if (rs != null && !rs.isClosed()) {
+                    if ((provider != null) && rs.returnsRows()) {
+                        DependencyManager dmgr = getDataDictionary().getDependencyManager();
 
                         throw StandardException.newException(SQLState.LANG_CANT_INVALIDATE_OPEN_RESULT_SET,
-                                dmgr.getActionString(action),
-                                provider.getObjectName());
+                            dmgr.getActionString(action),
+                            provider.getObjectName());
 
                     }
                     return true;
@@ -2224,7 +2244,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      *
      * @return String the authorization id of the session user.
      */
-    public String getSessionUserId(){
+    public String getSessionUserId() {
         return sessionUser;
     }
 
@@ -2247,73 +2267,73 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         // (*) SpaceTable#getConglomInfo,
         //     SystemProcedures#{INSTALL|REPLACE|REMOVE}_JAR
 
-        SchemaDescriptor s=getDefaultSchema();
-        if(null==s)
+        SchemaDescriptor s = getDefaultSchema();
+        if (null == s)
             return null;
         return s.getSchemaName();
     }
 
     @Override
     public String getCurrentSchemaName(Activation a) {
-        SchemaDescriptor s=getDefaultSchema(a);
-        if(null==s)
+        SchemaDescriptor s = getDefaultSchema(a);
+        if (null == s)
             return null;
         return s.getSchemaName();
     }
 
     @Override
-    public boolean isInitialDefaultSchema(String schemaName){
+    public boolean isInitialDefaultSchema(String schemaName) {
         return cachedInitialDefaultSchemaDescr.getSchemaName().
-                equals(schemaName);
+            equals(schemaName);
     }
 
     @Override
-    public void setDefaultSchema(SchemaDescriptor sd) throws StandardException{
-        if(sd==null){
-            sd=getInitialDefaultSchemaDescriptor();
+    public void setDefaultSchema(SchemaDescriptor sd) throws StandardException {
+        if (sd == null) {
+            sd = getInitialDefaultSchemaDescriptor();
         }
         getCurrentSQLSessionContext().setDefaultSchema(sd);
     }
 
     @Override
-    public void setDefaultSchema(Activation a,SchemaDescriptor sd) throws StandardException{
-        if(sd==null){
-            sd=getInitialDefaultSchemaDescriptor();
+    public void setDefaultSchema(Activation a, SchemaDescriptor sd) throws StandardException {
+        if (sd == null) {
+            sd = getInitialDefaultSchemaDescriptor();
         }
 
         getCurrentSQLSessionContext(a).setDefaultSchema(sd);
     }
 
     @Override
-    public void resetSchemaUsages(Activation activation,String schemaName) throws StandardException{
+    public void resetSchemaUsages(Activation activation, String schemaName) throws StandardException {
 
-        Activation parent=activation.getParentActivation();
-        SchemaDescriptor defaultSchema=getInitialDefaultSchemaDescriptor();
+        Activation parent = activation.getParentActivation();
+        SchemaDescriptor defaultSchema = getInitialDefaultSchemaDescriptor();
 
         // walk SQL session context chain
-        while(parent!=null){
-            SQLSessionContext ssc=parent.getSQLSessionContextForChildren();
-            SchemaDescriptor s=ssc.getDefaultSchema();
+        while (parent != null) {
+            SQLSessionContext ssc = parent.getSQLSessionContextForChildren();
+            SchemaDescriptor s = ssc.getDefaultSchema();
 
-            if(SanityManager.DEBUG){
-                SanityManager.ASSERT(s!=null,"s should not be empty here");
+            if (SanityManager.DEBUG) {
+                SanityManager.ASSERT(s != null, "s should not be empty here");
             }
 
-            if(schemaName.equals(s.getSchemaName())){
+            if (schemaName.equals(s.getSchemaName())) {
                 ssc.setDefaultSchema(defaultSchema);
             }
-            parent=parent.getParentActivation();
+            parent = parent.getParentActivation();
         }
 
         // finally top level
-        SQLSessionContext top=getTopLevelSQLSessionContext();
-        SchemaDescriptor sd=top.getDefaultSchema();
+        SQLSessionContext top = getTopLevelSQLSessionContext();
+        SchemaDescriptor sd = top.getDefaultSchema();
 
-        if(SanityManager.DEBUG){
-            SanityManager.ASSERT(sd!=null,"sd should not be empty here");
+        if (SanityManager.DEBUG) {
+            SanityManager.ASSERT(sd != null, "sd should not be empty here");
         }
 
-        if(schemaName.equals(sd.getSchemaName())){
+        if (schemaName.equals(sd.getSchemaName())) {
             top.setDefaultSchema(defaultSchema);
         }
     }
@@ -2324,8 +2344,8 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @return the generated identity column value
      */
     @Override
-    public Long getIdentityValue(){
-        return identityNotNull?identityVal:null;
+    public Long getIdentityValue() {
+        return identityNotNull ? identityVal : null;
     }
 
     /**
@@ -2334,9 +2354,9 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @param val the generated identity column value
      */
     @Override
-    public void setIdentityValue(long val){
-        identityVal=val;
-        identityNotNull=true;
+    public void setIdentityValue(long val) {
+        identityVal = val;
+        identityNotNull = true;
     }
 
     /**
@@ -2347,7 +2367,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @return the compiler context
      */
     @Override
-    public final CompilerContext pushCompilerContext(){
+    public final CompilerContext pushCompilerContext() {
         return pushCompilerContext(null);
     }
 
@@ -2379,52 +2399,52 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * on the given input above.
      */
     @Override
-    public CompilerContext pushCompilerContext(SchemaDescriptor sd){
+    public CompilerContext pushCompilerContext(SchemaDescriptor sd) {
         CompilerContext cc;
-        boolean firstCompilerContext=false;
+        boolean firstCompilerContext = false;
 
-        cc=(CompilerContext)(getContextManager().getContext(CompilerContext.CONTEXT_ID));
+        cc = (CompilerContext) (getContextManager().getContext(CompilerContext.CONTEXT_ID));
 
         /*
-        ** If there is no compiler context, this is the first one on the
-        ** stack, so don't pop it when we're done (saves time).
-        */
-        if(cc==null){
-            firstCompilerContext=true;
+         ** If there is no compiler context, this is the first one on the
+         ** stack, so don't pop it when we're done (saves time).
+         */
+        if (cc == null) {
+            firstCompilerContext = true;
         }
 
-        if(cc==null || cc.getInUse()){
-            cc=new CompilerContextImpl(getContextManager(),this,tcf);
-            if(firstCompilerContext){
+        if (cc == null || cc.getInUse()) {
+            cc = new CompilerContextImpl(getContextManager(), this, tcf);
+            if (firstCompilerContext) {
                 cc.firstOnStack();
             }
-        }else{
-            /* Reset the next column,table, subquery and ResultSet numbers at 
-            * the beginning of each statement 
-            */
+        } else {
+            /* Reset the next column,table, subquery and ResultSet numbers at
+             * the beginning of each statement
+             */
             cc.resetContext();
         }
 
         cc.setInUse(true);
 
-        StatementContext sc=getStatementContext();
-        if(sc.getSystemCode())
+        StatementContext sc = getStatementContext();
+        if (sc.getSystemCode())
             cc.setReliability(CompilerContext.INTERNAL_SQL_LEGAL);
 
         /*
          * Set the compilation schema when its UUID is available.
          * i.e.:  Schema may not have been physically created yet, so
          *        its UUID will be null.
-         * 
+         *
          * o For trigger SPS recompilation, the system must use its
-         *   compilation schema to recompile the statement. 
-         * 
+         *   compilation schema to recompile the statement.
+         *
          * o For view recompilation, we set the compilation schema
          *   for this compiler context if its UUID is available.
          *   Otherwise, the compilation schema will be determined
          *   at execution time of view creation.
          */
-        if(sd!=null && sd.getUUID()!=null){
+        if (sd != null && sd.getUUID() != null) {
             cc.setCompilationSchema(sd);
         }
 
@@ -2438,13 +2458,13 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @param cc The compiler context.
      */
     @Override
-    public void popCompilerContext(CompilerContext cc){
+    public void popCompilerContext(CompilerContext cc) {
         cc.setCurrentDependent(null);
         cc.setInUse(false);
         /* Only pop the compiler context if it's not the first one on the stack. */
-        if(!cc.isFirstOnStack()){
+        if (!cc.isFirstOnStack()) {
             cc.popMe();
-        }else{
+        } else {
             cc.setCompilationSchema(null);
         }
     }
@@ -2471,63 +2491,63 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @return StatementContext  The statement context.
      */
     @Override
-    public StatementContext pushStatementContext(boolean isAtomic,boolean isForReadOnly,
-                                                 String stmtText,ParameterValueSet pvs,
+    public StatementContext pushStatementContext(boolean isAtomic, boolean isForReadOnly,
+                                                 String stmtText, ParameterValueSet pvs,
                                                  boolean rollbackParentContext,
                                                  long timeoutMillis) {
-        int parentStatementDepth=statementDepth;
-        boolean inTrigger=false;
-        boolean parentIsAtomic=false;
+        int parentStatementDepth = statementDepth;
+        boolean inTrigger = false;
+        boolean parentIsAtomic = false;
 
         // by default, assume we are going to use the outermost statement context
-        StatementContext statementContext=statementContexts[0];
+        StatementContext statementContext = statementContexts[0];
 
         /*
-        ** If we haven't allocated any statement contexts yet, allocate
-        ** the outermost stmt context now and push it.
-        */
+         ** If we haven't allocated any statement contexts yet, allocate
+         ** the outermost stmt context now and push it.
+         */
 
-        if(statementContext==null){
-            statementContext=statementContexts[0]=new GenericStatementContext(this);
+        if (statementContext == null) {
+            statementContext = statementContexts[0] = new GenericStatementContext(this);
             statementContext.
-                    setSQLSessionContext(getTopLevelSQLSessionContext());
-        }else if(statementDepth>0){
+                setSQLSessionContext(getTopLevelSQLSessionContext());
+        } else if (statementDepth > 0) {
             StatementContext parentStatementContext;
             /*
-            ** We also cache a 2nd statement context, though we still
-            ** push and pop it. Note, new contexts are automatically pushed.
-            */
-            if(statementDepth==1){
-                statementContext=statementContexts[1];
+             ** We also cache a 2nd statement context, though we still
+             ** push and pop it. Note, new contexts are automatically pushed.
+             */
+            if (statementDepth == 1) {
+                statementContext = statementContexts[1];
 
-                if(statementContext==null)
-                    statementContext=statementContexts[1]=new GenericStatementContext(this);
+                if (statementContext == null)
+                    statementContext = statementContexts[1] = new GenericStatementContext(this);
                 else
                     statementContext.pushMe();
 
-                parentStatementContext=statementContexts[0];
-            }else{
-                parentStatementContext=(StatementContext)getContextManager().getContext(ContextId.LANG_STATEMENT);
-                statementContext=new GenericStatementContext(this);
+                parentStatementContext = statementContexts[0];
+            } else {
+                parentStatementContext = (StatementContext) getContextManager().getContext(ContextId.LANG_STATEMENT);
+                statementContext = new GenericStatementContext(this);
             }
 
             statementContext.setSQLSessionContext(
-                    parentStatementContext.getSQLSessionContext());
+                parentStatementContext.getSQLSessionContext());
 
-            inTrigger=parentStatementContext.inTrigger() || (outermostTrigger==parentStatementDepth);
-            parentIsAtomic=parentStatementContext.isAtomic();
-            statementContext.setSQLAllowed(parentStatementContext.getSQLAllowed(),false);
-            if(parentStatementContext.getSystemCode())
+            inTrigger = parentStatementContext.inTrigger() || (outermostTrigger == parentStatementDepth);
+            parentIsAtomic = parentStatementContext.isAtomic();
+            statementContext.setSQLAllowed(parentStatementContext.getSQLAllowed(), false);
+            if (parentStatementContext.getSystemCode())
                 statementContext.setSystemCode();
-        }else{
+        } else {
             statementContext.
-                    setSQLSessionContext(getTopLevelSQLSessionContext());
+                setSQLSessionContext(getTopLevelSQLSessionContext());
         }
 
         incrementStatementDepth();
 
-        statementContext.setInUse(inTrigger,isAtomic || parentIsAtomic,isForReadOnly,stmtText,pvs,timeoutMillis);
-        if(rollbackParentContext)
+        statementContext.setInUse(inTrigger, isAtomic || parentIsAtomic, isForReadOnly, stmtText, pvs, timeoutMillis);
+        if (rollbackParentContext)
             statementContext.setParentRollback();
         return statementContext;
     }
@@ -2539,63 +2559,63 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @param error            The error, if any  (Only relevant for DEBUG)
      */
     @Override
-    public void popStatementContext(StatementContext statementContext,Throwable error){
-        if(statementContext!=null){
+    public void popStatementContext(StatementContext statementContext, Throwable error) {
+        if (statementContext != null) {
             /*
-            ** If someone beat us to the punch, then it is ok,
-            ** just silently ignore it.  We probably got here
-            ** because we had a try catch block around a push/pop
-            ** statement context, and we already got the context
-            ** on a cleanupOnError.
-            */
-            if(!statementContext.inUse()){
+             ** If someone beat us to the punch, then it is ok,
+             ** just silently ignore it.  We probably got here
+             ** because we had a try catch block around a push/pop
+             ** statement context, and we already got the context
+             ** on a cleanupOnError.
+             */
+            if (!statementContext.inUse()) {
                 return;
             }
             statementContext.clearInUse();
         }
 
         decrementStatementDepth();
-        if(statementDepth==-1){
+        if (statementDepth == -1) {
             /*
              * Only ignore the pop request for an already
              * empty stack when dealing with a session exception.
              */
-            if(SanityManager.DEBUG){
-                int severity=(error instanceof StandardException)?
-                        ((StandardException)error).getSeverity():
-                        0;
-                SanityManager.ASSERT(error!=null,
-                        "Must have error to try popStatementContext with 0 depth");
+            if (SanityManager.DEBUG) {
+                int severity = (error instanceof StandardException) ?
+                    ((StandardException) error).getSeverity() :
+                    0;
+                SanityManager.ASSERT(error != null,
+                    "Must have error to try popStatementContext with 0 depth");
                 SanityManager.ASSERT(
-                        (severity==ExceptionSeverity.SESSION_SEVERITY),
-                        "Must have session severity error to try popStatementContext with 0 depth");
-                SanityManager.ASSERT(statementContext==statementContexts[0],
-                        "statementContext is expected to equal statementContexts[0]");
+                    (severity == ExceptionSeverity.SESSION_SEVERITY),
+                    "Must have session severity error to try popStatementContext with 0 depth");
+                SanityManager.ASSERT(statementContext == statementContexts[0],
+                    "statementContext is expected to equal statementContexts[0]");
             }
             resetStatementDepth(); // pretend we did nothing.
-        }else if(statementDepth==0){
-            if(SanityManager.DEBUG){
+        } else if (statementDepth == 0) {
+            if (SanityManager.DEBUG) {
                 /* Okay to pop last context on a session exception.
                  * (We call clean up on error when exiting connection.)
                  */
-                int severity=(error instanceof StandardException)?
-                        ((StandardException)error).getSeverity():
-                        0;
-                if((error==null) ||
-                        (severity!=ExceptionSeverity.SESSION_SEVERITY)){
-                    SanityManager.ASSERT(statementContext==statementContexts[0],
-                            "statementContext is expected to equal statementContexts[0]");
+                int severity = (error instanceof StandardException) ?
+                    ((StandardException) error).getSeverity() :
+                    0;
+                if ((error == null) ||
+                    (severity != ExceptionSeverity.SESSION_SEVERITY)) {
+                    SanityManager.ASSERT(statementContext == statementContexts[0],
+                        "statementContext is expected to equal statementContexts[0]");
                 }
             }
-        }else{
-            if(SanityManager.DEBUG){
-                SanityManager.ASSERT(statementContext!=statementContexts[0],
-                        "statementContext is not expected to equal statementContexts[0]");
-                if(statementDepth<=0)
+        } else {
+            if (SanityManager.DEBUG) {
+                SanityManager.ASSERT(statementContext != statementContexts[0],
+                    "statementContext is not expected to equal statementContexts[0]");
+                if (statementDepth <= 0)
                     SanityManager.THROWASSERT(
-                            "statement depth expected to be >0, was "+statementDepth);
+                        "statement depth expected to be >0, was " + statementDepth);
 
-                if(getContextManager().getContext(statementContext.getIdName())!=statementContext){
+                if (getContextManager().getContext(statementContext.getIdName()) != statementContext) {
                     SanityManager.THROWASSERT("trying to pop statement context from middle of stack");
                 }
             }
@@ -2621,7 +2641,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @param validator the validator to add
      */
     @Override
-    public void pushExecutionStmtValidator(ExecutionStmtValidator validator){
+    public void pushExecutionStmtValidator(ExecutionStmtValidator validator) {
         stmtValidators.add(validator);
     }
 
@@ -2632,11 +2652,11 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @param validator the validator to remove
      */
     @Override
-    public void popExecutionStmtValidator(ExecutionStmtValidator validator) throws StandardException{
-        boolean foundElement=stmtValidators.remove(validator);
-        if(SanityManager.DEBUG){
-            if(!foundElement){
-                SanityManager.THROWASSERT("statement validator "+validator+" not found");
+    public void popExecutionStmtValidator(ExecutionStmtValidator validator) throws StandardException {
+        boolean foundElement = stmtValidators.remove(validator);
+        if (SanityManager.DEBUG) {
+            if (!foundElement) {
+                SanityManager.THROWASSERT("statement validator " + validator + " not found");
             }
         }
     }
@@ -2648,12 +2668,12 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @throws StandardException on trigger recursion error
      */
     @Override
-    public void pushTriggerExecutionContext(TriggerExecutionContext tec) throws StandardException{
-        if(triggerStack==null){
-            triggerStack=new TriggerExecutionStack();
+    public void pushTriggerExecutionContext(TriggerExecutionContext tec) throws StandardException {
+        if (triggerStack == null) {
+            triggerStack = new TriggerExecutionStack();
         }
-        if(outermostTrigger==-1){
-            outermostTrigger=statementDepth;
+        if (outermostTrigger == -1) {
+            outermostTrigger = statementDepth;
         }
         triggerStack.pushTriggerExecutionContext(tec);
     }
@@ -2664,19 +2684,19 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @param tec the tec to remove
      */
     @Override
-    public void popTriggerExecutionContext(TriggerExecutionContext tec) throws StandardException{
-        if(outermostTrigger==statementDepth){
-            outermostTrigger=-1;
+    public void popTriggerExecutionContext(TriggerExecutionContext tec) throws StandardException {
+        if (outermostTrigger == statementDepth) {
+            outermostTrigger = -1;
         }
-        if(triggerStack!=null){
+        if (triggerStack != null) {
             triggerStack.popTriggerExecutionContext(tec);
         }
     }
 
     @Override
-    public void popAllTriggerExecutionContexts(){
-        outermostTrigger=-1;
-        if(triggerStack!=null){
+    public void popAllTriggerExecutionContexts() {
+        outermostTrigger = -1;
+        if (triggerStack != null) {
             triggerStack.popAllTriggerExecutionContexts();
         }
     }
@@ -2685,8 +2705,8 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * Get the topmost tec.
      */
     @Override
-    public TriggerExecutionContext getTriggerExecutionContext(){
-        if(triggerStack==null){
+    public TriggerExecutionContext getTriggerExecutionContext() {
+        if (triggerStack == null) {
             return null;
         }
         return triggerStack.getTriggerExecutionContext();
@@ -2700,12 +2720,12 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @param constantAction the constantAction that is about to be executed (and should be validated
      * @throws StandardException on validation failure
      */
-    public void validateStmtExecution(ConstantAction constantAction) throws StandardException{
-        if(SanityManager.DEBUG){
-            SanityManager.ASSERT(constantAction!=null,"constantAction is null");
+    public void validateStmtExecution(ConstantAction constantAction) throws StandardException {
+        if (SanityManager.DEBUG) {
+            SanityManager.ASSERT(constantAction != null, "constantAction is null");
         }
-        if(!stmtValidators.isEmpty()){
-            for(ExecutionStmtValidator stmtValidator : stmtValidators){
+        if (!stmtValidators.isEmpty()) {
+            for (ExecutionStmtValidator stmtValidator : stmtValidators) {
                 stmtValidator.validateStatement(constantAction);
             }
         }
@@ -2717,7 +2737,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @param td the table that the trigger is defined upon
      */
     @Override
-    public void pushTriggerTable(TableDescriptor td){
+    public void pushTriggerTable(TableDescriptor td) {
         triggerTables.add(td);
     }
 
@@ -2727,11 +2747,11 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @param td the table to remove from the stack.
      */
     @Override
-    public void popTriggerTable(TableDescriptor td){
-        boolean foundElement=triggerTables.remove(td);
-        if(SanityManager.DEBUG){
-            if(!foundElement){
-                SanityManager.THROWASSERT("trigger table not found: "+td);
+    public void popTriggerTable(TableDescriptor td) {
+        boolean foundElement = triggerTables.remove(td);
+        if (SanityManager.DEBUG) {
+            if (!foundElement) {
+                SanityManager.THROWASSERT("trigger table not found: " + td);
             }
         }
     }
@@ -2743,46 +2763,44 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * aren't in the middle of compiling a create
      * trigger.
      */
-    public TableDescriptor getTriggerTable(){
-        return triggerTables.isEmpty() ?null:triggerTables.get(triggerTables.size()-1);
+    public TableDescriptor getTriggerTable() {
+        return triggerTables.isEmpty() ? null : triggerTables.get(triggerTables.size() - 1);
     }
 
     @Override
-    public InternalDatabase getDatabase(){
+    public InternalDatabase getDatabase() {
         return db;
     }
 
     @Override
-    public int incrementBindCount(){
+    public int incrementBindCount() {
         bindCount++;
         return bindCount;
     }
 
     @Override
-    public int decrementBindCount(){
+    public int decrementBindCount() {
         bindCount--;
-        if(SanityManager.DEBUG){
-            if(bindCount<0)
+        if (SanityManager.DEBUG) {
+            if (bindCount < 0)
                 SanityManager.THROWASSERT(
-                        "Level of nested binding == "+bindCount);
+                    "Level of nested binding == " + bindCount);
         }
         return bindCount;
     }
 
     @Override
-    public int getBindCount(){
+    public int getBindCount() {
         return bindCount;
     }
 
     @Override
-    public final void setDataDictionaryWriteMode()
-    {
+    public final void setDataDictionaryWriteMode() {
         ddWriteMode = true;
     }
 
     @Override
-    public final boolean dataDictionaryInWriteMode()
-    {
+    public final boolean dataDictionaryInWriteMode() {
         return ddWriteMode;
     }
 
@@ -2792,25 +2810,25 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @return a statement level >= OUTERMOST_STATEMENT
      */
     @Override
-    public int getStatementDepth(){
+    public int getStatementDepth() {
         return statementDepth;
     }
 
     @Override
-    public boolean isIsolationLevelSetUsingSQLorJDBC(){
+    public boolean isIsolationLevelSetUsingSQLorJDBC() {
         return isolationLevelSetUsingSQLorJDBC;
     }
 
     @Override
-    public void resetIsolationLevelFlagUsedForSQLandJDBC(){
-        isolationLevelSetUsingSQLorJDBC=false;
+    public void resetIsolationLevelFlagUsedForSQLandJDBC() {
+        isolationLevelSetUsingSQLorJDBC = false;
     }
 
     @Override
-    public void setIsolationLevel(int isolationLevel) throws StandardException{
-        StatementContext stmtCtxt=getStatementContext();
-        if(stmtCtxt!=null && stmtCtxt.inTrigger())
-            throw StandardException.newException(SQLState.LANG_NO_XACT_IN_TRIGGER,getTriggerExecutionContext().toString());
+    public void setIsolationLevel(int isolationLevel) throws StandardException {
+        StatementContext stmtCtxt = getStatementContext();
+        if (stmtCtxt != null && stmtCtxt.inTrigger())
+            throw StandardException.newException(SQLState.LANG_NO_XACT_IN_TRIGGER, getTriggerExecutionContext().toString());
 
         // find if there are any held cursors from previous isolation level.
         // if yes, then throw an exception that isolation change not allowed until
@@ -2820,8 +2838,8 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         // there still would be held cursors but the transaction state would be idle.
         // In order to check the above mentioned case, the held cursor check
         // shouldn't rely on transaction state.
-        if(this.isolationLevel!=isolationLevel){
-            if(!verifyAllHeldResultSetsAreClosed()){
+        if (this.isolationLevel != isolationLevel) {
+            if (!verifyAllHeldResultSetsAreClosed()) {
                 throw StandardException.newException(SQLState.LANG_CANT_CHANGE_ISOLATION_HOLD_CURSOR);
             }
         }
@@ -2830,106 +2848,106 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
          * NOTE: We commit first in case there's some kind
          * of error, like can't commit within a server side jdbc call.
          */
-        TransactionController tc=getTransactionExecute();
-        if(!tc.isIdle()){
+        TransactionController tc = getTransactionExecute();
+        if (!tc.isIdle()) {
             // If this transaction is in progress, commit it.
             // However, do not allow commit to happen if this is a global
             // transaction.
-            if(tc.isGlobal())
+            if (tc.isGlobal())
                 throw StandardException.newException(SQLState.LANG_NO_SET_TRAN_ISO_IN_GLOBAL_CONNECTION);
 
             userCommit();
         }
-        this.isolationLevel=isolationLevel;
-        this.isolationLevelExplicitlySet=true;
-        this.isolationLevelSetUsingSQLorJDBC=true;
+        this.isolationLevel = isolationLevel;
+        this.isolationLevelExplicitlySet = true;
+        this.isolationLevelSetUsingSQLorJDBC = true;
     }
 
     @Override
-    public int getCurrentIsolationLevel(){
-        return (isolationLevel==ExecutionContext.UNSPECIFIED_ISOLATION_LEVEL)?defaultIsolationLevel:isolationLevel;
+    public int getCurrentIsolationLevel() {
+        return (isolationLevel == ExecutionContext.UNSPECIFIED_ISOLATION_LEVEL) ? defaultIsolationLevel : isolationLevel;
     }
 
     @Override
-    public String getCurrentIsolationLevelStr(){
-        if(isolationLevel>=0 && isolationLevel<ExecutionContext.CS_TO_SQL_ISOLATION_MAP.length)
+    public String getCurrentIsolationLevelStr() {
+        if (isolationLevel >= 0 && isolationLevel < ExecutionContext.CS_TO_SQL_ISOLATION_MAP.length)
             return ExecutionContext.CS_TO_SQL_ISOLATION_MAP[isolationLevel][0];
         return ExecutionContext.CS_TO_SQL_ISOLATION_MAP[ExecutionContext.UNSPECIFIED_ISOLATION_LEVEL][0];
     }
 
     @Override
-    public void setPrepareIsolationLevel(int level){
-        prepareIsolationLevel=level;
+    public void setPrepareIsolationLevel(int level) {
+        prepareIsolationLevel = level;
     }
 
     @Override
-    public int getPrepareIsolationLevel(){
-        if(!isolationLevelExplicitlySet)
+    public int getPrepareIsolationLevel() {
+        if (!isolationLevelExplicitlySet)
             return prepareIsolationLevel;
         else
             return ExecutionContext.UNSPECIFIED_ISOLATION_LEVEL;
     }
 
     @Override
-    public StatementContext getStatementContext(){
+    public StatementContext getStatementContext() {
         StatementContext sCtx = statementContexts[0];
-        if(sCtx==null)
-            sCtx = (StatementContext)getContextManager().getContext(ContextId.LANG_STATEMENT);
+        if (sCtx == null)
+            sCtx = (StatementContext) getContextManager().getContext(ContextId.LANG_STATEMENT);
         return sCtx;
     }
 
     @Override
-    public boolean setOptimizerTrace(boolean onOrOff){
-        if(of==null){
+    public boolean setOptimizerTrace(boolean onOrOff) {
+        if (of == null) {
             return false;
         }
-        if(!of.supportsOptimizerTrace()){
+        if (!of.supportsOptimizerTrace()) {
             return false;
         }
-        optimizerTrace=onOrOff;
+        optimizerTrace = onOrOff;
         return true;
     }
 
     @Override
-    public boolean getOptimizerTrace(){
+    public boolean getOptimizerTrace() {
         return optimizerTrace;
     }
 
     /**
      * @see LanguageConnectionContext#setOptimizerTraceHtml
      */
-    public boolean setOptimizerTraceHtml(boolean onOrOff){
-        if(of==null){
+    public boolean setOptimizerTraceHtml(boolean onOrOff) {
+        if (of == null) {
             return false;
         }
-        if(!of.supportsOptimizerTrace()){
+        if (!of.supportsOptimizerTrace()) {
             return false;
         }
-        optimizerTraceHtml=onOrOff;
+        optimizerTraceHtml = onOrOff;
         return true;
     }
 
     @Override
-    public boolean getOptimizerTraceHtml(){
+    public boolean getOptimizerTraceHtml() {
         return optimizerTraceHtml;
     }
 
     @Override
-    public void setOptimizerTraceOutput(String startingText){
-        if(optimizerTrace){
-            lastOptimizerTraceOutput=optimizerTraceOutput;
-            optimizerTraceOutput=startingText;
+    public void setOptimizerTraceOutput(String startingText) {
+        if (optimizerTrace) {
+            lastOptimizerTraceOutput = optimizerTraceOutput;
+            optimizerTraceOutput = startingText;
         }
     }
 
     @Override
-    public void appendOptimizerTraceOutput(String output){
-        optimizerTraceOutput=
-                (optimizerTraceOutput==null)?output:optimizerTraceOutput+output;
+    public void appendOptimizerTraceOutput(String output) {
+        optimizerTraceOutput =
+            (optimizerTraceOutput == null) ? output : optimizerTraceOutput + output;
     }
 
     @Override
-    public String getOptimizerTraceOutput(){
+    public String getOptimizerTraceOutput() {
         return lastOptimizerTraceOutput;
     }
 
@@ -2940,7 +2958,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * false otherwise
      */
     @Override
-    public boolean isTransactionPristine(){
+    public boolean isTransactionPristine() {
         return getTransactionExecute().isPristine();
     }
 
@@ -2973,47 +2991,47 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      *                           cleanupOnError's to throw exceptions.
      */
     @Override
-    public void cleanupOnError(Throwable error) throws StandardException{
+    public void cleanupOnError(Throwable error) throws StandardException {
 
         /*
-        ** If it isn't a StandardException, then assume
-        ** session severity. It is probably an unexpected
-        ** java error somewhere in the language.
-        ** Store layer treats JVM error as session severity, 
-        ** hence to be consistent and to avoid getting rawstore
-        ** protocol violation errors, we treat java errors here
-        ** to be of session severity.
-        */
+         ** If it isn't a StandardException, then assume
+         ** session severity. It is probably an unexpected
+         ** java error somewhere in the language.
+         ** Store layer treats JVM error as session severity,
+         ** hence to be consistent and to avoid getting rawstore
+         ** protocol violation errors, we treat java errors here
+         ** to be of session severity.
+         */
 
-        int severity=(error instanceof StandardException)?
-                ((StandardException)error).getSeverity():
-                ExceptionSeverity.SESSION_SEVERITY;
+        int severity = (error instanceof StandardException) ?
+            ((StandardException) error).getSeverity() :
+            ExceptionSeverity.SESSION_SEVERITY;
 
-        if(statementContexts[0]!=null){
+        if (statementContexts[0] != null) {
             statementContexts[0].clearInUse();
 
             // Force the StatementContext that's normally
             // left on the stack for optimization to be popped
             // when the session is closed. Ensures full cleanup
             // and no hanging refrences in the ContextManager.
-            if(severity>=ExceptionSeverity.SESSION_SEVERITY)
+            if (severity >= ExceptionSeverity.SESSION_SEVERITY)
                 statementContexts[0].popMe();
         }
-        if(statementContexts[1]!=null){
+        if (statementContexts[1] != null) {
             statementContexts[1].clearInUse();
         }
 
         // closing the activations closes all the open cursors.
         // the activations are, for all intents and purposes, the
         // cursors.
-        if(severity>=ExceptionSeverity.SESSION_SEVERITY){
-            for(int i=acts.size()-1;i>=0;i--){
+        if (severity >= ExceptionSeverity.SESSION_SEVERITY) {
+            for (int i = acts.size() - 1; i >= 0; i--) {
                 // it maybe the case that a reset()/close() ends up closing
                 // one or more activation leaving our index beyond
                 // the end of the array
-                if(i>=acts.size())
+                if (i >= acts.size())
                     continue;
-                Activation a=acts.get(i);
+                Activation a = acts.get(i);
                 a.reset();
                 a.close();
             }
@@ -3024,11 +3042,11 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         }
 
         /*
-        ** We have some global state that we need
-        ** to clean up no matter what.  Be sure
-        ** to do so.
-        */
-        else if(severity>=ExceptionSeverity.TRANSACTION_SEVERITY){
+         ** We have some global state that we need
+         ** to clean up no matter what.  Be sure
+         ** to do so.
+         */
+        else if (severity >= ExceptionSeverity.TRANSACTION_SEVERITY) {
             internalRollback();
         }
     }
@@ -3058,25 +3076,25 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      *
      * @throws StandardException thrown on failure
      */
-    private void endTransactionActivationHandling(boolean forRollback) throws StandardException{
+    private void endTransactionActivationHandling(boolean forRollback) throws StandardException {
 
         // don't use an enumeration as the activation may remove
         // itself from the list, thus invalidating the Enumeration
-        for(int i=acts.size()-1;i>=0;i--){
+        for (int i = acts.size() - 1; i >= 0; i--) {
 
             // it maybe the case that a reset() ends up closing
             // one or more activation leaving our index beyond
             // the end of the array
-            if(i>=acts.size())
+            if (i >= acts.size())
                 continue;
 
-            Activation a=acts.get(i);
+            Activation a = acts.get(i);
             /*
-            ** Look for stale activations.  Activations are
-            ** marked as unused during statement finalization.
-            ** Here, we sweep and remove this inactive ones.
-            */
-            if(!a.isInUse()){
+             ** Look for stale activations.  Activations are
+             ** marked as unused during statement finalization.
+             ** Here, we sweep and remove this inactive ones.
+             */
+            if (!a.isInUse()) {
                 a.close();
                 continue;
             }
@@ -3085,12 +3103,12 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             //returns rows. For such an activation, we need to take special
             //actions during commit and rollback as explained in the comments
             //below.
-            ResultSet activationResultSet=a.getResultSet();
-            boolean resultsetReturnsRows=
-                    (activationResultSet!=null) && activationResultSet.returnsRows();
+            ResultSet activationResultSet = a.getResultSet();
+            boolean resultsetReturnsRows =
+                (activationResultSet != null) && activationResultSet.returnsRows();
 
-            if(forRollback){
-                if(resultsetReturnsRows) {
+            if (forRollback) {
+                if (resultsetReturnsRows) {
                     //Since we are dealing with rollback, we need to reset 
                     //the activation no matter what the holdability might 
                     //be provided that resultset returns rows. An example
@@ -3109,10 +3127,10 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
                         ps.makeInvalid(DependencyManager.ROLLBACK, this);
                     }
                 }
-            }else{
+            } else {
                 //We are dealing with commit here. 
-                if(resultsetReturnsRows){
-                    if(!a.getResultSetHoldability())
+                if (resultsetReturnsRows) {
+                    if (!a.getResultSetHoldability())
                         //Close result sets that return rows and are not held 
                         //across commit. This is to implement closing JDBC 
                         //result sets that are CLOSE_CURSOR_ON_COMMIT at commit 
@@ -3145,34 +3163,34 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     /**
      * Increments the statement depth.
      */
-    private void incrementStatementDepth(){
+    private void incrementStatementDepth() {
         statementDepth++;
     }
 
     /**
      * Decrements the statement depth
      */
-    private void decrementStatementDepth(){
+    private void decrementStatementDepth() {
         statementDepth--;
     }
 
     /**
      * Resets the statementDepth.
      */
-    protected void resetStatementDepth(){
-        statementDepth=0;
+    protected void resetStatementDepth() {
+        statementDepth = 0;
     }
 
     @Override
-    public DataDictionary getDataDictionary(){
+    public DataDictionary getDataDictionary() {
         return getDatabase().getDataDictionary();
     }
 
     @Override
-    public void setReadOnly(boolean on) throws StandardException{
-        if(!tran.isPristine())
+    public void setReadOnly(boolean on) throws StandardException {
+        if (!tran.isPristine())
             throw StandardException.newException(SQLState.AUTH_SET_CONNECTION_READ_ONLY_IN_ACTIVE_XACT);
-        getAuthorizer().setReadOnlyConnection(on,true);
+        getAuthorizer().setReadOnlyConnection(on, true);
     }
 
     @Override
@@ -3207,51 +3225,51 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @see com.splicemachine.db.iapi.db.ConnectionInfo#lastAutoincrementValue
      */
     @Override
-    public Long lastAutoincrementValue(String schemaName,String tableName,String columnName){
-        String aiKey=AutoincrementCounter.makeIdentity(schemaName,tableName,columnName);
-        if(triggerStack!=null){
-            for(TriggerExecutionContext tec : triggerStack.asList()){
-                Long value=tec.getAutoincrementValue(aiKey);
-                if(value==null){
+    public Long lastAutoincrementValue(String schemaName, String tableName, String columnName) {
+        String aiKey = AutoincrementCounter.makeIdentity(schemaName, tableName, columnName);
+        if (triggerStack != null) {
+            for (TriggerExecutionContext tec : triggerStack.asList()) {
+                Long value = tec.getAutoincrementValue(aiKey);
+                if (value == null) {
                     continue;
                 }
                 return value;
             }
         }
-        if(autoincrementHT==null){
+        if (autoincrementHT == null) {
             return null;
         }
         return autoincrementHT.get(aiKey);
     }
 
     @Override
-    public void setAutoincrementUpdate(boolean flag){
-        autoincrementUpdate=flag;
+    public void setAutoincrementUpdate(boolean flag) {
+        autoincrementUpdate = flag;
     }
 
     @Override
-    public boolean getAutoincrementUpdate(){
+    public boolean getAutoincrementUpdate() {
         return autoincrementUpdate;
     }
 
     @Override
-    public void autoincrementCreateCounter(String s,String t,String c,
-                                           Long initialValue,long increment,
-                                           int position){
-        String key=AutoincrementCounter.makeIdentity(s,t,c);
-        if(autoincrementCacheHashtable==null){
-            autoincrementCacheHashtable=new HashMap<>();
+    public void autoincrementCreateCounter(String s, String t, String c,
+                                           Long initialValue, long increment,
+                                           int position) {
+        String key = AutoincrementCounter.makeIdentity(s, t, c);
+        if (autoincrementCacheHashtable == null) {
+            autoincrementCacheHashtable = new HashMap<>();
         }
 
-        AutoincrementCounter aic=autoincrementCacheHashtable.get(key);
-        if(aic!=null){
-            if(SanityManager.DEBUG){
-                SanityManager.THROWASSERT("Autoincrement Counter already exists:"+key);
+        AutoincrementCounter aic = autoincrementCacheHashtable.get(key);
+        if (aic != null) {
+            if (SanityManager.DEBUG) {
+                SanityManager.THROWASSERT("Autoincrement Counter already exists:" + key);
             }
             return;
         }
-        aic=new AutoincrementCounter(initialValue,increment,0,s,t,c,position);
-        autoincrementCacheHashtable.put(key,aic);
+        aic = new AutoincrementCounter(initialValue, increment, 0, s, t, c, position);
+        autoincrementCacheHashtable.put(key, aic);
     }
 
     /**
@@ -3264,17 +3282,17 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @param columnName identify the column uniquely in the system.
      */
     @Override
-    public long nextAutoincrementValue(String schemaName,String tableName,
-                                       String columnName) throws StandardException{
-        String key=AutoincrementCounter.makeIdentity(schemaName,tableName,columnName);
-        AutoincrementCounter aic=autoincrementCacheHashtable.get(key);
+    public long nextAutoincrementValue(String schemaName, String tableName,
+                                       String columnName) throws StandardException {
+        String key = AutoincrementCounter.makeIdentity(schemaName, tableName, columnName);
+        AutoincrementCounter aic = autoincrementCacheHashtable.get(key);
 
-        if(aic==null){
-            if(SanityManager.DEBUG){
-                SanityManager.THROWASSERT("counter doesn't exist:"+key);
+        if (aic == null) {
+            if (SanityManager.DEBUG) {
+                SanityManager.THROWASSERT("counter doesn't exist:" + key);
             }
             return 0;
-        }else{
+        } else {
             return aic.update();
         }
     }
@@ -3290,20 +3308,20 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * @see com.splicemachine.db.iapi.db.ConnectionInfo#lastAutoincrementValue
      */
     @Override
-    public void autoincrementFlushCache(UUID tableUUID) throws StandardException{
-        if(autoincrementCacheHashtable==null)
+    public void autoincrementFlushCache(UUID tableUUID) throws StandardException {
+        if (autoincrementCacheHashtable == null)
             return;
 
-        if(autoincrementHT==null)
-            autoincrementHT= new HashMap<>();
+        if (autoincrementHT == null)
+            autoincrementHT = new HashMap<>();
 
-        DataDictionary dd=getDataDictionary();
-        for(Map.Entry<String, AutoincrementCounter> stringAutoincrementCounterEntry : autoincrementCacheHashtable.entrySet()){
-            AutoincrementCounter aic= stringAutoincrementCounterEntry.getValue();
-            Long value=aic.getCurrentValue();
-            aic.flushToDisk(getTransactionExecute(),dd,tableUUID);
-            if(value!=null){
-                autoincrementHT.put(stringAutoincrementCounterEntry.getKey(),value);
+        DataDictionary dd = getDataDictionary();
+        for (Map.Entry<String, AutoincrementCounter> stringAutoincrementCounterEntry : autoincrementCacheHashtable.entrySet()) {
+            AutoincrementCounter aic = stringAutoincrementCounterEntry.getValue();
+            Long value = aic.getCurrentValue();
+            aic.flushToDisk(getTransactionExecute(), dd, tableUUID);
+            if (value != null) {
+                autoincrementHT.put(stringAutoincrementCounterEntry.getKey(), value);
             }
         }
         autoincrementCacheHashtable.clear();
@@ -3315,23 +3333,23 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * kept in the languageconnectioncontext.
      */
     @Override
-    public void copyHashtableToAIHT(Map<String, Long> from){
-        if(from.isEmpty()){
+    public void copyHashtableToAIHT(Map<String, Long> from) {
+        if (from.isEmpty()) {
             return;
         }
-        if(autoincrementHT==null){
-            autoincrementHT=new HashMap<>();
+        if (autoincrementHT == null) {
+            autoincrementHT = new HashMap<>();
         }
         autoincrementHT.putAll(from);
     }
 
     @Override
-    public int getInstanceNumber(){
+    public int getInstanceNumber() {
         return instanceNumber;
     }
 
     @Override
-    public String getDrdaID(){
+    public String getDrdaID() {
         return drdaID;
     }
 
@@ -3341,28 +3359,28 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     }
 
     @Override
-    public void setDrdaID(String drdaID){
-        this.drdaID=drdaID;
+    public void setDrdaID(String drdaID) {
+        this.drdaID = drdaID;
     }
 
     @Override
-    public String getDbname(){
+    public String getDbname() {
         return dbname;
     }
 
     @Override
-    public Activation getLastActivation(){
-        return acts.get(acts.size()-1);
+    public Activation getLastActivation() {
+        return acts.get(acts.size() - 1);
     }
 
     @Override
-    public StringBuffer appendErrorInfo(){
+    public StringBuffer appendErrorInfo() {
 
-        TransactionController tc=getTransactionExecute();
-        if(tc==null)
+        TransactionController tc = getTransactionExecute();
+        if (tc == null)
             return null;
 
-        StringBuffer sb=new StringBuffer(200);
+        StringBuffer sb = new StringBuffer(200);
 
         sb.append(LanguageConnectionContext.xidStr);
         sb.append(tc.getTransactionIdString());
@@ -3440,14 +3458,14 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
 
     @Override
     public String getCurrentGroupUserDelimited(Activation a) throws StandardException {
-        if(LOG.isDebugEnabled()) {
+        if (LOG.isDebugEnabled()) {
             LOG.debug(String.format("getCurrentGroupUserDelimited():%n" +
-                            "sessionUser: %s,%n" +
-                            "defaultRoles: %s,%n" +
-                            "groupUserList: %s%n",
-                    sessionUser,
-                    (defaultRoles==null?"null":defaultRoles.toString()),
-                    (groupuserlist==null?"null":groupuserlist.toString())));
+                    "sessionUser: %s,%n" +
+                    "defaultRoles: %s,%n" +
+                    "groupUserList: %s%n",
+                sessionUser,
+                (defaultRoles == null ? "null" : defaultRoles.toString()),
+                (groupuserlist == null ? "null" : groupuserlist.toString())));
         }
         List<String> groupUsers = getCurrentSQLSessionContext(a).getCurrentGroupUser();
 
@@ -3455,7 +3473,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             return null;
 
         String listString = null;
-        for (String groupUser: groupUsers) {
+        for (String groupUser : groupUsers) {
             if (listString == null)
                 listString = IdUtil.normalToDelimited(groupUser);
             else
@@ -3466,18 +3484,18 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     }
 
     @Override
-    public String getCurrentRoleIdDelimited(Activation a) throws StandardException{
-        if(LOG.isDebugEnabled()) {
+    public String getCurrentRoleIdDelimited(Activation a) throws StandardException {
+        if (LOG.isDebugEnabled()) {
             LOG.debug(String.format("getCurrentRoleIdDelimited():%n" +
-                            "sessionUser: %s,%n" +
-                            "defaultRoles: %s,%n" +
-                            "groupUserList: %s%n",
-                    sessionUser,
-                    (defaultRoles==null?"null":defaultRoles.toString()),
-                    (groupuserlist==null?"null":groupuserlist.toString())));
+                    "sessionUser: %s,%n" +
+                    "defaultRoles: %s,%n" +
+                    "groupUserList: %s%n",
+                sessionUser,
+                (defaultRoles == null ? "null" : defaultRoles.toString()),
+                (groupuserlist == null ? "null" : groupuserlist.toString())));
         }
 
-        List<String> roles=getCurrentSQLSessionContext(a).getRoles();
+        List<String> roles = getCurrentSQLSessionContext(a).getRoles();
 
         refreshCurrentRoles(a);
         String roleListString = null;
@@ -3502,7 +3520,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         if (rolesToRemove == null || rolesToRemove.isEmpty())
             return;
 
-        for (String aRole: rolesToRemove)
+        for (String aRole : rolesToRemove)
             getCurrentSQLSessionContext(a).removeRole(aRole);
 
         return;
@@ -3510,8 +3528,8 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
 
     @Override
     public void setSessionProperties(Properties newProperties) {
-        for (Map.Entry<Object, Object> propertyEntry: newProperties.entrySet()) {
-            SessionProperties.PROPERTYNAME propertyName = (SessionProperties.PROPERTYNAME)propertyEntry.getKey();
+        for (Map.Entry<Object, Object> propertyEntry : newProperties.entrySet()) {
+            SessionProperties.PROPERTYNAME propertyName = (SessionProperties.PROPERTYNAME) propertyEntry.getKey();
             sessionProperties.setProperty(propertyName, propertyEntry.getValue());
         }
 
@@ -3529,27 +3547,27 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     }
 
     @Override
-    public boolean roleIsSettable(Activation a,String role) throws StandardException{
+    public boolean roleIsSettable(Activation a, String role) throws StandardException {
 
-        DataDictionary dd=getDataDictionary();
-        String dbo=dd.getAuthorizationDatabaseOwner();
+        DataDictionary dd = getDataDictionary();
+        String dbo = dd.getAuthorizationDatabaseOwner();
 
-        RoleGrantDescriptor grantDesc=null;
-        String currentUser=getCurrentUserId(a);
+        RoleGrantDescriptor grantDesc = null;
+        String currentUser = getCurrentUserId(a);
         List<String> groupuserList = getCurrentGroupUser(a);
 
-        if(currentUser.equals(dbo) || (groupuserList != null && groupuserList.contains(dbo))){
-            grantDesc=dd.getRoleDefinitionDescriptor(role);
-        }else{
+        if (currentUser.equals(dbo) || (groupuserList != null && groupuserList.contains(dbo))) {
+            grantDesc = dd.getRoleDefinitionDescriptor(role);
+        } else {
             // since DB-6636, we allow non-splice admin user, roles' grantor is no longer necessary splice(dbo)
             // set grantor to null to fetch grant description regardless of the grantor
-            grantDesc=dd.getRoleGrantDescriptor
-                    (role,currentUser);
+            grantDesc = dd.getRoleGrantDescriptor
+                (role, currentUser);
 
-            if(grantDesc==null){
+            if (grantDesc == null) {
                 // or if not, via PUBLIC?
-                grantDesc=dd.getRoleGrantDescriptor
-                        (role,Authorizer.PUBLIC_AUTHORIZATION_ID);
+                grantDesc = dd.getRoleGrantDescriptor
+                    (role, Authorizer.PUBLIC_AUTHORIZATION_ID);
             }
 
             // or via group user
@@ -3561,7 +3579,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
                 }
             }
         }
-        return grantDesc!=null;
+        return grantDesc != null;
     }
 
     /**
@@ -3572,16 +3590,16 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     private SQLSessionContext getCurrentSQLSessionContext(Activation activation) {
         SQLSessionContext curr;
 
-        Activation parent=activation.getParentActivation();
+        Activation parent = activation.getParentActivation();
 
-        if(parent==null){
+        if (parent == null) {
             // top level
-            curr=getTopLevelSQLSessionContext();
-        }else{
+            curr = getTopLevelSQLSessionContext();
+        } else {
             // inside a nested connection (stored procedure/function), or when
             // executing a substatement the SQL session context is maintained
             // in the activation of the parent
-            curr=parent.getSQLSessionContextForChildren();
+            curr = parent.getSQLSessionContextForChildren();
         }
 
         return curr;
@@ -3592,20 +3610,20 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * Return the current SQL session context based on statement context
      */
     private SQLSessionContext getCurrentSQLSessionContext() {
-        StatementContext ctx=getStatementContext();
+        StatementContext ctx = getStatementContext();
         SQLSessionContext curr;
 
-        if(ctx==null || !ctx.inUse()){
-            curr=getTopLevelSQLSessionContext();
-        }else{
+        if (ctx == null || !ctx.inUse()) {
+            curr = getTopLevelSQLSessionContext();
+        } else {
             // We are inside a nested connection in a procedure of
             // function.
-            curr=ctx.getSQLSessionContext();
+            curr = ctx.getSQLSessionContext();
 
-            if(SanityManager.DEBUG){
+            if (SanityManager.DEBUG) {
                 SanityManager.ASSERT(
-                        curr!=null,
-                        "SQL session context should never be empty here");
+                    curr != null,
+                    "SQL session context should never be empty here");
             }
         }
 
@@ -3613,33 +3631,33 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     }
 
     @Override
-    public void setupNestedSessionContext(Activation a,boolean definersRights,String definer) throws StandardException{
-        setupSessionContextMinion(a,true,definersRights,definer);
+    public void setupNestedSessionContext(Activation a, boolean definersRights, String definer) throws StandardException {
+        setupSessionContextMinion(a, true, definersRights, definer);
     }
 
     private void setupSessionContextMinion(
-            Activation a,
-            boolean push,
-            boolean definersRights,
-            String definer) throws StandardException{
+        Activation a,
+        boolean push,
+        boolean definersRights,
+        String definer) throws StandardException {
 
-        if(SanityManager.DEBUG){
-            if(definersRights){
+        if (SanityManager.DEBUG) {
+            if (definersRights) {
                 SanityManager.ASSERT(push);
             }
         }
 
-        SQLSessionContext sc=a.setupSQLSessionContextForChildren(push);
+        SQLSessionContext sc = a.setupSQLSessionContextForChildren(push);
 
-        if(definersRights){
+        if (definersRights) {
             sc.setUser(definer);
-        }else{
+        } else {
             // A priori: invoker's rights: Current user
             sc.setUser(getCurrentUserId(a));
         }
 
 
-        if(definersRights){
+        if (definersRights) {
             // No role a priori. Cf. SQL 2008, section 10.4 <routine
             // invocation>, GR 5 j) i) 1) B) "If the external security
             // characteristic of R is DEFINER, then the top cell of the
@@ -3647,7 +3665,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             // authorization identifier of R.
 
             sc.setRole(null);
-        }else{
+        } else {
             // Semantics for roles dictate (SQL 4.34.1.1 and 4.27.3.) that the
             // role is initially inherited from the current session context
             // when we run with INVOKER security characteristic.
@@ -3655,26 +3673,26 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         }
 
 
-        if(definersRights){
-            SchemaDescriptor sd=getDataDictionary().getSchemaDescriptor(
-                    definer,
-                    getTransactionExecute(),
-                    false);
+        if (definersRights) {
+            SchemaDescriptor sd = getDataDictionary().getSchemaDescriptor(
+                definer,
+                getTransactionExecute(),
+                false);
 
-            if(sd==null){
-                sd=new SchemaDescriptor(
-                        getDataDictionary(),definer,definer,(UUID)null,false);
+            if (sd == null) {
+                sd = new SchemaDescriptor(
+                    getDataDictionary(), definer, definer, (UUID) null, false);
             }
 
             sc.setDefaultSchema(sd);
-        }else{
+        } else {
             // Inherit current default schema. The initial value of the
             // default schema is implementation defined. In Derby we
             // inherit it when we invoke stored procedures and functions.
             sc.setDefaultSchema(getDefaultSchema(a));
         }
 
-        StatementContext stmctx=getStatementContext();
+        StatementContext stmctx = getStatementContext();
 
         // Since the statement is an invocation (iff push=true), it will now be
         // associated with the pushed SQLSessionContext (and no longer just
@@ -3694,17 +3712,17 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
 
 
     @Override
-    public void setupSubStatementSessionContext(Activation a) throws StandardException{
-        setupSessionContextMinion(a,false,false,null);
+    public void setupSubStatementSessionContext(Activation a) throws StandardException {
+        setupSessionContextMinion(a, false, false, null);
     }
 
     @Override
     public SQLSessionContext getTopLevelSQLSessionContext() {
-        if(topLevelSSC==null){
-            topLevelSSC=new SQLSessionContextImpl(
-                    getInitialDefaultSchemaDescriptor(),
-                    getSessionUserId(),
-                    defaultRoles, groupuserlist);
+        if (topLevelSSC == null) {
+            topLevelSSC = new SQLSessionContextImpl(
+                getInitialDefaultSchemaDescriptor(),
+                getSessionUserId(),
+                defaultRoles, groupuserlist);
         }
         return topLevelSSC;
     }
@@ -3713,9 +3731,9 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     @Override
     public SQLSessionContext createSQLSessionContext() {
         return new SQLSessionContextImpl(
-                getInitialDefaultSchemaDescriptor(),
-                getSessionUserId() /* a priori */,
-                defaultRoles, groupuserlist);
+            getInitialDefaultSchemaDescriptor(),
+            getSessionUserId() /* a priori */,
+            defaultRoles, groupuserlist);
     }
 
     /**
@@ -3724,67 +3742,67 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      *
      * @see com.splicemachine.db.impl.sql.compile.QueryTreeNode#treePrint(int)
      */
-    Map printedObjectsMap=null;
+    Map printedObjectsMap = null;
 
     @Override
-    public Map getPrintedObjectsMap(){
-        if(printedObjectsMap==null){
-            printedObjectsMap=new IdentityHashMap();
+    public Map getPrintedObjectsMap() {
+        if (printedObjectsMap == null) {
+            printedObjectsMap = new IdentityHashMap();
         }
         return printedObjectsMap;
     }
 
     @Override
-    public void setASTVisitor(ASTVisitor visitor){
-        astWalker=visitor;
+    public void setASTVisitor(ASTVisitor visitor) {
+        astWalker = visitor;
     }
 
     @Override
-    public ASTVisitor getASTVisitor(){
+    public ASTVisitor getASTVisitor() {
         return astWalker;
     }
 
     @Override
-    public void setInterruptedException(StandardException e){
-        interruptedException=e;
+    public void setInterruptedException(StandardException e) {
+        interruptedException = e;
     }
 
     @Override
-    public StandardException getInterruptedException(){
+    public StandardException getInterruptedException() {
         return interruptedException;
     }
 
     @Override
-    public FormatableBitSet getReferencedColumnMap(TableDescriptor td){
+    public FormatableBitSet getReferencedColumnMap(TableDescriptor td) {
         return referencedColumnMap.get(td);
     }
 
     @Override
-    public void setReferencedColumnMap(TableDescriptor td,FormatableBitSet map){
-        referencedColumnMap.put(td,map);
+    public void setReferencedColumnMap(TableDescriptor td, FormatableBitSet map) {
+        referencedColumnMap.put(td, map);
     }
 
     @Override
-    public void enterRestoreMode(){
-        this.restoreMode=true;
+    public void enterRestoreMode() {
+        this.restoreMode = true;
     }
 
     @Override
-    public void setTriggerStack(TriggerExecutionStack triggerStack){
-        if(this.triggerStack!=null){
+    public void setTriggerStack(TriggerExecutionStack triggerStack) {
+        if (this.triggerStack != null) {
             SanityManager.THROWASSERT("LCC already has a trigger stack.");
         }
-        this.triggerStack=triggerStack;
+        this.triggerStack = triggerStack;
     }
 
     @Override
-    public TriggerExecutionStack getTriggerStack(){
+    public TriggerExecutionStack getTriggerStack() {
         return this.triggerStack;
     }
 
     @Override
-    public boolean hasTriggers(){
-        return !(this.triggerStack==null || this.triggerStack.isEmpty());
+    public boolean hasTriggers() {
+        return !(this.triggerStack == null || this.triggerStack.isEmpty());
     }
 
     @Override
@@ -3842,18 +3860,19 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         return sparkExecutionType;
     }
 
-    public void materialize() throws StandardException {}
+    public void materialize() throws StandardException {
+    }
 
-    protected Map<String,TableDescriptor> withDescriptors;
+    protected Map<String, TableDescriptor> withDescriptors;
 
     @Override
-    public void setWithStack(Map<String,TableDescriptor> withDescriptors) {
+    public void setWithStack(Map<String, TableDescriptor> withDescriptors) {
         this.withDescriptors = withDescriptors;
     }
 
     @Override
     public TableDescriptor getWithDescriptor(String name) {
-        if (withDescriptors==null)
+        if (withDescriptors == null)
             return null;
         return withDescriptors.get(name);
     }
@@ -3882,7 +3901,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     public void logStartCompiling(String statement) {
         if (stmtLogger.isInfoEnabled()) {
             stmtLogger.info(String.format("Begin compiling prepared statement. %s, %s",
-                    getLogHeader(), formatLogStmt(statement)));
+                getLogHeader(), formatLogStmt(statement)));
         }
     }
 
@@ -3890,7 +3909,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     public void logEndCompiling(String statement, long nanoTimeSpent) {
         if (stmtLogger.isInfoEnabled()) {
             stmtLogger.info(String.format("End compiling prepared statement. %s, timeSpent=%dms, %s",
-                    getLogHeader(), nanoTimeSpent / 1000000, formatLogStmt(statement)));
+                getLogHeader(), nanoTimeSpent / 1000000, formatLogStmt(statement)));
         }
     }
 
@@ -3898,7 +3917,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     public void logErrorCompiling(String statement, Throwable t, long nanoTimeSpent) {
         if (stmtLogger.isEnabledFor(Level.WARN)) {
             stmtLogger.warn(String.format("Error compiling prepared statement. %s, timeSpent=%dms, %s",
-                    getLogHeader(), nanoTimeSpent / 1000000, formatLogStmt(statement)), t);
+                getLogHeader(), nanoTimeSpent / 1000000, formatLogStmt(statement)), t);
         }
     }
 
@@ -3920,7 +3939,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     public void logStartFetching(String uuid, String statement) {
         if (stmtLogger.isInfoEnabled()) {
             stmtLogger.info(String.format("Start fetching from the result set. %s, uuid=%s, %s",
-                    getLogHeader(), uuid, formatLogStmt(statement)));
+                getLogHeader(), uuid, formatLogStmt(statement)));
         }
     }
 
@@ -3928,7 +3947,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     public void logEndFetching(String uuid, String statement, long fetchedRows) {
         if (stmtLogger.isInfoEnabled()) {
             stmtLogger.info(String.format("End fetching from the result set. %s, uuid=%s, fetchedRows=%d, %s",
-                    getLogHeader(), uuid, fetchedRows, formatLogStmt(statement)));
+                getLogHeader(), uuid, fetchedRows, formatLogStmt(statement)));
         }
     }
 
@@ -3937,9 +3956,9 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
                                   ParameterValueSet pvs) {
         if (stmtLogger.isInfoEnabled()) {
             stmtLogger.info(String.format(
-                    "Start executing query. %s, uuid=%s, engine=%s, %s, paramsCount=%d, params=[ %s ], sessionProperties=[ %s ]",
-                    getLogHeader(), uuid, engine, formatLogStmt(stmt),
-                    pvs.getParameterCount(), pvs.toString(), ps.getSessionPropertyValues()));
+                "Start executing query. %s, uuid=%s, engine=%s, %s, paramsCount=%d, params=[ %s ], sessionProperties=[ %s ]",
+                getLogHeader(), uuid, engine, formatLogStmt(stmt),
+                pvs.getParameterCount(), pvs.toString(), ps.getSessionPropertyValues()));
         }
     }
 
@@ -3947,37 +3966,37 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     public void logNextBatch(ParameterValueSet pvs) {
         if (stmtLogger.isDebugEnabled()) {
             stmtLogger.debug(String.format(
-                    "Next batch for query. %s, paramsCount=%d, params=[ %s ]",
-                    getLogHeader(),
-                    pvs.getParameterCount(), pvs.toString()));
+                "Next batch for query. %s, paramsCount=%d, params=[ %s ]",
+                getLogHeader(),
+                pvs.getParameterCount(), pvs.toString()));
         }
     }
 
     @Override
     public void logEndExecuting(String uuid, long modifiedRows, long badRecords, long
-            nanoTimeSpent) {
+        nanoTimeSpent) {
         if (stmtLogger.isInfoEnabled()) {
             stmtLogger.info(String.format("End executing query. %s, uuid=%s, timeSpent=%dms, " +
-                            "modifiedRows=%d, badRecords=%d",
-                    getLogHeader(), uuid, nanoTimeSpent / 1000000, modifiedRows, badRecords));
+                    "modifiedRows=%d, badRecords=%d",
+                getLogHeader(), uuid, nanoTimeSpent / 1000000, modifiedRows, badRecords));
         }
     }
 
     private String getLogHeader() {
         return String.format(
-                "XID=%s, SessionID=%s, Database=%s, DRDAID=%s, UserID=%s",
-                getTransactionExecute().getTransactionIdString(),
-                getInstanceNumber(),
-                getDbname(),
-                getDrdaID(),
-                getSessionUserId());
+            "XID=%s, SessionID=%s, Database=%s, DRDAID=%s, UserID=%s",
+            getTransactionExecute().getTransactionIdString(),
+            getInstanceNumber(),
+            getDbname(),
+            getDrdaID(),
+            getSessionUserId());
     }
 
     private String formatLogStmt(String statement) {
         if (statement == null) {
             return "sqlHash=null, statement=null";
         }
-        synchronized(this) {
+        synchronized (this) {
             // cache formatted statement log
             if (statement.equals(lastLogStmt)) {
                 return lastLogStmtFormat;
@@ -4018,7 +4037,9 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         return ignoreCommentOptEnabled;
     }
 
-    public boolean clientSupportsDecimal38() { return clientSupportsDecimal38; }
+    public boolean clientSupportsDecimal38() {
+        return clientSupportsDecimal38;
+    }
 
     public void setClientSupportsDecimal38(boolean newVal) {
         clientSupportsDecimal38 = newVal;
@@ -4081,8 +4102,8 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         }
         return null;
     }
-    
-    @Override      
+
+    @Override
     public boolean isSparkJob() {
         return sparkContext != null;
     }
@@ -4131,7 +4152,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         if (applicationJarsHashCode == this.applicationJarsHashCode)
             return;
 
-        for (String jarPath:applicationJars)
+        for (String jarPath : applicationJars)
             sparkSQLUtils.addUserJarToSparkContext(sparkContext, jarPath);
 
         this.applicationJarsHashCode = applicationJarsHashCode;
@@ -4161,4 +4182,36 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     public void setCompilingStoredPreparedStatement(boolean newValue) {
         compilingStoredPreparedStatement = newValue;
     }
+
+    @Override
+    public void setupLocalSPSCache(boolean fromSparkExecution,
+                                   SPSDescriptor fromTableDmlSpsDescriptor) throws StandardException {
+        // Only use the local cache for spark execution, or if we have a temporary
+        // trigger created for execution of a FROM FINAL TABLE clause, which
+        // does not store its SPS in the data dictionary, so needs to use
+        // a ManagedCache.
+        DataDictionary dd = getDataDictionary();
+        final boolean canWriteCache = dd != null && dd.canWriteCache(null);
+
+        if (fromSparkExecution || fromTableDmlSpsDescriptor != null || !canWriteCache) {
+            if (this.spsCache == null) {
+                CacheBuilder cacheBuilder = CacheBuilder.newBuilder().recordStats().
+                                            maximumSize(LOCAL_MANAGED_CACHE_MAX_SIZE);
+                this.spsCache = new ManagedCache<>(cacheBuilder.build(), LOCAL_MANAGED_CACHE_MAX_SIZE);
+            }
+            if (fromTableDmlSpsDescriptor != null)
+                spsCache.put(fromTableDmlSpsDescriptor.getUUID(), fromTableDmlSpsDescriptor);
+        }
+    }
+
+    @Override
+    public ManagedCache<UUID, SPSDescriptor> getLocalSpsCache() {
+        return spsCache;
+    }
+
+    @Override
+    public long getActiveStateTxId() {
+        return activeStateTxId;
+    }
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionFactory.java
@@ -31,6 +31,7 @@
 
 package com.splicemachine.db.impl.sql.conn;
 
+import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.db.InternalDatabase;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.*;
@@ -56,13 +57,16 @@ import com.splicemachine.db.iapi.sql.Statement;
 import com.splicemachine.db.iapi.sql.compile.*;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionFactory;
+import com.splicemachine.db.iapi.sql.dictionary.SPSDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
 import com.splicemachine.db.iapi.sql.execute.ExecutionFactory;
 import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.db.iapi.store.access.conglomerate.Conglomerate;
 import com.splicemachine.db.iapi.types.DataValueFactory;
 import com.splicemachine.db.iapi.util.IdUtil;
 import com.splicemachine.db.iapi.util.StringUtil;
 import com.splicemachine.db.impl.sql.GenericStatement;
+import com.splicemachine.db.impl.sql.catalog.ManagedCache;
 import com.splicemachine.db.impl.sql.misc.CommentStripper;
 
 import java.io.Serializable;
@@ -157,6 +161,10 @@ public class GenericLanguageConnectionFactory
             double defaultSelectvityFactor,
             String ipAddresss,
             String defaultSchema,
+            ManagedCache<UUID, SPSDescriptor> spsCache,
+            List<String> defaultRoles,
+            SchemaDescriptor initialDefaultSchemaDescriptor,
+            long driverTxnId,
             Properties sessionProperties) throws StandardException {
         return new GenericLanguageConnectionContext(
                 cm,
@@ -176,6 +184,10 @@ public class GenericLanguageConnectionFactory
                 defaultSelectvityFactor,
                 ipAddresss,
                 defaultSchema,
+                spsCache,
+                defaultRoles,
+                initialDefaultSchemaDescriptor,
+                driverTxnId,
                 sessionProperties);
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BaseActivation.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BaseActivation.java
@@ -219,6 +219,8 @@ public abstract class BaseActivation implements CursorActivation, GeneratedByteC
 
     private boolean isSubStatement = false;
 
+    private boolean isRowTrigger = false;
+
     public boolean ignoreSequence() {
         return ignoreSequence;
     }
@@ -1786,6 +1788,14 @@ public abstract class BaseActivation implements CursorActivation, GeneratedByteC
 	@Override
         public void setSubStatement(boolean newValue) {
 	    isSubStatement = newValue;
+	}
+
+	@Override
+	public boolean isRowTrigger() { return isRowTrigger; }
+
+	@Override
+        public void setIsRowTrigger(boolean newValue) {
+	    isRowTrigger = newValue;
 	}
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericExecutionFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericExecutionFactory.java
@@ -44,6 +44,7 @@ import com.splicemachine.db.iapi.services.monitor.Monitor;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.ResultColumnDescriptor;
 import com.splicemachine.db.iapi.sql.ResultDescription;
+import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.dictionary.IndexRowGenerator;
 import com.splicemachine.db.iapi.sql.dictionary.SPSDescriptor;
 import com.splicemachine.db.iapi.sql.execute.*;
@@ -261,48 +262,8 @@ public abstract class GenericExecutionFactory implements ModuleControl, ModuleSu
      *
      * @throws StandardException Thrown on error
      */
-    public TriggerExecutionContext getTriggerExecutionContext(ConnectionContext cc,
-                                                              String statementText,
-                                                              int[] changedColIds,
-                                                              String[] changedColNames,
-                                                              UUID targetTableId,
-                                                              String targetTableName,
-                                                              Vector<AutoincrementCounter> aiCounters) throws StandardException {
-        return new TriggerExecutionContext(cc,
-                statementText,
-                changedColIds,
-                changedColNames,
-                targetTableId,
-                targetTableName,
-                aiCounters,
-                null,
-                false,
-                (SPSDescriptor) null);
-    }
 
-    public TriggerExecutionContext getTriggerExecutionContext(ConnectionContext cc,
-                                                              String statementText,
-                                                              int[] changedColIds,
-                                                              String[] changedColNames,
-                                                              UUID targetTableId,
-                                                              String targetTableName,
-                                                              Vector<AutoincrementCounter> aiCounters,
-                                                              FormatableBitSet heapList,
-                                                              boolean fromSparkExecution) throws StandardException {
-        return getTriggerExecutionContext(cc,
-                                          statementText,
-                                          changedColIds,
-                                          changedColNames,
-                                          targetTableId,
-                                          targetTableName,
-                                          aiCounters,
-                                          heapList,
-                                          fromSparkExecution,
-                                          (SPSDescriptor) null);
-
-    }
-
-    public TriggerExecutionContext getTriggerExecutionContext(ConnectionContext cc,
+    public TriggerExecutionContext getTriggerExecutionContext(LanguageConnectionContext lcc,
                                                               String statementText,
                                                               int[] changedColIds,
                                                               String[] changedColNames,
@@ -312,7 +273,7 @@ public abstract class GenericExecutionFactory implements ModuleControl, ModuleSu
                                                               FormatableBitSet heapList,
                                                               boolean fromSparkExecution,
                                                               SPSDescriptor fromTableDmlSpsDescriptor) throws StandardException {
-        return new TriggerExecutionContext(cc,
+        return new TriggerExecutionContext(lcc,
                 statementText,
                 changedColIds,
                 changedColNames,

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericTriggerExecutor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/GenericTriggerExecutor.java
@@ -112,7 +112,7 @@ public abstract class GenericTriggerExecutor {
     private SPSDescriptor getWhenClause() throws StandardException {
         if (!whenClauseRetrieved) {
             whenClauseRetrieved = true;
-            whenClause = triggerd.getWhenClauseSPS(lcc, tec.getSpsCache());
+            whenClause = triggerd.getWhenClauseSPS(lcc, activation);
         }
         return whenClause;
     }
@@ -120,7 +120,7 @@ public abstract class GenericTriggerExecutor {
     private SPSDescriptor getAction(int index) throws StandardException {
         if (!actionRetrievedList.get(index)) {
             actionRetrievedList.set(index, true);
-            actionList.set(index, triggerd.getActionSPS(lcc, index, tec.getSpsCache()));
+            actionList.set(index, triggerd.getActionSPS(lcc, activation, index));
         }
         return actionList.get(index);
     }
@@ -298,6 +298,7 @@ public abstract class GenericTriggerExecutor {
                          ExecPreparedStatement ps,
                          int index) throws StandardException {
         boolean isWhen = index == -1;
+        boolean isRowTrigger = this instanceof RowTriggerExecutor;
 
         // The SPS activation will set its parent activation from
         // the statement context. Reset it to the original parent
@@ -305,7 +306,7 @@ public abstract class GenericTriggerExecutor {
         // the previously executed SPS as parent. DERBY-6348.
         lcc.getStatementContext().setActivation(activation);
 
-        ps = sps.getPreparedStatement();
+        ps = sps.getPreparedStatement(true, lcc);
         /*
          * We need to clone the prepared statement so we don't
          * wind up marking that ps that is tied to sps as finished
@@ -316,6 +317,8 @@ public abstract class GenericTriggerExecutor {
         // it should be valid since we've just prepared for it
         ps.setValid();
         Activation spsActivation = ps.getActivation(lcc, false);
+        if (isRowTrigger)
+            spsActivation.setIsRowTrigger(true);
 
         /*
          * Normally, we want getSource() for an sps invocation

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerEventActivator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerEventActivator.java
@@ -225,16 +225,14 @@ public class TriggerEventActivator {
             if (td.isRowTrigger()) {
                 // Now both control and Spark can use concurrent row triggers.
                 boolean runConcurrently = true;
-                if (runConcurrently) {
-                    for (String sql : td.getTriggerDefinitionList()) {
-                        sql = sql.toUpperCase();
-                        Matcher matcher = pattern.matcher(sql);
-                        if ((sql.contains("INSERT") && sql.contains("INTO")) ||
-                                (sql.contains("UPDATE") && sql.contains("SET")) ||
-                                (sql.contains("DELETE") && sql.contains("FROM")) ||
-                                matcher.find()) {
-                            runConcurrently = false;
-                        }
+                for (String sql : td.getTriggerDefinitionList()) {
+                    sql = sql.toUpperCase();
+                    Matcher matcher = pattern.matcher(sql);
+                    if ((sql.contains("INSERT") && sql.contains("INTO")) ||
+                            (sql.contains("UPDATE") && sql.contains("SET")) ||
+                            (sql.contains("DELETE") && sql.contains("FROM")) ||
+                            matcher.find()) {
+                        runConcurrently = false;
                     }
                 }
                 if (runConcurrently) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerEventActivator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerEventActivator.java
@@ -33,7 +33,7 @@ package com.splicemachine.db.impl.sql.execute;
 
 import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.iapi.jdbc.ConnectionContext;
+import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.context.ContextService;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.sql.Activation;
@@ -67,7 +67,6 @@ public class TriggerEventActivator {
     private Map<TriggerEvent, List<TriggerDescriptor>> rowExecutorsMap = new HashMap<>();
     private Map<TriggerEvent, List<TriggerDescriptor>> rowConcurrentExecutorsMap = new HashMap<>();
     private Activation activation;
-    private ConnectionContext connectionContext;
     private String statementText;
     private UUID tableId;
     private String tableName;
@@ -113,8 +112,8 @@ public class TriggerEventActivator {
         if (triggerInfo == null) {
             return;
         }
-        // extrapolate the table name from the triggerdescriptors
-        this.tableName = triggerInfo.getTriggerDescriptors()[0].getTableDescriptor().getQualifiedName();
+
+        this.tableName = getTableNameFromTriggerInfo(triggerInfo);
         this.activation = activation;
         this.tableId = tableId;
         this.triggerInfo = triggerInfo;
@@ -125,13 +124,18 @@ public class TriggerEventActivator {
             this.statementText = context.getStatementText();
         }
         this.heapList = heapList;
-        connectionContext = (ConnectionContext) getLcc().getContextManager().getContext(ConnectionContext.CONTEXT_ID);
         // fromSparkExecution has to be set before initTriggerExecContext() as the latter uses this variable
         this.fromSparkExecution = fromSparkExecution;
         initTriggerExecContext(aiCounters);
-        setupExecutors(triggerInfo);
+        setupExecutors(triggerInfo, activation);
         this.executorService = executorService;
         this.withContext = withContext;
+    }
+
+    private String getTableNameFromTriggerInfo(TriggerInfo triggerInfo) {
+        if (triggerInfo instanceof TriggerInfo2)
+            return ((TriggerInfo2) triggerInfo).getTableName();
+        return null;
     }
 
     private void pushExecutionStmtValidator() throws StandardException {
@@ -194,9 +198,11 @@ public class TriggerEventActivator {
     }
 
     private void initTriggerExecContext(Vector<AutoincrementCounter> aiCounters) throws StandardException {
-        GenericExecutionFactory executionFactory = (GenericExecutionFactory) getLcc().getLanguageConnectionFactory().getExecutionFactory();
+        LanguageConnectionContext lcc = getLcc();
+        lcc.setupLocalSPSCache(fromSparkExecution, fromTableDmlSpsDescriptor);
+        GenericExecutionFactory executionFactory = (GenericExecutionFactory) lcc.getLanguageConnectionFactory().getExecutionFactory();
         this.tec = executionFactory.getTriggerExecutionContext(
-        connectionContext, statementText, triggerInfo.getColumnIds(), triggerInfo.getColumnNames(),
+        lcc, statementText, triggerInfo.getColumnIds(), triggerInfo.getColumnNames(),
                 tableId, tableName, aiCounters, heapList, fromSparkExecution, fromTableDmlSpsDescriptor);
     }
 
@@ -206,10 +212,10 @@ public class TriggerEventActivator {
      */
     void reopen() throws StandardException {
         initTriggerExecContext(null);
-        setupExecutors(triggerInfo);
+        setupExecutors(triggerInfo, activation);
     }
 
-    private void setupExecutors(TriggerInfo triggerInfo) throws StandardException {
+    private void setupExecutors(TriggerInfo triggerInfo, Activation activation) throws StandardException {
         // The SET statement cannot be executed in parallel.
         String regex    =   "(^set[\\s]+)|([\\s]+set[\\s]+)";
         Pattern pattern =   Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
@@ -217,11 +223,8 @@ public class TriggerEventActivator {
         for (TriggerDescriptor td : triggerInfo.getTriggerDescriptors()) {
             TriggerEvent event = td.getTriggerEvent();
             if (td.isRowTrigger()) {
-                // disable concurrent trigger for spark execution due to the high overhead
-                // to create lcc and TriggerExecutionContext for each row and each trigger,
-                // each make non-cached dictionary calls for
-                // defaultroles, defaultSchema, storedPreparedStatement ...
-                boolean runConcurrently = !fromSparkExecution;
+                // Now both control and Spark can use concurrent row triggers.
+                boolean runConcurrently = true;
                 if (runConcurrently) {
                     for (String sql : td.getTriggerDefinitionList()) {
                         sql = sql.toUpperCase();
@@ -242,7 +245,24 @@ public class TriggerEventActivator {
             } else {
                 addToStatementTriggersMap(statementExecutorsMap, event, new StatementTriggerExecutor(tec, td, activation, getLcc()));
             }
+            // Pre-compiling the triggers before execution makes sure the
+            // stored statements are cached so we can ship the cached statements
+            // to the executors to avoid dictionary lookups.
+            // Also, we avoid compiling them in parallel, which can cause
+            // contention or possibly concurrency exceptions.
+            if (activation != null) {
+                preCompileTrigger(td, activation);
+            }
         }
+    }
+
+    private void preCompileTrigger(TriggerDescriptor td,
+                                   Activation activation) throws StandardException {
+        LanguageConnectionContext lcc = activation.getLanguageConnectionContext();
+        td.getWhenClauseSPS(lcc, activation);
+        int numActions = td.getActionIdList().size();
+        for (int i=0; i < numActions; i++)
+            td.getActionSPS(lcc, activation, i);
     }
 
     /**
@@ -357,7 +377,7 @@ public class TriggerEventActivator {
                             ContextService.getFactory().setCurrentContextManager(cm);
                         }
                         lccPushed = pushLanguageConnectionContextToCM(lcc, cm);
-                        TriggerExecutionContext tec = executionFactory.getTriggerExecutionContext(connectionContext,
+                        TriggerExecutionContext tec = executionFactory.getTriggerExecutionContext(lcc,
                                 statementText, triggerInfo.getColumnIds(), triggerInfo.getColumnNames(),
                                 tableId, tableName, null, heapList, fromSparkExecution, fromTableDmlSpsDescriptor);
                         RowTriggerExecutor triggerExecutor = new RowTriggerExecutor(tec, td, activation, lcc);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerExecutionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerExecutionContext.java
@@ -36,6 +36,7 @@ import com.splicemachine.db.iapi.error.PublicAPI;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.jdbc.ConnectionContext;
 import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.services.context.Context;
 import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.io.ArrayUtil;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
@@ -47,14 +48,17 @@ import com.splicemachine.db.iapi.sql.dictionary.SPSDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.TriggerDescriptor;
 import com.splicemachine.db.iapi.sql.execute.*;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.db.impl.jdbc.EmbedConnection;
 import com.splicemachine.db.impl.jdbc.Util;
 import com.splicemachine.db.impl.sql.catalog.ManagedCache;
+import com.splicemachine.tools.EmbedConnectionMaker2;
 import splice.com.google.common.cache.CacheBuilder;
 
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.*;
@@ -88,6 +92,7 @@ public class TriggerExecutionContext implements ExecutionStmtValidator, External
     private String[] changedColNames;
     private String statementText;
     protected ConnectionContext cc;
+    private LanguageConnectionContext lcc;
     private UUID targetTableId;
     private String targetTableName;
     private ExecRow triggeringRow;
@@ -100,7 +105,6 @@ public class TriggerExecutionContext implements ExecutionStmtValidator, External
     private long conglomId;
 
     protected CursorResultSet  triggeringResultSet;
-    private ManagedCache<UUID, SPSDescriptor> spsCache = null;
     private boolean fromSparkExecution;
     private TemporaryRowHolder temporaryRowHolder;
     private SPSDescriptor fromTableDmlSpsDescriptor;
@@ -126,6 +130,7 @@ public class TriggerExecutionContext implements ExecutionStmtValidator, External
      */
     private Map<String, Long> aiHT;
 
+
     public TriggerExecutionContext() {}
 
     /**
@@ -138,7 +143,7 @@ public class TriggerExecutionContext implements ExecutionStmtValidator, External
      * @param targetTableName the name of the table upon which the trigger fired
      * @param aiCounters      A list of AutoincrementCounters to keep state of the ai columns in this insert trigger.
      */
-    public TriggerExecutionContext(ConnectionContext cc,
+    public TriggerExecutionContext(LanguageConnectionContext lcc,
                                    String statementText,
                                    int[] changedColIds,
                                    String[] changedColNames,
@@ -157,19 +162,11 @@ public class TriggerExecutionContext implements ExecutionStmtValidator, External
         this.aiCounters = aiCounters;
         this.heapList = heapList;
         this.resultSetVector = new Vector<>();
-        this.cc = cc;
+        this.lcc = lcc;
 
         this.fromSparkExecution = fromSparkExecution;
         this.fromTableDmlSpsDescriptor = fromTableDmlSpsDescriptor;
-        // Only use the local cache for spark execution, or if we have a temporary
-        // trigger created for execution of a FROM FINAL TABLE clause, which
-        // does not store its SPS in the data dictionary, so needs to use
-        // a ManagedCache.
-        if (fromSparkExecution || fromTableDmlSpsDescriptor != null) {
-            this.spsCache = new ManagedCache<>(CacheBuilder.newBuilder().recordStats().maximumSize(100).build(), 100);
-            if (fromTableDmlSpsDescriptor != null)
-                spsCache.put(fromTableDmlSpsDescriptor.getUUID(), fromTableDmlSpsDescriptor);
-        }
+
         if (SanityManager.DEBUG) {
             if ((changedColIds == null) != (changedColNames == null)) {
                 SanityManager.THROWASSERT("bad changed cols, " +
@@ -463,8 +460,29 @@ public class TriggerExecutionContext implements ExecutionStmtValidator, External
         return false;
     }
 
+    private void initConnectionContext() throws StandardException {
+        ConnectionContext existingContext = (ConnectionContext) lcc.getContextManager().getContext(ConnectionContext.CONTEXT_ID);
+        if (existingContext == null) {
+            try {
+                Properties dbProperties = new Properties();
+                dbProperties.put(EmbedConnection.INTERNAL_CONNECTION, "true");
+                Connection connection = new EmbedConnectionMaker2().createNew(dbProperties);
+                Context newContext = ((EmbedConnection) connection).getContextManager().getContext(ConnectionContext.CONTEXT_ID);
+                lcc.getContextManager().pushContext(newContext);
+                existingContext = (ConnectionContext)newContext;
+            } catch (SQLException e) {
+                throw StandardException.plainWrapException(e);
+            }
+        }
+        cc = existingContext;
+    }
+
     public void setConnectionContext(ConnectionContext cc) {
         this.cc = cc;
+    }
+
+    public void setLanguageConnectionContext(LanguageConnectionContext lcc) {
+        this.lcc = lcc;
     }
 
     /**
@@ -489,6 +507,7 @@ public class TriggerExecutionContext implements ExecutionStmtValidator, External
 			 * at multiple places independently in trigger action.  This is a bug found
 			 * during the fix of beetle 4373.
 			 */
+			initConnectionContext();
 			CursorResultSet ars = triggeringResultSet;
 			if (ars instanceof TemporaryRowHolderResultSet)
 				ars = (CursorResultSet) ((TemporaryRowHolderResultSet) ars).clone();
@@ -648,10 +667,6 @@ public class TriggerExecutionContext implements ExecutionStmtValidator, External
         out.writeBoolean(hasFromTableDmlSpsDescriptor);
         if (hasFromTableDmlSpsDescriptor)
             out.writeObject(fromTableDmlSpsDescriptor);
-        boolean hasSpsCache = spsCache != null;
-        out.writeBoolean(hasSpsCache);
-        if (hasSpsCache)
-            out.writeObject(spsCache);
     }
 
     @Override
@@ -686,14 +701,6 @@ public class TriggerExecutionContext implements ExecutionStmtValidator, External
         boolean hasFromTableDmlSpsDescriptor = in.readBoolean();
         if (hasFromTableDmlSpsDescriptor)
             fromTableDmlSpsDescriptor = (SPSDescriptor) in.readObject();
-        boolean hasSpsCache = in.readBoolean();
-        if (hasSpsCache)
-            spsCache = (ManagedCache<UUID, SPSDescriptor> ) in.readObject();
-        else if (fromSparkExecution || hasFromTableDmlSpsDescriptor) {
-            spsCache = new ManagedCache<>(CacheBuilder.newBuilder().recordStats().maximumSize(100).build(), 100);
-            if (hasFromTableDmlSpsDescriptor)
-                spsCache.put(fromTableDmlSpsDescriptor.getUUID(), fromTableDmlSpsDescriptor);
-        }
     }
 
     /**
@@ -830,18 +837,6 @@ public class TriggerExecutionContext implements ExecutionStmtValidator, External
         {
             triggeringResultSet.close();
         }
-    }
-
-    public SPSDescriptor getSPSDescriptor(UUID uuid) {
-        return spsCache.getIfPresent(uuid);
-    }
-
-    public void setSPSDescriptor(SPSDescriptor desc) {
-        spsCache.put(desc.getUUID(), desc);
-    }
-
-    public ManagedCache<UUID, SPSDescriptor> getSpsCache() {
-        return spsCache;
     }
 
     public TemporaryRowHolder getTemporaryRowHolder() {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerInfo.java
@@ -44,7 +44,6 @@ import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.dictionary.*;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import static com.splicemachine.db.shared.common.reference.SQLState.LANG_MODIFIED_FINAL_TABLE;
 
 /**
  * This is a simple class used to store the run time information
@@ -52,7 +51,7 @@ import static com.splicemachine.db.shared.common.reference.SQLState.LANG_MODIFIE
  * check.
  */
 @SuppressFBWarnings("EI_EXPOSE_REP")
-public final class TriggerInfo implements Formatable {
+public class TriggerInfo implements Formatable {
 
     private TriggerDescriptor[] triggerDescriptors;
     private String[] columnNames;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerInfo2.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerInfo2.java
@@ -47,6 +47,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class TriggerInfo2 extends TriggerInfo {
 
     private String tableName;
+    private static int versionNumber = 2;
 
     /**
      * Default constructor for Formattable
@@ -79,6 +80,7 @@ public class TriggerInfo2 extends TriggerInfo {
     public void writeExternal(ObjectOutput out) throws IOException {
         // DO NOT CHANGE THIS SERIALIZATION
         super.writeExternal(out);
+        out.writeInt(versionNumber);
         writeNullableUTF(out, tableName);
     }
 
@@ -91,6 +93,7 @@ public class TriggerInfo2 extends TriggerInfo {
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
         // DO NOT CHANGE THIS SERIALIZATION
         super.readExternal(in);
+        in.readInt();
         tableName = readNullableUTF(in);
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerInfo2.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerInfo2.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2020 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.impl.sql.execute;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import com.splicemachine.db.iapi.sql.dictionary.*;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+
+/**
+ * An extension to TriggerInfo so triggers serialized on disk
+ * or in jar files will still work.
+ */
+@SuppressFBWarnings("EI_EXPOSE_REP")
+public class TriggerInfo2 extends TriggerInfo {
+
+    private String tableName;
+
+    /**
+     * Default constructor for Formattable
+     */
+    public TriggerInfo2() {
+    }
+
+    public TriggerInfo2(TableDescriptor td, int[] changedCols, GenericDescriptorList<TriggerDescriptor> triggers) {
+        super(td, changedCols, triggers);
+        if (td != null)
+            this.tableName = td.getQualifiedName();
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+
+    @Override
+    public String toString() {
+        return super.toString() + ", targetTableName=" + tableName;
+    }
+
+    /**
+     * Write this object out
+     *
+     * @param out write bytes here
+     */
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        // DO NOT CHANGE THIS SERIALIZATION
+        super.writeExternal(out);
+        writeNullableUTF(out, tableName);
+    }
+
+    /**
+     * Read this object from a stream of stored objects.
+     *
+     * @param in read this.
+     */
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        // DO NOT CHANGE THIS SERIALIZATION
+        super.readExternal(in);
+        tableName = readNullableUTF(in);
+    }
+
+    public static void writeNullableUTF(ObjectOutput out, String str) throws IOException {
+        out.writeBoolean(str != null);
+        if (str != null)
+            out.writeUTF(str);
+    }
+
+    public static String readNullableUTF(ObjectInput in) throws IOException {
+        if (in.readBoolean()) {
+            return in.readUTF();
+        }
+        else {
+            return null;
+        }
+    }
+}

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
@@ -81,6 +81,7 @@ import org.apache.commons.lang3.mutable.MutableDouble;
 import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.serializer.KryoRegistrator;
 import splice.com.google.common.base.Optional;
+import splice.com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -872,5 +873,12 @@ public class SpliceSparkKryoRegistrator implements KryoRegistrator, KryoPool.Kry
         instance.register(Vector.class);
         instance.register(KafkaReadFunction.Message.class,EXTERNALIZABLE_SERIALIZER);
         instance.register(TriggerDescriptorV4.class,EXTERNALIZABLE_SERIALIZER);
+        instance.register(SPSDescriptor.class,EXTERNALIZABLE_SERIALIZER);
+        try {
+            instance.register(Class.forName("splice.com.google.common.collect.EmptyImmutableList"));
+        }
+        catch (ClassNotFoundException e) { }
+        instance.register(ImmutableList.class);
     }
+
 }

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/SpliceSparkKryoRegistrator.java
@@ -877,7 +877,9 @@ public class SpliceSparkKryoRegistrator implements KryoRegistrator, KryoPool.Kry
         try {
             instance.register(Class.forName("splice.com.google.common.collect.EmptyImmutableList"));
         }
-        catch (ClassNotFoundException e) { }
+        catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
         instance.register(ImmutableList.class);
     }
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/lifecycle/CostChoosingDataSetProcessorFactory.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/lifecycle/CostChoosingDataSetProcessorFactory.java
@@ -92,7 +92,8 @@ public class CostChoosingDataSetProcessorFactory implements DataSetProcessorFact
     public DataSetProcessor bulkProcessor(@Nullable Activation activation, @Nullable SpliceOperation op) {
         if (LOG.isTraceEnabled())
             SpliceLogUtils.trace(LOG, "bulkProcessor(): bulkProcessor provided for op %s", op==null?"null":op.getName());
-        if(! allowsDistributedExecution()){
+        // It is too costly to open a new bulk processor for every row processed in a row trigger.
+        if(! allowsDistributedExecution() && !activation.isRowTrigger()){
             /*
              * We are running in a distributed node, use the bulk processor to avoid saturating HBase
              */

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BroadcastedActivation.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/BroadcastedActivation.java
@@ -43,7 +43,7 @@ public class BroadcastedActivation implements Externalizable {
     private boolean DB2VarcharCompatibilityMode = false;
     protected long conglomID = 0;
 
-    public BroadcastedActivation() {
+        public BroadcastedActivation() {
 
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
+++ b/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
@@ -84,6 +84,7 @@ import de.javakaffee.kryoserializers.ArraysAsListSerializer;
 import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer;
 import org.apache.commons.lang3.mutable.MutableDouble;
 import splice.com.google.common.base.Optional;
+import splice.com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -898,5 +899,12 @@ public class SpliceKryoRegistry implements KryoPool.KryoRegistry{
         instance.register(TriggerDescriptorV3.class,EXTERNALIZABLE_SERIALIZER,335);
         instance.register(TriggerDescriptorV4.class,EXTERNALIZABLE_SERIALIZER,336);
         instance.register(Vector.class,110);
+        instance.register(SPSDescriptor.class,EXTERNALIZABLE_SERIALIZER,337);
+        try {
+            instance.register(Class.forName("splice.com.google.common.collect.EmptyImmutableList"), 338);
+        }
+        catch (ClassNotFoundException e) { }
+        instance.register(ImmutableList.class, 339);
+        instance.register(TriggerInfo2.class,EXTERNALIZABLE_SERIALIZER,340);
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
+++ b/splice_machine/src/main/java/com/splicemachine/SpliceKryoRegistry.java
@@ -903,7 +903,9 @@ public class SpliceKryoRegistry implements KryoPool.KryoRegistry{
         try {
             instance.register(Class.forName("splice.com.google.common.collect.EmptyImmutableList"), 338);
         }
-        catch (ClassNotFoundException e) { }
+        catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
         instance.register(ImmutableList.class, 339);
         instance.register(TriggerInfo2.class,EXTERNALIZABLE_SERIALIZER,340);
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/catalog/TriggerNewTransitionRows.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/catalog/TriggerNewTransitionRows.java
@@ -289,6 +289,7 @@ public class TriggerNewTransitionRows
                         lcc.pushTriggerExecutionContext(tec);
 
                     tec.setConnectionContext(cc);
+                    tec.setLanguageConnectionContext(lcc);
                     rowHolder.setActivation(activation);
                     tec.setTriggeringResultSet(rowHolder.getResultSet());
                     try {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
@@ -17,6 +17,7 @@ package com.splicemachine.derby.impl.db;
 import com.splicemachine.EngineDriver;
 import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.access.configuration.AuthenticationConfiguration;
+import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.ast.ISpliceVisitor;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.jdbc.AuthenticationService;
@@ -36,14 +37,17 @@ import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.depend.DependencyManager;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.sql.dictionary.FileInfoDescriptor;
+import com.splicemachine.db.iapi.sql.dictionary.SPSDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
 import com.splicemachine.db.iapi.sql.execute.ExecutionFactory;
 import com.splicemachine.db.iapi.store.access.AccessFactory;
 import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.db.iapi.store.access.conglomerate.Conglomerate;
 import com.splicemachine.db.iapi.util.IdUtil;
 import com.splicemachine.db.impl.ast.*;
 import com.splicemachine.db.impl.db.BasicDatabase;
 import com.splicemachine.db.impl.sql.catalog.DataDictionaryImpl;
+import com.splicemachine.db.impl.sql.catalog.ManagedCache;
 import com.splicemachine.db.impl.sql.execute.JarUtil;
 import com.splicemachine.db.shared.common.sanity.SanityManager;
 import com.splicemachine.ddl.DDLMessage;
@@ -169,13 +173,18 @@ public class SpliceDatabase extends BasicDatabase{
                                                                        SparkExecutionType sparkExecutionType, boolean skipStats,
                                                                        double defaultSelectivityFactor,
                                                                        String ipAddress,
+                                                                       ManagedCache<UUID, SPSDescriptor> spsCache,
+                                                                       List<String> defaultRoles,
+                                                                       SchemaDescriptor initialDefaultSchemaDescriptor,
+                                                                       long driverTxnId,
                                                                        TransactionController reuseTC) throws StandardException{
         TransactionController tc = reuseTC == null ? ((SpliceAccessManager)af).marshallTransaction(cm,txn) : reuseTC;
         cm.setLocaleFinder(this);
         pushDbContext(cm);
         LanguageConnectionContext lctx=lcf.newLanguageConnectionContext(cm,tc,lf,this,user,
                 groupuserlist,drdaID,dbname,rdbIntTkn,type, sparkExecutionType, skipStats, defaultSelectivityFactor,
-                ipAddress, null, null);
+                ipAddress, null,
+                spsCache, defaultRoles, initialDefaultSchemaDescriptor, driverTxnId, null);
 
         pushClassFactoryContext(cm,lcf.getClassFactory());
         ExecutionFactory ef=lcf.getExecutionFactory();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
@@ -1187,8 +1187,8 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
             //    FOR EACH ROW
             //    SELECT oldt.c11 from DERBY4998_SOFT_UPGRADE_RESTRICT
 
-            SPSDescriptor sps = isWhenClause ? trd.getWhenClauseSPS(lcc, null)
-                                             : trd.getActionSPS(lcc, index, null);
+            SPSDescriptor sps = isWhenClause ? trd.getWhenClauseSPS(lcc, activation)
+                                             : trd.getActionSPS(lcc, activation, index);
             int[] referencedColsInTriggerAction = new int[td.getNumberOfColumns()];
             java.util.Arrays.fill(referencedColsInTriggerAction, -1);
             String newText = dd.getTriggerActionString(node,
@@ -1230,7 +1230,7 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
             pa = newCC.getParser();
             StatementNode stmtnode = (StatementNode) pa.parseStatement(newText);
             // need a current dependent for bind
-            newCC.setCurrentDependent(sps.getPreparedStatement());
+            newCC.setCurrentDependent(sps.getPreparedStatement(true, lcc));
             stmtnode.bindStatement();
 
         } catch (StandardException se) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceAccessManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceAccessManager.java
@@ -17,6 +17,9 @@ package com.splicemachine.derby.impl.store.access;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.*;
+
+import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
+import com.splicemachine.utils.Pair;
 import splice.com.google.common.base.Preconditions;
 import com.splicemachine.derby.impl.db.SpliceDatabase;
 import com.splicemachine.derby.utils.ConglomerateUtils;
@@ -156,14 +159,15 @@ public class SpliceAccessManager implements AccessFactory, CacheableFactory, Mod
      **/
     Conglomerate conglomCacheFind(TransactionManager xact_mgr,long conglomid) throws StandardException {
         Conglomerate conglomerate = null;
-        if (database!=null && database.getDataDictionary() !=null) {
-            conglomerate = database.getDataDictionary().getDataDictionaryCache().conglomerateCacheFind(xact_mgr,conglomid);
+        DataDictionary dd = database!=null ? database.getDataDictionary() : null;
+        if (dd !=null) {
+            conglomerate = dd.getDataDictionaryCache().conglomerateCacheFind(xact_mgr,conglomid);
         }
         if (conglomerate != null)
             return conglomerate;
         conglomerate = getFactoryFromConglomId(conglomid).readConglomerate(xact_mgr, conglomid);
-        if (conglomerate!=null && database!=null && database.getDataDictionary() !=null)
-            database.getDataDictionary().getDataDictionaryCache().conglomerateCacheAdd(conglomid,conglomerate,xact_mgr);
+        if (conglomerate!=null && dd !=null)
+            dd.getDataDictionaryCache().conglomerateCacheAdd(conglomid,conglomerate,xact_mgr);
         return conglomerate;
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceInternalTransactionManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceInternalTransactionManager.java
@@ -17,7 +17,6 @@ package com.splicemachine.derby.impl.store.access;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.daemon.Serviceable;
-import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.store.raw.Transaction;
 import org.apache.log4j.Logger;
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceInternalTransactionManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceInternalTransactionManager.java
@@ -17,6 +17,7 @@ package com.splicemachine.derby.impl.store.access;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.daemon.Serviceable;
+import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.store.raw.Transaction;
 import org.apache.log4j.Logger;
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/jdbc/SpliceTransactionResourceImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/jdbc/SpliceTransactionResourceImpl.java
@@ -15,6 +15,7 @@
 package com.splicemachine.derby.jdbc;
 
 import com.splicemachine.access.configuration.SQLConfiguration;
+import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.error.PublicAPI;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.Attribute;
@@ -25,7 +26,10 @@ import com.splicemachine.db.iapi.services.monitor.Monitor;
 import com.splicemachine.db.iapi.sql.compile.DataSetProcessorType;
 import com.splicemachine.db.iapi.sql.compile.SparkExecutionType;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
+import com.splicemachine.db.iapi.sql.dictionary.SPSDescriptor;
+import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
 import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.db.iapi.store.access.conglomerate.Conglomerate;
 import com.splicemachine.db.iapi.util.IdUtil;
 import com.splicemachine.db.impl.sql.catalog.ManagedCache;
 import com.splicemachine.db.jdbc.InternalDriver;
@@ -37,6 +41,7 @@ import splice.com.google.common.base.Optional;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -86,15 +91,24 @@ public final class SpliceTransactionResourceImpl implements AutoCloseable{
     }
 
     public void marshallTransaction(TxnView txn) throws StandardException, SQLException {
-        this.marshallTransaction(txn, null);
-    }
-
-    public void marshallTransaction(TxnView txn, ManagedCache<String, Optional<String>> propertyCache) throws StandardException, SQLException {
-        this.marshallTransaction(txn, propertyCache, null, null, null);
+        this.marshallTransaction(txn, null, null, null, null, -1);
     }
 
     public void marshallTransaction(TxnView txn, ManagedCache<String, Optional<String>> propertyCache,
-                                       TransactionController reuseTC, String localUserName, Integer sessionNumber) throws StandardException, SQLException{
+                                    ManagedCache<UUID, SPSDescriptor>  storedPreparedStatementCache,
+                                    List<String> defaultRoles,
+                                    SchemaDescriptor initialDefaultSchemaDescriptor,
+                                    long driverTxnId) throws StandardException, SQLException {
+        this.marshallTransaction(txn, propertyCache, storedPreparedStatementCache, defaultRoles, initialDefaultSchemaDescriptor, driverTxnId, null, null, null);
+    }
+
+    public void marshallTransaction(TxnView txn, ManagedCache<String, Optional<String>> propertyCache,
+                                    ManagedCache<UUID, SPSDescriptor>  storedPreparedStatementCache,
+                                    List<String> defaultRoles,
+                                    SchemaDescriptor initialDefaultSchemaDescriptor,
+                                    long driverTxnId,
+                                    TransactionController reuseTC,
+                                    String localUserName, Integer sessionNumber) throws StandardException, SQLException{
         if (prepared) {
             throw new IllegalStateException("Cannot create a new marshall Transaction as the last one wasn't closed");
         }
@@ -118,7 +132,12 @@ public final class SpliceTransactionResourceImpl implements AutoCloseable{
                     txn, cm, userName,grouplist,drdaID, dbname, rdbIntTkn,
                     DataSetProcessorType.DEFAULT_OLTP, SparkExecutionType.UNSPECIFIED,
                     false, -1,
-                    ipAddress, reuseTC);
+                    ipAddress,
+                    storedPreparedStatementCache,
+                    defaultRoles,
+                    initialDefaultSchemaDescriptor,
+                    driverTxnId,
+                    reuseTC);
 
         } catch (Throwable t) {
             LOG.error("Exception during marshallTransaction", t);

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/ActivationHolder.java
@@ -15,10 +15,13 @@
 package com.splicemachine.derby.stream;
 
 import com.splicemachine.EngineDriver;
+import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.context.ContextService;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
+import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
+import com.splicemachine.db.iapi.sql.dictionary.SPSDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.store.access.conglomerate.TransactionManager;
@@ -30,6 +33,7 @@ import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperationContext;
 import com.splicemachine.derby.impl.sql.execute.operations.*;
 import com.splicemachine.derby.impl.store.access.BaseSpliceTransaction;
+import com.splicemachine.derby.impl.store.access.SpliceTransactionManager;
 import com.splicemachine.derby.jdbc.SpliceTransactionResourceImpl;
 import com.splicemachine.derby.serialization.SpliceObserverInstructions;
 import com.splicemachine.derby.utils.StatisticsOperation;
@@ -74,6 +78,10 @@ public class ActivationHolder implements Externalizable {
     private SchemaDescriptor schemaDescriptor;
     private List<String> groupUsers = null;
     private ManagedCache<String, Optional<String>> propertyCache = null;
+    private ManagedCache<UUID, SPSDescriptor> storedPreparedStatementCache = null;
+    private List<String> defaultRoles;
+    private SchemaDescriptor initialDefaultSchemaDescriptor = null;
+    private long activeStateTxId = -1;
     private boolean serializeOperationList;
     public ActivationHolder() {
 
@@ -141,6 +149,10 @@ public class ActivationHolder implements Externalizable {
             LanguageConnectionContext lcc = getActivation().getLanguageConnectionContext();
             txnResource.marshallTransaction(txn,
                                             lcc.getDataDictionary().getDataDictionaryCache().getPropertyCache(),
+                                            lcc.getLocalSpsCache(),
+                                            lcc.getDefaultRoles(),
+                                            lcc.getInitialDefaultSchemaDescriptor(),
+                                            lcc.getActiveStateTxId(),
                                             lcc.getTransactionExecute(), lcc.getUserName(), lcc.getInstanceNumber());
             if (needToSet)
                 impl.set(txnResource);
@@ -212,12 +224,34 @@ public class ActivationHolder implements Externalizable {
         } else {
             out.writeBoolean(false);
         }
-        out.writeObject(getActivation().getLanguageConnectionContext().getDataDictionary().getDataDictionaryCache().getPropertyCache());
+        LanguageConnectionContext lcc = getActivation().getLanguageConnectionContext();
+        DataDictionary dd = lcc.getDataDictionary();
+        out.writeObject(dd.getDataDictionaryCache().getPropertyCache());
+        out.writeObject(lcc.getLocalSpsCache());
+        List<String> defaultRoles = lcc.getDefaultRoles();
+        int numDefaultRoles = defaultRoles == null ? -1 : defaultRoles.size();
+        out.writeInt(numDefaultRoles);
+        if (numDefaultRoles > 0) {
+            for (String role:defaultRoles)
+                out.writeUTF(role);
+        }
+
+        SchemaDescriptor sd = lcc.getInitialDefaultSchemaDescriptor();
+        boolean hasSchemaDescriptor = sd != null;
+        out.writeBoolean(hasSchemaDescriptor);
+        if (hasSchemaDescriptor)
+            out.writeObject(sd);
+
+        long activeStateTxId = lcc.getActiveStateTxId() != -1 ? lcc.getActiveStateTxId() :
+                               ((SpliceTransactionManager) activation.getTransactionController()).getActiveStateTxId();
+        out.writeLong(activeStateTxId);
     }
 
     public LanguageConnectionContext getLCC() {
         SpliceTransactionResourceImpl txnResource = impl.get();
-        return txnResource.getLcc();
+        if (txnResource != null)
+            return txnResource.getLcc();
+        return null;
     }
 
     private void init(TxnView txn, boolean reinit){
@@ -229,7 +263,8 @@ public class ActivationHolder implements Externalizable {
             }
 
             txnResource = new SpliceTransactionResourceImpl();
-            txnResource.marshallTransaction(txn, propertyCache);
+            txnResource.marshallTransaction(txn, propertyCache, storedPreparedStatementCache, defaultRoles,
+                                            initialDefaultSchemaDescriptor, activeStateTxId);
             impl.set(txnResource);
             if (soi == null)
                 soi = SpliceObserverInstructions.create(this);
@@ -290,6 +325,18 @@ public class ActivationHolder implements Externalizable {
             schemaDescriptor = null;
         }
         propertyCache = (ManagedCache<String, Optional<String>>) in.readObject();
+        storedPreparedStatementCache = (ManagedCache<UUID, SPSDescriptor>) in.readObject();
+        int numDefaultRoles = in.readInt();
+        if (numDefaultRoles >= 0) {
+            defaultRoles = new ArrayList<>(numDefaultRoles);
+            for (int i = 0; i < numDefaultRoles; i++)
+                defaultRoles.add(in.readUTF());
+        }
+        boolean hasSchemaDescriptor = in.readBoolean();
+        if (hasSchemaDescriptor)
+            initialDefaultSchemaDescriptor = (SchemaDescriptor) in.readObject();
+        activeStateTxId = in.readLong();
+
         if (!serializeOperationList) {
             init(txn, true);
             updateLimitOffset((SpliceOperation) activation.getResultSet());

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
@@ -961,13 +961,13 @@ public class SpliceAdmin extends BaseAdminProcedures{
             // Transform the descriptors into the rows.
             for(Object aList : list){
                 SPSDescriptor spsd=(SPSDescriptor)aList;
-                ExecPreparedStatement ps=spsd.getPreparedStatement(false);
+                ExecPreparedStatement ps=spsd.getPreparedStatement(false, lcc);
                 dvds[0].setValue(spsd.getName());
                 dvds[1].setValue(spsd.getTypeAsString());
                 dvds[2].setValue(spsd.isValid());
                 dvds[3].setValue(spsd.getCompileTime());
                 dvds[4].setValue(spsd.initiallyCompilable());
-                dvds[5].setValue(spsd.getPreparedStatement(false)==null?null:"[object]");
+                dvds[5].setValue(spsd.getPreparedStatement(false, lcc)==null?null:"[object]");
                 rows.add(dataTemplate.getClone());
             }
 

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Performance_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Performance_IT.java
@@ -138,13 +138,16 @@ public class Trigger_Performance_IT extends SpliceUnitTest {
 
     @Test
     public void testConcurrentTriggersRuntimeUnderLimit() throws Exception {
-        long startTime = System.currentTimeMillis();
         // Make sure spark is warmed up
         if (useSpark) {
             try (ResultSet rs = methodWatcher.executeQuery("select * from sourceTable" +
                 "--splice-properties useSpark=" + useSpark + "\n")) {
             }
+            try (ResultSet rs = methodWatcher.executeQuery("select * from sourceTable" +
+                "--splice-properties useSpark=" + useSpark + "\n")) {
+            }
         }
+        long startTime = System.currentTimeMillis();
         methodWatcher.execute("insert into targetTable --splice-properties useSpark=" + useSpark +
                               "\n select * from sourceTable");
         long endTime = System.currentTimeMillis();

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Performance_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Performance_IT.java
@@ -82,7 +82,6 @@ public class Trigger_Performance_IT extends SpliceUnitTest {
 		spliceClassWatcher.executeUpdate(sqlText);
 		spliceClassWatcher.executeUpdate(sqlText);
 		spliceClassWatcher.executeUpdate(sqlText);
-		spliceClassWatcher.executeUpdate(sqlText);
 
 		spliceClassWatcher.execute(format("call syscs_util.syscs_flush_table('%s', 'sourceTable')", CLASS_NAME));
 

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Performance_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Performance_IT.java
@@ -141,7 +141,7 @@ public class Trigger_Performance_IT extends SpliceUnitTest {
         long startTime = System.currentTimeMillis();
         // Make sure spark is warmed up
         if (useSpark) {
-            try (ResultSet rs = methodWatcher.executeQuery("select * from sys.systables" +
+            try (ResultSet rs = methodWatcher.executeQuery("select * from sourceTable" +
                 "--splice-properties useSpark=" + useSpark + "\n")) {
             }
         }

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Performance_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Performance_IT.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2012 - 2021 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.test.SerialTest;
+import org.junit.*;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import splice.com.google.common.collect.Lists;
+
+import java.sql.ResultSet;
+import java.util.Collection;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test Row Trigger Performance
+ */
+@Category(value = {SerialTest.class})
+@RunWith(Parameterized.class)
+public class Trigger_Performance_IT extends SpliceUnitTest {
+    
+    private Boolean useSpark;
+    private static int numTables = 0;
+    private static boolean isMemPlatform = false;
+    
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        Collection<Object[]> params = Lists.newArrayListWithCapacity(2);
+        params.add(new Object[]{true});
+        params.add(new Object[]{false});
+        return params;
+    }
+    public static final String CLASS_NAME = Trigger_Performance_IT.class.getSimpleName().toUpperCase();
+    protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);
+    protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
+
+    @ClassRule
+    public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
+            .around(spliceSchemaWatcher);
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher(CLASS_NAME);
+    
+    public Trigger_Performance_IT(Boolean useSpark) {
+        this.useSpark = useSpark;
+    }
+
+    @BeforeClass
+    public static void createdSharedTables() throws Exception {
+        spliceClassWatcher.executeUpdate("create table dummyTable(a int, b int)");
+        spliceClassWatcher.executeUpdate("insert into dummyTable values(2,2)");
+
+        spliceClassWatcher.executeUpdate("create table sourceTable(a int, b int)");
+        spliceClassWatcher.executeUpdate("insert into sourceTable values(1,1)");
+
+        spliceClassWatcher.executeUpdate("create table targetTable(a int, b int)");
+
+        String sqlText = "insert into sourceTable select * from sourceTable";
+		spliceClassWatcher.executeUpdate(sqlText);
+		spliceClassWatcher.executeUpdate(sqlText);
+		spliceClassWatcher.executeUpdate(sqlText);
+		spliceClassWatcher.executeUpdate(sqlText);
+		spliceClassWatcher.executeUpdate(sqlText);
+		spliceClassWatcher.executeUpdate(sqlText);
+		spliceClassWatcher.executeUpdate(sqlText);
+		spliceClassWatcher.executeUpdate(sqlText);
+		spliceClassWatcher.executeUpdate(sqlText);
+
+		spliceClassWatcher.execute(format("call syscs_util.syscs_flush_table('%s', 'sourceTable')", CLASS_NAME));
+
+        sqlText = "CREATE TRIGGER Trig%d\n" +
+                "  NO CASCADE\n" +
+                "  BEFORE INSERT ON targetTable\n" +
+                "  REFERENCING NEW AS N\n" +
+                "  FOR EACH ROW\n" +
+                "  WHEN ((N.a NOT IN\n" +
+                "         (SELECT A.a FROM dummyTable A, dummyTable B WHERE A.a = B.a ))\n" +
+                "        AND\n" +
+                "        (N.b NOT IN (SELECT b FROM dummyTable C WHERE C.a = 2)))\n" +
+                "  BEGIN ATOMIC\n" +
+                "    select 1;\n" +
+                "  END";
+        for (int i=0; i < 15; i++)
+            spliceClassWatcher.executeUpdate(format(sqlText, i));
+    }
+
+    @BeforeClass
+    public static void recordNumTables() throws Exception {
+        isMemPlatform = isMemPlatform(spliceClassWatcher);
+        vacuum();
+        numTables = getNumTables();
+    }
+
+    @AfterClass
+    public static void checkNumTables() throws Exception {
+        spliceSchemaWatcher.cleanSchemaObjects();
+        spliceClassWatcher.close();
+        vacuum();
+        int newNumTables = getNumTables();
+        // Mem platform doesn't physically remove dropped tables, so
+        // this is an HBase-only check.
+        if (!isMemPlatform)
+            assertTrue("\nStarted with " + numTables + " tables and ended with " + newNumTables,
+                         numTables >= newNumTables);
+    }
+
+    public static void
+    vacuum() throws Exception{
+        // Mem doesn't have vacuum.
+        if (!isMemPlatform)
+            spliceClassWatcher.executeUpdate("CALL SYSCS_UTIL.VACUUM()");
+    }
+
+    public static int
+    getNumTables() throws Exception{
+        try (ResultSet rs = spliceClassWatcher.executeQuery("CALL SYSCS_UTIL.SYSCS_GET_TABLE_COUNT()")) {
+            rs.next();
+            return ((Integer)rs.getObject(1));
+        }
+    }
+
+    @Test
+    public void testConcurrentTriggersRuntimeUnderLimit() throws Exception {
+        long startTime = System.currentTimeMillis();
+        // Make sure spark is warmed up
+        if (useSpark) {
+            try (ResultSet rs = methodWatcher.executeQuery("select * from sys.systables" +
+                "--splice-properties useSpark=" + useSpark + "\n")) {
+            }
+        }
+        methodWatcher.execute("insert into targetTable --splice-properties useSpark=" + useSpark +
+                              "\n select * from sourceTable");
+        long endTime = System.currentTimeMillis();
+        long runTime = endTime - startTime;
+        assertTrue("Expected runtime to be less than 10 seconds.  Actual time: " + runTime + " milliseconds", runTime < 10000);
+
+    }
+
+}


### PR DESCRIPTION
This fixes poor performance running row triggers on Spark.
For example, in the IT added, the timings for the test run on Spark are:
| Without Fix | With Fix |
| --------- | --------- |
| 42505 ms | 4383 ms |

The changes include:

1. Do not save useSpark session hints active at the time of CREATE TRIGGER into the stored statement.
2. Precompile all triggers during operation initialization, if they are currently invalid, and save their SPSDescriptors in a local cache, which is serialized and sent to the spark executors and set up in LanguageConnectionContext.spsCache.  When marshallTransaction is called to get a new transaction for each concurrent trigger thread, this cache is saved in the LCC for later use.  When caching the SPSDescriptor from the DRDAConnThread, we have to make a shallow clone because it may get invalidated out from under us by other DDL operations or trigger compilations.
3. Update the txnAwareConglomerateCache to be accessed via the LCC instead of the TriggerExecutionContext, and save a single transaction id at the beginning of the operation to be used by all threads.  This transaction isn't used for actual transactional purposes because just keeping this statement's cache entries separate from other statements' entries.  Previously, by using different txn numbers for looking up cache entries in each thread meant we got less cache hits and did more dictionary lookups, so now all threads use the same txn number for the cache lookup and write.
4. Save the defaultRoles and initialDefaultSchemaDescriptor of the LCC at operation initialization time so we don't have to do dictionary lookups to populate these for every firing for a trigger, then pass them as parameters to the new LCC.
5. Make initialization of the trigger internal connection a lazy operation, so we only do it right before we need it in TriggerExecutionContext.
6. Make a new TriggerInfo2 class which contains the trigger table name as a String, so we avoid doing table descriptor lookups (just to get the name) in the executors when doing initialization for each firing of a trigger.
7. Avoid creating a bulk DataSetProcessor for row triggers, because this is too costly of an action to do for every single row.  Use a local DataSetProcessor instead.
8. Avoid building a qualifiersField if we have a zero-length predicate list.
9. BEFORE Row triggers now run concurrently on Spark.  Previously these triggers only ran concurrently on control.
