### PR TITLE
DB-11409 Add command line option -x to specify no headers for sqlshell

### DIFF
--- a/assembly/common/src/main/resources/bin/sqlshell.sh
+++ b/assembly/common/src/main/resources/bin/sqlshell.sh
@@ -43,15 +43,17 @@ show_help() {
    echo -e "\t-f script\t sql file to be executed"
    echo -e "\t-o output\t file for output"
    echo -e "\t-q \t\t quiet mode"
+   echo -e "\t-x \t\t WITHOUT HEADER mode"
 }
 
 HOSTARG=""
 PORTARG=""
 USERARG=""
 PASSARG=""
+ADDITIONAL_IJ_ARGS=""
 
 # Process command line args
-while getopts "U:h:p:u:Qs:PSk:K:w:f:o:q" opt; do
+while getopts "U:h:p:u:Qs:PSk:K:w:f:o:qx" opt; do
    case $opt in
       U)
          URL="${OPTARG}"
@@ -94,6 +96,9 @@ while getopts "U:h:p:u:Qs:PSk:K:w:f:o:q" opt; do
          ;;
       q)
          QUIET=1
+         ;;
+     x)
+         ADDITIONAL_IJ_ARGS="${ADDITIONAL_IJ_ARGS} -Dij.omitHeader=true"
          ;;
       \?)
          show_help
@@ -201,7 +206,7 @@ fi
 
 # Setup IJ_SYS_ARGS based on input options
 GEN_SYS_ARGS="-Djava.awt.headless=true"
-IJ_SYS_ARGS="-Djdbc.drivers=com.splicemachine.db.jdbc.ClientDriver"
+IJ_SYS_ARGS="-Djdbc.drivers=com.splicemachine.db.jdbc.ClientDriver ${ADDITIONAL_IJ_ARGS}"
 
 # add width via ij.maximumDisplayWidth
 if [[ "$WIDTH" != "128" ]]; then

--- a/assembly/common/src/main/resources/bin/winsqlshell.cmd
+++ b/assembly/common/src/main/resources/bin/winsqlshell.cmd
@@ -22,6 +22,7 @@ SET "USERARG="
 SET "PASSARG="
 SET SCRIPT_DIR="%~dp0"
 SET SCRIPT_NAME=%~n0%~x0
+SET "ADDITIONAL_IJ_ARGS="
 
 REM read user arguments
 :loop
@@ -80,6 +81,10 @@ IF NOT [%1] == [] (
     GOTO :loop
   ) ELSE IF "%1" == "-q" (
     SET QUIET=1
+    SHIFT
+    GOTO :loop
+  ) ELSE IF "%1" == "-x" (
+    SET ADDITIONAL_IJ_ARGS=%ADDITIONAL_IJ_ARGS% -Dij.omitHeader^=true
     SHIFT
     GOTO :loop
   ) ELSE (
@@ -189,9 +194,11 @@ REM Setup IJ_SYS_ARGS based on input options
 SET GEN_SYS_ARGS=-Djava.awt.headless^=true
 SET IJ_SYS_ARGS=-Djdbc.drivers^=com.splicemachine.db.jdbc.ClientDriver
 
+SET IJ_SYS_ARGS=%IJ_SYS_ARGS% %ADDITIONAL_IJ_ARGS%
+
 REM add width via ij.maximumDisplayWidth
 IF %WIDTH% NEQ 128 (
-   SET IJ_SYS_ARGS=%IJ_SYS_ARGS% -Dij.maximumDisplayWidth=%WIDTH%
+   SET IJ_SYS_ARGS=%IJ_SYS_ARGS% -Dij.maximumDisplayWidth^=%WIDTH%
 )
 
 IF NOT [%OUTPUT%] == [] (
@@ -262,15 +269,16 @@ REM get directory path from file path
   ECHO  -h host      IP address or hostname of Splice Machine (HBase RegionServer)
   ECHO  -p port      Port which Splice Machine is listening on, defaults to 1527
   ECHO  -u user      username for Splice Machine database
-  ECHO  -Q       Quote the username, e.g. for users with . - or @ in the username. e.g. dept-first.last@@company.com
+  ECHO  -Q           Quote the username, e.g. for users with . - or @ in the username. e.g. dept-first.last@@company.com
   ECHO  -s pass      password for Splice Machine database
-  ECHO  -P       prompt for unseen password
-  ECHO  -S       use ssl=basic on connection
-  ECHO  -k principal     kerberos principal (for kerberos)
+  ECHO  -P           prompt for unseen password
+  ECHO  -S           use ssl=basic on connection
+  ECHO  -k principal kerberos principal (for kerberos)
   ECHO  -K keytab    kerberos keytab - requires principal
   ECHO  -w width     output row width. defaults to 128
   ECHO  -f script    sql file to be executed
   ECHO  -o output    file for output
+  ECHO  -x           WITHOUT HEADER mode
   EXIT /B
 :endhelp
 

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/util.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/util.java
@@ -710,6 +710,14 @@ AppUI.out.println("SIZE="+l);
 		}
 	}
 
+	static boolean getSystemPropertyBoolean(String propertyName) {
+		String s = getSystemProperty(propertyName);
+		if( s == null || s.equalsIgnoreCase("false") || s.equalsIgnoreCase("0"))
+			return false;
+		else
+			return true;
+	}
+
 	private String key;
 
 	public final Object run() {

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/utilMain.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/utilMain.java
@@ -158,12 +158,16 @@ public class utilMain implements java.security.PrivilegedAction {
             commandGrabber[ictr] = new StatementFinder(langUtil.getNewInput(System.in), out, this.terminator);
             connEnv[ictr] = new ConnectionEnv(ictr, (numConnections > 1), (numConnections == 1));
         }
+        initOptions();
+    }
 
+    void initOptions() {
         /* Start with connection/user 0 */
         currCE = 0;
         fileInput = false;
         initialFileInput = false;
         firstRun = true;
+        omitHeader = util.getSystemPropertyBoolean("ij.omitHeader");
     }
 
     /**


### PR DESCRIPTION
# Description
You can now run `sqlshell.sh` or `winsqlshell.cmd` (on windows) with `-x` mode, which is the same as starting sqlshell and then do `WITHOUT HEADER;`.

# How to test
Run any query, e.g. `show tables`. In WITH HEADER mode, you get

```
splice> show tables;
TABLE_SCHEM         |TABLE_NAME                                        |CONGLOM_ID|REMARKS             
-------------------------------------------------------------------------------------------------------
SYS                 |SYSALIASES                                        |288       |                    
...
```

In WITHOUT HEADER mode you get
```
splice> show tables;
SYS                 |SYSALIASES                                        |288       |                    
...
```

By default (on startup of sqlshell, if no WITH or WITHOUT HEADER is executed), sqlshell will use WITH HEADER. If the option `-x` is given to `sqlshell.sh` or `winsqlshell.cmd` (on windows), the startup setting is WITHOUT HEADER.

# getting sqlshell.sh
```
# build
mvn -T 16 clean install -Pcore,cdh6.3.0,sqlshell
# go to target
cd assembly/target/sqlshell
# execute
./sqlshell.sh -x # or no -x
```

That assembly/target/sqlshell directory can also be used for checking windows, e.g.
```
cd assembly/target/sqlshell
winsqlshell.cmd -h mycluster123 -x
```

