### PR TITLE
DB-11267 Fix sqlshell error selecting from sys.systriggers

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -1598,6 +1598,12 @@
                                     </artifactItem>
                                     <artifactItem>
                                       <groupId>com.splicemachine</groupId>
+                                      <artifactId>db-engine</artifactId>
+                                      <version>${project.parent.version}</version>
+                                      <type>jar</type>
+                                    </artifactItem>
+                                    <artifactItem>
+                                      <groupId>com.splicemachine</groupId>
                                       <artifactId>db-tools-ij</artifactId>
                                       <version>${project.parent.version}</version>
                                       <type>jar</type>


### PR DESCRIPTION
'select * from sys.systriggers' doesn't work in the packaged sqlshell.
Need to include the db-engine jar so it can deserialize ReferencedColumnsDescriptorImpl.