### PR TITLE
DB-11400 Fix LTRIM grammar

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -7135,9 +7135,16 @@ trimFunction() throws StandardException :
     ValueNode    trimString = null;
 }
 {
-    trimType = trimType() <LEFT_PAREN> source = additiveExpression(null,0) [<COMMA> trimString = additiveExpression(null,0) ] <RIGHT_PAREN>
+    <RTRIM> <LEFT_PAREN> source = additiveExpression(null,0) [<COMMA> trimString = additiveExpression(null,0) ] <RIGHT_PAREN>
     {
+        trimType = ReuseFactory.getInteger(StringDataValue.TRAILING);
         return getTrimOperatorNode(trimType, trimString, source, trimString != null, null);
+    }
+|
+    <LTRIM> <LEFT_PAREN> source = additiveExpression(null,0) <RIGHT_PAREN>
+    {
+        trimType = ReuseFactory.getInteger(StringDataValue.LEADING);
+        return getTrimOperatorNode(trimType, null, source, null);
     }
 |
     <TRIM> ansiTrimNode = ansiTrim()

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
@@ -553,6 +553,17 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
     }
 
     @Test
+    public void testLTrimNegative() throws Exception{
+        try {
+            String sqlText = "values LTRIM('XXXXKATEXXXXXX', 'X')";
+            methodWatcher.executeQuery(sqlText);
+            Assert.fail("Query is expected to fail with syntax error!");
+        } catch (SQLSyntaxErrorException e) {
+            Assert.assertEquals(SQLState.LANG_SYNTAX_ERROR, e.getSQLState());
+        }
+    }
+
+    @Test
     public void testRepeatNegative() throws Exception {
         try {
             String sqlText = "select repeat(a, 3) from A order by 1";


### PR DESCRIPTION
LTRIM with a 2nd parameter is not supported and should throw a syntax error.
Regression of DB-11118.