### PR TITLE
DB-11405 Fix 'Unable to generate code' error with multiple subqueries

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QueryTreeNodeVector.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QueryTreeNodeVector.java
@@ -69,6 +69,11 @@ abstract class QueryTreeNodeVector<T extends QueryTreeNode> extends QueryTreeNod
         v.add(qt);
     }
 
+    public final void addElementIfNotPresent(T qt){
+        if (!v.contains(qt))
+            v.add(qt);
+    }
+
     public final void removeElementAt(int index){
         v.remove(index);
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryList.java
@@ -49,7 +49,7 @@ public class SubqueryList extends QueryTreeNodeVector<SubqueryNode>{
      */
 
     public void addSubqueryNode(SubqueryNode subqueryNode) throws StandardException {
-        addElement(subqueryNode);
+        addElementIfNotPresent(subqueryNode);
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
@@ -190,7 +190,6 @@ public class SubqueryNode extends ValueNode{
     protected int resultSetNumber=-1;
 
     private boolean hintNotFlatten=false;
-    private boolean thisSubqueryAddedToSubqueryList = false;
 
     /**
      * Initializer.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
@@ -689,10 +689,7 @@ public class SubqueryNode extends ValueNode{
         setDataTypeServices(resultColumns);
 
         /* Add this subquery to the subquery list */
-        if (!thisSubqueryAddedToSubqueryList) {
-            subqueryList.addSubqueryNode(this);
-            thisSubqueryAddedToSubqueryList = true;
-        }
+        subqueryList.addSubqueryNode(this);
 
         cc.popCurrentPrivType();
         return this;

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Exists_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Exists_IT.java
@@ -873,6 +873,22 @@ public class Subquery_Flattening_Exists_IT {
         rs.close();
     }
 
+    @Test
+    public void test_DB_11405() throws Exception {
+            String R = "1 |\n" +
+                        "----\n" +
+                        "14 |";
+
+            /* subquery selects constant */
+            assertUnorderedResult(conn(), "values (\n" +
+                "    nullif(\n" +
+                "        case when\n" +
+                "            EXISTS (select C1 from C where EXISTS (select A1 from A))\n" +
+                "        then 14 end,\n" +
+                "        4)\n" +
+                ")", THREE_SUBQUERY_NODES, R);
+     }
+
     private TestConnection conn() {
         return methodWatcher.getOrCreateConnection();
     }

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Exists_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_Exists_IT.java
@@ -886,7 +886,7 @@ public class Subquery_Flattening_Exists_IT {
                 "            EXISTS (select C1 from C where EXISTS (select A1 from A))\n" +
                 "        then 14 end,\n" +
                 "        4)\n" +
-                ")", THREE_SUBQUERY_NODES, R);
+                ")", TWO_SUBQUERY_NODES, R);
      }
 
     private TestConnection conn() {

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_InList_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_InList_IT.java
@@ -405,7 +405,7 @@ public class Subquery_Flattening_InList_IT extends SpliceUnitTest {
                 "            UNION " +
                 "            SELECT b1+b1 FROM B ))";
         assertUnorderedResult(methodWatcher.getOrCreateConnection(),
-                              sql , TWO_SUBQUERY_NODES, expected );
+                              sql , ONE_SUBQUERY_NODE, expected );
         expected =
             "A1 |A2 |\n" +
             "--------\n" +
@@ -452,7 +452,7 @@ public class Subquery_Flattening_InList_IT extends SpliceUnitTest {
                 "            UNION " +
                 "            SELECT -b1 FROM B ))";
         assertUnorderedResult(methodWatcher.getOrCreateConnection(),
-                              sql , TWO_SUBQUERY_NODES, expected );
+                              sql , ONE_SUBQUERY_NODE, expected );
 
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_InList_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_InList_IT.java
@@ -405,7 +405,7 @@ public class Subquery_Flattening_InList_IT extends SpliceUnitTest {
                 "            UNION " +
                 "            SELECT b1+b1 FROM B ))";
         assertUnorderedResult(methodWatcher.getOrCreateConnection(),
-                              sql , ONE_SUBQUERY_NODE, expected );
+                              sql , TWO_SUBQUERY_NODES, expected );
         expected =
             "A1 |A2 |\n" +
             "--------\n" +
@@ -452,7 +452,7 @@ public class Subquery_Flattening_InList_IT extends SpliceUnitTest {
                 "            UNION " +
                 "            SELECT -b1 FROM B ))";
         assertUnorderedResult(methodWatcher.getOrCreateConnection(),
-                              sql , ONE_SUBQUERY_NODE, expected );
+                              sql , TWO_SUBQUERY_NODES, expected );
 
     }
 


### PR DESCRIPTION
### Description
DB-10774 modified the binding code to only add a SubqueryNode once to a subqueryList in an effort to bind the subquery only once in a given subtree.  The problem is there could be different subtrees that maintain their own subqueryList and they reference that SubqueryNode as well.  The SubqueryNode should be added to those other subqueryLists as well, but since the new flag thisSubqueryAddedToSubqueryList is now false, we fail to do so.

example query:

> insert into B values (
>     nullif(
>         case when
>             EXISTS (select C1 from C where EXISTS (select A1 from A))
>         then 14 end,
>         4)
> );

ERROR 42Z50: INTERNAL ERROR: Unable to generate code for
com.splicemachine.db.impl.sql.compile.SelectNode@45eb0df

### Fix
The fix is to add the SubqueryNode to subqueryList, but only if it is not already present in the list.  The thisSubqueryAddedToSubqueryList flag is removed.