### PR TITLE
DB-11433 fix start-splice.sh use of BSD nc (3.0)

### DIFF
--- a/assembly/standalone/template/bin/functions.sh
+++ b/assembly/standalone/template/bin/functions.sh
@@ -154,3 +154,13 @@ _startKafka() {
 
 }
 
+function is_port_open
+{
+  host1=$1
+  port2=$2
+  # note there's two versions of nc: GNU and OpenBSD
+  # OpenBSD supports -z (only check port), but GNU not.
+  # GNU would work with 'exit', OpenBSD needs 'exit\n'
+  # this one works in both and on mac
+  echo 'exit\n' | nc ${host1} ${port2} > /dev/null 2> /dev/null
+}

--- a/assembly/standalone/template/bin/start-splice.sh
+++ b/assembly/standalone/template/bin/start-splice.sh
@@ -38,11 +38,11 @@ IN_MEM_PROFILE="mem"
 RUN_DIR="${BASE_DIR}/log"
 
 if [ ! -d $RUN_DIR ]; then
-	mkdir -p $RUN_DIR
+    mkdir -p $RUN_DIR
 fi
 
 if [ ! -d $BASE_DIR/db ]; then
-	mkdir -p $BASE_DIR/db
+    mkdir -p $BASE_DIR/db
 fi
 
 chmod -R 777 $BASE_DIR/demodata
@@ -161,7 +161,7 @@ HBASE_ROOT_DIR_URI="${BASE_DIR}/db/hbase"
 _startSplice "${BASE_DIR}" "${SPLICE_LOG}" "${LOG4J_FILE}" "${HBASE_ROOT_DIR_URI}" "${CP}"
 
 echo -n "  Waiting. "
- while ! echo exit | nc localhost 1527; do echo -n ". " ; sleep 5; done
+until is_port_open localhost 1527; do echo -n ". " ; sleep 2; done
 echo
 
 echo "done."


### PR DESCRIPTION
This fixes nc hangs on Ubuntu 18.04 with the BSD version of nc.
We are using the same code we added in DB-9930 to ./start-splice-cluster. This runs on Mac, BSD and GNU versions of netcat (nc).