### PR TITLE
DB-11434 fix escaping table name in DESCRIBE (redux)

### DIFF
--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijCommands.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijCommands.java
@@ -486,8 +486,8 @@ public class ijCommands {
      * Verify that a table exists within a schema. Throws an exception
      * if table does not exist.
      *
-     * @param schema Schema for the table
-     * @param table  Name of table to check for existence of
+     * @param schema Schema name pattern for the table (properly escaped)
+     * @param table  Table name pattern to check for existence of (properly escaped)
      */
     public void verifyTableExists(String schema, String table)
             throws SQLException {
@@ -522,8 +522,9 @@ public class ijCommands {
         ResultSet rs = null;
         try {
             haveConnection();
-            verifyTableExists(schema,table);
-
+            String escapedSchema = Utils.escape(schema);
+            String escapedTable = Utils.escape(table);
+            verifyTableExists(escapedSchema, escapedTable);
             DatabaseMetaData dbmd = theConnection.getMetaData();
 
             //Check if it's a synonym table
@@ -532,8 +533,10 @@ public class ijCommands {
                     Utils.defaultEscapeCharacter, Utils.defaultEscapeCharacter);
 
             PreparedStatement s = theConnection.prepareStatement(getSynonymAliasInfo);
-            s.setString(1, Utils.escape(schema));
-            s.setString(2, Utils.escape(table));
+
+            s.setString(1, escapedSchema);
+
+            s.setString(2, escapedTable);
             rs = s.executeQuery();
 
             if (rs.next()){
@@ -545,7 +548,7 @@ public class ijCommands {
             }
 
             if(hasServerLikeFix())
-                rs = dbmd.getColumns(null,Utils.escape(schema),Utils.escape(table),null);
+                rs = dbmd.getColumns(null, escapedSchema, escapedTable, null);
             else
                 rs = dbmd.getColumns(null,schema,table,null);
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/DatabaseMetaDataTestIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/DatabaseMetaDataTestIT.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.derby.test;
 
+import com.splicemachine.db.shared.common.sql.Utils;
 import com.splicemachine.derby.test.framework.*;
 import org.apache.commons.dbutils.DbUtils;
 import org.apache.log4j.Logger;
@@ -22,6 +23,8 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 import java.sql.*;
+import java.util.HashMap;
+import java.util.Map;
 
 public class DatabaseMetaDataTestIT {
 
@@ -66,6 +69,14 @@ public class DatabaseMetaDataTestIT {
     private static SpliceTableWatcher spliceTableWatcher5 = new SpliceTableWatcher("aZb", spliceSchemaWatcher.schemaName, "(incorrect int)");
     private static SpliceTableWatcher spliceTableWatcher6 = new SpliceTableWatcher("\"A%B\"", spliceSchemaWatcher.schemaName, "(incorrect int)");
     private static SpliceTableWatcher spliceTableWatcher7 = new SpliceTableWatcher("\"A\\B\"", spliceSchemaWatcher.schemaName, "(incorrect int)");
+
+    private static SpliceTableWatcher spliceTableWatcher8  = new SpliceTableWatcher("\"TEMP  _TABLE\"", spliceSchemaWatcher.schemaName, "(R8 int)");
+    private static SpliceTableWatcher spliceTableWatcher9  = new SpliceTableWatcher("\"TEMP ESCAPE '\\\\' TABLE\"", spliceSchemaWatcher.schemaName, "(R9 int)");
+    private static SpliceTableWatcher spliceTableWatcher10 = new SpliceTableWatcher("\"\\'TEMPTABLE\\'\"", spliceSchemaWatcher.schemaName, "(R10 int)");
+    private static SpliceTableWatcher spliceTableWatcher11 = new SpliceTableWatcher("\"TEMP\\TABLE\"", spliceSchemaWatcher.schemaName, "(R11 int)");
+    private static SpliceTableWatcher spliceTableWatcher12 = new SpliceTableWatcher("\"TEE%SSS\"", spliceSchemaWatcher.schemaName, "(R13 int)");
+    private static SpliceTableWatcher spliceTableWatcher13 = new SpliceTableWatcher("\"TEE%SSSS\"", spliceSchemaWatcher.schemaName, "(R14 int)");
+
     private static SpliceProcedureWatcher spliceProcedureWatcher1 = new SpliceProcedureWatcherWithCustomDrop("a_b", spliceSchemaWatcher.schemaName, "(correct varchar(2)) EXTERNAL NAME 'bla.returnsNothing' LANGUAGE JAVA PARAMETER STYLE JAVA");
     private static SpliceProcedureWatcher spliceProcedureWatcher2 = new SpliceProcedureWatcherWithCustomDrop("aXb", spliceSchemaWatcher.schemaName, "(incorrect varchar(2)) EXTERNAL NAME 'bla.returnsNothing' LANGUAGE JAVA PARAMETER STYLE JAVA");
     private static SpliceProcedureWatcher spliceProcedureWatcher3 = new SpliceProcedureWatcherWithCustomDrop("aYb", spliceSchemaWatcher.schemaName, "(incorrect varchar(2)) EXTERNAL NAME 'bla.returnsNothing' LANGUAGE JAVA PARAMETER STYLE JAVA");
@@ -83,6 +94,12 @@ public class DatabaseMetaDataTestIT {
             .around(spliceTableWatcher5)
             .around(spliceTableWatcher6)
             .around(spliceTableWatcher7)
+            .around(spliceTableWatcher8)
+            .around(spliceTableWatcher9)
+            .around(spliceTableWatcher10)
+            .around(spliceTableWatcher11)
+            .around(spliceTableWatcher12)
+            .around(spliceTableWatcher13)
             .around(spliceProcedureWatcher1)
             .around(spliceProcedureWatcher2)
             .around(spliceProcedureWatcher3)
@@ -138,6 +155,31 @@ public class DatabaseMetaDataTestIT {
         try(ResultSet rs = dmd.getColumns(null, spliceSchemaWatcher.schemaName, "A\\_B" /* simulating what ij.jj would do */, null)) {
             Assert.assertTrue(rs.next());
             Assert.assertEquals("CORRECT", rs.getString(4));
+            Assert.assertFalse(rs.next());
+        }
+    }
+
+    @Test
+    public void testDescribeTableWithQuoting() throws Exception {
+        Map<String, String> columns  = new HashMap();
+        columns.put("TEMP  _TABLE", "R8");
+        columns.put("TEMP ESCAPE '\\\\' TABLE", "R9");
+        columns.put("\\'TEMPTABLE\\'", "R10");
+        columns.put("TEMP\\TABLE", "R11");
+        columns.put("TEE%SSS", "R13");
+        columns.put("TEE%SSSS", "R14");
+
+        for(Map.Entry<String, String> entry : columns.entrySet()) {
+            verifyColumn(entry.getKey(), entry.getValue());
+        }
+    }
+
+    private void verifyColumn(String tableName, String columnName) throws SQLException {
+        TestConnection conn=methodWatcher.getOrCreateConnection();
+        DatabaseMetaData dmd=conn.getMetaData();
+        try(ResultSet rs = dmd.getColumns(null, spliceSchemaWatcher.schemaName, Utils.escape(tableName) /* simulating what ij.jj would do */, null)) {
+            Assert.assertTrue(rs.next());
+            Assert.assertEquals(columnName, rs.getString(4));
             Assert.assertFalse(rs.next());
         }
     }


### PR DESCRIPTION
Fix issues discovered by @dyang-splice in QA of DB-10890.

QA showed that if a table name contained escape or placeholder characters such as `\`, `_`, or `%` then `DESCRIBE` wasn't working as expected. The issue was not in `DESCRIBE` itself but in sqlshell's usage of a method that verifies the table exists, this method wasn't escaping the table name properly, now this is fixed.

Some test cases that were not working but now working (thanks @dyang-splice for providing those):

```
create table "TEMP  _TABLE"(j int);
create table "TEMP ESCAPE '\\' TABLE"(k int);
create table "\'TEMPTABLE\'"(p int);
create table "TEMP\TABLE"(q int);
create table "tee%sss"(X int);
create table "TEE%SSS"(Y int);
create table "TEE%SSSS"(z int);

describe  "TEMP  _TABLE"(j int);
describe  "TEMP ESCAPE '\\' TABLE";
describe  "\'TEMPTABLE\'";
describe  "TEMP\TABLE";
describe  "tee%sss";
describe  "TEE%SSS";
describe  "TEE%SSSS";
```