### PR TITLE
DB-11129 Implement POSSTR function

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/ast/ISpliceVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/ast/ISpliceVisitor.java
@@ -155,6 +155,7 @@ public interface ISpliceVisitor {
     Visitable visit(OrderedColumnList node) throws StandardException;
     Visitable visit(OrNode node) throws StandardException;
     Visitable visit(ParameterNode node) throws StandardException;
+    Visitable visit(PosStrOperatorNode node) throws StandardException;
     Visitable visit(Predicate node) throws StandardException;
     Visitable visit(PredicateList node) throws StandardException;
     Visitable visit(PrivilegeNode node) throws StandardException;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/C_NodeTypes.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/C_NodeTypes.java
@@ -296,9 +296,10 @@ public interface C_NodeTypes
     int DAYS_FUNCTION_NODE = 282;
     int SECOND_FUNCTION_NODE = 283;
     int MULTIPLY_ALT_FUNCTION_NODE = 284;
+    int POSSTR_OPERATOR_NODE = 285;
 
     // Final value in set, keep up to date!
-    int FINAL_VALUE = MULTIPLY_ALT_FUNCTION_NODE;
+    int FINAL_VALUE = POSSTR_OPERATOR_NODE;
 
     /**
      * Extensions to this interface can use nodetypes > MAX_NODE_TYPE with out fear of collision

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLChar.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLChar.java
@@ -2946,6 +2946,33 @@ public class SQLChar
         return result;
     }
 
+    public NumberDataValue positionOfString(StringDataValue leftOperand, StringDataValue rightOperand,
+                                            NumberDataValue result)
+            throws StandardException
+    {
+        if (result == null)
+        {
+            result = (NumberDataValue) getNewNull();
+        }
+
+        if (leftOperand == null || leftOperand.isNull() || leftOperand.getString() == null)
+        {
+            result.setToNull();
+            return result;
+        }
+
+        if (rightOperand == null || rightOperand.isNull() || rightOperand.getString() == null) {
+            result.setToNull();
+            return result;
+        }
+
+        String searchString = rightOperand.getString();
+        String expression = leftOperand.getString();
+        int position = expression.indexOf(searchString) + 1;
+
+        return new SQLInteger(position);
+    }
+
     public StringDataValue upperWithLocale(StringDataValue leftOperand, StringDataValue rightOperand,
                                                 StringDataValue result)
             throws StandardException

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/StringDataValue.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/StringDataValue.java
@@ -208,7 +208,9 @@ public interface StringDataValue extends ConcatableDataValue
 	 * Find the position of the searchString in an expressionString
 	 * @param expressionString The string to search
 	 * @param searchString  The substring to search for
-	 * @return 0 if not found, otherwise the 1-based position of the first character in the match
+	 * @return 0 if not found,
+	 *         null if either operand is null,
+	 *         otherwise the 1-based position of the first character in the match
 	 * @throws StandardException Thrown on error
 	 */
     NumberDataValue positionOfString(StringDataValue expressionString, StringDataValue searchString,

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/StringDataValue.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/StringDataValue.java
@@ -205,6 +205,15 @@ public interface StringDataValue extends ConcatableDataValue
 							throws StandardException;
 
 	/**
+	 * Find the position of the searchString in an expressionString
+	 * @param expressionString The string to search
+	 * @param searchString  The substring to search for
+	 * @return 0 if not found, otherwise the 1-based position of the first character in the match
+	 * @throws StandardException Thrown on error
+	 */
+    NumberDataValue positionOfString(StringDataValue expressionString, StringDataValue searchString,
+                                     NumberDataValue result) throws StandardException;
+	/**
 	 * Covert the string to lower case with specified locale.
 	 * @param str The string
 	 * @param locale  The locale

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/AbstractSpliceVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/AbstractSpliceVisitor.java
@@ -592,6 +592,11 @@ public abstract class AbstractSpliceVisitor implements ISpliceVisitor {
     }
 
     @Override
+    public Visitable visit(PosStrOperatorNode node) throws StandardException {
+        return defaultVisit(node);
+    }
+
+    @Override
     public Visitable visit(Predicate node) throws StandardException {
         return defaultVisit(node);
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryOperatorNode.java
@@ -119,6 +119,7 @@ public class BinaryOperatorNode extends OperatorNode
     public final static int REPEAT = 2;
     public final static int SIMPLE_LOCALE_STRING = 3;
     public final static int MULTIPLY_ALT = 3;
+    public final static int POSSTR = 4;
 
     // NOTE: in the following 4 arrays, order
     // IS important.
@@ -540,7 +541,7 @@ public class BinaryOperatorNode extends OperatorNode
     public boolean leftIsReceiver() throws StandardException {
         return (getLeftOperand().getTypeId().typePrecedence() >
                 getRightOperand().getTypeId().typePrecedence() ||
-                operatorType == REPEAT || operatorType == SIMPLE_LOCALE_STRING);
+                operatorType == REPEAT || operatorType == SIMPLE_LOCALE_STRING || operatorType == POSSTR);
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/C_NodeNames.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/C_NodeNames.java
@@ -222,6 +222,8 @@ public interface C_NodeNames
 
     String PARAMETER_NODE_NAME = "com.splicemachine.db.impl.sql.compile.ParameterNode";
 
+    String POSSTR_STRING_OPERATOR_NODE_NAME = "com.splicemachine.db.impl.sql.compile.PosStrOperatorNode";
+
     String PREDICATE_NAME = "com.splicemachine.db.impl.sql.compile.Predicate";
 
     String PREDICATE_LIST_NAME = "com.splicemachine.db.impl.sql.compile.PredicateList";

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
@@ -494,6 +494,13 @@ public class OperatorToString {
                     return format("concat(%s, %s) ", leftOperandString,
                                                      rightOperandString);
                 }
+                else if (operand instanceof PosStrOperatorNode) {
+                    throwNotImplementedError();
+                    // TODO: Position does not seem to work in
+                    //       native spark. Try to enable this later.
+                    return format("position(%s, %s) ", leftOperandString,
+                                                     rightOperandString);
+                }
                 else if (operand instanceof TruncateOperatorNode) {
                     if (vars.buildExpressionTree)
                         throwNotImplementedError();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
@@ -495,11 +495,10 @@ public class OperatorToString {
                                                      rightOperandString);
                 }
                 else if (operand instanceof PosStrOperatorNode) {
-                    throwNotImplementedError();
-                    // TODO: Position does not seem to work in
-                    //       native spark. Try to enable this later.
-                    return format("position(%s, %s) ", leftOperandString,
-                                                     rightOperandString);
+                    if (vars.buildExpressionTree)
+                        throwNotImplementedError();
+                    return format("position(%s, %s) ", rightOperandString,
+                                                     leftOperandString);
                 }
                 else if (operand instanceof TruncateOperatorNode) {
                     if (vars.buildExpressionTree)

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PosStrOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PosStrOperatorNode.java
@@ -1,0 +1,191 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2020 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.ClassName;
+import com.splicemachine.db.iapi.reference.Limits;
+import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
+import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+import com.splicemachine.db.iapi.types.TypeId;
+
+import java.sql.Types;
+import java.util.List;
+
+/**
+ * This node represents a binary upper or lower operator with loccale
+ *
+ */
+
+public class PosStrOperatorNode extends BinaryOperatorNode
+{
+    /**
+     * Initializer for a PosStrOperatorNode
+     *
+     * @param leftOperand        The expression
+     * @param rightOperand        The search string
+     */
+
+    public void init(Object leftOperand, Object rightOperand)
+    {
+        super.init(leftOperand, rightOperand, "positionOfString", "positionOfString", ClassName.StringDataValue,
+                ClassName.StringDataValue, ClassName.NumberDataValue, POSSTR);
+    }
+
+    private void castToVarChar(ValueNode operand, boolean isLeft) throws StandardException {
+        /*
+        ** Check the type of the operand - this function is allowed only on
+        ** string value (char and bit) types.
+        */
+        TypeId operandType = operand.getTypeId();
+
+        int operandWidth = operand.getTypeCompiler().getCastToCharWidth(
+                operand.getTypeServices(), getCompilerContext());
+        if (operandWidth > Limits.DB2_LOB_MAXWIDTH / 2) {
+            throw StandardException.newException(SQLState.BLOB_LENGTH_TOO_LONG, methodName,
+                    operandWidth * 2);
+        }
+        int width = operandWidth * 2;
+
+        switch (operandType.getJDBCTypeId())
+        {
+                case Types.CHAR:
+                case Types.VARCHAR:
+                case Types.LONGVARCHAR:
+                case Types.CLOB:
+                    operandType = getResultType(width, operandType);
+                    break;
+                case Types.JAVA_OBJECT:
+                case Types.OTHER:
+                {
+                    throw StandardException.newException(SQLState.LANG_UNARY_FUNCTION_BAD_TYPE,
+                                        methodName,
+                                        operandType.getSQLTypeName());
+                }
+
+                default:
+                    operandType = getResultType(width, TypeId.getBuiltInTypeId(TypeId.VARCHAR_NAME));
+                    DataTypeDescriptor dtd = DataTypeDescriptor.getBuiltInDataTypeDescriptor(
+                            operandType.getJDBCTypeId(),
+                            true,
+                            width);
+
+                    ValueNode castNode = (ValueNode)
+                        getNodeFactory().getNode(
+                            C_NodeTypes.CAST_NODE,
+                            operand,
+                            dtd,
+                            getContextManager());
+                    castNode.setCollationUsingCompilationSchema();
+                    ((CastNode) castNode).bindCastNodeOnly();
+
+                    if (isLeft)
+                        setLeftOperand(castNode);
+                    else
+                        setRightOperand(castNode);
+        }
+
+    }
+
+    /**
+     * Get the result type give the width. It will cast the value to a new type if the width exceed current type's
+     * width limit.
+     * @param width The width
+     * @param defaultType The original type. Must be one of CLOB, LONGVARCHAR, VARCHAR, CHAR
+     * @return The casted type.
+     */
+    private TypeId getResultType(int width, TypeId defaultType) {
+        int type = defaultType.getJDBCTypeId();
+        if (type == Types.CLOB || width > Limits.DB2_LONGVARCHAR_MAXWIDTH) {
+            return TypeId.getBuiltInTypeId(TypeId.CLOB_NAME);
+        }
+        if (type == Types.LONGVARCHAR || width > Limits.DB2_VARCHAR_MAXWIDTH) {
+            return TypeId.getBuiltInTypeId(TypeId.LONGVARCHAR_NAME);
+        }
+        if (type == Types.VARCHAR || width > Limits.DB2_CHAR_MAXWIDTH) {
+            return TypeId.getBuiltInTypeId(TypeId.VARCHAR_NAME);
+        }
+        return defaultType;
+    }
+
+    /**
+     * Bind this operator
+     *
+     * @param fromList            The query's FROM list
+     * @param subqueryList        The subquery list being built as we find SubqueryNodes
+     * @param aggregateVector    The aggregate vector being built as we find AggregateNodes
+     *
+     * @return    The new top of the expression tree.
+     *
+     * @exception StandardException        Thrown on error
+     */
+    @Override
+    public ValueNode bindExpression(FromList fromList,
+                                    SubqueryList subqueryList,
+                                    List<AggregateNode> aggregateVector) throws StandardException {
+        bindOperands(fromList, subqueryList, aggregateVector);
+
+        if( getLeftOperand().requiresTypeFromContext())
+        {
+            getLeftOperand().setType(new DataTypeDescriptor(TypeId.getBuiltInTypeId(Types.VARCHAR), true));
+            getLeftOperand().setCollationUsingCompilationSchema();
+        }
+
+        if( getRightOperand().requiresTypeFromContext())
+        {
+            getRightOperand().setType(new DataTypeDescriptor(TypeId.getBuiltInTypeId(Types.VARCHAR), false));
+            getRightOperand().setCollationUsingCompilationSchema();
+        }
+
+        castToVarChar(getLeftOperand(), true);
+        castToVarChar(getRightOperand(), false);
+
+        setType( new DataTypeDescriptor( TypeId.getBuiltInTypeId( Types.INTEGER), true));
+
+        return this;
+    }
+
+    /**
+     * This is a length operator node.  Overrides this method
+     * in UnaryOperatorNode for code generation purposes.
+     */
+    public String getReceiverInterfaceName() {
+        return ClassName.StringDataValue;
+    }
+
+    @Override
+    public double getBaseOperationCost() throws StandardException {
+        double localCost = SIMPLE_OP_COST * Math.min(getLeftOperand().getTypeServices().getNull().getLength(), 64);
+        return localCost + SIMPLE_OP_COST * FN_CALL_COST_FACTOR + super.getBaseOperationCost();
+    }
+}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PosStrOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PosStrOperatorNode.java
@@ -83,7 +83,6 @@ public class PosStrOperatorNode extends BinaryOperatorNode
                 case Types.VARCHAR:
                 case Types.LONGVARCHAR:
                 case Types.CLOB:
-                    operandType = getResultType(width, operandType);
                     break;
                 case Types.JAVA_OBJECT:
                 case Types.OTHER:

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -1899,6 +1899,7 @@ TOKEN [IGNORE_CASE] :
 |   <PHYSICAL: "physical">
 |    <PLAIN: "plain">
 |    <PLI: "pli">
+|   <POSSTR: "posstr">
 |    <PRECISION: "precision">
 |   <RECURSIVE: "recursive">
 |    <RELEASE: "release">
@@ -7104,6 +7105,17 @@ characterValueFunction() throws StandardException :
         }
     }
 |
+    /* POSSTR(stringExpression, searchString) */
+    <POSSTR> <LEFT_PAREN> str1 = additiveExpression(null,0) <COMMA>
+            str2 = additiveExpression(null,0) <RIGHT_PAREN>
+    {
+        return (ValueNode) nodeFactory.getNode(
+                            C_NodeTypes.POSSTR_OPERATOR_NODE,
+                            str1,
+                            str2,
+                            getContextManager());
+    }
+|
     /* REPEAT(string, num) */
     <REPEAT> <LEFT_PAREN> str1 = additiveExpression(null,0) <COMMA>
             str2 = additiveExpression(null,0) <RIGHT_PAREN>
@@ -7542,6 +7554,7 @@ miscBuiltins() throws StandardException :
                 getToken(1).kind == MONTHNAME ||
                 getToken(1).kind == MULTIPLY_ALT ||
                 getToken(1).kind == NVL ||
+                getToken(1).kind == POSSTR ||
                 getToken(1).kind == QUARTER ||
                 getToken(1).kind == REPEAT ||
                 getToken(1).kind == REPLACE ||
@@ -17527,6 +17540,7 @@ nonReservedKeyword()  :
     |   tok = <PERCENTWORD>
     |    tok = <PLAIN>
     |    tok = <PLI>
+    |    tok = <POSSTR>
     |    tok = <PRECISION>
     |    tok = <PROPERTIES>
     |    tok = <PURGE>

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceNodeFactoryImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceNodeFactoryImpl.java
@@ -304,6 +304,9 @@ public class SpliceNodeFactoryImpl extends NodeFactory implements ModuleControl,
             case C_NodeTypes.USERTYPE_CONSTANT_NODE:
                 return C_NodeNames.USERTYPE_CONSTANT_NODE_NAME;
 
+            case C_NodeTypes.POSSTR_OPERATOR_NODE:
+                return C_NodeNames.POSSTR_STRING_OPERATOR_NODE_NAME;
+
             case C_NodeTypes.PREDICATE:
                 return C_NodeNames.PREDICATE_NAME;
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
@@ -465,45 +465,17 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
     }
 
     @Test
-    public void testPosStrFunction() throws Exception {
-	    String expected = "B        |     C      |  3  |\n" +
-                        "------------------------------------\n" +
-                        "    Bam Bam     |Bam Bam Bam |  0  |\n" +
-                        " Barney Rubble  |   Wilma    |  0  |\n" +
-                        "     Betty      |            |  1  |\n" +
-                        "Fred Flintstone |     F      |  5  |\n" +
-                        "Fred Flintstone |   Flint    |  6  |\n" +
-                        "Fred Flintstone |Flintstone  |  6  |\n" +
-                        "Fred Flintstone |   Fred     |  1  |\n" +
-                        "Fred Flintstone |  stoner    |  0  |\n" +
-                        "     NULL       |   NULL     |NULL |";
+    public void testPosStrFunction() throws Exception  {
+        String[] joins = {"nestedloop", "sortmerge", "broadcast"};
+        for (String join:joins) {
+            testPosStrFunctionHelper(false, join);
+            testPosStrFunctionHelper(true, join);
+        }
 
-	    String query = "SELECT b, c, POSSTR(b, c) from " + tableWatcherB;
-	    testQuery(query, expected, methodWatcher);
-
-        expected = "A   |  C   | 3 |\n" +
-                    "-------------------\n" +
-                    "       |      | 1 |\n" +
-                    "       |      | 1 |\n" +
-                    "  CVS  | CVS  | 1 |\n" +
-                    " Zicam | Zi   | 1 |\n" +
-                    "  aaa  |      | 1 |\n" +
-                    "  aaa  | aaa  | 1 |\n" +
-                    " ab c  |      | 1 |\n" +
-                    "  abc  |      | 1 |\n" +
-                    "  abc  | ab   | 1 |\n" +
-                    "  abc  | abc  | 1 |\n" +
-                    "  abc  | abc  | 1 |\n" +
-                    " abc g |abc g | 1 |\n" +
-                    "abcabc |      | 1 |";
-
-	    query = "SELECT a, c, POSSTR(a, c) from " + tableWatcherK;
-	    testQuery(query, expected, methodWatcher);
-
-	    query = "Values(POSSTR(cast(null as char(3)), ''))";
-	    expected = "1  |\n" +
-                    "------\n" +
-                    "NULL |";
+	    String query = "Values(POSSTR(cast(null as char(3)), ''))";
+	    String expected = "1  |\n" +
+                            "------\n" +
+                            "NULL |";
         testQuery(query, expected, methodWatcher);
 	    query = "Values(POSSTR(cast(null as char(3)), cast(null as char(3))))";
         testQuery(query, expected, methodWatcher);
@@ -533,6 +505,44 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
                     " 6 |";
 	    query = "Values(POSSTR('bcabCabc', 'abc'))";
         testQuery(query, expected, methodWatcher);
+    }
+
+    private void testPosStrFunctionHelper(boolean useSpark, String strategy) throws Exception {
+	    String expected = "B        |     C      |  3  |\n" +
+                        "------------------------------------\n" +
+                        "    Bam Bam     |Bam Bam Bam |  0  |\n" +
+                        " Barney Rubble  |   Wilma    |  0  |\n" +
+                        "     Betty      |            |  1  |\n" +
+                        "Fred Flintstone |     F      |  5  |\n" +
+                        "Fred Flintstone |   Flint    |  6  |\n" +
+                        "Fred Flintstone |Flintstone  |  6  |\n" +
+                        "Fred Flintstone |   Fred     |  1  |\n" +
+                        "Fred Flintstone |  stoner    |  0  |\n" +
+                        "     NULL       |   NULL     |NULL |";
+
+	    String query = "SELECT a.b, a.c, POSSTR(a.b, a.c) from " + tableWatcherB + format(" a --splice-properties joinStrategy=%s,useSpark=", strategy) + useSpark +
+                    "\n, " + tableWatcherB + " b where a.a = b.a";
+	    testQuery(query, expected, methodWatcher);
+
+        expected = "A   |  C   | 3 |\n" +
+                    "-------------------\n" +
+                    "       |      | 1 |\n" +
+                    "       |      | 1 |\n" +
+                    "  CVS  | CVS  | 1 |\n" +
+                    " Zicam | Zi   | 1 |\n" +
+                    "  aaa  |      | 1 |\n" +
+                    "  aaa  | aaa  | 1 |\n" +
+                    " ab c  |      | 1 |\n" +
+                    "  abc  |      | 1 |\n" +
+                    "  abc  | ab   | 1 |\n" +
+                    "  abc  | abc  | 1 |\n" +
+                    "  abc  | abc  | 1 |\n" +
+                    " abc g |abc g | 1 |\n" +
+                    "abcabc |      | 1 |";
+
+	    query = "SELECT a.a, a.c, POSSTR(a.a, a.c) from " + tableWatcherK + format(" a --splice-properties joinStrategy=%s,useSpark=", strategy) + useSpark +
+                    "\n, " + tableWatcherK + " b where a.a = b.a and a.b = b.b";
+	    testQuery(query, expected, methodWatcher);
     }
 
     @Test

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
@@ -465,6 +465,77 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
     }
 
     @Test
+    public void testPosStrFunction() throws Exception {
+	    String expected = "B        |     C      |  3  |\n" +
+                        "------------------------------------\n" +
+                        "    Bam Bam     |Bam Bam Bam |  0  |\n" +
+                        " Barney Rubble  |   Wilma    |  0  |\n" +
+                        "     Betty      |            |  1  |\n" +
+                        "Fred Flintstone |     F      |  5  |\n" +
+                        "Fred Flintstone |   Flint    |  6  |\n" +
+                        "Fred Flintstone |Flintstone  |  6  |\n" +
+                        "Fred Flintstone |   Fred     |  1  |\n" +
+                        "Fred Flintstone |  stoner    |  0  |\n" +
+                        "     NULL       |   NULL     |NULL |";
+
+	    String query = "SELECT b, c, POSSTR(b, c) from " + tableWatcherB;
+	    testQuery(query, expected, methodWatcher);
+
+        expected = "A   |  C   | 3 |\n" +
+                    "-------------------\n" +
+                    "       |      | 1 |\n" +
+                    "       |      | 1 |\n" +
+                    "  CVS  | CVS  | 1 |\n" +
+                    " Zicam | Zi   | 1 |\n" +
+                    "  aaa  |      | 1 |\n" +
+                    "  aaa  | aaa  | 1 |\n" +
+                    " ab c  |      | 1 |\n" +
+                    "  abc  |      | 1 |\n" +
+                    "  abc  | ab   | 1 |\n" +
+                    "  abc  | abc  | 1 |\n" +
+                    "  abc  | abc  | 1 |\n" +
+                    " abc g |abc g | 1 |\n" +
+                    "abcabc |      | 1 |";
+
+	    query = "SELECT a, c, POSSTR(a, c) from " + tableWatcherK;
+	    testQuery(query, expected, methodWatcher);
+
+	    query = "Values(POSSTR(cast(null as char(3)), ''))";
+	    expected = "1  |\n" +
+                    "------\n" +
+                    "NULL |";
+        testQuery(query, expected, methodWatcher);
+	    query = "Values(POSSTR(cast(null as char(3)), cast(null as char(3))))";
+        testQuery(query, expected, methodWatcher);
+	    query = "Values(POSSTR('', cast(null as char(3))))";
+        testQuery(query, expected, methodWatcher);
+
+        expected = "1 |\n" +
+                    "----\n" +
+                    " 2 |";
+	    query = "Values(POSSTR('123', 2))";
+        testQuery(query, expected, methodWatcher);
+
+        expected = "1 |\n" +
+                    "----\n" +
+                    " 0 |";
+	    query = "Values(POSSTR('123', 1234))";
+        testQuery(query, expected, methodWatcher);
+
+        expected = "1 |\n" +
+                    "----\n" +
+                    " 3 |";
+	    query = "Values(POSSTR('  \t', '\t'))";
+        testQuery(query, expected, methodWatcher);
+
+        expected = "1 |\n" +
+                    "----\n" +
+                    " 6 |";
+	    query = "Values(POSSTR('bcabCabc', 'abc'))";
+        testQuery(query, expected, methodWatcher);
+    }
+
+    @Test
     public void testConcatFunction() throws Exception {
 	    String sCell1 = null;
 	    String sCell2 = null;


### PR DESCRIPTION
Implement the POSSTR function, which finds the position of a search string in an expression.
Example:

> values posstr('abc','bc');
> 1          
> //-----------
> 2          

