### PR TITLE
DB-11119 Support TRANSLATE function

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/ast/ISpliceVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/ast/ISpliceVisitor.java
@@ -191,6 +191,7 @@ public interface ISpliceVisitor {
     Visitable visit(TernaryOperatorNode node) throws StandardException;
     Visitable visit(TestConstraintNode node) throws StandardException;
     Visitable visit(TimestampOperatorNode node) throws StandardException;
+    Visitable visit(TranslateFunctionNode node) throws StandardException;
     Visitable visit(TruncateOperatorNode node) throws StandardException;
     Visitable visit(TypeofOperatorNode node) throws StandardException;
     Visitable visit(UnaryArithmeticOperatorNode node) throws StandardException;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/C_NodeTypes.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/C_NodeTypes.java
@@ -296,9 +296,10 @@ public interface C_NodeTypes
     int DAYS_FUNCTION_NODE = 282;
     int SECOND_FUNCTION_NODE = 283;
     int MULTIPLY_ALT_FUNCTION_NODE = 284;
+    int TRANSLATE_FUNCTION_NODE = 285;
 
     // Final value in set, keep up to date!
-    int FINAL_VALUE = MULTIPLY_ALT_FUNCTION_NODE;
+    int FINAL_VALUE = TRANSLATE_FUNCTION_NODE;
 
     /**
      * Extensions to this interface can use nodetypes > MAX_NODE_TYPE with out fear of collision

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/ConcatableDataValue.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/ConcatableDataValue.java
@@ -41,84 +41,91 @@ import com.splicemachine.db.iapi.error.StandardException;
  * bit datatypes.  
  *
  * The following methods are defined herein:
- *		charLength()
+ *        charLength()
  *
  * The following is defined by the sub classes (bit and char)
- *		concatenate()
+ *        concatenate()
  * 
  */
 public interface ConcatableDataValue extends DataValueDescriptor, VariableSizeDataValue
 {
 
-	/**
-	 * The SQL char_length() function.
-	 *
-	 * @param result	The result of a previous call to this method,
-	 *					null if not called yet.
-	 *
-	 * @return	A NumberDataValue containing the result of the char_length
-	 *
-	 * @exception StandardException		Thrown on error
-	 */
-	NumberDataValue charLength(NumberDataValue result)
-							throws StandardException;
+    /**
+     * The SQL char_length() function.
+     *
+     * @param result    The result of a previous call to this method,
+     *                    null if not called yet.
+     *
+     * @return    A NumberDataValue containing the result of the char_length
+     *
+     * @exception StandardException        Thrown on error
+     */
+    NumberDataValue charLength(NumberDataValue result)
+                            throws StandardException;
 
-	/**
-	 * substr() function matchs DB2 syntax and behaviour.
-	 *
-	 * @param start		Start of substr
-	 * @param length	Length of substr
-	 * @param result	The result of a previous call to this method,
-	 *					null if not called yet.
-	 * @param maxLen	Maximum length of the result string
-	 *
-	 * @return	A ConcatableDataValue containing the result of the substr()
-	 *
-	 * @exception StandardException		Thrown on error
-	 */
-	ConcatableDataValue substring(
-			NumberDataValue start,
-			NumberDataValue length,
-			ConcatableDataValue result,
-			int maxLen,
-			boolean isFixedLength)
-		throws StandardException;
+    /**
+     * substr() function matchs DB2 syntax and behaviour.
+     *
+     * @param start        Start of substr
+     * @param length    Length of substr
+     * @param result    The result of a previous call to this method,
+     *                    null if not called yet.
+     * @param maxLen    Maximum length of the result string
+     *
+     * @return    A ConcatableDataValue containing the result of the substr()
+     *
+     * @exception StandardException        Thrown on error
+     */
+    ConcatableDataValue substring(
+            NumberDataValue start,
+            NumberDataValue length,
+            ConcatableDataValue result,
+            int maxLen,
+            boolean isFixedLength)
+        throws StandardException;
 
-	/**
-	 * The SQL replace() function.
-	 *
-	 * @param fromStr the substring to be found and replaced
-	 *        within this containing string
-	 * @param toStr the string to replace the provided substring
-	 *        <code>fromStr</code> within this containing string
-	 * @param result the result of a previous call to this method,
-	 *        or null if not called yet.
-	 *
-	 * @return ConcatableDataValue containing the result of the replace()
-	 *
-	 * @exception StandardException if an error occurs
-	 */
-	ConcatableDataValue replace(
-			StringDataValue fromStr,
-			StringDataValue toStr,
-			ConcatableDataValue result)
+    /**
+     * The SQL replace() function.
+     *
+     * @param fromStr the substring to be found and replaced
+     *        within this containing string
+     * @param toStr the string to replace the provided substring
+     *        <code>fromStr</code> within this containing string
+     * @param result the result of a previous call to this method,
+     *        or null if not called yet.
+     *
+     * @return ConcatableDataValue containing the result of the replace()
+     *
+     * @exception StandardException if an error occurs
+     */
+    ConcatableDataValue replace(
+            StringDataValue fromStr,
+            StringDataValue toStr,
+            ConcatableDataValue result)
             throws StandardException;
 
-	/**
-	 * Position in searchFrom of the first occurrence of this.value.
-	 * The search begins from position start.  0 is returned if searchFrom does
-	 * not contain this.value.  Position 1 is the first character in searchFrom.
-	 *
-	 * @param searchFrom    - The string or binary string to search from
-	 * @param start         - The position to search from in string searchFrom
-	 * @param result        - The object to return
-	 *
-	 * @return  The position in searchFrom the fist occurrence of this.value.
-	 *              0 is returned if searchFrom does not contain this.value.
-	 * @exception StandardException     Thrown on error
-	 */
-	NumberDataValue locate(ConcatableDataValue searchFrom,
-						   NumberDataValue start,
-						   NumberDataValue result)
-			throws StandardException;
+    ConcatableDataValue translate(
+            StringDataValue outputTranslationTable,
+            StringDataValue inputTranslationTable,
+            StringDataValue pad,
+            ConcatableDataValue result)
+            throws StandardException;
+
+    /**
+     * Position in searchFrom of the first occurrence of this.value.
+     * The search begins from position start.  0 is returned if searchFrom does
+     * not contain this.value.  Position 1 is the first character in searchFrom.
+     *
+     * @param searchFrom    - The string or binary string to search from
+     * @param start         - The position to search from in string searchFrom
+     * @param result        - The object to return
+     *
+     * @return  The position in searchFrom the fist occurrence of this.value.
+     *              0 is returned if searchFrom does not contain this.value.
+     * @exception StandardException     Thrown on error
+     */
+    NumberDataValue locate(ConcatableDataValue searchFrom,
+                           NumberDataValue start,
+                           NumberDataValue result)
+            throws StandardException;
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLBinary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLBinary.java
@@ -1100,6 +1100,16 @@ abstract class SQLBinary
         throw StandardException.newException(SQLState.NOT_IMPLEMENTED);
     }
 
+    public ConcatableDataValue translate(
+            StringDataValue outputTranslationTable,
+            StringDataValue inputTranslationTable,
+            StringDataValue pad,
+            ConcatableDataValue result)
+            throws StandardException
+    {
+        throw StandardException.newException(SQLState.NOT_IMPLEMENTED);
+    }
+
     /**
         Host variables are rejected if their length is
         bigger than the declared length, regardless of

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLChar.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLChar.java
@@ -57,13 +57,12 @@ import org.joda.time.DateTime;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.sql.*;
+import java.sql.Date;
 import java.text.CollationKey;
 import java.text.RuleBasedCollator;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Locale;
-import java.util.MissingResourceException;
+import java.util.*;
 import java.util.regex.Pattern;
+import java.util.stream.Collector;
 
 
 /**
@@ -2778,6 +2777,59 @@ public class SQLChar
 
         stringResult.setValue(getString().replace(fromStr.getString(), toStr.toString()));
 
+        return stringResult;
+    }
+
+    public ConcatableDataValue translate(
+            StringDataValue outputTranslationTable,
+            StringDataValue inputTranslationTable,
+            StringDataValue pad,
+            ConcatableDataValue result)
+            throws StandardException
+    {
+        StringDataValue stringResult;
+        if (result == null) {
+            result = getNewVarchar();
+        }
+
+        stringResult = (StringDataValue) result;
+
+        if (this.isNull() ||
+                outputTranslationTable.isNull() || outputTranslationTable.getString() == null ||
+                inputTranslationTable.isNull() || inputTranslationTable.getString() == null) {
+            stringResult.setToNull();
+            return stringResult;
+        }
+
+        String output = outputTranslationTable.getString();
+        String input = inputTranslationTable.getString();
+
+        char padChar;
+        if (pad == null || pad.isNull() || pad.getString() == null) {
+            padChar = ' ';
+        } else {
+            if (pad.getString().length() != 1) {
+                throw StandardException.newException(
+                        SQLState.LANG_INVALID_TRANSLATE_PADDING, pad.getString());
+            }
+            padChar = pad.getString().charAt(0);
+        }
+
+        HashMap<Character, Character> table = new HashMap<>();
+        for (int i = 0; i < input.length(); ++i) {
+            table.putIfAbsent(input.charAt(i), i < output.length() ? output.charAt(i) : padChar);
+        }
+
+        stringResult.setValue(getString()
+                .codePoints()
+                .map(c -> table.getOrDefault((char)c, (char)c))
+                .mapToObj(c -> (char) c)
+                .collect(Collector.of(
+                        StringBuilder::new,
+                        StringBuilder::append,
+                        StringBuilder::append,
+                        StringBuilder::toString))
+        );
         return stringResult;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/AbstractSpliceVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/AbstractSpliceVisitor.java
@@ -777,6 +777,11 @@ public abstract class AbstractSpliceVisitor implements ISpliceVisitor {
     }
 
     @Override
+    public Visitable visit(TranslateFunctionNode node) throws StandardException {
+        return defaultVisit(node);
+    }
+
+    @Override
     public Visitable visit(TypeofOperatorNode node) throws StandardException {
         return defaultVisit(node);
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorNode.java
@@ -463,4 +463,25 @@ public abstract class OperatorNode extends ValueNode
                         getContextManager()));
         ((CastNode) operands.get(operandIndex)).bindCastNodeOnly();
     }
+
+    @Override
+    public void generateExpression(ExpressionClassBuilder acb, MethodBuilder mb) throws StandardException
+    {
+        /* Allocate an object for re-use to hold the result of the operator */
+        LocalField field = acb.newFieldDeclaration(Modifier.PRIVATE, resultInterfaceType);
+        for (int i = 0; i < operands.size(); ++i) {
+            if (operands.get(i) != null)
+            {
+                operands.get(i).generateExpression(acb, mb);
+                mb.upCast(interfaceTypes.get(i));
+            }
+            else
+            {
+                mb.pushNull(interfaceTypes.get(i));
+            }
+        }
+        mb.getField(field);
+
+        mb.callMethod(VMOpcode.INVOKEINTERFACE, resultInterfaceType, methodName, resultInterfaceType, operands.size());
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TranslateFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TranslateFunctionNode.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.ClassName;
+import com.splicemachine.db.iapi.reference.SQLState;
+import com.splicemachine.db.iapi.services.classfile.VMOpcode;
+import com.splicemachine.db.iapi.services.compiler.LocalField;
+import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.context.ContextManager;
+import com.splicemachine.db.iapi.services.io.StoredFormatIds;
+import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
+import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+import com.splicemachine.db.iapi.types.DataTypeUtilities;
+import com.splicemachine.db.iapi.types.TypeId;
+
+import java.lang.reflect.Modifier;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ */
+public class TranslateFunctionNode extends OperatorNode {
+    public TranslateFunctionNode(ValueNode expression, ValueNode outputTranslationTable, ValueNode inputTranslationTable, ValueNode pad, ContextManager cm) {
+        setContextManager(cm);
+        setNodeType(C_NodeTypes.TRANSLATE_FUNCTION_NODE);
+        operator = "TRANSLATE";
+        methodName = "translate";
+        operands = new ArrayList<>();
+        operands.add(expression);
+        operands.add(outputTranslationTable);
+        operands.add(inputTranslationTable);
+        operands.add(pad);
+        interfaceTypes = new ArrayList<>(Arrays.asList(ClassName.ConcatableDataValue, ClassName.StringDataValue, ClassName.StringDataValue, ClassName.StringDataValue));
+        resultInterfaceType = ClassName.ConcatableDataValue;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ValueNode bindExpression(FromList fromList,
+                                    SubqueryList subqueryList,
+                                    List<AggregateNode> aggregateVector) throws StandardException {
+        bindOperands(fromList, subqueryList, aggregateVector);
+
+        for (int i = 0; i < 3; ++i) {
+            if (operands.get(i).requiresTypeFromContext()) {
+                castOperandAndBindCast(i, DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR));
+            }
+            if (!operands.get(i).getTypeId().isStringTypeId()) {
+                throw StandardException.newException(SQLState.LANG_UNARY_FUNCTION_BAD_TYPE,
+                        "TRANSLATE", operands.get(i).getTypeId().getSQLTypeName());
+            }
+        }
+        if (operands.get(3) != null) {
+            if (operands.get(3).requiresTypeFromContext()) {
+                operands.get(3).setType(DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.CHAR, 1));
+            }
+            if (!operands.get(3).getTypeId().isStringTypeId()) {
+                throw StandardException.newException(SQLState.LANG_UNARY_FUNCTION_BAD_TYPE,
+                        "TRANSLATE", operands.get(3).getTypeId().getSQLTypeName());
+            }
+            if (operands.get(3).getTypeServices().getMaximumWidth() != 1) {
+                throw StandardException.newException(
+                        SQLState.LANG_INVALID_TRANSLATE_PADDING, operands.get(3).getTypeId().getSQLTypeName());
+            }
+        }
+        setType(DataTypeDescriptor.getBuiltInDataTypeDescriptor(
+                Types.VARCHAR,
+                operands.stream().anyMatch(op -> op != null && op.getTypeServices().isNullable()),
+                operands.get(0).getTypeServices().getMaximumWidth()));
+        return this;
+    }
+}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -104,6 +104,7 @@ import com.splicemachine.db.impl.sql.compile.TableElementNode;
 import com.splicemachine.db.impl.sql.compile.TableOperatorNode;
 import com.splicemachine.db.impl.sql.compile.BasicPrivilegesNode;
 import com.splicemachine.db.impl.sql.compile.TransactionStatementNode;
+import com.splicemachine.db.impl.sql.compile.TranslateFunctionNode;
 import com.splicemachine.db.impl.sql.compile.TriggerReferencingStruct;
 import com.splicemachine.db.impl.sql.compile.UnionNode;
 import com.splicemachine.db.impl.sql.compile.IntersectOrExceptNode;
@@ -6599,6 +6600,26 @@ escapedValueFunction() throws StandardException :
 
 }
 
+ValueNode translateFunctionNode() throws StandardException:
+{
+    ValueNode stringExpression;
+    ValueNode toString;
+    ValueNode fromString;
+    ValueNode pad = null;
+}
+{
+    <LEFT_PAREN>
+        stringExpression = additiveExpression(null, 0)
+    <COMMA> toString = additiveExpression(null, 0)
+    <COMMA> fromString = additiveExpression(null, 0)
+    [ <COMMA> pad = additiveExpression(null, 0) ]
+
+    <RIGHT_PAREN>
+    {
+        return new TranslateFunctionNode(stringExpression, toString, fromString, pad, getContextManager());
+    }
+}
+
 /*
  * <A NAME="escapedSYSFUNFunctions">escapedSYSFUNFunctions</A>
  */
@@ -7059,6 +7080,11 @@ characterValueFunction() throws StandardException :
     <REPLACE> <LEFT_PAREN> value = additiveExpression(null,0) <COMMA> str1 = additiveExpression(null,0) <COMMA> str2 = additiveExpression(null,0) <RIGHT_PAREN>
     {
         return getReplaceNode( value, str1, str2 );
+    }
+|
+    <TRANSLATE>
+    {
+        return translateFunctionNode();
     }
 |
     ( upperTok = <UPPER> | lowerTok = <LOWER> ) <LEFT_PAREN> value = additiveExpression(null,0) [ <COMMA> locale = additiveExpression(null,0) ] <RIGHT_PAREN>
@@ -7559,6 +7585,7 @@ miscBuiltins() throws StandardException :
                 getToken(1).kind == TINYINT ||
                 getToken(1).kind == TO_HBASE_ESCAPED ||
                 getToken(1).kind == TO_INSTANT ||
+                getToken(1).kind == TRANSLATE ||
                 getToken(1).kind == TRIM ||
                 getToken(1).kind == TRUNC ||
                 getToken(1).kind == TRUNCATE ||

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -737,6 +737,7 @@ public interface SQLState {
     String LANG_INVALID_ESCAPE_CHARACTER              = "22019";
     String LANG_INVALID_TRIM_CHARACTER                = "22020";
     String LANG_INVALID_CHARACTER_ENCODING            = "22021";
+    String LANG_INVALID_TRANSLATE_PADDING             = "22022";
     String LANG_INVALID_ESCAPE_SEQUENCE               = "22025";
     String LANG_INVALID_TRIM_SET                      = "22027";
     String LANG_STRING_TOO_LONG                       = "22028";

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -831,6 +831,12 @@ Guide.
             <text>Unknown character encoding '{0}'.</text>
             <arg>typeName</arg>
           </msg>
+
+            <msg>
+                <name>22022</name>
+                <text>Invalid pad parameter to TRANSLATE: '{0}' is not of length 1.</text>
+                <arg>pad</arg>
+            </msg>
             <msg>
                 <name>22025</name>
                 <text>Escape character must be followed by escape character, '_', or '%'. It cannot be followed by any other character or be at the end of the pattern.</text>

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
@@ -1028,11 +1028,19 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
             checkStringExpression("TRANSLATE('ABCDEFG', '', 'ACE')", " B D FG", conn);
             checkStringExpression("TRANSLATE('ABCDEFG', 'acefoo', 'ACE')", "aBcDeFG", conn);
             checkStringExpression("TRANSLATE('ABCDEFG', 'ace', '')", "ABCDEFG", conn);
+            checkStringExpression("TRANSLATE('ABABACBABCABA', 'ac', 'AC')", "aBaBacBaBcaBa", conn);
 
+            checkStringExpression("TRANSLATE('ABCDEFG', 'ace', 'ACE', 'U')", "aBcDeFG", conn);
             checkStringExpression("TRANSLATE('ABCDEFG', 'ac', 'ACE', 'U')", "aBcDUFG", conn);
             assertFailed(conn, "select translate('ABCDEFG', 'ac', 'ACE', 'UU')", "22022");
 
             checkStringExpression("TRANSLATE('ABCDEFG', 'ac', 'ACE', 'U')", "aBcDUFG", conn);
+
+            checkStringExpression("TRANSLATE('ABCDEFG', 'ac', x'00')", "ABCDEFG", conn);
+            checkStringExpression("TRANSLATE(cast(x'00' as varchar(1) for sbcs data), 'a', x'00')", "a", conn);
+
+            checkStringExpression("STRIP(replace(translate('19013191 ',' ',x'00'),' ',''))", "19013191", conn);
+
         }
 
         methodWatcher.execute("drop table testTranslate if exists");


### PR DESCRIPTION
### **Description**
This PR introduces TRANSLATE as a new SQL function. It is inspired from the DB2 implementation of translate that can be found here:

https://www.ibm.com/support/knowledgecenter/SSEPEK_10.0.0/sqlref/src/tpc/db2z_bif_translate.html

Usage:
`TRANSLATE(string_expression, outputTranslationTable, inputTranslationTable [, pad])
`

This function returns a new string, of type TYPEOF(string_expression)
If any operand is null, we return null

This new string is constructed the following way:

for each character c in string_expression:
if c is present in inputTranslationTable (position n), use outputTranslationTable[n]
else use c
 
For example:
```
translate('ABC', 'b', 'B') = 'AbC'
translate('ABC', 'ba', 'BA') = 'abC'

```
If outputTranslationTable is longer than inputTranslationTable, we ignore the excess characters
If inputTranslationTable is longer than outputTranslationTable, we pad outputTranslationTable with pad (or with ' ' if pad isn't specified)


string_expression must be a char / varchar
inputTranslationTable and outputTranslationTable must be char / varchar, or char / varchar for bit data. If 'for bit data', then we reinterpret it as varchar
pad must be a char / varchar of size 1 (else we throw SQLState 22022)

### **Testing**
This is tested with a variety of combinations and dimensions: 

OLTP / OLAP / OLAP with native spark

Prepared / Non prepared statements

NULL / not NULLS

Characters appearing more than once in the string expression

outputTranslationTable longer than inputTranslationTable

inputTranslationTable longer than outputTranslationTable

pad being ignored because both tables have equal size
