### PR TITLE
DB-11207 Support creation of table LIKE other table

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstraintDefinitionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstraintDefinitionNode.java
@@ -57,457 +57,457 @@ import java.util.Properties;
 
 public class ConstraintDefinitionNode extends TableElementNode
 {
-	
-	private TableName constraintName;
-	protected int constraintType;
-	protected Properties properties;
-	ProviderList apl;
 
-	UUIDFactory		uuidFactory;
+    private TableName constraintName;
+    protected int constraintType;
+    protected Properties properties;
+    ProviderList apl;
 
-	String			backingIndexName;
-	UUID			backingIndexUUID;
-	int[]			 checkColumnReferences;
-	ResultColumnList columnList;
-	String			 constraintText;
-	ValueNode		 checkCondition;
-	private int				 behavior;
+    UUIDFactory        uuidFactory;
+
+    String            backingIndexName;
+    UUID            backingIndexUUID;
+    int[]             checkColumnReferences;
+    ResultColumnList columnList;
+    String             constraintText;
+    ValueNode         checkCondition;
+    private int                 behavior;
     private int verifyType = DataDictionary.DROP_CONSTRAINT; // By default do not check the constraint type
-	private boolean canBeIgnored;
+    private boolean canBeIgnored;
 
-	public void init(
-					Object constraintName,
-					Object constraintType,
-					Object rcl,
-					Object properties,
-					Object checkCondition,
-					Object constraintText,
-					Object behavior)
-	{
-		this.constraintName = (TableName) constraintName;
+    public void init(
+                    Object constraintName,
+                    Object constraintType,
+                    Object rcl,
+                    Object properties,
+                    Object checkCondition,
+                    Object constraintText,
+                    Object behavior)
+    {
+        this.constraintName = (TableName) constraintName;
 
-		/* We need to pass null as name to TableElementNode's constructor 
-		 * since constraintName may be null.
-		 */
-		super.init(null);
-		if (this.constraintName != null)
-		{
-			this.name = this.constraintName.getTableName();
-		}
-		this.constraintType = (Integer) constraintType;
-		this.properties = (Properties) properties;
-		this.columnList = (ResultColumnList) rcl;
-		this.checkCondition = (ValueNode) checkCondition;
-		this.constraintText = (String) constraintText;
-		this.behavior = (Integer) behavior;
-		this.setCanBeIgnored(false);
-	}
+        /* We need to pass null as name to TableElementNode's constructor
+         * since constraintName may be null.
+         */
+        super.init(null);
+        if (this.constraintName != null)
+        {
+            this.name = this.constraintName.getTableName();
+        }
+        this.constraintType = (Integer) constraintType;
+        this.properties = (Properties) properties;
+        this.columnList = (ResultColumnList) rcl;
+        this.checkCondition = (ValueNode) checkCondition;
+        this.constraintText = (String) constraintText;
+        this.behavior = (Integer) behavior;
+        this.setCanBeIgnored(false);
+    }
 
-	public void init(
-					Object constraintName,
-					Object constraintType,
-					Object rcl,
-					Object properties,
-					Object checkCondition,
-					Object constraintText)
-	{
-		init(
-					constraintName,
-					constraintType,
-					rcl,
-					properties, 
-					checkCondition,
-					constraintText,
-					ReuseFactory.getInteger(StatementType.DROP_DEFAULT)
-					);
-	}
+    public void init(
+                    Object constraintName,
+                    Object constraintType,
+                    Object rcl,
+                    Object properties,
+                    Object checkCondition,
+                    Object constraintText)
+    {
+        init(
+                    constraintName,
+                    constraintType,
+                    rcl,
+                    properties,
+                    checkCondition,
+                    constraintText,
+                    ReuseFactory.getInteger(StatementType.DROP_DEFAULT)
+                    );
+    }
 
-	public void init(
-					Object constraintName,
-					Object constraintType,
-					Object rcl,
-					Object properties,
-					Object checkCondition,
-					Object constraintText,
-					Object behavior,
+    public void init(
+                    Object constraintName,
+                    Object constraintType,
+                    Object rcl,
+                    Object properties,
+                    Object checkCondition,
+                    Object constraintText,
+                    Object behavior,
                     Object verifyType)
-	{
+    {
         init( constraintName, constraintType, rcl, properties, checkCondition, constraintText, behavior);
         this.verifyType = (Integer) verifyType;
     }
     
-	/**
-	 * Convert this object to a String.  See comments in QueryTreeNode.java
-	 * for how this should be done for tree printing.
-	 *
-	 * @return	This object as a String
-	 */
+    /**
+     * Convert this object to a String.  See comments in QueryTreeNode.java
+     * for how this should be done for tree printing.
+     *
+     * @return    This object as a String
+     */
 
-	public String toString()
-	{
-		if (SanityManager.DEBUG)
-		{
-			return "constraintName: " + 
-				( ( constraintName != null) ?
-						constraintName.toString() : "null" ) + "\n" +
-				"constraintType: " + constraintType + "\n" + 
-				"properties: " +
-				((properties != null) ? properties.toString() : "null") + "\n" +
-				super.toString();
-		}
-		else
-		{
-			return "";
-		}
-	}
+    public String toString()
+    {
+        if (SanityManager.DEBUG)
+        {
+            return "constraintName: " +
+                ( ( constraintName != null) ?
+                        constraintName.toString() : "null" ) + "\n" +
+                "constraintType: " + constraintType + "\n" +
+                "properties: " +
+                ((properties != null) ? properties.toString() : "null") + "\n" +
+                super.toString();
+        }
+        else
+        {
+            return "";
+        }
+    }
 
-	/**
-	 * Bind this constraint definition. 
-	 *
-	   @param ddlNode the create or alter table node
-	 * @param dd the dd
-	 *
-	 * @exception StandardException on error
-	 */
-	protected void bind(DDLStatementNode ddlNode, DataDictionary dd)	throws StandardException
-	{
-		// we need to allow drops on constraints with different schemas
-		// to support removing constraints created pre 5.2.
-		if (constraintType == DataDictionary.DROP_CONSTRAINT)
-			return;
+    /**
+     * Bind this constraint definition.
+     *
+       @param ddlNode the create or alter table node
+     * @param dd the dd
+     *
+     * @exception StandardException on error
+     */
+    protected void bind(DDLStatementNode ddlNode, DataDictionary dd)    throws StandardException
+    {
+        // we need to allow drops on constraints with different schemas
+        // to support removing constraints created pre 5.2.
+        if (constraintType == DataDictionary.DROP_CONSTRAINT)
+            return;
 
-		// ensure the schema of the constraint matches the schema of the table
-		if (constraintName != null) {
+        // ensure the schema of the constraint matches the schema of the table
+        if (constraintName != null) {
 
-			String constraintSchema = constraintName.getSchemaName();
-
-
-			if (constraintSchema != null) {
+            String constraintSchema = constraintName.getSchemaName();
 
 
-
-				TableName tableName = ddlNode.getObjectName();
-				String tableSchema = tableName.getSchemaName();
-				if (tableSchema == null) {
-					tableSchema = getSchemaDescriptor((String) null).getSchemaName();
-					tableName.setSchemaName(tableSchema);
-				}
-				if (!constraintSchema.equals(tableSchema)) {
-					throw StandardException.newException(SQLState.LANG_CONSTRAINT_SCHEMA_MISMATCH,
-												constraintName, tableName);
-
-				}
-			}
-		}
-		else {
-			name = getBackingIndexName(dd);
-		}
-	}
-
-	/**
-	  *	Get the name of the constraint. If the user didn't provide one, we make one up. This allows Replication
-	  *	to agree with the core compiler on the names of constraints.
-	  *
-	  *	@return	constraint name
-	  */
-	String	getConstraintMoniker()
-	{
-		return name;
-	}
-
-	/**
-		To support dropping exisiting constraints that may have mismatched schema names
-		we need to support ALTER TABLE S1.T DROP CONSTRAINT S2.C.
-		If a constraint name was specified this returns it, otherwise it returns null.
-	*/
-	String getDropSchemaName() {
-		if (constraintName != null)
-			return constraintName.getSchemaName();
-		return null;
-	}
-
-	/**
-	  *	Allocates a UUID if one doesn't already exist for the index backing this constraint. This allows Replication
-	  *	logic to agree with the core compiler on what the UUIDs of indices are.
-	  *
-	  *	@return	a UUID for the constraint. allocates one if this is the first time this method is called.
-	  */
-	UUID	getBackingIndexUUID()
-	{
-		if ( backingIndexUUID == null )
-		{
-			backingIndexUUID = getUUIDFactory().createUUID();
-		}
-
-		return	backingIndexUUID;
-	}
-
-	/**
-	  *	Gets a unique name for the backing index for this constraint of the form SQLyymmddhhmmssxxn
-	  *	  yy - year, mm - month, dd - day of month, hh - hour, mm - minute, ss - second,
-	  *	  xx - the first 2 digits of millisec because we don't have enough space to keep the exact millisec value,
-	  *	  n - number between 0-9
-	  *
-	  *	@return	name of backing index
-	  */
-	String	getBackingIndexName(DataDictionary dd)
-	{
-		if ( backingIndexName == null )
-			backingIndexName = dd.getSystemSQLName();
-
-		return	backingIndexName;
-	}
-
-	/**
-	 * Set the auxiliary provider list.
-	 *
-	 * @param apl	The new auxiliary provider list.
-	 */
-	void setAuxiliaryProviderList(ProviderList apl)
-	{
-		this.apl = apl;
-	}
-
-	/**
-	 * Return the auxiliary provider list.
-	 *
-	 * @return	The auxiliary provider list.
-	 */
-	public ProviderList getAuxiliaryProviderList()
-	{
-		return apl;
-	}
-
-	/**
-	 * Is this a primary key constraint.
-	 *
-	 * @return boolean	Whether or not this is a primary key constraint
-	 */
-	boolean hasPrimaryKeyConstraint()
-	{
-		return constraintType == DataDictionary.PRIMARYKEY_CONSTRAINT;
-	}
-
-	/**
-	 * Is this a unique key constraint.
-	 *
-	 * @return boolean	Whether or not this is a unique key constraint
-	 */
-	boolean hasUniqueKeyConstraint()
-	{
-		return constraintType == DataDictionary.UNIQUE_CONSTRAINT;
-	}
-
-	/**
-	 * Is this a foreign key constraint.
-	 *
-	 * @return boolean	Whether or not this is a unique key constraint
-	 */
-	boolean hasForeignKeyConstraint()
-	{
-		return constraintType == DataDictionary.FOREIGNKEY_CONSTRAINT;
-	}
-
-	/**
-	 * Does this element have a check constraint.
-	 *
-	 * @return boolean	Whether or not this element has a check constraint
-	 */
-	boolean hasCheckConstraint()
-	{
-		return constraintType == DataDictionary.CHECK_CONSTRAINT;
-	}
-
-	/**
-	 * Does this element have a constraint on it.
-	 *
-	 * @return boolean	Whether or not this element has a constraint on it
-	 */
-	boolean hasConstraint()
-	{
-		return true;
-	}
-
-	/**
-	 * Is this a foreign key constraint.
-	 *
-	 * @return boolean	Whether or not this is a unique key constraint
-	 */
-	public boolean requiresBackingIndex()
-	{
-		switch (constraintType)
-		{
-			case DataDictionary.FOREIGNKEY_CONSTRAINT:
-			case DataDictionary.PRIMARYKEY_CONSTRAINT:
-			case DataDictionary.UNIQUE_CONSTRAINT:
-				return true;
-			default:
-				return false;
-		}
-	}	
-
-	/**
-	 * Is this a foreign key constraint.
-	 *
-	 * @return boolean	Whether or not this is a unique key constraint
-	 */
-	public boolean requiresUniqueIndex()
-	{
-		switch (constraintType)
-		{
-			case DataDictionary.PRIMARYKEY_CONSTRAINT:
-			case DataDictionary.UNIQUE_CONSTRAINT:
-				return true;
-			default:
-				return false;
-		}
-	}
-
-	/**
-	 * Get the constraint type
-	 *
-	 * @return constraintType	The constraint type.
-	 */
-	int getConstraintType()
-	{
-		return constraintType;
-	}
-
-	/**
-	 * Set the optional properties for the backing index to this constraint.
-	 *
-	 * @param properties	The optional Properties for this constraint.
-	 */
-	public void setProperties(Properties properties)
-	{
-		this.properties = properties;
-	}
-
-	/** 
-	 * Get the optional properties for the backing index to this constraint.
-	 *
-	 *
-	 * @return The optional properties for the backing index to this constraint
-	 */
-	public Properties getProperties()
-	{
-		return properties;
-	}
+            if (constraintSchema != null) {
 
 
-	/** 
-	 * Is this constraint referenced.
-	 *
-	 * @return true/false
-	 */
-	public boolean isReferenced()
-	{
-		return false;
-	}
 
-	/** 
-	 * Get the count of enabled fks
-	 * that reference this constraint
-	 *
-	 * @return the number
-	 */
-	public int getReferenceCount()
-	{
-		return 0;
-	}
-	/** 
-	 * Is this constraint enabled.
-	 *
-	 * @return true/false
-	 */
-	public boolean isEnabled()
-	{
-		return true;
-	}
+                TableName tableName = ddlNode.getObjectName();
+                String tableSchema = tableName.getSchemaName();
+                if (tableSchema == null) {
+                    tableSchema = getSchemaDescriptor((String) null).getSchemaName();
+                    tableName.setSchemaName(tableSchema);
+                }
+                if (!constraintSchema.equals(tableSchema)) {
+                    throw StandardException.newException(SQLState.LANG_CONSTRAINT_SCHEMA_MISMATCH,
+                                                constraintName, tableName);
 
-	/**
-	 * Get the column list from this node.
-	 *
-	 * @return ResultColumnList The column list from this table constraint.
-	 */
-	public ResultColumnList getColumnList()
-	{
-		return columnList;
-	}
+                }
+            }
+        }
+        else {
+            name = getBackingIndexName(dd);
+        }
+    }
 
-	/**
-	 * Set the column list for this node.  This is useful for check constraints
-	 * where the list of referenced columns is built at bind time.
-	 *
-	 * @param columnList	The new columnList.
-	 */
-	public void setColumnList(ResultColumnList columnList)
-	{
-		this.columnList = columnList;
-	}
+    /**
+      *    Get the name of the constraint. If the user didn't provide one, we make one up. This allows Replication
+      *    to agree with the core compiler on the names of constraints.
+      *
+      *    @return    constraint name
+      */
+    String    getConstraintMoniker()
+    {
+        return name;
+    }
 
-	/**
-	 * Get the check condition from this table constraint.
-	 *
-	 * @return The check condition from this node.
-	 */
-	public ValueNode getCheckCondition()
-	{
-		return checkCondition;
-	}
+    /**
+        To support dropping exisiting constraints that may have mismatched schema names
+        we need to support ALTER TABLE S1.T DROP CONSTRAINT S2.C.
+        If a constraint name was specified this returns it, otherwise it returns null.
+    */
+    String getDropSchemaName() {
+        if (constraintName != null)
+            return constraintName.getSchemaName();
+        return null;
+    }
 
-	/**
-	 * Set the check condition for this table constraint.
-	 *
-	 * @param checkCondition	The check condition
-	 */
-	public void setCheckCondition(ValueNode checkCondition)
-	{
-		this.checkCondition = checkCondition;
-	}
+    /**
+      *    Allocates a UUID if one doesn't already exist for the index backing this constraint. This allows Replication
+      *    logic to agree with the core compiler on what the UUIDs of indices are.
+      *
+      *    @return    a UUID for the constraint. allocates one if this is the first time this method is called.
+      */
+    UUID    getBackingIndexUUID()
+    {
+        if ( backingIndexUUID == null )
+        {
+            backingIndexUUID = getUUIDFactory().createUUID();
+        }
 
-	/**
-	 * Get the text of the constraint. (Only meaningful for check constraints.)
-	 *
-	 * @return The constraint text.
-	 */
-	public String getConstraintText()
-	{
-		return constraintText;
-	}
+        return    backingIndexUUID;
+    }
 
-	/**
-	 * Get the array of 1-based column references for a check constraint.
-	 *
-	 * @return	The array of 1-based column references for a check constraint.
-	 */
-	@SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "DB-9810")
-	public int[] getCheckColumnReferences()
-	{
-		return checkColumnReferences;
-	}
+    /**
+      *    Gets a unique name for the backing index for this constraint of the form SQLyymmddhhmmssxxn
+      *      yy - year, mm - month, dd - day of month, hh - hour, mm - minute, ss - second,
+      *      xx - the first 2 digits of millisec because we don't have enough space to keep the exact millisec value,
+      *      n - number between 0-9
+      *
+      *    @return    name of backing index
+      */
+    String    getBackingIndexName(DataDictionary dd)
+    {
+        if ( backingIndexName == null )
+            backingIndexName = dd.getSystemSQLName();
 
-	/**
-	 * Set the array of 1-based column references for a check constraint.
-	 *
-	 * @param checkColumnReferences	The array of 1-based column references
-	 *								for the check constraint.
-	 */
-	@SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "DB-9810")
-	public void setCheckColumnReferences(int[] checkColumnReferences)
-	{
-		this.checkColumnReferences = checkColumnReferences;
-	}
+        return    backingIndexName;
+    }
 
-	/**
-	 * Return the behavior of this constriant (DropStatementNode.xxx)	
-	 *
-	 * @return the behavior
-	 */
-	int getDropBehavior()
-	{
-		return behavior;
-	}
+    /**
+     * Set the auxiliary provider list.
+     *
+     * @param apl    The new auxiliary provider list.
+     */
+    void setAuxiliaryProviderList(ProviderList apl)
+    {
+        this.apl = apl;
+    }
+
+    /**
+     * Return the auxiliary provider list.
+     *
+     * @return    The auxiliary provider list.
+     */
+    public ProviderList getAuxiliaryProviderList()
+    {
+        return apl;
+    }
+
+    /**
+     * Is this a primary key constraint.
+     *
+     * @return boolean    Whether or not this is a primary key constraint
+     */
+    boolean hasPrimaryKeyConstraint()
+    {
+        return constraintType == DataDictionary.PRIMARYKEY_CONSTRAINT;
+    }
+
+    /**
+     * Is this a unique key constraint.
+     *
+     * @return boolean    Whether or not this is a unique key constraint
+     */
+    boolean hasUniqueKeyConstraint()
+    {
+        return constraintType == DataDictionary.UNIQUE_CONSTRAINT;
+    }
+
+    /**
+     * Is this a foreign key constraint.
+     *
+     * @return boolean    Whether or not this is a unique key constraint
+     */
+    boolean hasForeignKeyConstraint()
+    {
+        return constraintType == DataDictionary.FOREIGNKEY_CONSTRAINT;
+    }
+
+    /**
+     * Does this element have a check constraint.
+     *
+     * @return boolean    Whether or not this element has a check constraint
+     */
+    boolean hasCheckConstraint()
+    {
+        return constraintType == DataDictionary.CHECK_CONSTRAINT;
+    }
+
+    /**
+     * Does this element have a constraint on it.
+     *
+     * @return boolean    Whether or not this element has a constraint on it
+     */
+    boolean hasConstraint()
+    {
+        return true;
+    }
+
+    /**
+     * Is this a foreign key constraint.
+     *
+     * @return boolean    Whether or not this is a unique key constraint
+     */
+    public boolean requiresBackingIndex()
+    {
+        switch (constraintType)
+        {
+            case DataDictionary.FOREIGNKEY_CONSTRAINT:
+            case DataDictionary.PRIMARYKEY_CONSTRAINT:
+            case DataDictionary.UNIQUE_CONSTRAINT:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Is this a foreign key constraint.
+     *
+     * @return boolean    Whether or not this is a unique key constraint
+     */
+    public boolean requiresUniqueIndex()
+    {
+        switch (constraintType)
+        {
+            case DataDictionary.PRIMARYKEY_CONSTRAINT:
+            case DataDictionary.UNIQUE_CONSTRAINT:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Get the constraint type
+     *
+     * @return constraintType    The constraint type.
+     */
+    int getConstraintType()
+    {
+        return constraintType;
+    }
+
+    /**
+     * Set the optional properties for the backing index to this constraint.
+     *
+     * @param properties    The optional Properties for this constraint.
+     */
+    public void setProperties(Properties properties)
+    {
+        this.properties = properties;
+    }
+
+    /**
+     * Get the optional properties for the backing index to this constraint.
+     *
+     *
+     * @return The optional properties for the backing index to this constraint
+     */
+    public Properties getProperties()
+    {
+        return properties;
+    }
+
+
+    /**
+     * Is this constraint referenced.
+     *
+     * @return true/false
+     */
+    public boolean isReferenced()
+    {
+        return false;
+    }
+
+    /**
+     * Get the count of enabled fks
+     * that reference this constraint
+     *
+     * @return the number
+     */
+    public int getReferenceCount()
+    {
+        return 0;
+    }
+    /**
+     * Is this constraint enabled.
+     *
+     * @return true/false
+     */
+    public boolean isEnabled()
+    {
+        return true;
+    }
+
+    /**
+     * Get the column list from this node.
+     *
+     * @return ResultColumnList The column list from this table constraint.
+     */
+    public ResultColumnList getColumnList()
+    {
+        return columnList;
+    }
+
+    /**
+     * Set the column list for this node.  This is useful for check constraints
+     * where the list of referenced columns is built at bind time.
+     *
+     * @param columnList    The new columnList.
+     */
+    public void setColumnList(ResultColumnList columnList)
+    {
+        this.columnList = columnList;
+    }
+
+    /**
+     * Get the check condition from this table constraint.
+     *
+     * @return The check condition from this node.
+     */
+    public ValueNode getCheckCondition()
+    {
+        return checkCondition;
+    }
+
+    /**
+     * Set the check condition for this table constraint.
+     *
+     * @param checkCondition    The check condition
+     */
+    public void setCheckCondition(ValueNode checkCondition)
+    {
+        this.checkCondition = checkCondition;
+    }
+
+    /**
+     * Get the text of the constraint. (Only meaningful for check constraints.)
+     *
+     * @return The constraint text.
+     */
+    public String getConstraintText()
+    {
+        return constraintText;
+    }
+
+    /**
+     * Get the array of 1-based column references for a check constraint.
+     *
+     * @return    The array of 1-based column references for a check constraint.
+     */
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "DB-9810")
+    public int[] getCheckColumnReferences()
+    {
+        return checkColumnReferences;
+    }
+
+    /**
+     * Set the array of 1-based column references for a check constraint.
+     *
+     * @param checkColumnReferences    The array of 1-based column references
+     *                                for the check constraint.
+     */
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "DB-9810")
+    public void setCheckColumnReferences(int[] checkColumnReferences)
+    {
+        this.checkColumnReferences = checkColumnReferences;
+    }
+
+    /**
+     * Return the behavior of this constriant (DropStatementNode.xxx)
+     *
+     * @return the behavior
+     */
+    int getDropBehavior()
+    {
+        return behavior;
+    }
 
     /**
      * @return the expected type of the constraint, DataDictionary.DROP_CONSTRAINT if the constraint is
@@ -518,31 +518,31 @@ public class ConstraintDefinitionNode extends TableElementNode
         return verifyType;
     }
 
-	///////////////////////////////////////////////////////////////////////////
-	//
-	//	MINIONS
-	//
-	///////////////////////////////////////////////////////////////////////////
-	/**
-	  *	Get the UUID factory
-	  *
-	  *	@return	the UUID factory
-	  *
-	  */
-	private	UUIDFactory	getUUIDFactory()
-	{
-		if ( uuidFactory == null )
-		{
-			uuidFactory = Monitor.getMonitor().getUUIDFactory();
-		}
-		return	uuidFactory;
-	}
+    ///////////////////////////////////////////////////////////////////////////
+    //
+    //    MINIONS
+    //
+    ///////////////////////////////////////////////////////////////////////////
+    /**
+      *    Get the UUID factory
+      *
+      *    @return    the UUID factory
+      *
+      */
+    private    UUIDFactory    getUUIDFactory()
+    {
+        if ( uuidFactory == null )
+        {
+            uuidFactory = Monitor.getMonitor().getUUIDFactory();
+        }
+        return    uuidFactory;
+    }
 
-	public boolean canBeIgnored() {
-		return canBeIgnored;
-	}
+    public boolean canBeIgnored() {
+        return canBeIgnored;
+    }
 
-	public void setCanBeIgnored(boolean canBeIgnored) {
-		this.canBeIgnored = canBeIgnored;
-	}
+    public void setCanBeIgnored(boolean canBeIgnored) {
+        this.canBeIgnored = canBeIgnored;
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateTableNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateTableNode.java
@@ -35,16 +35,15 @@ import com.splicemachine.db.iapi.error.ExceptionSeverity;
 import com.splicemachine.db.iapi.reference.Property;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.reference.Limits;
+import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.services.property.PropertyUtil;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.StatementType;
 import com.splicemachine.db.iapi.sql.compile.*;
+import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ConstantAction;
 import com.splicemachine.db.iapi.sql.depend.ProviderList;
-import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
-import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
-import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.sql.conn.Authorizer;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.impl.sql.execute.ColumnInfo;
@@ -62,298 +61,315 @@ import java.util.Properties;
 
 public class CreateTableNode extends DDLStatementNode
 {
-	private int                 createBehavior;
-	private char				lockGranularity;
-	private boolean				onCommitDeleteRows; //If true, on commit delete rows else on commit preserve rows of temporary table.
-	private boolean				onRollbackDeleteRows; //If true, on rollback delete rows from temp table if it was logically modified in that UOW. true is the only supported value
-	private Properties			properties;
-	private TableElementList	tableElementList;
-	protected int	tableType; //persistent table or global temporary table
-	private ResultColumnList	resultColumns;
-	private ResultSetNode		queryExpression;
+    private int                 createBehavior;
+    private char                lockGranularity;
+    private boolean                onCommitDeleteRows; //If true, on commit delete rows else on commit preserve rows of temporary table.
+    private boolean                onRollbackDeleteRows; //If true, on rollback delete rows from temp table if it was logically modified in that UOW. true is the only supported value
+    private Properties            properties;
+    private TableElementList    tableElementList;
+    private FromTable           likeTable;
+    protected int    tableType; //persistent table or global temporary table
+    private ResultColumnList    resultColumns;
+    private ResultSetNode        queryExpression;
     private String              queryString;
-	boolean             		  isExternal;
-	ResultColumnList			  partitionedResultColumns;
-	CharConstantNode              terminationChar;
-	CharConstantNode              escapedByChar;
-	CharConstantNode              linesTerminatedByChar;
-	String              		  storageFormat;
-	CharConstantNode              location;
-	String              		  compression;
+    boolean                       isExternal;
+    ResultColumnList              partitionedResultColumns;
+    CharConstantNode              terminationChar;
+    CharConstantNode              escapedByChar;
+    CharConstantNode              linesTerminatedByChar;
+    String                        storageFormat;
+    CharConstantNode              location;
+    String                        compression;
     boolean                       mergeSchema;
-	boolean                       presplit;
-	boolean                       isLogicalKey;
-	String                        splitKeyPath;
-	String                        columnDelimiter;
-	String                        characterDelimiter;
-	String                        timestampFormat;
-	String                        dateFormat;
-	String                        timeFormat;
+    boolean                       presplit;
+    boolean                       isLogicalKey;
+    String                        splitKeyPath;
+    String                        columnDelimiter;
+    String                        characterDelimiter;
+    String                        timestampFormat;
+    String                        dateFormat;
+    String                        timeFormat;
 
-	/**
-	 * Initializer for a CreateTableNode for a base table
-	 *
-	 * @param newObjectName		The name of the new object being created (ie base table)
-	 * @param tableElementList	The elements of the table: columns,
-	 *				constraints, etc.
-	 * @param properties		The optional list of properties associated with
-	 *							the table.
-	 * @param lockGranularity	The lock granularity.
-	 *
-	 * @exception StandardException		Thrown on error
-	 */
+    /**
+     * Initializer for a CreateTableNode for a base table
+     *
+     * @param newObjectName        The name of the new object being created (ie base table)
+     * @param tableElementList    The elements of the table: columns,
+     *                constraints, etc.
+     * @param properties        The optional list of properties associated with
+     *                            the table.
+     * @param lockGranularity    The lock granularity.
+     *
+     * @exception StandardException        Thrown on error
+     */
 
-	public void init(
-			Object newObjectName,
-			Object createBehavior,
-			Object tableElementList,
-			Object properties,
-			Object lockGranularity,
-			Object isExternal,
-			Object partitionedResultColumns,
-			Object terminationChar,
-			Object escapedByChar,
-			Object linesTerminatedByChar,
-			Object storageFormat,
-			Object location,
-			Object compression,
-			Object mergeSchema) throws StandardException
-	{
-		this.createBehavior = ((Integer) createBehavior).intValue();
-		this.isExternal = (Boolean) isExternal;
-		if (this.isExternal)
-			tableType = TableDescriptor.EXTERNAL_TYPE;
-		else
-			tableType = TableDescriptor.BASE_TABLE_TYPE;
-		this.lockGranularity = (Character) lockGranularity;
-		implicitCreateSchema = true;
+    public CreateTableNode(
+            Object newObjectName,
+            Integer createBehavior,
+            TableElementList tableElementList,
+            FromTable likeTable,
+            Properties properties,
+            Character lockGranularity,
+            Boolean isExternal,
+            ResultColumnList partitionedResultColumns,
+            CharConstantNode terminationChar,
+            CharConstantNode escapedByChar,
+            CharConstantNode linesTerminatedByChar,
+            String storageFormat,
+            CharConstantNode location,
+            String compression,
+            Boolean mergeSchema,
+            ContextManager cm) throws StandardException
+    {
+        setContextManager(cm);
+        setNodeType(C_NodeTypes.CREATE_TABLE_NODE);
+        this.createBehavior = createBehavior;
+        this.isExternal = isExternal;
+        if (this.isExternal)
+            tableType = TableDescriptor.EXTERNAL_TYPE;
+        else
+            tableType = TableDescriptor.BASE_TABLE_TYPE;
+        this.lockGranularity = lockGranularity;
+        implicitCreateSchema = true;
 
-		if (SanityManager.DEBUG)
-		{
-			if (this.lockGranularity != TableDescriptor.TABLE_LOCK_GRANULARITY &&
-					this.lockGranularity != TableDescriptor.ROW_LOCK_GRANULARITY)
-			{
-				SanityManager.THROWASSERT(
-						"Unexpected value for lockGranularity = " + this.lockGranularity);
-			}
-		}
-		initAndCheck(newObjectName);
-		this.tableElementList = (TableElementList) tableElementList;
-		this.properties = (Properties) properties;
-		this.partitionedResultColumns = (ResultColumnList) partitionedResultColumns;
-		this.terminationChar = (CharConstantNode) terminationChar;
-		this.escapedByChar = (CharConstantNode) escapedByChar;
-		this.linesTerminatedByChar = (CharConstantNode) linesTerminatedByChar;
-		this.storageFormat = (String) storageFormat;
-		this.location = (CharConstantNode) location;
-		this.compression = (String) compression;
-		this.mergeSchema = (Boolean)mergeSchema;
-	}
+        if (SanityManager.DEBUG)
+        {
+            if (this.lockGranularity != TableDescriptor.TABLE_LOCK_GRANULARITY &&
+                    this.lockGranularity != TableDescriptor.ROW_LOCK_GRANULARITY)
+            {
+                SanityManager.THROWASSERT(
+                        "Unexpected value for lockGranularity = " + this.lockGranularity);
+            }
+        }
+        initAndCheck(newObjectName);
+        this.tableElementList = tableElementList;
+        this.likeTable = likeTable;
+        this.properties = properties;
+        this.partitionedResultColumns = partitionedResultColumns;
+        this.terminationChar = terminationChar;
+        this.escapedByChar = escapedByChar;
+        this.linesTerminatedByChar = linesTerminatedByChar;
+        this.storageFormat = storageFormat;
+        this.location = location;
+        this.compression = compression;
+        this.mergeSchema = mergeSchema;
+    }
 
-	public void init(
-			Object newObjectName,
-			Object createBehavior,
-			Object tableElementList,
-			Object properties,
-			Object lockGranularity,
-			Object presplit,
-			Object isLogicalKey,
-			Object splitKeyPath,
-			Object columnDelimiter,
-			Object characterDelimiter,
-			Object timestampFormat,
-			Object dateFormat,
-			Object timeFormat
-		)
-		throws StandardException
-	{
-		this.createBehavior = ((Integer) createBehavior).intValue();
-		this.isExternal = (Boolean) isExternal;
-		if (this.isExternal)
-			tableType = TableDescriptor.EXTERNAL_TYPE;
-		else
-			tableType = TableDescriptor.BASE_TABLE_TYPE;
-		this.lockGranularity = (Character) lockGranularity;
-		implicitCreateSchema = true;
+    public CreateTableNode(
+            Object newObjectName,
+            Integer createBehavior,
+            TableElementList tableElementList,
+            FromTable likeTable,
+            Properties properties,
+            Object lockGranularity,
+            Boolean presplit,
+            Boolean isLogicalKey,
+            CharConstantNode splitKeyPath,
+            CharConstantNode columnDelimiter,
+            CharConstantNode characterDelimiter,
+            CharConstantNode timestampFormat,
+            CharConstantNode dateFormat,
+            CharConstantNode timeFormat,
+            ContextManager cm
+        )
+        throws StandardException
+    {
+        setContextManager(cm);
+        setNodeType(C_NodeTypes.CREATE_TABLE_NODE);
+        this.createBehavior = createBehavior;
+        if (this.isExternal)
+            tableType = TableDescriptor.EXTERNAL_TYPE;
+        else
+            tableType = TableDescriptor.BASE_TABLE_TYPE;
+        this.lockGranularity = (Character) lockGranularity;
+        implicitCreateSchema = true;
 
-		if (SanityManager.DEBUG)
-		{
-			if (this.lockGranularity != TableDescriptor.TABLE_LOCK_GRANULARITY &&
-				this.lockGranularity != TableDescriptor.ROW_LOCK_GRANULARITY)
-			{
-				SanityManager.THROWASSERT(
-				"Unexpected value for lockGranularity = " + this.lockGranularity);
-			}
-		}
-		initAndCheck(newObjectName);
-		this.tableElementList = (TableElementList) tableElementList;
-		this.properties = (Properties) properties;
-		this.presplit = (Boolean) presplit;
-		this.isLogicalKey = (Boolean)isLogicalKey;
-        this.splitKeyPath = splitKeyPath!=null ? ((CharConstantNode)splitKeyPath).getString() : null;
-        this.columnDelimiter = columnDelimiter != null ? ((CharConstantNode)columnDelimiter).getString() : null;
-        this.characterDelimiter = characterDelimiter != null ? ((CharConstantNode)characterDelimiter).getString() : null;
-        this.timestampFormat = timestampFormat != null ? ((CharConstantNode)timestampFormat).getString() : null;
-        this.dateFormat = dateFormat != null ? ((CharConstantNode)dateFormat).getString() : null;
-        this.timeFormat = timeFormat != null ? ((CharConstantNode)timeFormat).getString() : null;
-	}
+        if (SanityManager.DEBUG)
+        {
+            if (this.lockGranularity != TableDescriptor.TABLE_LOCK_GRANULARITY &&
+                this.lockGranularity != TableDescriptor.ROW_LOCK_GRANULARITY)
+            {
+                SanityManager.THROWASSERT(
+                "Unexpected value for lockGranularity = " + this.lockGranularity);
+            }
+        }
+        initAndCheck(newObjectName);
+        this.tableElementList = tableElementList;
+        this.likeTable = likeTable;
+        this.properties = properties;
+        this.presplit = presplit;
+        this.isLogicalKey = isLogicalKey;
+        this.splitKeyPath = splitKeyPath!=null ? splitKeyPath.getString() : null;
+        this.columnDelimiter = columnDelimiter != null ? columnDelimiter.getString() : null;
+        this.characterDelimiter = characterDelimiter != null ? characterDelimiter.getString() : null;
+        this.timestampFormat = timestampFormat != null ? timestampFormat.getString() : null;
+        this.dateFormat = dateFormat != null ? dateFormat.getString() : null;
+        this.timeFormat = timeFormat != null ? timeFormat.getString() : null;
+    }
 
-	/**
-	 * Initializer for a CreateTableNode for a global temporary table
-	 *
-	 * @param newObjectName		The name of the new object being declared (ie temporary table)
-	 * @param tableElementList	The elements of the table: columns,
-	 *				constraints, etc.
-	 * @param properties		The optional list of properties associated with
-	 *							the table.
-	 * @param onCommitDeleteRows	If true, on commit delete rows else on commit preserve rows of temporary table.
-	 * @param onRollbackDeleteRows	If true, on rollback, delete rows from temp tables which were logically modified. true is the only supported value
-	 *
-	 * @exception StandardException		Thrown on error
-	 */
+    /**
+     * Initializer for a CreateTableNode for a global temporary table
+     *
+     * @param newObjectName        The name of the new object being declared (ie temporary table)
+     * @param tableElementList    The elements of the table: columns,
+     *                constraints, etc.
+     * @param properties        The optional list of properties associated with
+     *                            the table.
+     * @param onCommitDeleteRows    If true, on commit delete rows else on commit preserve rows of temporary table.
+     * @param onRollbackDeleteRows    If true, on rollback, delete rows from temp tables which were logically modified. true is the only supported value
+     *
+     * @exception StandardException        Thrown on error
+     */
 
-	public void init(
-			Object newObjectName,
-			Object createBehavior,
-			Object tableElementList,
-			Object properties,
-			Object onCommitDeleteRows,
-			Object onRollbackDeleteRows)
-		throws StandardException
-	{
-		this.createBehavior = ((Integer) createBehavior).intValue();
-		tableType = TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE;
-		lockGranularity = TableDescriptor.DEFAULT_LOCK_GRANULARITY;
-		implicitCreateSchema = true;
+    public CreateTableNode(
+            Object newObjectName,
+            Integer createBehavior,
+            TableElementList tableElementList,
+            FromTable likeTable,
+            Properties properties,
+            Boolean onCommitDeleteRows,
+            Boolean onRollbackDeleteRows,
+            ContextManager cm)
+        throws StandardException
+    {
+        setContextManager(cm);
+        setNodeType(C_NodeTypes.CREATE_TABLE_NODE);
+        this.createBehavior = createBehavior;
+        tableType = TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE;
+        lockGranularity = TableDescriptor.DEFAULT_LOCK_GRANULARITY;
+        implicitCreateSchema = true;
 
-		this.onCommitDeleteRows = (Boolean) onCommitDeleteRows;
-		this.onRollbackDeleteRows = (Boolean) onRollbackDeleteRows;
-		initAndCheck(newObjectName);
-		this.tableElementList = (TableElementList) tableElementList;
-		this.properties = (Properties) properties;
+        this.onCommitDeleteRows = onCommitDeleteRows;
+        this.onRollbackDeleteRows = onRollbackDeleteRows;
+        initAndCheck(newObjectName);
+        this.tableElementList = tableElementList;
+        this.likeTable = likeTable;
+        this.properties = properties;
 
-		if (SanityManager.DEBUG)
-		{
-			if (!this.onRollbackDeleteRows)
-			{
-				SanityManager.THROWASSERT(
-				"Unexpected value for onRollbackDeleteRows = " + this.onRollbackDeleteRows);
-			}
-		}
+        if (SanityManager.DEBUG)
+        {
+            if (!this.onRollbackDeleteRows)
+            {
+                SanityManager.THROWASSERT(
+                "Unexpected value for onRollbackDeleteRows = " + this.onRollbackDeleteRows);
+            }
+        }
+    }
 
-	}
-	
-	/**
-	 * Initializer for a CreateTableNode for a base table create from a query
-	 * 
-	 * @param newObjectName		The name of the new object being created
-	 * 	                        (ie base table).
-	 * @param resultColumns		The optional column list.
-	 * @param queryExpression	The query expression for the table.
-	 */
-	public void init(
-			Object newObjectName,
-			Object createBehavior,
-			Object resultColumns,
-			Object queryExpression,
-			Object isExternal,
-			Object partitionedResultColumns,
-			Object terminationChar,
-			Object escapedByChar,
-			Object linesTerminatedByChar,
-			Object storageFormat,
-			Object location)
-		throws StandardException
-	{
-		this.createBehavior = ((Integer) createBehavior).intValue();
-		tableType = TableDescriptor.BASE_TABLE_TYPE;
-		lockGranularity = TableDescriptor.DEFAULT_LOCK_GRANULARITY;
-		implicitCreateSchema = true;
-		initAndCheck(newObjectName);
-		this.resultColumns = (ResultColumnList) resultColumns;
-		this.queryExpression = (ResultSetNode) queryExpression;
-		this.isExternal = (Boolean) isExternal;
-		this.partitionedResultColumns = (ResultColumnList) partitionedResultColumns;
-		this.terminationChar = (CharConstantNode) terminationChar;
-		this.escapedByChar = (CharConstantNode) escapedByChar;
-		this.linesTerminatedByChar = (CharConstantNode) linesTerminatedByChar;
-		this.storageFormat = (String) storageFormat;
-		this.location = (CharConstantNode) location;
-	}
+    /**
+     * Initializer for a CreateTableNode for a base table create from a query
+     *
+     * @param newObjectName        The name of the new object being created
+     *                             (ie base table).
+     * @param resultColumns        The optional column list.
+     * @param queryExpression    The query expression for the table.
+     */
+    public CreateTableNode(
+            Object newObjectName,
+            Integer createBehavior,
+            ResultColumnList resultColumns,
+            ResultSetNode queryExpression,
+            Boolean isExternal,
+            ResultColumnList partitionedResultColumns,
+            CharConstantNode terminationChar,
+            CharConstantNode escapedByChar,
+            CharConstantNode linesTerminatedByChar,
+            String storageFormat,
+            CharConstantNode location,
+            ContextManager cm)
+        throws StandardException
+    {
+        setContextManager(cm);
+        setNodeType(C_NodeTypes.CREATE_TABLE_NODE);
+        this.createBehavior = createBehavior;
+        tableType = TableDescriptor.BASE_TABLE_TYPE;
+        lockGranularity = TableDescriptor.DEFAULT_LOCK_GRANULARITY;
+        implicitCreateSchema = true;
+        initAndCheck(newObjectName);
+        this.resultColumns = resultColumns;
+        this.queryExpression = queryExpression;
+        this.isExternal = isExternal;
+        this.partitionedResultColumns = partitionedResultColumns;
+        this.terminationChar = terminationChar;
+        this.escapedByChar = escapedByChar;
+        this.linesTerminatedByChar = linesTerminatedByChar;
+        this.storageFormat = storageFormat;
+        this.location = location;
+    }
 
     public void setQueryString(String queryString) {
         this.queryString = queryString;
     }
 
-	/**
-	 * Convert this object to a String.  See comments in QueryTreeNode.java
-	 * for how this should be done for tree printing.
-	 *
-	 * @return	This object as a String
-	 */
+    /**
+     * Convert this object to a String.  See comments in QueryTreeNode.java
+     * for how this should be done for tree printing.
+     *
+     * @return    This object as a String
+     */
 
-	public String toString()
-	{
-		if (SanityManager.DEBUG)
-		{
-			String tempString = "";
-			if (tableType == TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE)
-			{
-				tempString = tempString + "onCommitDeleteRows: " + "\n" + onCommitDeleteRows + "\n";
-				tempString = tempString + "onRollbackDeleteRows: " + "\n" + onRollbackDeleteRows + "\n";
-			} else
-				tempString = tempString +
-					(properties != null ?
-					 "properties: " + "\n" + properties + "\n" :
-					 "") +
-					"lockGranularity: " + lockGranularity + "\n";
-			return super.toString() +  tempString;
-		}
-		else
-		{
-			return "";
-		}
-	}
+    public String toString()
+    {
+        if (SanityManager.DEBUG)
+        {
+            String tempString = "";
+            if (tableType == TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE)
+            {
+                tempString = tempString + "onCommitDeleteRows: " + "\n" + onCommitDeleteRows + "\n";
+                tempString = tempString + "onRollbackDeleteRows: " + "\n" + onRollbackDeleteRows + "\n";
+            } else
+                tempString = tempString +
+                    (properties != null ?
+                     "properties: " + "\n" + properties + "\n" :
+                     "") +
+                    "lockGranularity: " + lockGranularity + "\n";
+            return super.toString() +  tempString;
+        }
+        else
+        {
+            return "";
+        }
+    }
 
-	/**
-	 * Prints the sub-nodes of this object.  See QueryTreeNode.java for
-	 * how tree printing is supposed to work.
-	 * @param depth		The depth to indent the sub-nodes
-	 */
-	public void printSubNodes(int depth) {
-		if (SanityManager.DEBUG) {
-			printLabel(depth, "tableElementList: ");
-			tableElementList.treePrint(depth + 1);
-		}
-	}
+    /**
+     * Prints the sub-nodes of this object.  See QueryTreeNode.java for
+     * how tree printing is supposed to work.
+     * @param depth        The depth to indent the sub-nodes
+     */
+    public void printSubNodes(int depth) {
+        if (SanityManager.DEBUG) {
+            printLabel(depth, "tableElementList: ");
+            tableElementList.treePrint(depth + 1);
+        }
+    }
 
 
-	public String statementToString()
-	{
-		if (tableType == TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE)
-			return "DECLARE GLOBAL TEMPORARY TABLE";
-		else
-			return "CREATE TABLE";
-	}
+    public String statementToString()
+    {
+        if (tableType == TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE)
+            return "DECLARE GLOBAL TEMPORARY TABLE";
+        else
+            return "CREATE TABLE";
+    }
 
-	// We inherit the generate() method from DDLStatementNode.
+    // We inherit the generate() method from DDLStatementNode.
 
-	/**
-	 * Bind this CreateTableNode.  This means doing any static error checking that can be
-	 * done before actually creating the base table or declaring the global temporary table.
-	 * For eg, verifying that the TableElementList does not contain any duplicate column names.
-	 *
-	 *
-	 * @exception StandardException		Thrown on error
-	 */
+    /**
+     * Bind this CreateTableNode.  This means doing any static error checking that can be
+     * done before actually creating the base table or declaring the global temporary table.
+     * For eg, verifying that the TableElementList does not contain any duplicate column names.
+     *
+     *
+     * @exception StandardException        Thrown on error
+     */
 
-	public void bindStatement() throws StandardException
-	{
-		DataDictionary	dataDictionary = getDataDictionary();
-		int numPrimaryKeys = 0;
-		int numCheckConstraints = 0;
-		int numReferenceConstraints = 0;
-		int numUniqueConstraints = 0;
+    public void bindStatement() throws StandardException
+    {
+        DataDictionary    dataDictionary = getDataDictionary();
+        int numPrimaryKeys = 0;
+        int numCheckConstraints = 0;
+        int numReferenceConstraints = 0;
+        int numUniqueConstraints = 0;
         int numGenerationClauses = 0;
 
         SchemaDescriptor sd = getSchemaDescriptor
@@ -362,287 +378,291 @@ public class CreateTableNode extends DDLStatementNode
         TableDescriptor td = getTableDescriptor( objectName.tableName, sd );
         if (td != null && createBehavior == StatementType.CREATE_IF_NOT_EXISTS)
         {
-        	StandardException e = StandardException.newException(SQLState.LANG_OBJECT_ALREADY_EXISTS_IN_OBJECT,
-					"table", objectName.tableName, "schema", sd.getSchemaName());
-        	e.setSeverity(ExceptionSeverity.WARNING_SEVERITY);
-        	throw e;
+            StandardException e = StandardException.newException(SQLState.LANG_OBJECT_ALREADY_EXISTS_IN_OBJECT,
+                    "table", objectName.tableName, "schema", sd.getSchemaName());
+            e.setSeverity(ExceptionSeverity.WARNING_SEVERITY);
+            throw e;
         }
 
-		if (queryExpression != null)
-		{
-			FromList fromList = (FromList) getNodeFactory().getNode(
-					C_NodeTypes.FROM_LIST,
-					getNodeFactory().doJoinOrderOptimization(),
-					getContextManager());
-			
-			CompilerContext cc = getCompilerContext();
-			ProviderList prevAPL = cc.getCurrentAuxiliaryProviderList();
-			ProviderList apl = new ProviderList();
-			
-			try
-			{
-				cc.setCurrentAuxiliaryProviderList(apl);
-				cc.pushCurrentPrivType(Authorizer.SELECT_PRIV);
-				
-				/* Bind the tables in the queryExpression */
-				queryExpression =
-					queryExpression.bindNonVTITables(dataDictionary, fromList);
-				queryExpression = queryExpression.bindVTITables(fromList);
-				
-				/* Bind the expressions under the resultSet */
-				queryExpression.bindExpressions(fromList);
-				
-				/* Bind the query expression */
-				queryExpression.bindResultColumns(fromList);
-				
-				/* Reject any untyped nulls in the RCL */
-				/* e.g. CREATE TABLE t1 (x) AS VALUES NULL WITH NO DATA */
-				queryExpression.bindUntypedNullsToResultColumns(null);
-			}
-			finally
-			{
-				cc.popCurrentPrivType();
-				cc.setCurrentAuxiliaryProviderList(prevAPL);
-			}
-			
-			/* If there is an RCL for the table definition then copy the
-			 * names to the queryExpression's RCL after verifying that
-			 * they both have the same size.
-			 */
-			ResultColumnList qeRCL = queryExpression.getResultColumns();
-			
-			if (resultColumns != null)
-			{
-				if (resultColumns.size() != qeRCL.visibleSize())
-				{
-					throw StandardException.newException(
-							SQLState.LANG_TABLE_DEFINITION_R_C_L_MISMATCH,
-							getFullName());
-				}
-				qeRCL.copyResultColumnNames(resultColumns);
-			}
-			
-			int schemaCollationType = sd.getCollationType();
-	    
-			/* Create table element list from columns in query expression */
-			tableElementList = new TableElementList();
-			
-			for (int index = 0; index < qeRCL.size(); index++)
-			{
-				ResultColumn rc = qeRCL.elementAt(index);
-				if (rc.isGenerated()) 
-				{
-					continue;
-				}
-				/* Raise error if column name is system generated. */
-				if (rc.isNameGenerated())
-				{
-					throw StandardException.newException(
-							SQLState.LANG_TABLE_REQUIRES_COLUMN_NAMES);
-				}
+        if (likeTable != null && tableElementList == null) {
+            fillTableElementListFromLikeTable();
+        }
 
-				DataTypeDescriptor dtd = rc.getExpression().getTypeServices();
-				if ((dtd != null) && !dtd.isUserCreatableType())
-				{
-					throw StandardException.newException(
-							SQLState.LANG_INVALID_COLUMN_TYPE_CREATE_TABLE,
-							dtd.getFullSQLTypeName(),
-							rc.getName());
-				}
-				else if (dtd == null)
-				{
-					throw StandardException.newException(
-							SQLState.LANG_INVALID_COLUMN_TYPE_CREATE_TABLE,
-							"<UNKNOWN>",
-							rc.getName());
-				}
-				//DERBY-2879  CREATE TABLE AS <subquery> does not maintain the 
-				//collation for character types. 
-				//eg for a territory based collation database
-				//create table t as select tablename from sys.systables with no data;
-				//Derby at this point does not support for a table's character 
-				//columns to have a collation different from it's schema's
-				//collation. Which means that in a territory based database, 
-				//the query above will cause table t's character columns to
-				//have collation of UCS_BASIC but the containing schema of t
-				//has collation of territory based. This is not supported and
-				//hence we will throw an exception below for the query above in
-				//a territory based database. 
-				if (dtd.getTypeId().isStringTypeId() &&
-						dtd.getCollationType() != schemaCollationType)
-				{
-					throw StandardException.newException(
-							SQLState.LANG_CAN_NOT_CREATE_TABLE,
-							dtd.getCollationName(),
-							DataTypeDescriptor.getCollationName(schemaCollationType));
-				}
+        if (queryExpression != null)
+        {
+            FromList fromList = (FromList) getNodeFactory().getNode(
+                    C_NodeTypes.FROM_LIST,
+                    getNodeFactory().doJoinOrderOptimization(),
+                    getContextManager());
 
-				ColumnDefinitionNode column = (ColumnDefinitionNode) getNodeFactory().getNode
+            CompilerContext cc = getCompilerContext();
+            ProviderList prevAPL = cc.getCurrentAuxiliaryProviderList();
+            ProviderList apl = new ProviderList();
+
+            try
+            {
+                cc.setCurrentAuxiliaryProviderList(apl);
+                cc.pushCurrentPrivType(Authorizer.SELECT_PRIV);
+
+                /* Bind the tables in the queryExpression */
+                queryExpression =
+                    queryExpression.bindNonVTITables(dataDictionary, fromList);
+                queryExpression = queryExpression.bindVTITables(fromList);
+
+                /* Bind the expressions under the resultSet */
+                queryExpression.bindExpressions(fromList);
+
+                /* Bind the query expression */
+                queryExpression.bindResultColumns(fromList);
+
+                /* Reject any untyped nulls in the RCL */
+                /* e.g. CREATE TABLE t1 (x) AS VALUES NULL WITH NO DATA */
+                queryExpression.bindUntypedNullsToResultColumns(null);
+            }
+            finally
+            {
+                cc.popCurrentPrivType();
+                cc.setCurrentAuxiliaryProviderList(prevAPL);
+            }
+
+            /* If there is an RCL for the table definition then copy the
+             * names to the queryExpression's RCL after verifying that
+             * they both have the same size.
+             */
+            ResultColumnList qeRCL = queryExpression.getResultColumns();
+
+            if (resultColumns != null)
+            {
+                if (resultColumns.size() != qeRCL.visibleSize())
+                {
+                    throw StandardException.newException(
+                            SQLState.LANG_TABLE_DEFINITION_R_C_L_MISMATCH,
+                            getFullName());
+                }
+                qeRCL.copyResultColumnNames(resultColumns);
+            }
+
+            int schemaCollationType = sd.getCollationType();
+
+            /* Create table element list from columns in query expression */
+            tableElementList = new TableElementList(getContextManager());
+
+            for (int index = 0; index < qeRCL.size(); index++)
+            {
+                ResultColumn rc = qeRCL.elementAt(index);
+                if (rc.isGenerated())
+                {
+                    continue;
+                }
+                /* Raise error if column name is system generated. */
+                if (rc.isNameGenerated())
+                {
+                    throw StandardException.newException(
+                            SQLState.LANG_TABLE_REQUIRES_COLUMN_NAMES);
+                }
+
+                DataTypeDescriptor dtd = rc.getExpression().getTypeServices();
+                if ((dtd != null) && !dtd.isUserCreatableType())
+                {
+                    throw StandardException.newException(
+                            SQLState.LANG_INVALID_COLUMN_TYPE_CREATE_TABLE,
+                            dtd.getFullSQLTypeName(),
+                            rc.getName());
+                }
+                else if (dtd == null)
+                {
+                    throw StandardException.newException(
+                            SQLState.LANG_INVALID_COLUMN_TYPE_CREATE_TABLE,
+                            "<UNKNOWN>",
+                            rc.getName());
+                }
+                //DERBY-2879  CREATE TABLE AS <subquery> does not maintain the
+                //collation for character types.
+                //eg for a territory based collation database
+                //create table t as select tablename from sys.systables with no data;
+                //Derby at this point does not support for a table's character
+                //columns to have a collation different from it's schema's
+                //collation. Which means that in a territory based database,
+                //the query above will cause table t's character columns to
+                //have collation of UCS_BASIC but the containing schema of t
+                //has collation of territory based. This is not supported and
+                //hence we will throw an exception below for the query above in
+                //a territory based database.
+                if (dtd.getTypeId().isStringTypeId() &&
+                        dtd.getCollationType() != schemaCollationType)
+                {
+                    throw StandardException.newException(
+                            SQLState.LANG_CAN_NOT_CREATE_TABLE,
+                            dtd.getCollationName(),
+                            DataTypeDescriptor.getCollationName(schemaCollationType));
+                }
+
+                ColumnDefinitionNode column = (ColumnDefinitionNode) getNodeFactory().getNode
                     ( C_NodeTypes.COLUMN_DEFINITION_NODE, rc.getName(), null, rc.getType(), null, getContextManager() );
-				tableElementList.addTableElement(column);
-			}
-		} else {
-			//Set the collation type and collation derivation of all the 
-			//character type columns. Their collation type will be same as the 
-			//collation of the schema they belong to. Their collation 
-			//derivation will be "implicit". 
-			//Earlier we did this in makeConstantAction but that is little too 
-			//late (DERBY-2955)
-			//eg 
-			//CREATE TABLE STAFF9 (EMPNAME CHAR(20),
-			//  CONSTRAINT STAFF9_EMPNAME CHECK (EMPNAME NOT LIKE 'T%'))
-			//For the query above, when run in a territory based db, we need 
-			//to have the correct collation set in bind phase of create table 
-			//so that when LIKE is handled in LikeEscapeOperatorNode, we have 
-			//the correct collation set for EMPNAME otherwise it will throw an 
-			//exception for 'T%' having collation of territory based and 
-			//EMPNAME having the default collation of UCS_BASIC
-			tableElementList.setCollationTypesOnCharacterStringColumns(
-				getSchemaDescriptor(
-					tableType != TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE,
-					true));
-		}
+                tableElementList.addTableElement(column);
+            }
+        } else {
+            //Set the collation type and collation derivation of all the
+            //character type columns. Their collation type will be same as the
+            //collation of the schema they belong to. Their collation
+            //derivation will be "implicit".
+            //Earlier we did this in makeConstantAction but that is little too
+            //late (DERBY-2955)
+            //eg
+            //CREATE TABLE STAFF9 (EMPNAME CHAR(20),
+            //  CONSTRAINT STAFF9_EMPNAME CHECK (EMPNAME NOT LIKE 'T%'))
+            //For the query above, when run in a territory based db, we need
+            //to have the correct collation set in bind phase of create table
+            //so that when LIKE is handled in LikeEscapeOperatorNode, we have
+            //the correct collation set for EMPNAME otherwise it will throw an
+            //exception for 'T%' having collation of territory based and
+            //EMPNAME having the default collation of UCS_BASIC
+            tableElementList.setCollationTypesOnCharacterStringColumns(
+                getSchemaDescriptor(
+                    tableType != TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE,
+                    true));
+        }
 
-		tableElementList.validate(this, dataDictionary, (TableDescriptor) null);
+        tableElementList.validate(this, dataDictionary, (TableDescriptor) null);
 
-		/* Only 1012 columns allowed per table */
-		if (tableElementList.countNumberOfColumns() > Limits.DB2_MAX_COLUMNS_IN_TABLE)
-		{
-			throw StandardException.newException(SQLState.LANG_TOO_MANY_COLUMNS_IN_TABLE_OR_VIEW,
-				String.valueOf(tableElementList.countNumberOfColumns()),
-				getRelativeName(),
-				String.valueOf(Limits.DB2_MAX_COLUMNS_IN_TABLE));
-		}
+        /* Only 1012 columns allowed per table */
+        if (tableElementList.countNumberOfColumns() > Limits.DB2_MAX_COLUMNS_IN_TABLE)
+        {
+            throw StandardException.newException(SQLState.LANG_TOO_MANY_COLUMNS_IN_TABLE_OR_VIEW,
+                String.valueOf(tableElementList.countNumberOfColumns()),
+                getRelativeName(),
+                String.valueOf(Limits.DB2_MAX_COLUMNS_IN_TABLE));
+        }
 
-		numPrimaryKeys = tableElementList.countConstraints(
-								DataDictionary.PRIMARYKEY_CONSTRAINT);
+        numPrimaryKeys = tableElementList.countConstraints(
+                                DataDictionary.PRIMARYKEY_CONSTRAINT);
 
-		/* Only 1 primary key allowed per table */
-		if (numPrimaryKeys > 1) {
-			throw StandardException.newException(SQLState.LANG_TOO_MANY_PRIMARY_KEY_CONSTRAINTS, getRelativeName());
-		}
+        /* Only 1 primary key allowed per table */
+        if (numPrimaryKeys > 1) {
+            throw StandardException.newException(SQLState.LANG_TOO_MANY_PRIMARY_KEY_CONSTRAINTS, getRelativeName());
+        }
 
-		/* Check the validity of all check constraints */
-		numCheckConstraints = tableElementList.countConstraints(
-									DataDictionary.CHECK_CONSTRAINT);
+        /* Check the validity of all check constraints */
+        numCheckConstraints = tableElementList.countConstraints(
+                                    DataDictionary.CHECK_CONSTRAINT);
 
-		numReferenceConstraints = tableElementList.countConstraints(
-									DataDictionary.FOREIGNKEY_CONSTRAINT);
+        numReferenceConstraints = tableElementList.countConstraints(
+                                    DataDictionary.FOREIGNKEY_CONSTRAINT);
 
-		numUniqueConstraints = tableElementList.countConstraints(
-									DataDictionary.UNIQUE_CONSTRAINT);
+        numUniqueConstraints = tableElementList.countConstraints(
+                                    DataDictionary.UNIQUE_CONSTRAINT);
 
         numGenerationClauses = tableElementList.countGenerationClauses();
 
-		if (tableType == TableDescriptor.EXTERNAL_TYPE) {
-			if (numPrimaryKeys>0)
-				throw StandardException.newException(SQLState.EXTERNAL_TABLES_NO_PRIMARY_KEYS,getRelativeName());
-			if (numCheckConstraints>0)
-				throw StandardException.newException(SQLState.EXTERNAL_TABLES_NO_CHECK_CONSTRAINTS,getRelativeName());
-			if (numReferenceConstraints>0)
-				throw StandardException.newException(SQLState.EXTERNAL_TABLES_NO_REFERENCE_CONSTRAINTS,getRelativeName());
-			if (numUniqueConstraints>0)
-				throw StandardException.newException(SQLState.EXTERNAL_TABLES_NO_UNIQUE_CONSTRAINTS,getRelativeName());
-			if (numGenerationClauses>0)
-				throw StandardException.newException(SQLState.EXTERNAL_TABLES_NO_GENERATION_CLAUSES,getRelativeName());
+        if (tableType == TableDescriptor.EXTERNAL_TYPE) {
+            if (numPrimaryKeys>0)
+                throw StandardException.newException(SQLState.EXTERNAL_TABLES_NO_PRIMARY_KEYS,getRelativeName());
+            if (numCheckConstraints>0)
+                throw StandardException.newException(SQLState.EXTERNAL_TABLES_NO_CHECK_CONSTRAINTS,getRelativeName());
+            if (numReferenceConstraints>0)
+                throw StandardException.newException(SQLState.EXTERNAL_TABLES_NO_REFERENCE_CONSTRAINTS,getRelativeName());
+            if (numUniqueConstraints>0)
+                throw StandardException.newException(SQLState.EXTERNAL_TABLES_NO_UNIQUE_CONSTRAINTS,getRelativeName());
+            if (numGenerationClauses>0)
+                throw StandardException.newException(SQLState.EXTERNAL_TABLES_NO_GENERATION_CLAUSES,getRelativeName());
 
-		}
+        }
 
 
-		//temp tables can't have foreign key constraints defined on them
-		if ((tableType == TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE) &&
-			(numReferenceConstraints > 0))
-				throw StandardException.newException(SQLState.LANG_NOT_ALLOWED_FOR_TEMP_TABLE);
+        //temp tables can't have foreign key constraints defined on them
+        if ((tableType == TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE) &&
+            (numReferenceConstraints > 0))
+                throw StandardException.newException(SQLState.LANG_NOT_ALLOWED_FOR_TEMP_TABLE);
 
-		//each of these constraints have a backing index in the back. We need to make sure that a table never has more
-		//more than 32767 indexes on it and that is why this check.
-		if ((numPrimaryKeys + numReferenceConstraints + numUniqueConstraints) > Limits.DB2_MAX_INDEXES_ON_TABLE)
-		{
-			throw StandardException.newException(SQLState.LANG_TOO_MANY_INDEXES_ON_TABLE, 
-				String.valueOf(numPrimaryKeys + numReferenceConstraints + numUniqueConstraints),
-				getRelativeName(),
-				String.valueOf(Limits.DB2_MAX_INDEXES_ON_TABLE));
-		}
+        //each of these constraints have a backing index in the back. We need to make sure that a table never has more
+        //more than 32767 indexes on it and that is why this check.
+        if ((numPrimaryKeys + numReferenceConstraints + numUniqueConstraints) > Limits.DB2_MAX_INDEXES_ON_TABLE)
+        {
+            throw StandardException.newException(SQLState.LANG_TOO_MANY_INDEXES_ON_TABLE,
+                String.valueOf(numPrimaryKeys + numReferenceConstraints + numUniqueConstraints),
+                getRelativeName(),
+                String.valueOf(Limits.DB2_MAX_INDEXES_ON_TABLE));
+        }
 
-		if ( (numCheckConstraints > 0) || (numGenerationClauses > 0) || (numReferenceConstraints > 0) )
-		{
-			/* In order to check the validity of the check constraints and
-			 * generation clauses
-			 * we must goober up a FromList containing a single table,
-			 * the table being created, with an RCL containing the
-			 * new columns and their types.  This will allow us to
-			 * bind the constraint definition trees against that
-			 * FromList.  When doing this, we verify that there are
-			 * no nodes which can return non-deterministic results.
-			 */
-			FromList fromList = makeFromList( null, tableElementList, true );
+        if ( (numCheckConstraints > 0) || (numGenerationClauses > 0) || (numReferenceConstraints > 0) )
+        {
+            /* In order to check the validity of the check constraints and
+             * generation clauses
+             * we must goober up a FromList containing a single table,
+             * the table being created, with an RCL containing the
+             * new columns and their types.  This will allow us to
+             * bind the constraint definition trees against that
+             * FromList.  When doing this, we verify that there are
+             * no nodes which can return non-deterministic results.
+             */
+            FromList fromList = makeFromList( null, tableElementList, true );
             FormatableBitSet    generatedColumns = new FormatableBitSet();
 
-			/* Now that we've finally goobered stuff up, bind and validate
-			 * the check constraints and generation clauses.
-			 */
-			if  (numGenerationClauses > 0) { tableElementList.bindAndValidateGenerationClauses( sd, fromList, generatedColumns, null ); }
-			if  (numCheckConstraints > 0) { tableElementList.bindAndValidateCheckConstraints(fromList); }
+            /* Now that we've finally goobered stuff up, bind and validate
+             * the check constraints and generation clauses.
+             */
+            if  (numGenerationClauses > 0) { tableElementList.bindAndValidateGenerationClauses( sd, fromList, generatedColumns, null ); }
+            if  (numCheckConstraints > 0) { tableElementList.bindAndValidateCheckConstraints(fromList); }
             if ( numReferenceConstraints > 0) { tableElementList.validateForeignKeysOnGenerationClauses( fromList, generatedColumns ); }
-		}
+        }
 
         if ( numPrimaryKeys > 0 ) {
-			tableElementList.validatePrimaryKeyNullability();
-		}
-	}
+            tableElementList.validatePrimaryKeyNullability();
+        }
+    }
 
-	/**
-	 * Return true if the node references SESSION schema tables (temporary or permanent)
-	 *
-	 * @return	true if references SESSION schema tables, else false
-	 *
-	 * @exception StandardException		Thrown on error
-	 */
-	@Override
-	public boolean referencesSessionSchema()
-		throws StandardException
-	{
-		//If table being created/declared is in SESSION schema, then return true.
-		return isSessionSchema(
-			getSchemaDescriptor(
-				tableType != TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE,
-				true));
-	}
+    /**
+     * Return true if the node references SESSION schema tables (temporary or permanent)
+     *
+     * @return    true if references SESSION schema tables, else false
+     *
+     * @exception StandardException        Thrown on error
+     */
+    @Override
+    public boolean referencesSessionSchema()
+        throws StandardException
+    {
+        //If table being created/declared is in SESSION schema, then return true.
+        return isSessionSchema(
+            getSchemaDescriptor(
+                tableType != TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE,
+                true));
+    }
 
-	/**
-	 * Return true if the node references temporary tables no matter under which schema
-	 *
-	 * @return true if references temporary tables, else false
-	 */
-	@Override
-	public boolean referencesTemporaryTable()
-	{
-		return tableType == TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE;
-	}
+    /**
+     * Return true if the node references temporary tables no matter under which schema
+     *
+     * @return true if references temporary tables, else false
+     */
+    @Override
+    public boolean referencesTemporaryTable()
+    {
+        return tableType == TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE;
+    }
 
-	/**
-	 * Create the Constant information that will drive the guts of Execution.
-	 *
-	 * @exception StandardException		Thrown on failure
-	 */
-	public ConstantAction	makeConstantAction() throws StandardException
-	{
-		TableElementList		coldefs = tableElementList;
+    /**
+     * Create the Constant information that will drive the guts of Execution.
+     *
+     * @exception StandardException        Thrown on failure
+     */
+    public ConstantAction    makeConstantAction() throws StandardException
+    {
+        TableElementList        coldefs = tableElementList;
 
-		// for each column, stuff system.column
-		ColumnInfo[] colInfos = new ColumnInfo[coldefs.countNumberOfColumns()];
+        // for each column, stuff system.column
+        ColumnInfo[] colInfos = new ColumnInfo[coldefs.countNumberOfColumns()];
 
-	    int numConstraints = coldefs.genColumnInfos(colInfos, this.partitionedResultColumns);
+        int numConstraints = coldefs.genColumnInfos(colInfos, this.partitionedResultColumns);
 
-		/* If we've seen a constraint, then build a constraint list */
-		ConstantAction[] conActions = null;
+        /* If we've seen a constraint, then build a constraint list */
+        ConstantAction[] conActions = null;
 
-		SchemaDescriptor sd = getSchemaDescriptor(tableType != TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE,true);
-		
-		if (numConstraints > 0) {
-			conActions = getGenericConstantActionFactory().createConstraintConstantActionArray(numConstraints);
-			coldefs.genConstraintActions(true,conActions, getRelativeName(), sd, getDataDictionary());
-		}
+        SchemaDescriptor sd = getSchemaDescriptor(tableType != TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE,true);
+
+        if (numConstraints > 0) {
+            conActions = getGenericConstantActionFactory().createConstraintConstantActionArray(numConstraints);
+            coldefs.genConstraintActions(true,conActions, getRelativeName(), sd, getDataDictionary());
+        }
 
         // if the any of columns are "long" and user has not specified a
         // page size, set the pagesize to 32k.
@@ -664,7 +684,7 @@ public class CreateTableNode extends DDLStatementNode
 
         if (table_has_long_column || (approxLength > Property.TBL_PAGE_SIZE_BUMP_THRESHOLD))
         {
-			if (((properties == null) ||
+            if (((properties == null) ||
                  (properties.get(Property.PAGE_SIZE_PARAMETER) == null)) &&
                 (PropertyUtil.getServiceProperty(
                      getLanguageConnectionContext().getTransactionCompile(),
@@ -682,7 +702,7 @@ public class CreateTableNode extends DDLStatementNode
             }
         }
 
-		return(
+        return(
             getGenericConstantActionFactory().getCreateTableConstantAction(
                     sd.getSchemaName(),
                     getRelativeName(),
@@ -714,30 +734,57 @@ public class CreateTableNode extends DDLStatementNode
             ));
     }
 
-	/**
-	 * Accept the visitor for all visitable children of this node.
-	 * 
-	 * @param v the visitor
-	 */
+    /**
+     * Accept the visitor for all visitable children of this node.
+     *
+     * @param v the visitor
+     */
     @Override
-	public void acceptChildren(Visitor v) throws StandardException {
-		super.acceptChildren(v);
+    public void acceptChildren(Visitor v) throws StandardException {
+        super.acceptChildren(v);
 
-		if (tableElementList != null)
-		{
-			tableElementList.accept(v, this);
-		}
-	}
+        if (tableElementList != null)
+        {
+            tableElementList.accept(v, this);
+        }
+    }
 
-	@Override
-	public void optimizeStatement() throws StandardException {
-    	for(int i=tableElementList.size()-1; i>=0; --i) {
-    		Object element = tableElementList.elementAt(i);
-			if(element instanceof ConstraintDefinitionNode) {
-				if(((ConstraintDefinitionNode)element).canBeIgnored()) {
-					tableElementList.removeElementAt(i);
-				}
-			}
-		}
-	}
+    @Override
+    public void optimizeStatement() throws StandardException {
+        for(int i=tableElementList.size()-1; i>=0; --i) {
+            Object element = tableElementList.elementAt(i);
+            if(element instanceof ConstraintDefinitionNode) {
+                if(((ConstraintDefinitionNode)element).canBeIgnored()) {
+                    tableElementList.removeElementAt(i);
+                }
+            }
+        }
+    }
+
+    private void fillTableElementListFromLikeTable() throws StandardException {
+        if (!(likeTable instanceof FromBaseTable)) {
+            throw StandardException.newException(
+                    SQLState.LANG_TABLE_REQUIRES_COLUMN_NAMES); // XXX define own
+        }
+        tableElementList = new TableElementList(getContextManager());
+        TableDescriptor likeTd = ((FromBaseTable) likeTable).bindTableDescriptor();
+        for (ColumnDescriptor cd: likeTd.getColumnDescriptorList()) {
+
+            DefaultNode defaultNode = cd.getDefaultInfo() == null ? null :
+                    (DefaultNode) getNodeFactory().getNode(
+                            C_NodeTypes.DEFAULT_NODE,
+                            DefaultNode.parseDefault(cd.getDefaultInfo().getDefaultText(), getLanguageConnectionContext(), getCompilerContext()),
+                            cd.getDefaultInfo().getDefaultText(),
+                            getContextManager());
+
+            ColumnDefinitionNode column = (ColumnDefinitionNode) getNodeFactory().getNode(
+                    C_NodeTypes.COLUMN_DEFINITION_NODE,
+                    cd.getColumnName(),
+                    defaultNode,
+                    cd.getType(),
+                    null, // Ignore autoincrement
+                    getContextManager() );
+            tableElementList.addTableElement(column);
+        }
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -1489,7 +1489,7 @@ public class FromBaseTable extends FromTable {
      *
      * @throws StandardException Thrown on error
      */
-    private TableDescriptor bindTableDescriptor()
+    TableDescriptor bindTableDescriptor()
             throws StandardException{
         String schemaName=tableName.getSchemaName();
         SchemaDescriptor sd=getSchemaDescriptor(schemaName);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLGrammarImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLGrammarImpl.java
@@ -1189,8 +1189,9 @@ class SQLGrammarImpl {
                                                 Boolean isGlobal,
                                                 TableName tableName,
                                                 TableElementList tableElementList,
+                                                FromTable likeTable,
                                                 Integer createBehavior) throws StandardException {
-        // NOT LOGGED is allways true
+        // NOT LOGGED is always true
         // if ON COMMIT behavior not explicitly specified in DECLARE command, default to ON COMMIT PRESERVE ROWS
         assert declareTableClauses.length == 3;
         if (declareTableClauses[1] == null) {
@@ -1204,15 +1205,16 @@ class SQLGrammarImpl {
             // ON ROLLBACK DELETE ROWS is not supported
             throw StandardException.newException(SQLState.LANG_TEMP_TABLE_DELETE_ROWS_NO_SUPPORTED, "ROLLBACK");
         } else {
-            // set it to TRUE anyway. too much expects is to be so dispite it never working
+            // set it to TRUE anyway. too much expects is to be so despite it never working
             declareTableClauses[2] = Boolean.TRUE;
         }
-        return (StatementNode) nodeFactory.getNode(
-                C_NodeTypes.CREATE_TABLE_NODE,
+
+        return new CreateTableNode(
                 tableName,
                 createBehavior,
                 tableElementList,
-                (Properties)null,
+                likeTable,
+                null,
                 (Boolean) declareTableClauses[1],
                 (Boolean) declareTableClauses[2],
                 getContextManager());

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -68,6 +68,7 @@ import com.splicemachine.db.impl.sql.compile.CastNode;
 import com.splicemachine.db.impl.sql.compile.ColumnDefinitionNode;
 import com.splicemachine.db.impl.sql.compile.ColumnReference;
 import com.splicemachine.db.impl.sql.compile.CreateAliasNode;
+import com.splicemachine.db.impl.sql.compile.CreateTableNode;
 import com.splicemachine.db.impl.sql.compile.CursorNode;
 import com.splicemachine.db.impl.sql.compile.DaysFunctionNode;
 import com.splicemachine.db.impl.sql.compile.ExplainNode.SparkExplainKind;
@@ -3918,19 +3919,21 @@ StatementNode
 declareTemporaryTableDeclaration() throws StandardException :
 {
     TableName            tableName;
-    TableElementList tableElementList;
+    TableElementList tableElementList = null;
+    FromTable likeTable = null;
     Object[] declareTableClauses = new Object[3];
     Token ifTok = null;
     Token ifTok2 = null;
 }
 {
     <DECLARE> <GLOBAL> <TEMPORARY> <TABLE> [ ifTok = <IF> <NOT> <EXISTS> ] tableName = qualifiedName(Limits.MAX_IDENTIFIER_LENGTH) [ ifTok2 = <IF> <NOT> <EXISTS> ]
-        tableElementList = tableElementList()
+
+        (tableElementList = tableElementList() | <LIKE> likeTable = tableReference(false))
         ( declareTableClause(declareTableClauses) ) *
     {
         boolean ifNotExists = ifTok != null || ifTok2 != null;
 
-        return verifySyntaxAndCreate(declareTableClauses, true, tableName, tableElementList,
+        return verifySyntaxAndCreate(declareTableClauses, true, tableName, tableElementList, likeTable,
                                      (ifNotExists ? new Integer(StatementType.CREATE_IF_NOT_EXISTS) :
                                                     new Integer(StatementType.CREATE_DEFAULT)));
     }
@@ -3963,7 +3966,7 @@ createTemporaryTableDeclaration() throws StandardException :
     {
         boolean ifNotExists = ifTok != null || ifTok2 != null;
 
-        return verifySyntaxAndCreate(declareTableClauses, (localTok == null), tableName, tableElementList,
+        return verifySyntaxAndCreate(declareTableClauses, (localTok == null), tableName, tableElementList, null,
                                      (ifNotExists ? new Integer(StatementType.CREATE_IF_NOT_EXISTS) :
                                                     new Integer(StatementType.CREATE_DEFAULT)));
     }
@@ -4025,10 +4028,7 @@ onCommitRollback() :
 TableElementList
 tableElementList() throws StandardException :
 {
-    TableElementList    tableElementList =
-                    (TableElementList) nodeFactory.getNode(
-                                    C_NodeTypes.TABLE_ELEMENT_LIST,
-                                    getContextManager());
+    TableElementList    tableElementList = new TableElementList(getContextManager());
 }
 {
     <LEFT_PAREN> tableElement(tableElementList)
@@ -12137,6 +12137,7 @@ tableDefinition() throws StandardException :
     Properties            properties = null;
     TableName            tableName;
     TableElementList    tableElementList = null;
+    FromTable           likeTable = null;
     ResultColumnList    resultColumns = null;
     QueryTreeNode        queryExpression;
     boolean                withData = true;
@@ -12170,10 +12171,11 @@ tableDefinition() throws StandardException :
     <TABLE> [ ifTok = <IF> <NOT> <EXISTS> ] tableName = qualifiedName(Limits.MAX_IDENTIFIER_LENGTH) [ ifTok2 = <IF> <NOT> <EXISTS> ]
             // Lookahead needed to choose between
             // tableElementList and tableColumnList
-    (        LOOKAHEAD({getToken(1).kind == LEFT_PAREN &&
+    (        LOOKAHEAD({(getToken(1).kind == LEFT_PAREN &&
                        getToken(3).kind != COMMA &&
-                       getToken(3).kind != RIGHT_PAREN})
-            tableElementList = tableElementList()
+                       getToken(3).kind != RIGHT_PAREN)
+                       || getToken(1).kind == LIKE })
+            (tableElementList = tableElementList() | <LIKE> likeTable = tableReference(false))
             [ properties = propertyList(false)<CHECK_PROPERTIES>]
             ([<LOGICAL> {isLogicalKey = Boolean.TRUE;} |<PHYSICAL> {isLogicalKey = Boolean.FALSE;}]
               <SPLITKEYS> {presplit = Boolean.TRUE;}
@@ -12188,24 +12190,23 @@ tableDefinition() throws StandardException :
                                 linesTerminatedByChar, location,compression, partitionedResultColumns, tableElementList);
 
                       boolean ifNotExists = ifTok != null || ifTok2 != null;
-
-                          return (StatementNode) nodeFactory.getNode(
-                                              C_NodeTypes.CREATE_TABLE_NODE,
-                                              tableName,
-                                              (ifNotExists ? new Integer(StatementType.CREATE_IF_NOT_EXISTS) :
-                                                             new Integer(StatementType.CREATE_DEFAULT)),
-                                              tableElementList,
-                                              properties,
-                                              new Character(lockGranularity),
-                                              presplit,
-                                              isLogicalKey,
-                                              splitKeysPath,
-                                              columnDelimiter,
-                                              characterDelimiter,
-                                              timestampFormat,
-                                              dateFormat,
-                                              timeFormat,
-                                              getContextManager());
+                          return new CreateTableNode(
+                              tableName,
+                              (ifNotExists ? new Integer(StatementType.CREATE_IF_NOT_EXISTS) :
+                                             new Integer(StatementType.CREATE_DEFAULT)),
+                              tableElementList,
+                              likeTable,
+                              properties,
+                              new Character(lockGranularity),
+                              presplit,
+                              isLogicalKey,
+                              (CharConstantNode) splitKeysPath,
+                              (CharConstantNode) columnDelimiter,
+                              (CharConstantNode) characterDelimiter,
+                              (CharConstantNode) timestampFormat,
+                              (CharConstantNode) dateFormat,
+                              (CharConstantNode) timeFormat,
+                              getContextManager());
                           }
             |[<COMMA>]
              [ <COMPRESSED> <WITH> compression =compressedAs() ]
@@ -12230,24 +12231,24 @@ tableDefinition() throws StandardException :
 
             ifNotExists = ifTok != null || ifTok2 != null;
 
-                return (StatementNode) nodeFactory.getNode(
-                                        C_NodeTypes.CREATE_TABLE_NODE,
-                                        tableName,
-                                        (ifNotExists ? new Integer(StatementType.CREATE_IF_NOT_EXISTS) :
-                                                       new Integer(StatementType.CREATE_DEFAULT)),
-                                        tableElementList,
-                                        properties,
-                                        new Character(lockGranularity),
-                                        isExternal,
-                                        partitionedResultColumns,
-                                        terminationChar,
-                                        escapedByChar,
-                                        linesTerminatedByChar,
-                                        storageFormat,
-                                        location,
-                                        compression,
-                                        mergeSchema,
-                                        getContextManager());
+                return new CreateTableNode(
+                    tableName,
+                    (ifNotExists ? new Integer(StatementType.CREATE_IF_NOT_EXISTS) :
+                                   new Integer(StatementType.CREATE_DEFAULT)),
+                    tableElementList,
+                    likeTable,
+                    properties,
+                    new Character(lockGranularity),
+                    isExternal,
+                    partitionedResultColumns,
+                    (CharConstantNode) terminationChar,
+                    (CharConstantNode) escapedByChar,
+                    (CharConstantNode) linesTerminatedByChar,
+                    storageFormat,
+                    (CharConstantNode) location,
+                    compression,
+                    mergeSchema,
+                    getContextManager());
             })
         |
             [ <LEFT_PAREN> resultColumns = tableColumnList() <RIGHT_PAREN> ]
@@ -12294,21 +12295,20 @@ tableDefinition() throws StandardException :
 
                 boolean ifNotExists = ifTok != null || ifTok2 != null;
 
-                StatementNode node = (StatementNode)nodeFactory.getNode(
-                                        C_NodeTypes.CREATE_TABLE_NODE,
-                                        tableName,
-                                        (ifNotExists ? new Integer(StatementType.CREATE_IF_NOT_EXISTS) :
-                                                       new Integer(StatementType.CREATE_DEFAULT)),
-                                        resultColumns,
-                                        queryExpression,
-                                        isExternal,
-                                        partitionedResultColumns,
-                                        terminationChar,
-                                        escapedByChar,
-                                        linesTerminatedByChar,
-                                        storageFormat,
-                                        location,
-                                        getContextManager());
+                StatementNode node = new CreateTableNode(
+                    tableName,
+                    (ifNotExists ? new Integer(StatementType.CREATE_IF_NOT_EXISTS) :
+                                   new Integer(StatementType.CREATE_DEFAULT)),
+                    resultColumns,
+                    (ResultSetNode) queryExpression,
+                    isExternal,
+                    partitionedResultColumns,
+                    (CharConstantNode) terminationChar,
+                    (CharConstantNode) escapedByChar,
+                    (CharConstantNode) linesTerminatedByChar,
+                    storageFormat,
+                    (CharConstantNode) location,
+                    getContextManager());
                 if (node instanceof CreateTableNode) {
                     ((CreateTableNode)node).setQueryString(queryString);
                 }
@@ -15665,10 +15665,7 @@ alterTableBody(TableName tableName) throws StandardException :
     StatementNode sn;
     char                lockGranularity = '\0';
     String               newTableName;
-    TableElementList    tableElementList =
-                                    (TableElementList) nodeFactory.getNode(
-                                                C_NodeTypes.TABLE_ELEMENT_LIST,
-                                                getContextManager());
+    TableElementList    tableElementList = new TableElementList(getContextManager());
     int[]                changeType = new int[1];
     int[]                behavior = new int[1];
         String indexName = null;

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/DeclareLikeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/DeclareLikeIT.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.impl.sql.execute.actions;
+
+import com.splicemachine.derby.test.framework.*;
+import com.splicemachine.homeless.TestUtils;
+import org.apache.commons.lang.StringUtils;
+import org.junit.*;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import splice.com.google.common.collect.Lists;
+
+import java.sql.*;
+import java.util.Collection;
+
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+public class DeclareLikeIT extends SpliceUnitTest {
+    public static final String CLASS_NAME = DeclareLikeIT.class.getSimpleName().toUpperCase();
+    private static final String schema = CLASS_NAME;
+    private static SpliceSchemaWatcher schemaWatcher = new SpliceSchemaWatcher(schema);
+
+    protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher();
+
+    @ClassRule
+    public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
+                                            .around(schemaWatcher);
+
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher();
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        Collection<Object[]> params = Lists.newArrayListWithCapacity(2);
+        params.add(new Object[]{true});
+        params.add(new Object[]{false});
+        return params;
+    }
+
+    private boolean temporary;
+
+    public DeclareLikeIT(boolean temporary) {
+        this.temporary = temporary;
+    }
+
+    /*
+     * Helper function to strip header, divider, and create table line
+     * to be able to compare SHOW CREATE TABLE from two different tables
+     *
+     * Example:
+     * DDL                                        |
+     *  ------------------------------------------------------------------------------------
+     * CREATE LOCAL TEMPORARY TABLE "DECLARELIKEIT"."SIMPLE_TABLE_TEMP" (
+     * "A" INTEGER
+     * ) ; |
+     *
+     * would return
+     * "A" INTEGER
+     * ) ; |
+     *
+     */
+    private String stripHeaderAndFooter(String s) {
+        String[] lines = s.split("\\r?\\n");
+        int begin = 3;
+        int end = lines.length - 1;
+        if (lines[end].equals(") ; |")) {
+            end = end -1;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = begin; i <= end; ++i) {
+            sb.append(lines[i]).append("\n");
+        }
+        return sb.toString();
+    }
+
+    private String removeConstraints(String s) {
+        String[] lines = s.split("\\r?\\n");
+        StringBuilder sb = new StringBuilder();
+        for (String line: lines) {
+            if (!line.startsWith(", CONSTRAINT")) {
+                sb.append(line).append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    private void createBaseAndDeclareLikeLikeBase(String name, String definition) throws Exception {
+        methodWatcher.executeUpdate(format("drop table %s.%s_base if exists", schema, name));
+        methodWatcher.executeUpdate(format("create table %s.%s_base %s", schema, name, definition));
+        methodWatcher.executeUpdate(format("drop table %s.%s_like if exists", schema, name));
+        if (temporary)
+            methodWatcher.executeUpdate(format("DECLARE GLOBAL TEMPORARY TABLE %s.%s_like LIKE %s.%s_base", schema, name, schema, name));
+        else
+            methodWatcher.executeUpdate(format("CREATE TABLE %s.%s_like LIKE %s.%s_base", schema, name, schema, name));
+    }
+
+    private String show(String name) throws Exception {
+        try (ResultSet rs = methodWatcher.executeQuery(format("CALL SYSCS_UTIL.SHOW_CREATE_TABLE('%s', '%s')", schema, name))) {
+            return TestUtils.FormattedResult.ResultFactory.toString(rs);
+        }
+    }
+
+    private String showBase(String name) throws Exception {
+        return show(name + "_base");
+    }
+
+    private String showLike(String name) throws Exception {
+        return show(name + "_like");
+    }
+
+    private void testIdentical(String name, String definition) throws Exception {
+        createBaseAndDeclareLikeLikeBase(name, definition);
+        Assert.assertEquals(stripHeaderAndFooter(showBase(name)), stripHeaderAndFooter(showLike(name)));
+    }
+
+    private void testConstraintsRemoved(String name, String definition) throws Exception {
+        createBaseAndDeclareLikeLikeBase(name, definition);
+        Assert.assertEquals(
+                removeConstraints(stripHeaderAndFooter(showBase(name))),
+                stripHeaderAndFooter(showLike(name))
+                );
+    }
+
+    @Test
+    public void testSimpleTable() throws Exception {
+        testIdentical("simple_table", "(a int)");
+    }
+
+    @Test
+    public void testNotNull() throws Exception {
+        testIdentical("NOT_NULL", "(a int not null)");
+    }
+
+    @Test
+    public void testDefault() throws Exception {
+        testIdentical("DEFAULT_NOT_NULL", "(a int not null with default 4)");
+        testIdentical("DEFAULT_NULL", "(a int with default 4)");
+    }
+
+    @Test
+    public void testEmptyDefault() throws Exception {
+        testIdentical("EMPTY_DEFAULT", "(a int not null with default)");
+        testIdentical("EMPTY_DEFAULT2", "(a timestamp not null with default)");
+    }
+
+    @Test
+    public void testPrimaryKey() throws Exception {
+        // The new table does not have a primary key
+        testConstraintsRemoved("PRIMARY_KEY", "(a int not null primary key)");
+        testConstraintsRemoved("PRIMARY_KEY2", "(a int not null, b int not null, primary key(a, b))");
+    }
+}

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/DeclareLikeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/DeclareLikeIT.java
@@ -160,6 +160,11 @@ public class DeclareLikeIT extends SpliceUnitTest {
     }
 
     @Test
+    public void testMultipleColumns() throws Exception {
+        testIdentical("MULTIPLE_COLUMNS", "(a int, b int not null, c int not null with default 4, d int with default 5)");
+    }
+
+    @Test
     public void testPrimaryKey() throws Exception {
         // The new table does not have a primary key
         testConstraintsRemoved("PRIMARY_KEY", "(a int not null primary key)");

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/DeclareLikeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/DeclareLikeIT.java
@@ -14,23 +14,27 @@
 
 package com.splicemachine.derby.impl.sql.execute.actions;
 
-import com.splicemachine.derby.test.framework.*;
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
 import com.splicemachine.homeless.TestUtils;
-import org.apache.commons.lang.StringUtils;
-import org.junit.*;
+import com.splicemachine.test.SerialTest;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import splice.com.google.common.collect.Lists;
 
-import java.sql.*;
+import java.sql.ResultSet;
 import java.util.Collection;
 
-import static junit.framework.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 @RunWith(Parameterized.class)
+@Category(SerialTest.class)
 public class DeclareLikeIT extends SpliceUnitTest {
     public static final String CLASS_NAME = DeclareLikeIT.class.getSimpleName().toUpperCase();
     private static final String schema = CLASS_NAME;

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/DeclareLikeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/actions/DeclareLikeIT.java
@@ -100,14 +100,22 @@ public class DeclareLikeIT extends SpliceUnitTest {
         return sb.toString();
     }
 
+    private String baseTableName(String name) {
+        return name + "_base";
+    }
+
+    private String likeTableName(String name) {
+        return name + "_like" + (temporary ? "_temp" : "");
+    }
+
     private void createBaseAndDeclareLikeLikeBase(String name, String definition) throws Exception {
-        methodWatcher.executeUpdate(format("drop table %s.%s_base if exists", schema, name));
-        methodWatcher.executeUpdate(format("create table %s.%s_base %s", schema, name, definition));
-        methodWatcher.executeUpdate(format("drop table %s.%s_like if exists", schema, name));
+        methodWatcher.executeUpdate(format("drop table %s.%s if exists", schema, baseTableName(name)));
+        methodWatcher.executeUpdate(format("create table %s.%s %s", schema, baseTableName(name), definition));
+        methodWatcher.executeUpdate(format("drop table %s.%s if exists", schema, likeTableName(name)));
         if (temporary)
-            methodWatcher.executeUpdate(format("DECLARE GLOBAL TEMPORARY TABLE %s.%s_like LIKE %s.%s_base", schema, name, schema, name));
+            methodWatcher.executeUpdate(format("DECLARE GLOBAL TEMPORARY TABLE %s.%s LIKE %s.%s", schema, likeTableName(name), schema, baseTableName(name)));
         else
-            methodWatcher.executeUpdate(format("CREATE TABLE %s.%s_like LIKE %s.%s_base", schema, name, schema, name));
+            methodWatcher.executeUpdate(format("CREATE TABLE %s.%s LIKE %s.%s", schema, likeTableName(name), schema, baseTableName(name)));
     }
 
     private String show(String name) throws Exception {
@@ -117,11 +125,11 @@ public class DeclareLikeIT extends SpliceUnitTest {
     }
 
     private String showBase(String name) throws Exception {
-        return show(name + "_base");
+        return show(baseTableName(name));
     }
 
     private String showLike(String name) throws Exception {
-        return show(name + "_like");
+        return show(likeTableName(name));
     }
 
     private void testIdentical(String name, String definition) throws Exception {


### PR DESCRIPTION
### Description:
This ticket introduces a new way to create tables:

```
create table base (a INT);
CREATE TABLE T1 LIKE base; 

show create table t1;
DDL
---
CREATE TABLE "SPLICE"."T1" (
"A" INTEGER
) ;
```

The newly created table will have the same column structure as the original one. Nullability and default values will also be the same as for the original one.
As DB2, we do not reproduce constraints, primary keys, etc. Only the column structure is ported to the new table

 

This is also supported when creating temporary tables:

```
DECLARE GLOBAL TEMPORARY TABLE T2 LIKE base;

show create table t2;
DDL
---
CREATE LOCAL TEMPORARY TABLE "SPLICE"."T2" (
"A" INTEGER
) ;
```
### Testing:
This was tested with temporary and non-temporary tables, with nullable and non nullable columns, with default (empty or not) values for columns.

We also tested that constraints are not carried over from base table to new table.

