### PR TITLE
DB-10872 consider QUOTE_ALWAYS when exporting FOR BIT DATA field 

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportCSVWriterBuilder.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportCSVWriterBuilder.java
@@ -16,6 +16,7 @@ package com.splicemachine.derby.impl.sql.execute.operations.export;
 
 import com.splicemachine.db.iapi.sql.ResultColumnDescriptor;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+import com.splicemachine.db.iapi.types.TypeId;
 import org.supercsv.io.CsvListWriter;
 import org.supercsv.prefs.CsvPreference;
 import org.supercsv.quote.ColumnQuoteMode;
@@ -42,7 +43,10 @@ public class ExportCSVWriterBuilder {
         switch (exportParams.getQuoteMode()) {
             case ALWAYS:
                 boolean[] toQuote = new boolean[exportColumns.length];
-                IntStream.range(0, exportColumns.length).forEach(i -> toQuote[i] = exportColumns[i].getType().getTypeId().isCharOrVarChar());
+                for (int i = 0; i < exportColumns.length; ++i) {
+                    TypeId typeId = exportColumns[i].getType().getTypeId();
+                    toQuote[i] = typeId.isCharOrVarChar() || typeId.isBitTypeId();
+                }
                 preference.useQuoteMode(new ColumnQuoteMode(toQuote));
                 break;
             case DEFAULT:

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/export/ExportOperationIT.java
@@ -145,22 +145,24 @@ public class ExportOperationIT {
     public void export_defaultDelimiter() throws Exception {
 
         new TableCreator(methodWatcher.getOrCreateConnection())
-                .withCreate(String.format("create table export_local_%s(a smallint,b double, c time,d varchar(20))", getSuffix()))
-                .withInsert(String.format("insert into export_local_%s values(?,?,?,?)", getSuffix()))
+                .withCreate(String.format("create table export_local_%s(a smallint,b double, c time,d varchar(20), e varchar(20) for bit data)", getSuffix()))
+                .withInsert(String.format("insert into export_local_%s values(?,?,?,?,?)", getSuffix()))
                 .withRows(getTestRows()).create();
 
         String exportSQL = buildExportSQL(String.format("select * from export_local_%s order by a asc", getSuffix()), "None");
 
-        exportAndAssertExportResults(exportSQL, 6);
+        exportAndAssertExportResults(exportSQL, 8);
         File[] files = temporaryFolder.listFiles(new PatternFilenameFilter(".*csv"));
         assertEquals(1, files.length);
-        assertEquals("" +
-                        "25,3.14159,14:31:20,varchar1\n" +
-                        "26,3.14159,14:31:20,varchar1\n" +
-                        "27,3.14159,14:31:20,varchar1 space\n" +
-                        "28,3.14159,14:31:20,\"varchar1 , comma\"\n" +
-                        "29,3.14159,14:31:20,\"varchar1 \"\" quote\"\n" +
-                        "30,3.14159,14:31:20,varchar1\n",
+        assertEquals(
+                "0,0.0,00:00:00,,\n" +
+                        "25,3.14159,14:31:20,varchar1,6269746461746131\n" +
+                        "26,3.14159,14:31:20,varchar1,6269746461746131\n" +
+                        "27,3.14159,14:31:20,varchar1 space,626974206461746131\n" +
+                        "28,3.14159,14:31:20,\"varchar1 , comma\",62697464617461202c2031\n" +
+                        "29,3.14159,14:31:20,\"varchar1 \"\" quote\",6269746461746120222c2031\n" +
+                        "30,3.14159,14:31:20,varchar1,6269746461746131\n" +
+                        ",,,,\n",
                 Files.toString(files[0], Charsets.UTF_8));
     }
 
@@ -168,22 +170,24 @@ public class ExportOperationIT {
     public void export_withAlternateRecordDelimiter() throws Exception {
 
         new TableCreator(methodWatcher.getOrCreateConnection())
-                .withCreate(String.format("create table pipe_%s(a smallint,b double, c time,d varchar(20))", getSuffix()))
-                .withInsert(String.format("insert into pipe_%s values(?,?,?,?)", getSuffix()))
+                .withCreate(String.format("create table pipe_%s(a smallint,b double, c time,d varchar(20), e varchar(20) for bit data)", getSuffix()))
+                .withInsert(String.format("insert into pipe_%s values(?,?,?,?,?)", getSuffix()))
                 .withRows(getTestRows()).create();
 
         String exportSQL = buildExportSQL(String.format("select * from pipe_%s order by a asc", getSuffix()), "NONE", "|");
 
-        exportAndAssertExportResults(exportSQL, 6);
+        exportAndAssertExportResults(exportSQL, 8);
         File[] files = temporaryFolder.listFiles(new PatternFilenameFilter(".*csv"));
         assertEquals(1, files.length);
-        assertEquals("" +
-                        "25|3.14159|14:31:20|varchar1\n" +
-                        "26|3.14159|14:31:20|varchar1\n" +
-                        "27|3.14159|14:31:20|varchar1 space\n" +
-                        "28|3.14159|14:31:20|varchar1 , comma\n" +
-                        "29|3.14159|14:31:20|\"varchar1 \"\" quote\"\n" +
-                        "30|3.14159|14:31:20|varchar1\n",
+        assertEquals(
+                "0|0.0|00:00:00||\n" +
+                        "25|3.14159|14:31:20|varchar1|6269746461746131\n" +
+                        "26|3.14159|14:31:20|varchar1|6269746461746131\n" +
+                        "27|3.14159|14:31:20|varchar1 space|626974206461746131\n" +
+                        "28|3.14159|14:31:20|varchar1 , comma|62697464617461202c2031\n" +
+                        "29|3.14159|14:31:20|\"varchar1 \"\" quote\"|6269746461746120222c2031\n" +
+                        "30|3.14159|14:31:20|varchar1|6269746461746131\n" +
+                        "||||\n",
                 Files.toString(files[0], Charsets.UTF_8));
     }
 
@@ -191,22 +195,26 @@ public class ExportOperationIT {
     public void export_withTabs() throws Exception {
 
         new TableCreator(methodWatcher.getOrCreateConnection())
-                .withCreate(String.format("create table tabs_%s(a smallint,b double, c time,d varchar(20))", getSuffix()))
-                .withInsert(String.format("insert into tabs_%s values(?,?,?,?)", getSuffix()))
+                .withCreate(String.format("create table tabs_%s(a smallint,b double, c time,d varchar(20), e varchar(20) for bit data)", getSuffix()))
+                .withInsert(String.format("insert into tabs_%s values(?,?,?,?,?)", getSuffix()))
                 .withRows(getTestRows()).create();
 
         String exportSQL = buildExportSQL(String.format("select * from tabs_%s order by a asc", getSuffix()), " none ", "\\t");
 
-        exportAndAssertExportResults(exportSQL, 6);
+        exportAndAssertExportResults(exportSQL, 8);
         File[] files = temporaryFolder.listFiles(new PatternFilenameFilter(".*csv"));
         assertEquals(1, files.length);
-        assertEquals("" +
-                        "25\t3.14159\t14:31:20\tvarchar1\n" +
-                        "26\t3.14159\t14:31:20\tvarchar1\n" +
-                        "27\t3.14159\t14:31:20\tvarchar1 space\n" +
-                        "28\t3.14159\t14:31:20\tvarchar1 , comma\n" +
-                        "29\t3.14159\t14:31:20\t\"varchar1 \"\" quote\"\n" +
-                        "30\t3.14159\t14:31:20\tvarchar1\n",
+        assertEquals(
+                "0\t0.0\t00:00:00\t\t\n" +
+                        "25\t3.14159\t14:31:20\tvarchar1\t6269746461746131\n" +
+                        "26\t3.14159\t14:31:20\tvarchar1\t6269746461746131\n" +
+                        "27\t3.14159\t14:31:20\tvarchar1 space\t626974206461746131\n" +
+                        "28\t3.14159\t14:31:20\tvarchar1 , comma\t62697464617461202c2031\n" +
+                        "29\t3.14159\t14:31:20\t\"varchar1 \"\" quote\"\t6269746461746120222c2031\n" +
+                        "30\t3.14159\t14:31:20\tvarchar1\t6269746461746131\n" +
+                        "\t\t\t\t\n",
+
+
                 Files.toString(files[0], Charsets.UTF_8));
     }
 
@@ -264,22 +272,24 @@ public class ExportOperationIT {
     public void export_compressed_bz2() throws Exception {
 
         new TableCreator(methodWatcher.getOrCreateConnection())
-                .withCreate(String.format("create table export_compressed_bz2_%s(a smallint,b double, c time,d varchar(20))", getSuffix()))
-                .withInsert(String.format("insert into export_compressed_bz2_%s values(?,?,?,?)", getSuffix()))
+                .withCreate(String.format("create table export_compressed_bz2_%s(a smallint,b double, c time,d varchar(20), e varchar(20) for bit data)", getSuffix()))
+                .withInsert(String.format("insert into export_compressed_bz2_%s values(?,?,?,?,?)", getSuffix()))
                 .withRows(getTestRows()).create();
 
         String exportSQL = buildExportSQL(String.format("select * from export_compressed_bz2_%s order by a asc", getSuffix()), "BZ2");
 
-        exportAndAssertExportResults(exportSQL, 6);
+        exportAndAssertExportResults(exportSQL, 8);
         File[] files = temporaryFolder.listFiles(new PatternFilenameFilter(".*csv.bz2"));
         assertEquals(1, files.length);
-        assertEquals("" +
-                        "25,3.14159,14:31:20,varchar1\n" +
-                        "26,3.14159,14:31:20,varchar1\n" +
-                        "27,3.14159,14:31:20,varchar1 space\n" +
-                        "28,3.14159,14:31:20,\"varchar1 , comma\"\n" +
-                        "29,3.14159,14:31:20,\"varchar1 \"\" quote\"\n" +
-                        "30,3.14159,14:31:20,varchar1\n",
+        assertEquals(
+                "0,0.0,00:00:00,,\n" +
+                        "25,3.14159,14:31:20,varchar1,6269746461746131\n" +
+                        "26,3.14159,14:31:20,varchar1,6269746461746131\n" +
+                        "27,3.14159,14:31:20,varchar1 space,626974206461746131\n" +
+                        "28,3.14159,14:31:20,\"varchar1 , comma\",62697464617461202c2031\n" +
+                        "29,3.14159,14:31:20,\"varchar1 \"\" quote\",6269746461746120222c2031\n" +
+                        "30,3.14159,14:31:20,varchar1,6269746461746131\n" +
+                        ",,,,\n",
                 IOUtils.toString(new BZip2CompressorInputStream(new FileInputStream(files[0]))));
     }
 
@@ -287,22 +297,24 @@ public class ExportOperationIT {
     public void export_compressed_gz() throws Exception {
 
         new TableCreator(methodWatcher.getOrCreateConnection())
-                .withCreate(String.format("create table export_compressed_gz_%s(a smallint,b double, c time,d varchar(20))", getSuffix()))
-                .withInsert(String.format("insert into export_compressed_gz_%s values(?,?,?,?)", getSuffix()))
+                .withCreate(String.format("create table export_compressed_gz_%s(a smallint,b double, c time,d varchar(20), e varchar(20) for bit data)", getSuffix()))
+                .withInsert(String.format("insert into export_compressed_gz_%s values(?,?,?,?,?)", getSuffix()))
                 .withRows(getTestRows()).create();
 
         String exportSQL = buildExportSQL(String.format("select * from export_compressed_gz_%s order by a asc", getSuffix()), "GZIP");
 
-        exportAndAssertExportResults(exportSQL, 6);
+        exportAndAssertExportResults(exportSQL, 8);
         File[] files = temporaryFolder.listFiles(new PatternFilenameFilter(".*csv.gz"));
         assertEquals(1, files.length);
-        assertEquals("" +
-                        "25,3.14159,14:31:20,varchar1\n" +
-                        "26,3.14159,14:31:20,varchar1\n" +
-                        "27,3.14159,14:31:20,varchar1 space\n" +
-                        "28,3.14159,14:31:20,\"varchar1 , comma\"\n" +
-                        "29,3.14159,14:31:20,\"varchar1 \"\" quote\"\n" +
-                        "30,3.14159,14:31:20,varchar1\n",
+        assertEquals(
+                "0,0.0,00:00:00,,\n" +
+                        "25,3.14159,14:31:20,varchar1,6269746461746131\n" +
+                        "26,3.14159,14:31:20,varchar1,6269746461746131\n" +
+                        "27,3.14159,14:31:20,varchar1 space,626974206461746131\n" +
+                        "28,3.14159,14:31:20,\"varchar1 , comma\",62697464617461202c2031\n" +
+                        "29,3.14159,14:31:20,\"varchar1 \"\" quote\",6269746461746120222c2031\n" +
+                        "30,3.14159,14:31:20,varchar1,6269746461746131\n" +
+                        ",,,,\n",
                 IOUtils.toString(new GZIPInputStream(new FileInputStream(files[0]))));
     }
 
@@ -310,22 +322,23 @@ public class ExportOperationIT {
     public void export_compressed_gz2() throws Exception {
 
         new TableCreator(methodWatcher.getOrCreateConnection())
-                .withCreate(String.format("create table export_compressed_gz2_%s(a smallint,b double, c time,d varchar(20))", getSuffix()))
-                .withInsert(String.format("insert into export_compressed_gz2_%s values(?,?,?,?)", getSuffix()))
+                .withCreate(String.format("create table export_compressed_gz2_%s(a smallint,b double, c time,d varchar(20),e varchar(20) for bit data)", getSuffix()))
+                .withInsert(String.format("insert into export_compressed_gz2_%s values(?,?,?,?,?)", getSuffix()))
                 .withRows(getTestRows()).create();
 
         String exportSQL = buildExportSQL(String.format("select * from export_compressed_gz2_%s order by a asc", getSuffix()), true);
 
-        exportAndAssertExportResults(exportSQL, 6);
+        exportAndAssertExportResults(exportSQL, 8);
         File[] files = temporaryFolder.listFiles(new PatternFilenameFilter(".*csv.gz"));
         assertEquals(1, files.length);
-        assertEquals("" +
-                        "25,3.14159,14:31:20,varchar1\n" +
-                        "26,3.14159,14:31:20,varchar1\n" +
-                        "27,3.14159,14:31:20,varchar1 space\n" +
-                        "28,3.14159,14:31:20,\"varchar1 , comma\"\n" +
-                        "29,3.14159,14:31:20,\"varchar1 \"\" quote\"\n" +
-                        "30,3.14159,14:31:20,varchar1\n",
+        assertEquals("0,0.0,00:00:00,,\n" +
+                        "25,3.14159,14:31:20,varchar1,6269746461746131\n" +
+                        "26,3.14159,14:31:20,varchar1,6269746461746131\n" +
+                        "27,3.14159,14:31:20,varchar1 space,626974206461746131\n" +
+                        "28,3.14159,14:31:20,\"varchar1 , comma\",62697464617461202c2031\n" +
+                        "29,3.14159,14:31:20,\"varchar1 \"\" quote\",6269746461746120222c2031\n" +
+                        "30,3.14159,14:31:20,varchar1,6269746461746131\n" +
+                        ",,,,\n",
                 IOUtils.toString(new GZIPInputStream(new FileInputStream(files[0]))));
     }
 
@@ -642,12 +655,15 @@ public class ExportOperationIT {
 
     private Iterable<Iterable<Object>> getTestRows() {
         return rows(
-                row(25, 3.14159, "14:31:20", "varchar1"),
-                row(26, 3.14159, "14:31:20", "varchar1"),
-                row(27, 3.14159, "14:31:20", "varchar1 space"),
-                row(28, 3.14159, "14:31:20", "varchar1 , comma"),
-                row(29, 3.14159, "14:31:20", "varchar1 \" quote"),
-                row(30, 3.14159, "14:31:20", "varchar1")
+                row(25, 3.14159, "14:31:20", "varchar1", "bitdata1"),
+                row(26, 3.14159, "14:31:20", "varchar1", "bitdata1"),
+                row(27, 3.14159, "14:31:20", "varchar1 space", "bit data1"),
+                row(28, 3.14159, "14:31:20", "varchar1 , comma", "bitdata , 1"),
+                row(29, 3.14159, "14:31:20", "varchar1 \" quote", "bitdata \", 1"),
+                row(30, 3.14159, "14:31:20", "varchar1", "bitdata1"),
+                row(null, null, null, null, null),
+                row(0, 0.0, "00:00:00", "", "")
+
         );
     }
 
@@ -677,24 +693,25 @@ public class ExportOperationIT {
             return;
 
         new TableCreator(methodWatcher.getOrCreateConnection())
-                .withCreate(String.format("create table export_quote_always_%s (a smallint,b double, c time,d varchar(20))", getSuffix()))
-                .withInsert(String.format("insert into export_quote_always_%s values(?,?,?,?)", getSuffix()))
+                .withCreate(String.format("create table export_quote_always_%s (a smallint, b double, c time, d varchar(20), e varchar(20) for bit data)", getSuffix()))
+                .withInsert(String.format("insert into export_quote_always_%s values(?,?,?,?,?)", getSuffix()))
                 .withRows(getTestRows()).create();
 
         String exportPath = temporaryFolder.getAbsolutePath();
         String exportSQL = buildExportSQL(String.format("select * from export_quote_always_%s order by a asc", getSuffix()),
                 exportPath, null, null, null, null, null, "always");
 
-        exportAndAssertExportResults(exportSQL, 6);
+        exportAndAssertExportResults(exportSQL, 8);
         File[] files = temporaryFolder.listFiles(new PatternFilenameFilter(".*csv"));
         assertEquals(1, files.length);
-        assertEquals("" +
-                        "25,3.14159,14:31:20,\"varchar1\"\n" +
-                        "26,3.14159,14:31:20,\"varchar1\"\n" +
-                        "27,3.14159,14:31:20,\"varchar1 space\"\n" +
-                        "28,3.14159,14:31:20,\"varchar1 , comma\"\n" +
-                        "29,3.14159,14:31:20,\"varchar1 \"\" quote\"\n" +
-                        "30,3.14159,14:31:20,\"varchar1\"\n",
+        assertEquals("0,0.0,00:00:00,\"\",\"\"\n" +
+                        "25,3.14159,14:31:20,\"varchar1\",\"6269746461746131\"\n" +
+                        "26,3.14159,14:31:20,\"varchar1\",\"6269746461746131\"\n" +
+                        "27,3.14159,14:31:20,\"varchar1 space\",\"626974206461746131\"\n" +
+                        "28,3.14159,14:31:20,\"varchar1 , comma\",\"62697464617461202c2031\"\n" +
+                        "29,3.14159,14:31:20,\"varchar1 \"\" quote\",\"6269746461746120222c2031\"\n" +
+                        "30,3.14159,14:31:20,\"varchar1\",\"6269746461746131\"\n" +
+                        ",,,,\n",
                 Files.toString(files[0], Charsets.UTF_8));
     }
 


### PR DESCRIPTION
### Description
`QUOTE_MODE` was ignored when running `EXPORT` on `[VAR]CHAR FOR BIT DATA` fields. We now properly surround those fields with `QUOTE_CHARACTER` when `QUOTE_MODE` is set to `ALWAYS`

Example:

```
DROP TABLE foo if exists;
CREATE TABLE foo (a int, b varchar(5) , c varchar(5) for bit data, d char(5) for bit data );

insert into foo values (4, 'abcde', 'abcde', 'abcde');
insert into foo values (0, '', '', '');
insert into foo values (null, null, null, null);

EXPORT to '/tmp/DB-10872'
AS CSV
FIELD_SEPARATOR ','
QUOTE_CHARACTER '"'
QUOTE_MODE ALWAYS
```
 
```
$ cat /tmp/DB-10872/part-r-00000.csv
,,,
4,"abcde","6162636465","6162636465"
0,"","","2020202020"

``` 

### Testing
Tests were added to ExportOperationIT . We now test that properly for BIT DATA columns. We also added empty strings and NULL tests.