### PR TITLE
DB-11498 enable JMX for mem profile.

### DIFF
--- a/start-splice-cluster
+++ b/start-splice-cluster
@@ -227,7 +227,8 @@ function _start_mem
 {
   MEM_LOG="${RUN_DIR}/spliceMem.log"
   echo "Starting MEM. Log file is ${MEM_LOG}"
-  (MAVEN_OPTS="${MAVEN_OPTS} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=4000" \
+  export JMX_CONFIG="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=10102"
+  (MAVEN_OPTS="${MAVEN_OPTS} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=4000 ${JMX_CONFIG}" \
                 ${MVN} -Pmem exec:java > ${MEM_LOG} 2>&1) & ## IN MEMORY
 }
 


### PR DESCRIPTION
In this PR we enable JMX for running in mem-profile, this helps reproducing mem-profile tests which was passing on Jenkins but failing locally because in Jenkins we set the JMX when running these ITs under mem-profile, but when starting a local mem-profile cluster we do not.