### PR TITLE
DB-11145: fix ExternalTableIT

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
@@ -328,10 +328,7 @@ public class OperatorToString {
                     if (functionName.equals("SECOND") || functionName.equals("WEEK")) {
                         throwNotImplementedError();
                     } else if (functionName.equals("WEEKDAY") || functionName.equals("DAYOFWEEK_ISO")) {
-                        if( getSparkVersion().getMajorVersionNumber() >= 3 )
-                            return format("(weekday(%s)+1)", opToString2(uop.getOperand(), vars));
-                        else
-                            return format("cast(date_format(%s, \"u\") as int) ", opToString2(uop.getOperand(), vars));
+                        return format("(weekday(%s)+1)", opToString2(uop.getOperand(), vars));
                     } else if (functionName.equals("WEEKDAYNAME")) {
                         return format("date_format(%s, \"EEEE\") ", opToString2(uop.getOperand(), vars));
                     } else {


### PR DESCRIPTION
getSparkVersion().getMajorVersionNumber seems to be not reliable,
so we used date_format with 'u', which is not supported by Spark3.0 anymore.
I changed this now to using weekday(x)+1 exclusively, since i noticed
that is supported by both Spark3.0 and Spark2.4

This is currently hard to test locally, since it looks like we might pick up 2.4 jars but getSparkVersion().getMajorVersionNumber reports 3.0. So i tested the SQL methods with the official spark3.0 docker image

```
docker run --rm -it spark3.0:latest bin/spark-shell

// date_format + c NOT supported anymore
scala> spark.sql("""select date_format(date '1970-12-01', "c");""").show() // EXCEPTION

// date_format + EEEE (WEEKDAYNAME) works
scala> spark.sql("""select date_format(date '1970-12-01', "EEEE");""").show() // OK, Tuesday

// WEEKDAY also works
scala> spark.sql("""select WEEKDAY(date '1970-12-01')+1;""").show() // OK, 2
```

see also
- https://spark.apache.org/docs/3.0.1/api/sql/#weekday (supported from 2.4 ... )
- supported date_format patterns: https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html