### PR TITLE
DB-11509 Make weekday format specific to spark version.

### DIFF
--- a/db-engine/pom.xml
+++ b/db-engine/pom.xml
@@ -260,6 +260,36 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- http://stackoverflow.com/questions/270445 -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.12</version>
+                <executions>
+                    <execution>
+                        <id>1</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/main/${spark.major.version}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <!--execution>
+                        <id>2</id>
+                        <phase>generate-sources</phase>
+                        <goals><goal>add-test-source</goal></goals>
+                        <configuration>
+                            <sources>
+                                <source>src/test/${spark.major.version}</source>
+                            </sources>
+                        </configuration>
+                    </execution-->
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
@@ -328,10 +328,7 @@ public class OperatorToString {
                     if (functionName.equals("SECOND") || functionName.equals("WEEK")) {
                         throwNotImplementedError();
                     } else if (functionName.equals("WEEKDAY") || functionName.equals("DAYOFWEEK_ISO")) {
-                        if( getSparkVersion().getMajorVersionNumber() >= 3 )
-                            return format("(weekday(%s)+1)", opToString2(uop.getOperand(), vars));
-                        else
-                            return format("cast(date_format(%s, \"u\") as int) ", opToString2(uop.getOperand(), vars));
+                        return format(SparkVersionSpecificItems.WEEKDAY_FORMAT, opToString2(uop.getOperand(), vars));
                     } else if (functionName.equals("WEEKDAYNAME")) {
                         return format("date_format(%s, \"EEEE\") ", opToString2(uop.getOperand(), vars));
                     } else {

--- a/db-engine/src/main/spark2.3/com/splicemachine/db/impl/sql/compile/SparkVersionSpecificItems.java
+++ b/db-engine/src/main/spark2.3/com/splicemachine/db/impl/sql/compile/SparkVersionSpecificItems.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2020 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+public class SparkVersionSpecificItems {
+    static final String WEEKDAY_FORMAT = "cast(date_format(%s, \"u\") as int) ";
+}

--- a/db-engine/src/main/spark2.4/com/splicemachine/db/impl/sql/compile/SparkVersionSpecificItems.java
+++ b/db-engine/src/main/spark2.4/com/splicemachine/db/impl/sql/compile/SparkVersionSpecificItems.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2020 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+public class SparkVersionSpecificItems {
+    static final String WEEKDAY_FORMAT = "(weekday(%s)+1)";
+}

--- a/db-engine/src/main/spark3.0/com/splicemachine/db/impl/sql/compile/SparkVersionSpecificItems.java
+++ b/db-engine/src/main/spark3.0/com/splicemachine/db/impl/sql/compile/SparkVersionSpecificItems.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2020 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+public class SparkVersionSpecificItems {
+    static final String WEEKDAY_FORMAT = "(weekday(%s)+1)";
+}


### PR DESCRIPTION
This is an alternative fix for DB-11145 https://github.com/splicemachine/spliceengine/pull/5201 which may not work for hdp3.1.5.  DB-11145 and DB-11509 seem to have the same root cause, so made this PR for 11509.

On this branch DB-11145-jp, I ran SpliceDateFunctionsIT and ExternalTableIT successfully in my standalone for dbaas3.0, cdh6.3.0, and hdp3.1.5.

The issue now with this branch is that jenkins isn't substituting the spark version in the pom, as mentioned below.

Hopefully, either this PR or https://github.com/splicemachine/spliceengine/pull/5201 can be driven to a final solution.  Just looking to get one of them to work.