### PR TITLE
DB-11511 Fix logical conflict between DB-11121 & DB-10968

### DIFF
--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceDateFunctionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceDateFunctionsIT.java
@@ -235,7 +235,7 @@ public class SpliceDateFunctionsIT extends SpliceUnitTest {
     public SpliceWatcher methodWatcher = new SpliceWatcher(CLASS_NAME);
 
     private void withSecondCompatibilityMode(String mode) throws Exception {
-        methodWatcher.executeUpdate(String.format("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'splice.function.secondCompatibilityMode', '%s' )", mode));
+        methodWatcher.execute(String.format("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'splice.function.secondCompatibilityMode', '%s' )", mode));
     }
 
     @Test


### PR DESCRIPTION
DB-11121 introduced a new call to executeUpdate(CALL SYSCS_UTIL) but DB-10968 changed those to execute instead of executeUpdate