### PR TITLE
DB-11145 Set MANIFEST only for hbase/mem_sql modules

### DIFF
--- a/hbase_sql/pom.xml
+++ b/hbase_sql/pom.xml
@@ -381,6 +381,18 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <!-- TODO: buildnumber plugin must point to open splice repo (SCM) -->
+                                <Implementation-Version>${buildNumber}</Implementation-Version>
+                                <!--<Implementation-Version>13</Implementation-Version>-->
+                                <Release>${project.version}</Release>
+                                <Build-Time>${maven.build.timestamp}</Build-Time>
+                                <URL>http://www.splicemachine.com</URL>
+                                <Spark-Major-Version>${spark.major.version}</Spark-Major-Version>
+                                <Spark-Version>${spark.version}</Spark-Version>
+                            </manifestEntries>
+                        </archive>
                     <excludes>
                         <exclude>**/*log4j.properties</exclude>
                     </excludes>

--- a/mem_sql/pom.xml
+++ b/mem_sql/pom.xml
@@ -99,6 +99,24 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <!-- TODO: buildnumber plugin must point to open splice repo (SCM) -->
+                                <Implementation-Version>${buildNumber}</Implementation-Version>
+                                <!--<Implementation-Version>13</Implementation-Version>-->
+                                <Release>${project.version}</Release>
+                                <Build-Time>${maven.build.timestamp}</Build-Time>
+                                <URL>http://www.splicemachine.com</URL>
+                                <Spark-Major-Version>${spark.major.version}</Spark-Major-Version>
+                                <Spark-Version>${spark.version}</Spark-Version>
+                            </manifestEntries>
+                        </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <excludedGroups>com.splicemachine.si.testenv.ArchitectureIndependent, ${excluded.longerthan}</excludedGroups>

--- a/pom.xml
+++ b/pom.xml
@@ -626,18 +626,6 @@
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.1.0</version>
                     <configuration>
-                        <archive>
-                            <manifestEntries>
-                                <!-- TODO: buildnumber plugin must point to open splice repo (SCM) -->
-                                <Implementation-Version>${buildNumber}</Implementation-Version>
-                                <!--<Implementation-Version>13</Implementation-Version>-->
-                                <Release>${project.version}</Release>
-                                <Build-Time>${maven.build.timestamp}</Build-Time>
-                                <URL>http://www.splicemachine.com</URL>
-                                <Spark-Major-Version>${spark.major.version}</Spark-Major-Version>
-                                <Spark-Version>${spark.version}</Spark-Version>
-                            </manifestEntries>
-                        </archive>
                         <excludes>
                             <exclude>**/*log4j.properties</exclude>
                             <exclude>**/splice-site.xml</exclude>


### PR DESCRIPTION
# Short Description
Include MANIFEST only on top modules (hbase_sql or mem_sql)

# Long Description
`getSparkVersion()` reads the Spark version used to compile the Splice build from a MANIFEST file. We include MANIFEST files for all jars though, even those that don't depend on a specific Spark version, if we read the version from one of those we end up with the wrong one.

This fix only generates MANIFEST files for the top modules (hbase_sql and mem_sql)

# How to test
Run Spark version-dependent code on platforms with different Spark versions, e.g. hdp3.1.5 (Spark 2.3) and dbaas3.0 (Spark 3.0)