### PR TITLE
DB-11517 DB2 compatible varchar for (Native)SparkDataSet.distinct()

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/DataSet.java
@@ -139,7 +139,7 @@ public interface DataSet<V> extends //Iterable<V>,
      *
      * @return
      */
-    DataSet<V> distinct(OperationContext context);
+    DataSet<V> distinct(OperationContext context) throws StandardException;
 
     /**
      *
@@ -153,7 +153,7 @@ public interface DataSet<V> extends //Iterable<V>,
      * @param scopeDetail
      * @return
      */
-    DataSet<V> distinct(String name, boolean isLast, OperationContext context, boolean pushScope, String scopeDetail);
+    DataSet<V> distinct(String name, boolean isLast, OperationContext context, boolean pushScope, String scopeDetail) throws StandardException;
 
     /**
      *

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
@@ -106,16 +106,16 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
                 .withCreate("create table z (v1 varchar(10), v2 varchar(10))")
                 .withInsert("insert into z values(?,?)")
                 .withRows(rows(
-                        row("1", ""),
-                        row("1", "     ")))
+                        row("1", "a    "),
+                        row("1", "a        ")))
                 .create();
 
         new TableCreator(conn)
                 .withCreate("create table y (v3 varchar(10), v4 varchar(10))")
                 .withInsert("insert into y values(?,?)")
                 .withRows(rows(
-                        row("1", ""),
-                        row("1", "   ")))
+                        row("1", "a    "),
+                        row("1", "a      ")))
                 .create();
     }
 
@@ -503,7 +503,7 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
             // only one row because trailing spaces are removed in comparing varchar under DB2 compatible mode
             String expected = "V1 |V2 |\n" +
                     "--------\n" +
-                    " 1 |   |";
+                    " 1 | a |";
             Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         }
 
@@ -517,7 +517,7 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
             // only one row because trailing spaces are removed in comparing varchar under DB2 compatible mode
             String expected = "V1 |V2 |V3 |V4 |\n" +
                     "----------------\n" +
-                    " 1 |   | 1 |   |";
+                    " 1 | a | 1 | a |";
             Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         }
     }


### PR DESCRIPTION
This change fixes distinct operation when result set contains varchar columns on native Spark. According to SQL standard, character string comparison are done by padding the shorter string to the longer string's length according to collation in use. On native Spark, however, there is no such padding. 'abc' and 'abc  ' are different strings. Method `distinct()` or `dropDuplicates()` do not remove any of them since they are different.

To make Spark's `distinct()` and `dropDuplicates()` work as SQL standard defines, all StringType columns are rtrimmed before running the distinct operation. rtrimmed columns are added as extra columns to the data frame so that in the end we return a row from original data for each group, not a row with rtrimmed values.

This fix is currently guarded under DB2 compatible varchar mode. Although it should be standard compliant, exposing it unconditionally would lead to inconsistent results on OLTP and OLAP. Moreover, Postgresql doesn't seem to be standard compliant on this point, either.

Current tests include
1. explicit distinct keyword in select list, and
2. union distinct semantic.