### PR TITLE
DB-11006 Don't pick NestedLoopJoin on Spark unless there's no alternative

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizer.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizer.java
@@ -418,4 +418,6 @@ public interface Optimizer{
     public boolean isForSpark();
 
     int getJoinPosition();
+
+    default boolean isMemPlatform() { return false; };
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
@@ -28,8 +28,11 @@ import com.splicemachine.db.impl.sql.compile.*;
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.log4j.Logger;
 
+import static com.splicemachine.db.impl.sql.compile.JoinNode.INNERJOIN;
+
 public class NestedLoopJoinStrategy extends BaseJoinStrategy{
     private static final Logger LOG=Logger.getLogger(NestedLoopJoinStrategy.class);
+    private static final double NLJ_ON_SPARK_PENALTY = 1e15;  // msirek-temp
 
     public NestedLoopJoinStrategy(){
     }
@@ -276,17 +279,76 @@ public class NestedLoopJoinStrategy extends BaseJoinStrategy{
         innerCost.setBase(innerCost.cloneMe());
         double totalRowCount = outerCost.rowCount()*innerCost.rowCount();
 
+        double nljOnSparkPenalty = getNljOnSparkPenalty(innerTable, predList, innerCost, outerCost, optimizer);
         innerCost.setRowOrdering(outerCost.getRowOrdering());
         innerCost.setEstimatedHeapSize((long) SelectivityUtil.getTotalHeapSize(innerCost, outerCost, totalRowCount));
         innerCost.setParallelism(outerCost.getParallelism());
         innerCost.setRowCount(totalRowCount);
         double remoteCostPerPartition = SelectivityUtil.getTotalPerPartitionRemoteCost(innerCost, outerCost, optimizer);
+        remoteCostPerPartition += nljOnSparkPenalty;
         innerCost.setRemoteCost(remoteCostPerPartition);
         innerCost.setRemoteCostPerParallelTask(remoteCostPerPartition);
         double joinCost = nestedLoopJoinStrategyLocalCost(innerCost, outerCost, totalRowCount, optimizer.isForSpark());
+        joinCost += nljOnSparkPenalty;
         innerCost.setLocalCost(joinCost);
         innerCost.setLocalCostPerParallelTask(joinCost);
         innerCost.setSingleScanRowCount(innerCost.getEstimatedRowCount());
+    }
+
+    // Nested loop join is most useful if it can be used to
+    // derive an index point-lookup predicate, otherwise it can be
+    // very slow on Spark.
+    // NOTE: The following description of the behavior will
+    //       only be enabled once DB-11521 is fixed:
+    // Detect when no join predicates are present that have
+    // both a start key and a stop key.  If none are present,
+    // or we're reading more than 10 rows from the outer table,
+    // return a large cost penalty so we'll avoid such joins.
+    private double getNljOnSparkPenalty(Optimizable table,
+                                        OptimizablePredicateList predList,
+                                        CostEstimate innerCost,
+                                        CostEstimate outerCost,
+                                        Optimizer optimizer) {
+        double retval = 0.0d;
+        if (!optimizer.isForSpark())
+            return retval;
+        if (table.getCurrentAccessPath().isHintedJoinStrategy())
+            return retval;
+        if (isSingleTableScan(optimizer))
+            return retval;
+        double multiplier = innerCost.getFromBaseTableRows();
+        if (multiplier < 1d)
+            multiplier = 1d;
+        // TODO:  Enable this code when DB-11521 is fixed.
+        //        Currently join cardinality is grossly underestimated,
+        //        so what we think is a safe nested loop join may in fact
+        //        be joining hundreds or thousands of rows from the left table.
+//        if (!isBaseTable(table))
+//            return NLJ_ON_SPARK_PENALTY * multiplier;
+//        if (hasJoinPredicateWithIndexKeyLookup(predList) && outerCost.rowCount() <= 10)
+//            return retval;
+        return NLJ_ON_SPARK_PENALTY * multiplier;
+    }
+
+    private boolean isSingleTableScan(Optimizer optimizer) {
+        return optimizer.getJoinPosition() == 0   &&
+               optimizer.getJoinType() < INNERJOIN;
+    }
+
+    private boolean isBaseTable(Optimizable table) {
+        return table instanceof FromBaseTable;
+    }
+
+    private boolean hasJoinPredicateWithIndexKeyLookup(OptimizablePredicateList predList) {
+        if (predList != null) {
+            for (int i = 0; i < predList.size(); i++) {
+                Predicate p = (Predicate) predList.getOptPredicate(i);
+                if (p.getReferencedSet().cardinality() > 1 &&
+                    p.isStartKey() && p.isStopKey())
+                    return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
@@ -310,7 +310,7 @@ public class NestedLoopJoinStrategy extends BaseJoinStrategy{
                                         CostEstimate outerCost,
                                         Optimizer optimizer) {
         double retval = 0.0d;
-        if (!optimizer.isForSpark())
+        if (!optimizer.isForSpark() || optimizer.isMemPlatform())
             return retval;
         if (table.getCurrentAccessPath().isHintedJoinStrategy())
             return retval;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceLevel2OptimizerImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceLevel2OptimizerImpl.java
@@ -155,6 +155,8 @@ public class SpliceLevel2OptimizerImpl extends Level2OptimizerImpl{
 
     private final long minTimeout;
     private final long maxTimeout;
+    private final boolean isMemPlatform;
+
     public SpliceLevel2OptimizerImpl(OptimizableList optimizableList,
                                      OptimizablePredicateList predicateList,
                                      DataDictionary dDictionary,
@@ -182,6 +184,7 @@ public class SpliceLevel2OptimizerImpl extends Level2OptimizerImpl{
         SConfiguration configuration=EngineDriver.driver().getConfiguration();
         this.minTimeout=configuration.getOptimizerPlanMinimumTimeout();
         this.maxTimeout=configuration.getOptimizerPlanMaximumTimeout();
+        isMemPlatform = EngineDriver.isMemPlatform();
         tracer().trace(OptimizerFlag.STARTED,0,0,0.0,null);
     }
 
@@ -238,4 +241,7 @@ public class SpliceLevel2OptimizerImpl extends Level2OptimizerImpl{
     protected long getMaxTimeout() {
         return maxTimeout;
     }
+
+    @Override
+    public boolean isMemPlatform() { return isMemPlatform; };
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/JoinOrderJumpModeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/JoinOrderJumpModeIT.java
@@ -194,7 +194,7 @@ public class JoinOrderJumpModeIT extends SpliceUnitTest {
     public void testResetJumpModeForNextRound() throws Exception {
         String sqlText = "explain SELECT GA.LOGDAT,GA.USERID,ST.SKB \n" +
                 "FROM\n" +
-                "     TABLE_1 GA\n" +
+                "     TABLE_1 GA --splice-properties useSpark=false\n" +
                 "   , TABLE_2 MD\n" +
                 "   , TABLE_3 MP\n" +
                 "   , TABLE_4 SL\n" +

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/JoinSelectionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/JoinSelectionIT.java
@@ -182,7 +182,7 @@ public class JoinSelectionIT extends SpliceUnitTest  {
     public void testLeftOuterJoinWithSubqueryFilterExactCriteria() throws Exception {
         fourthRowContainsQuery(
             format("explain select a2.pid from %s a2 left outer join " +
-            		  "(select person.pid from %s) as a3 " +
+            		  "(select person.pid from %s) as a3 --splice-properties useSpark=false\n" +
             		  " on a2.pid = a3.pid " +
             		  " where a2.pid = 100", spliceTableWatcher2, spliceTableWatcher),
                 LO_NESTED_LOOP_JOIN, methodWatcher);
@@ -211,7 +211,7 @@ public class JoinSelectionIT extends SpliceUnitTest  {
     @Test
     public void testRPLeftOuterJoinWithNestedSubqueriesFilterExactCriteria() throws Exception {
         fourthRowContainsQuery(
-            format("explain SELECT a2.pid FROM %s a2 " + 
+            format("explain SELECT a2.pid FROM %s a2 --splice-properties useSpark=false\n" +
             		  "LEFT OUTER JOIN " +
             		  "(SELECT a4.PID FROM %s a4 WHERE EXISTS " +
             				  "(SELECT a5.PID FROM %s a5 WHERE a4.PID = a5.PID)) AS a3 " +


### PR DESCRIPTION
This effectively disables nested loop join on Spark by adding a huge cost penalty in the join planner.
Initially the idea was to only apply the penalty if no join predicates with low cardinality that enabled index access were present.
But due to underestimated join cardinality, documented in [DB-11521](https://splicemachine.atlassian.net/browse/DB-11521), bad nested loop joins could still get picked.  So for now we just avoid nested loop join whenever possible on Spark.