### PR TITLE
DB-10865 force statistics collection during analyze execution.

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
@@ -1256,7 +1256,7 @@ public class StatisticsAdmin extends BaseAdminProcedures {
                         throw new RuntimeException(e);
                     }
                 }
-            });
+            }).toList();
         } else {
             return FluentIterable.from(movingExecutionWindow).transformAndConcat(new Function<StatisticsOperation, Iterable<ExecRow>>() {
                 @Nullable
@@ -1314,7 +1314,7 @@ public class StatisticsAdmin extends BaseAdminProcedures {
                         throw new RuntimeException(e);
                     }
                 }
-            });
+            }).toList();
         }
     }
 


### PR DESCRIPTION
Previously, collection of table statistics of a schema was done lazily during streaming of results, i.e. whenever DRDA requests a new row of `analyze` result set we return a row pertaining one of the analyzed tables so far and we might trigger analyzing a new table assuming as long as we do not exceed `splice.statistics.collectSchemaStatisticsMaximumConcurrent` concurrent operations.

This is probably fine since the user normally wait for the results to arrive to consider the statement's execution complete, however if the user monitors active operations using `SYSCS_UTIL.SYSCS_GET_RUNNING_OPERATIONS` then some inconsistencies will be noticed, the reason is that `SYSCS_GET_RUNNING_OPERATIONS` reads information about running operation from a `OperationManager`, this manager has certain hooks for registration and de-registration of running queries that are put around a query's execution activity and not result streaming activity. Therefore `analyze` appears only for a short while as a running operation, although it might take minutes longer to finish execution to the behavior described above of collecting statistics lazily.

To fix this issue, we force collecting the statistics for all tables during the execution time of the `analyze` allowing us to report its activity correctly in `SYSCS_GET_RUNNING_OPERATIONS`.

Writing tests for this PR is not straightforward since it is not easy to easily observe this behavior without some API mocking and I leave it for QA to verify.