### PR TITLE
DB-11535 Fix trigger performance regression from DB-10276

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TriggerDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TriggerDescriptor.java
@@ -430,8 +430,6 @@ public class TriggerDescriptor extends TupleDescriptor implements UniqueSQLObjec
             //By this point, we are finished transforming the trigger action if
             //it has any references to old/new transition variables.
             //Recompile it to store the latest updates in sys.sysstatements.
-            if (isDRDAConnThread)
-                sps = sps.shallowClone();
             sps.getPreparedStatement(true, lcc);
         }
         // Force recompile before execution if Olap.

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Performance_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Performance_IT.java
@@ -148,8 +148,6 @@ public class Trigger_Performance_IT extends SpliceUnitTest {
                 "--splice-properties useSpark=" + useSpark + "\n")) {
             }
         }
-        else  // Only test Spark, the target of the performance fix.
-            return;
         long startTime = System.currentTimeMillis();
         methodWatcher.execute("insert into targetTable --splice-properties useSpark=" + useSpark +
                               "\n select * from sourceTable");


### PR DESCRIPTION
## Short Description
DB-10276 improved the performance of parallel row triggers on spark, but performance of serial row triggers on control got worse.

## Long Description
DB-10276 added a shallow clone of the SPSDescriptor on trigger compilation because when a table has multiple triggers, compiling one trigger invalidates the other triggers because they are dependent objects.  The SPSDescriptors are pre-compiled before statement execution and added to a local cache before being shipped off to the spark executors.  The shallow clone assures that compiling more triggers as part of the statement doesn't invalidate what is in the local cache.  However, DB-10276 also added code to do a shallow clone for statements run on control.  This prevented the dictionary cache from getting updated with the valid version of the SPSDescriptor since trigger compilation used to work directly on the descriptor in the dictionary cache.  Since statements on control don't use a local SPSDescriptor cache, on every firing of the trigger we look up the invalid SPSDescriptor from dictionary cache and recompile it, adding large overhead.

The fix is to remove the extra shallow clone for statements on control, and only do the shallow clone if the statement is targeted to run on Spark.  The Trigger_Performance_IT is re-enabled on control.  It's likely that this bug was what was causing it to fail in some of the IT runs on Jenkins.

## How to test
Run the benchmark program attached to DB-11506.

Results:
java -jar SpliceBenchmark.jar -S 10000 -c 1 -n 10000
```
##### INSERT vs. UPDATE Trigger Benchmark #####
2021-02-24 23:03:16    Setup
2021-02-24 23:03:18    Create and populate tables
2021-02-24 23:03:36    Statistics:
	CREATE	calls: 20000	time: 17 s	avg: 1 ms
2021-02-24 23:03:36    Analyze schema, create triggers
2021-02-24 23:03:38    Do inserts
2021-02-24 23:04:38    Statistics:
	INSERT_T	calls: 6769	time: 34 s	avg: 5 ms
	INSERT_NOT	calls: 6768	time: 25 s	avg: 4 ms
2021-02-24 23:05:06    Statistics:
	INSERT_T	calls: 3231	time: 15 s	avg: 5 ms
	INSERT_NOT	calls: 3232	time: 12 s	avg: 4 ms
2021-02-24 23:05:06    Do updates
2021-02-24 23:06:06    Statistics:
	UPDATE_T	calls: 4764	time: 33 s	avg: 7 ms
	UPDATE_NOT	calls: 4764	time: 26 s	avg: 6 ms
2021-02-24 23:07:06    Statistics:
	UPDATE_T	calls: 4849	time: 33 s	avg: 7 ms
	UPDATE_NOT	calls: 4848	time: 26 s	avg: 6 ms
2021-02-24 23:07:11    Statistics:
	UPDATE_T	calls: 387	time: 2 s	avg: 7 ms
	UPDATE_NOT	calls: 388	time: 2 s	avg: 6 ms
2021-02-24 23:07:11    Finished
```
 
