### PR TITLE
DB-10968 fix Trigger_Exec_Stored_Proc_IT

### DIFF
--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Exec_Stored_Proc_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Exec_Stored_Proc_IT.java
@@ -39,7 +39,7 @@ import splice.com.google.common.collect.Lists;
  * Note the dependency on user-defined stored procedures in this test class.<br/>
  * See {@link TriggerProcs} for instructions on adding/modifying store procedures.
  */
-@Category({SerialTest.class})
+@Category({SerialTest.class, LongerThanTwoMinutes.class})
 @RunWith(Parameterized.class)
 public class Trigger_Exec_Stored_Proc_IT  extends SpliceUnitTest {
 

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Exec_Stored_Proc_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Exec_Stored_Proc_IT.java
@@ -39,7 +39,7 @@ import splice.com.google.common.collect.Lists;
  * Note the dependency on user-defined stored procedures in this test class.<br/>
  * See {@link TriggerProcs} for instructions on adding/modifying store procedures.
  */
-@Category({SerialTest.class, LongerThanTwoMinutes.class})
+@Category({SerialTest.class})
 @RunWith(Parameterized.class)
 public class Trigger_Exec_Stored_Proc_IT  extends SpliceUnitTest {
 
@@ -126,7 +126,7 @@ public class Trigger_Exec_Stored_Proc_IT  extends SpliceUnitTest {
             System.err.println("Ignoring in test teardown: " + e.getLocalizedMessage());
         }
         try {
-            classWatcher.executeUpdate(String.format(CALL_SET_CLASSPATH_STRING, "NULL"));
+            classWatcher.execute(String.format(CALL_SET_CLASSPATH_STRING, "NULL"));
         } catch (Exception e) {
             System.err.println("Ignoring in test teardown: " + e.getLocalizedMessage());
         }
@@ -386,7 +386,7 @@ public class Trigger_Exec_Stored_Proc_IT  extends SpliceUnitTest {
         if (originalLevel.equals("INFO")) {
             newlevel = "WARN";
         }
-        tb.named("log_level_change").before().insert().on("S").statement().
+        tb.named("log_level_change").after().insert().on("S").statement().
             then("call SYSCS_UTIL.SYSCS_SET_LOGGER_LEVEL('com.splicemachine.tools.version.ManifestFinder', '"+newlevel+"')");
         createTrigger(tb);
 


### PR DESCRIPTION
## Short Description
fixing IT failure in Trigger_Exec_Stored_Proc_IT

## Long Description
1. fixing IT failure in Trigger_Exec_Stored_Proc_IT
2. `SYSCS_SET_LOGGER_LEVEL` is now set to only allow admins to change this - normal user shouldn't set log level to DEBUG and slow down the system. Execution prevention is currently implemented with  `RoutineAliasInfo.MODIFIES_SQL_DATA` (we should change this, see DB-11542), which also prevents this function then to be used in BEFORE triggers (`java.sql.SQLSyntaxErrorException: Procedures that modify SQL data are not allowed in BEFORE triggers`). Therefore we're now using .after() in `Trigger_Exec_Stored_Proc_IT.testStatementTriggerSysStoredProc`.

## How to test
(fix for IT)