### PR TITLE
DB-11541 Cache predicate scan selectivity

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
@@ -92,7 +92,8 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
 
     private ReferencedColumnsMap referencedColumns;
 
-    private HashMap<Optimizable, Double> scanSelectivityCache;
+    // table number -> scan selectivity
+    private HashMap<Integer, Double> scanSelectivityCache;
 
     public ReferencedColumnsMap getReferencedColumns() {
         return referencedColumns;
@@ -313,11 +314,12 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
         if (scanSelectivityCache == null) {
             scanSelectivityCache = new HashMap<>(referencedSet.cardinality());
         }
-        if (scanSelectivityCache.containsKey(innerTable)) {
-            return scanSelectivityCache.get(innerTable);
+        int tableNumber = innerTable.getTableNumber();
+        if (scanSelectivityCache.containsKey(tableNumber)) {
+            return scanSelectivityCache.get(tableNumber);
         } else {
             double scanSelectivity = andNode.getLeftOperand().scanSelectivity(innerTable);
-            scanSelectivityCache.put(innerTable, scanSelectivity);
+            scanSelectivityCache.put(tableNumber, scanSelectivity);
             return scanSelectivity;
         }
     }


### PR DESCRIPTION
## Short Description
This change fixes a performance issue of `Predicate.scanSelectivity()`.

## Long Description
`Predicate.scanSelectivity()` has been working well. The problem occurs, however, when frequency sketch size is increased to 8192. In optimizing query hash `SsPX#UKs`, JProfiler shows that over 30% of the time is spent on doing `ReversePurgeItemHashMap.hashProbe()`, indicating that `ReversePurgeItemHashMap` in sketch library may have a performance issue when map size is big (although 8192 is not very big...). 

A solution on our side is to cache scan selectivity of a predicate so that `scanSelectivity()` doesn't always ask statistics and calculates over and over again. Given a predicate, its scan selectivity should stay the same for a given table. With that in mind, we can have a HashMap<Optimizable, Double> to cache calculated scan selectivities.

Also, not every predicate would be considered as a scan predicate of a merge join. So this cache is only allocated at the first time `scanSelectivity()` is called on a `Predicate` object. This is OK because optimizer doesn't process predicates in parallel.

## How to test
1. Restore the customer back up on a cluster.
2. Find a query with hash `SsPX#UKs`, explain this query.

Before the fix:
Execution finishes no less than 1000 ms on a k8s cluster, value typically ranges from 3000 - 7000.
On a standalone cluster, this value ranges from 200 - 700.

After the fix:
Execution finishes no more than 1000 ms on a k8s cluster, value typically ranges from 400 - 900.
On a standalone cluster, this value ranges from 70 - 130.
