### PR TITLE
DB-10382/DB-11470 fix exception paths

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/catalog/SystemProcedures.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/SystemProcedures.java
@@ -657,8 +657,8 @@ public class SystemProcedures{
         TransactionController tc=lcc.getTransactionExecute();
         try{
             tc.elevate("dbprops");
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        }catch(Throwable t){
+            throw PublicAPI.wrapThrowable(t);
         }
         PropertyInfo.setDatabaseProperty(key,value);
     }
@@ -678,8 +678,8 @@ public class SystemProcedures{
 
         try{
             return PropertyUtil.getDatabaseProperty(lcc.getTransactionExecute(),key);
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        }catch(Throwable t){
+            throw PublicAPI.wrapThrowable(t);
         }
     }
 
@@ -1043,8 +1043,8 @@ public class SystemProcedures{
             if(td!=null && td.getTableType()==TableDescriptor.VTI_TYPE){
                 return;
             }
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        }catch(Throwable t){
+            throw PublicAPI.wrapThrowable(t);
         }
 
         //Send all the other inplace compress requests to ALTER TABLE
@@ -1135,8 +1135,8 @@ public class SystemProcedures{
 
             JarUtil.replace(lcc,
                     schemaName,sqlName,url);
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        }catch(Throwable t){
+            throw PublicAPI.wrapThrowable(t);
         }
     }
 
@@ -1171,8 +1171,8 @@ public class SystemProcedures{
 
             JarUtil.drop(lcc,schemaName,sqlName);
 
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        }catch(Throwable t){
+            throw PublicAPI.wrapThrowable(t);
         }
     }
 
@@ -1530,8 +1530,8 @@ public class SystemProcedures{
             DataDictionary dd=lcc.getDataDictionary();
 
             dd.recompileInvalidSPSPlans(lcc);
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        }catch(Throwable t){
+            throw PublicAPI.wrapThrowable(t);
         }
     }
 
@@ -1546,8 +1546,8 @@ public class SystemProcedures{
             DataDictionary dd=lcc.getDataDictionary();
 
             dd.invalidateAllSPSPlans(lcc);
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        }catch(Throwable t){
+            throw PublicAPI.wrapThrowable(t);
         }
     }
 
@@ -1562,8 +1562,8 @@ public class SystemProcedures{
             dc.clearSpsNameCache();
             dc.clearStoredPreparedStatementCache();
 
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        }catch(Throwable t){
+            throw PublicAPI.wrapThrowable(t);
         }
     }
 
@@ -1589,8 +1589,8 @@ public class SystemProcedures{
             dd.startWriting(lcc);
 
             dd.updateMetadataSPSes(tc);
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        }catch(Throwable t){
+            throw PublicAPI.wrapThrowable(t);
         }
     }
 
@@ -1623,8 +1623,8 @@ public class SystemProcedures{
             dd.startWriting(lcc);
 
             dd.createSystemProcedure(schemaName,procName,tc);
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        }catch(Throwable t){
+            throw PublicAPI.wrapThrowable(t);
         }
     }
 
@@ -1657,8 +1657,8 @@ public class SystemProcedures{
             dd.startWriting(lcc);
 
             dd.dropSystemProcedure(schemaName,procName,tc);
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        }catch(Throwable t){
+            throw PublicAPI.wrapThrowable(t);
         }
     }
 
@@ -1744,6 +1744,8 @@ public class SystemProcedures{
             status = false;
             reason = sqle.getMessage();
             throw sqle;
+        }catch(Throwable t){
+            throw PublicAPI.wrapThrowable(t);
         }
         finally {
             if (AUDITLOG.isInfoEnabled())
@@ -1824,8 +1826,8 @@ public class SystemProcedures{
                 //    tc.setProperty
                 //        ( Property.AUTHENTICATION_PROVIDER_PARAMETER, Property.AUTHENTICATION_PROVIDER_NATIVE_LOCAL, true );
             }
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        }catch(Throwable t){
+            throw PublicAPI.wrapThrowable(t);
         }
     }
 
@@ -1881,8 +1883,8 @@ public class SystemProcedures{
             dd.startWriting(lcc);
             // Change system schemas to be owned by aid
             dd.updateSystemSchemaAuthorization(aid,tc);
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        }catch(Throwable t){
+            throw PublicAPI.wrapThrowable(t);
         }
     }
 
@@ -1945,8 +1947,8 @@ public class SystemProcedures{
 
             dd.updateUser(userDescriptor,tc);
 
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        }catch(Throwable t){
+            throw PublicAPI.wrapThrowable(t);
         }
     }
 
@@ -2017,14 +2019,17 @@ public class SystemProcedures{
 
             dd.dropUser(userName,lcc.getTransactionExecute());
             status = true;
-
-        }catch(StandardException se){
+        }
+        catch(Throwable t) {
+            StandardException se = StandardException.getOrWrap(t);
             status = false;
             reason = se.getMessage();
-            throw PublicAPI.wrapStandardException(se);
-        }finally {
+            throw PublicAPI.wrapThrowable(t);
+        }
+        finally {
             if (AUDITLOG.isInfoEnabled())
-                AUDITLOG.info(StringUtils.logSpliceAuditEvent(currentUser, AuditEventType.DROP_USER.name(),status,ip,lcc.getStatementContext().getStatementText(),reason));
+                AUDITLOG.info(StringUtils.logSpliceAuditEvent(currentUser, AuditEventType.DROP_USER.name(), status, ip,
+                        lcc.getStatementContext().getStatementText(), reason));
         }
     }
 
@@ -2046,8 +2051,8 @@ public class SystemProcedures{
             throws SQLException{
         try{
             return IdUtil.getUserAuthorizationId(userName);
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        } catch(Throwable t) {
+            throw PublicAPI.wrapThrowable(t);
         }
     }
 
@@ -2062,8 +2067,8 @@ public class SystemProcedures{
             throws SQLException{
         try{
             return ConnectionUtil.getCurrentLCC().getDataDictionary().peekAtSequence(schemaName,sequenceName);
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        } catch(Throwable t) {
+            throw PublicAPI.wrapThrowable(t);
         }
     }
 
@@ -2106,8 +2111,8 @@ public class SystemProcedures{
                         IdUtil.appendNormalToList(userName,addList));
             }
 
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        } catch(Throwable t) {
+            throw PublicAPI.wrapThrowable(t);
         }
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/error/PublicAPI.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/error/PublicAPI.java
@@ -37,22 +37,26 @@ import com.splicemachine.db.impl.jdbc.EmbedSQLException;
 
 
 /**
-	Class that wraps StandardExceptions in a SQLException.
-	This is used to make any public API methods always
-	throw SQLException rather than a random collection.
-	This wrapping is also special cased by TypeStatementException
-	to avoid double wrapping of some errors.
-	<P>
-	This will get cleaned up in main.
+ * Class that wraps StandardExceptions or Throwables in a SQLException.
+ * This is used to make any public API methods always
+ * throw SQLException rather than a random collection.
+ * This wrapping is also special cased by TypeStatementException
+ * to avoid double wrapping of some errors.
+ * <P>
+ * This will get cleaned up in main.
  */
 public class PublicAPI
 {
-	/**
-		Generates a SQLException for signalling that the
-		operation failed due to a database error.
-	 */
-	public static SQLException wrapStandardException(StandardException se) {
-		return EmbedSQLException.wrapStandardException(se.getMessage(),
-			se.getMessageId(), se.getSeverity(), se);
-	}
+    /**
+     * Generates a SQLException for signalling that the
+     * operation failed due to a database error.
+     */
+    public static SQLException wrapStandardException(StandardException se) {
+        return EmbedSQLException.wrapStandardException(se.getMessage(),
+            se.getMessageId(), se.getSeverity(), se);
+    }
+
+    public static SQLException wrapThrowable(Throwable t) {
+        return wrapStandardException(StandardException.getOrWrap(t));
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/error/StandardException.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/error/StandardException.java
@@ -80,7 +80,7 @@ public class StandardException extends Exception
 	public StandardException() {
 		
 	}
-	
+
 	public void setIsSignal(boolean isSignal) { this.isSignal = isSignal; }
 	public boolean isSignal() { return isSignal; }
 	
@@ -827,5 +827,15 @@ public class StandardException extends Exception
 
         return(SQLState.LOCK_TIMEOUT.equals(getSQLState()) ||
                SQLState.DEADLOCK.equals(getSQLState()));
+    }
+    /**
+     * @return if input is already a StandardException, return as is.
+	 *         Otherwise, use plainWrapException so we always return a StandardException
+     */
+	public static StandardException getOrWrap(Throwable e) {
+        if(e instanceof StandardException)
+            return (StandardException)e;
+        else
+            return plainWrapException(e);
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/error/StandardException.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/error/StandardException.java
@@ -67,7 +67,7 @@ public class StandardException extends Exception
 	 * Exception State
 	 */
 	private Object[] arguments;
-	private int severity;
+	private int severity = ExceptionSeverity.NO_APPLICABLE_SEVERITY;
 	private String textMessage;
 	private String sqlState;
 	private transient int report;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementPermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementPermission.java
@@ -283,6 +283,9 @@ public abstract class StatementPermission {
 				}
 				throw se;
 			}
+			catch(Throwable t) {
+				throw StandardException.getOrWrap(t);
+			}
 		}
 
 	} // end of genericCheck

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementPermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementPermission.java
@@ -144,7 +144,6 @@ public abstract class StatementPermission {
         throws StandardException
 	{
 		DataDictionary dd = lcc.getDataDictionary();
-		/*TransactionController tc = */ lcc.getTransactionExecute();
 		ExecPreparedStatement ps = activation.getPreparedStatement();
 		List<String> currentGroupuserlist = lcc.getCurrentGroupUser(activation);
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementPermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementPermission.java
@@ -144,7 +144,7 @@ public abstract class StatementPermission {
         throws StandardException
 	{
 		DataDictionary dd = lcc.getDataDictionary();
-		TransactionController tc = lcc.getTransactionExecute();
+		/*TransactionController tc = */ lcc.getTransactionExecute();
 		ExecPreparedStatement ps = activation.getPreparedStatement();
 		List<String> currentGroupuserlist = lcc.getCurrentGroupUser(activation);
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -142,7 +142,8 @@ public class GenericStatement implements Statement{
         boolean recompile=false;
         try{
             return prepMinion(lcc,true,null,null,forMetaData, boundAndOptimizedStatement);
-        } catch(StandardException se){
+        } catch(Throwable t){
+            StandardException se = StandardException.getOrWrap(t);
             // There is a chance that we didn't see the invalidation
             // request from a DDL operation in another thread because
             // the statement wasn't registered as a dependent until
@@ -429,12 +430,12 @@ public class GenericStatement implements Statement{
             if (internalSQL)
                 cc.setCompilingTrigger(true);
             fourPhasePrepare(lcc,paramDefaults,timestamps,foundInCache,cc,boundAndOptimizedStatement, cacheMe, false);
-        }catch(StandardException se){
+        } catch (Throwable e) {
             if(foundInCache)
                 ((GenericLanguageConnectionContext)lcc).removeStatement(this);
-
-            throw se;
-        }finally{
+            throw StandardException.getOrWrap(e);
+        }
+        finally{
             synchronized(preparedStmt){
                 preparedStmt.compilingStatement=false;
                 preparedStmt.notifyAll();
@@ -862,10 +863,12 @@ public class GenericStatement implements Statement{
 
             lcc.logEndCompiling(getSource(), System.nanoTime() - startTime);
             return qt;
-        } catch (StandardException e) {
-            lcc.logErrorCompiling(getSource(), e, System.nanoTime() - startTime);
-            throw e;
-        }  finally{ // for block introduced by pushCompilerContext()
+        } catch (Throwable e) {
+            StandardException se = StandardException.getOrWrap(e);
+            lcc.logErrorCompiling(getSource(), se, System.nanoTime() - startTime);
+            throw se;
+        }
+        finally{ // for block introduced by pushCompilerContext()
             lcc.resetDB2VarcharCompatibilityMode();
             lcc.setHasJoinStrategyHint(false);
             if (boundAndOptimizedStatement == null)
@@ -987,9 +990,9 @@ public class GenericStatement implements Statement{
             // Call user-written tree-printer if it exists
             walkAST(lcc,qt, CompilationPhase.AFTER_OPTIMIZE);
             saveTree(qt, CompilationPhase.AFTER_OPTIMIZE);
-        }catch(StandardException se){
+        }catch(Throwable t){
             lcc.commitNestedTransaction();
-            throw se;
+            throw StandardException.getOrWrap(t);
         }
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -7770,7 +7770,10 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
                 System.out.println("ASSERT FAILURE: "+strbuf.toString());
                 SanityManager.DEBUG_PRINT("ASSERT FAILURE",strbuf.toString());
             }catch(StandardException se){
-                strbuf.append("\ngot the following error when doing extra consistency checks:\n").append(se.toString());
+                strbuf.append("\ngot the following StandardException when doing extra consistency checks:\n").append(se.toString());
+            }
+            catch(Throwable t) {
+                strbuf.append("\ngot the following error when doing extra consistency checks:\n").append(t.toString());
             }
         }
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
@@ -460,10 +460,10 @@ public class BinaryRelationalOperatorNode
                 }
             }
 
-        }catch(StandardException se){
+        }catch(Throwable t){
             if(SanityManager.DEBUG){
                 SanityManager.THROWASSERT("Failed when trying to "+
-                        "find base table number for column reference check:",se);
+                        "find base table number for column reference check:", t);
             }
         }
 
@@ -2234,10 +2234,10 @@ public class BinaryRelationalOperatorNode
             valNodeBaseTables.and(optBaseTables);
             found=(valNodeBaseTables.getFirstSetBit()!=-1);
 
-        }catch(StandardException se){
+        }catch(Throwable t){
             if(SanityManager.DEBUG){
                 SanityManager.THROWASSERT("Failed when trying to "+
-                        "find base table numbers for reference check:",se);
+                        "find base table numbers for reference check:", t);
             }
         }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatchRefresher.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatchRefresher.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2012 - 2020 Splice Machine, Inc.
  *

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatchRefresher.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatchRefresher.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2012 - 2020 Splice Machine, Inc.
  *

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NormalizeOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/NormalizeOperation.java
@@ -115,8 +115,8 @@ public class NormalizeOperation extends SpliceBaseOperation{
     public ExecRow getExecRowDefinition(){
         try{
             return getFromResultDescription(resultDescription);
-        }catch(StandardException e){
-            SpliceLogUtils.logAndThrowRuntime(LOG,e);
+        }catch(Throwable t){
+            SpliceLogUtils.logAndThrowRuntime(LOG, StandardException.getOrWrap(t));
             return null;
         }
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
@@ -504,8 +504,8 @@ public class SpliceAdmin extends BaseAdminProcedures{
                         dvds[8].setValue(ex.getTotalCompletedTasks());
                         dvds[9].setValue(ex.getTotalRejectedTasks());
                         dvds[10].setValue(ex.getTotalScheduledTasks());
-                    }catch(StandardException se){
-                        throw PublicAPI.wrapStandardException(se);
+                    } catch(Throwable t) {
+                        throw PublicAPI.wrapThrowable(t);
                     }
                     rows.add(template.getClone());
                     i++;
@@ -546,8 +546,8 @@ public class SpliceAdmin extends BaseAdminProcedures{
                         dvds[4].setValue(ex.getMissRate());
                         dvds[5].setValue(ex.getHitCount());
                         dvds[6].setValue(ex.getHitRate());
-                    }catch(StandardException se){
-                        throw PublicAPI.wrapStandardException(se);
+                    } catch(Throwable t) {
+                        throw PublicAPI.wrapThrowable(t);
                     }
                     rows.add(template.getClone());
                     i++;
@@ -559,8 +559,8 @@ public class SpliceAdmin extends BaseAdminProcedures{
                 IteratorNoPutResultSet resultsToWrap = new IteratorNoPutResultSet(rows, MANAGED_CACHE_COLUMNS,lastActivation);
                 try {
                     resultsToWrap.openCore();
-                } catch (StandardException e) {
-                    throw PublicAPI.wrapStandardException(e);
+                } catch(Throwable t) {
+                    throw PublicAPI.wrapThrowable(t);
                 }
                 EmbedResultSet ers = new EmbedResultSet40(defaultConn, resultsToWrap,false,null,true);
                 resultSet[0] = ers;
@@ -682,8 +682,8 @@ public class SpliceAdmin extends BaseAdminProcedures{
 
             configMap.clear();
 
-        }catch(StandardException se){
-            throw PublicAPI.wrapStandardException(se);
+        } catch(Throwable t) {
+            throw PublicAPI.wrapThrowable(t);
         }
     }
 


### PR DESCRIPTION
## Bug Symptoms

Under some circumstances, the Server Connection gets in an erroneous state, and the connection to the client is dropped. Symptoms are one of the following:

When executing a query through sqlshell (or other JDBC shells):

- `ERROR 08006: Insufficient data while reading from the network - expected a minimum of 6 bytes and received only 0 bytes.  The connection has been terminated.`
- `ERROR 08006: A network protocol error was encountered and the connection has been terminated: the requested command encountered an unarchitected and implementation-specific condition for which there was no architected message (additional information may be available in the derby.log file on the server)`
- `ERROR 08003: DERBY SQL error: SQLCODE: -1, SQLSTATE: 08003, SQLERRMC: No current connection.`

## Fix

This fix will add catches for all `Throwable` and convert them into wrapped `SQLException` at all necessary places, and quite early up from `DRADConnThread`/`DRDAStatement` so that also unexpected Exceptions should not “escape” the connection thread.

The actual code that is dropping the connection is in `EmbedConnectionContext.cleanupOnError`, which is calling `conn.setInactive()` for all non-StandardExceptions, causing the DRDA Connection Stream to not continue, send results or follow-up messages, so that the client side might see a connection drop while still expecting data (hence the "insufficient data"). We now prevent this from happening for all cases except `ThreadDeath`.

Note this does NOT fix the actual cause of the exceptions, but rather display them correctly and prevent them from closing the connection.

## How to test

As this is about unexpected exceptions being thrown, this is quite hard to test by QA. See this [comment](https://splicemachine.atlassian.net/browse/DB-11470?focusedCommentId=74662) about how to force an unexpected exception in a SELECT query; 

On some versions `SELECT * SYS.SYSCOLUMNSTATS` runs into an error, see [DB-11267](https://splicemachine.atlassian.net/browse/DB-11267) , but this is not reliable.