### PR TITLE
DB-11559 Improve conglomerate cost estimation performance

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/ColumnStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/ColumnStatisticsImpl.java
@@ -507,7 +507,7 @@ public class ColumnStatisticsImpl implements ItemStatistics<DataValueDescriptor>
          * it with the lower bound of rpv and upper bound of total not-null rows.
          */
 
-        long qualifiedRows = 0;
+        long qualifiedRows;
         /* 1. range selectivity returned by CDF */
         if (!includeStart && start != null && !start.isNull())
             start = new StatsExcludeStartDVD(start);
@@ -517,7 +517,7 @@ public class ColumnStatisticsImpl implements ItemStatistics<DataValueDescriptor>
         double stopSelectivity = stop == null || stop.isNull() ? 1.0d : quantilesSketch.getCDF(new DataValueDescriptor[]{stop})[0];
         double totalSelectivity = stopSelectivity - startSelectivity;
         double count = (double) quantilesSketch.getN();
-        if (totalSelectivity == Double.NaN || count == 0)
+        if (Double.isNaN(totalSelectivity) || count == 0)
             qualifiedRows = 0;
         else
             qualifiedRows = Math.round(totalSelectivity * count);

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/ColumnStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/ColumnStatisticsImpl.java
@@ -70,6 +70,8 @@ public class ColumnStatisticsImpl implements ItemStatistics<DataValueDescriptor>
     protected DataValueDescriptor dvd;
     private long rpv=-1; //rows per value excluding skewed values
 
+    private com.yahoo.sketches.frequencies.ItemsSketch.Row<DataValueDescriptor>[] freqSketchNoFpItems;
+
     public ColumnStatisticsImpl() {
 
     }
@@ -151,6 +153,14 @@ public class ColumnStatisticsImpl implements ItemStatistics<DataValueDescriptor>
                 thetaMem.freeMemory();
 
         }
+    }
+
+    private com.yahoo.sketches.frequencies.ItemsSketch.Row<DataValueDescriptor>[] getFreqSketchNoFpItems() {
+        if (freqSketchNoFpItems == null) {
+            freqSketchNoFpItems = frequenciesSketch.getFrequentItems(ErrorType.NO_FALSE_POSITIVES);
+        }
+        assert freqSketchNoFpItems != null : "freqSketchNoFpItems is null";
+        return freqSketchNoFpItems;
     }
 
     /**
@@ -307,7 +317,7 @@ public class ColumnStatisticsImpl implements ItemStatistics<DataValueDescriptor>
             count = frequenciesSketch.getEstimate(lookUpElement);
         } else {
         // Iterated comparing
-            com.yahoo.sketches.frequencies.ItemsSketch.Row<DataValueDescriptor>[] items = frequenciesSketch.getFrequentItems(ErrorType.NO_FALSE_POSITIVES);
+            com.yahoo.sketches.frequencies.ItemsSketch.Row<DataValueDescriptor>[] items = getFreqSketchNoFpItems();
             for (com.yahoo.sketches.frequencies.ItemsSketch.Row<DataValueDescriptor> row: items) {
                 DataValueDescriptor skewedValue = row.getItem();
                 try {
@@ -332,7 +342,7 @@ public class ColumnStatisticsImpl implements ItemStatistics<DataValueDescriptor>
     private long getAvgRowsPerValueExcludingSkews() {
         long skewCount = 0;
         long skewNum = 0;
-        com.yahoo.sketches.frequencies.ItemsSketch.Row<DataValueDescriptor>[] items = frequenciesSketch.getFrequentItems(ErrorType.NO_FALSE_POSITIVES);
+        com.yahoo.sketches.frequencies.ItemsSketch.Row<DataValueDescriptor>[] items = getFreqSketchNoFpItems();
         for (com.yahoo.sketches.frequencies.ItemsSketch.Row<DataValueDescriptor> row: items) {
             skewCount += row.getEstimate();
             skewNum ++;
@@ -348,7 +358,7 @@ public class ColumnStatisticsImpl implements ItemStatistics<DataValueDescriptor>
 
     private long getSkewedRowCountInRange(DataValueDescriptor start, DataValueDescriptor stop, boolean includeStart, boolean includeStop) {
         long skewCount = 0;
-        com.yahoo.sketches.frequencies.ItemsSketch.Row<DataValueDescriptor>[] items = frequenciesSketch.getFrequentItems(ErrorType.NO_FALSE_POSITIVES);
+        com.yahoo.sketches.frequencies.ItemsSketch.Row<DataValueDescriptor>[] items = getFreqSketchNoFpItems();
         for (com.yahoo.sketches.frequencies.ItemsSketch.Row<DataValueDescriptor> row: items) {
             DataValueDescriptor skewedValue = row.getItem();
             try {
@@ -679,7 +689,7 @@ public class ColumnStatisticsImpl implements ItemStatistics<DataValueDescriptor>
     public long selectivityExcludingValueIfSkewed(DataValueDescriptor value) {
         long skewCount = 0;
         long skewNum = 0;
-        com.yahoo.sketches.frequencies.ItemsSketch.Row<DataValueDescriptor>[] items = frequenciesSketch.getFrequentItems(ErrorType.NO_FALSE_POSITIVES);
+        com.yahoo.sketches.frequencies.ItemsSketch.Row<DataValueDescriptor>[] items = getFreqSketchNoFpItems();
         for (com.yahoo.sketches.frequencies.ItemsSketch.Row<DataValueDescriptor> row: items) {
             DataValueDescriptor skewedValue = row.getItem();
             try {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CastNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CastNode.java
@@ -316,17 +316,7 @@ public class CastNode extends ValueNode
             }
         }
 
-        /* We can't chop out cast above an untyped null because
-         * the store can't handle it.
-         */
-        if ((castOperand instanceof ConstantNode) &&
-                !(castOperand instanceof UntypedNullConstantNode))
-        {
-            // Return the new constant if the cast was performed
-            return bindConstantCast();
-        }
-
-        return this;
+        return bindConstantCast();
     }
 
     /**
@@ -337,8 +327,7 @@ public class CastNode extends ValueNode
      *
      * @exception StandardException        Thrown on error
      */
-    public void bindCastNodeOnly()
-            throws StandardException
+    public void bindCastNodeOnly() throws StandardException
     {
 
         /*
@@ -421,6 +410,11 @@ public class CastNode extends ValueNode
                 )
         { setNullability( true ); }
         else { setNullability(castOperand.getTypeServices().isNullable()); }
+    }
+
+    public ValueNode bindImplicitCast() throws StandardException {
+        bindCastNodeOnly();
+        return bindConstantCast();
     }
 
     /**
@@ -1098,6 +1092,13 @@ public class CastNode extends ValueNode
     }
 
     private ValueNode bindConstantCast() throws StandardException {
+        /* We can't chop out cast above an untyped null because
+         * the store can't handle it.
+         */
+        if (!(castOperand instanceof ConstantNode) ||
+                (castOperand instanceof UntypedNullConstantNode)) {
+            return this;
+        }
         /* If the castOperand is a typed constant then we do the cast at
          * bind time and return a constant of the correct type.
          * NOTE: This could return an exception, but we're prepared to

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNode.java
@@ -1648,14 +1648,14 @@ public abstract class ValueNode extends QueryTreeNode implements ParentNode
                                     leftTypeId,
                                     true, leftOperand.getTypeServices().getMaximumWidth()),
                             getContextManager());
-            ((CastNode) rightOperand).bindCastNodeOnly();
+            rightOperand = ((CastNode) rightOperand).bindImplicitCast();
         } else if (leftTypeId.isNumericTypeId() && rightTypeId.isCharOrVarChar()) {
             rightOperand = (ValueNode) getNodeFactory().getNode(
                     C_NodeTypes.CAST_NODE,
                     rightOperand,
                     DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.DOUBLE),
                     getContextManager());
-            ((CastNode) rightOperand).bindCastNodeOnly();
+            rightOperand = ((CastNode) rightOperand).bindImplicitCast();
         }
         return rightOperand;
     }


### PR DESCRIPTION
## Short Description
This change improves conglomerate cost estimation performance.

## Long Description
After frequency sketch size is increased to 8192, some queries get slower on first run. The time spent in optimizer is increased drastically.

There are three issues:
1. String literals representing date/time/timestamp are used to compare with column statistics values directly. The string literals are converted to date/time/timestamp values over and over again. Example predicate is `DATE_COL > '2010-11-05'
`.
2. `frequenciesSketch.getFrequentItems(ErrorType.NO_FALSE_POSITIVES)` sorts items internally. With sketch size increased to 8192, this sort involves a lot of `DataType.compare()`, making it slow.
3. `ColumnStatisticsImpl.getSkewedRowCountInRange()` compares every skewed value to start value and stop value. With sketch size increased to 8192, the number of skewed values becomes big and the loop doing comparison becomes slow.

In this change, issue 2 is addressed by caching `NO_FALSE_POSITIVES` in `ColumnStatisticsImpl`. Issue 1 is addressed by evaluating the implicit cast in binary comparison operator after the implicit cast node is added if the cast operand is a constant. Doing so is consistent with explicit cast on constant literals, which gets evaluated by default.

After doing this two items, issue 3 doesn't seem to be a serious issue for now because comparing between `SQLDate`s without converting is pretty fast.

## How to test
1. Restore the customer backup.
2. Explain the query shown in Jira DB-11559.
Before the change, explaining the query takes no shorter than 2000 ms in hot runs (typically 2500 ms).
After the change, explaining the query should take no longer than 1000 ms in hot runs (typically around 500 ms).
