### PR TITLE
DB-11552 Fix DB2VarcharCompatibility mode for parameterized queries

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/StoredFormatIds.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/StoredFormatIds.java
@@ -271,6 +271,13 @@ public interface StoredFormatIds {
      */
     int VARCHAR_TYPE_ID =
             (MIN_ID_2 + 13);
+
+    /**
+     *  A special type id only for internal use, never exposed
+     *  in ColumnDescriptors decribing table schemas.
+     */
+    int VARCHAR_DB2_COMPATIBLE_TYPE_ID =
+            (MIN_ID_2 + 12);
     
     /**
         class com.splicemachine.db.iapi.types.VarcharTypeId

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ColumnDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ColumnDescriptor.java
@@ -179,7 +179,7 @@ public final class ColumnDescriptor extends TupleDescriptor
         this.autoincStart = autoincStart;
         this.autoincValue = autoincStart;
         this.autoincInc = autoincInc;
-        this.collectStatistics = allowsStatistics(columnType);
+        this.collectStatistics =  allowsStatistics(columnType);
         this.partitionPosition = partitionPosition;
         this.useExtrapolation = useExtrapolation;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataTypeDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataTypeDescriptor.java
@@ -1150,12 +1150,6 @@ public class DataTypeDescriptor implements Formatable{
         return new DataTypeDescriptor(this,isNullable);
     }
 
-    public DataTypeDescriptor getDB2CompatibleNullabilityType(boolean isNullable){
-        if(isNullable()==isNullable)
-            return this;
-
-        return new DataTypeDescriptor(this,isNullable);
-    }
 
     /**
      * Return a type description identical to this type

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataTypeDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataTypeDescriptor.java
@@ -60,7 +60,6 @@ import java.text.RuleBasedCollator;
 
 import static com.splicemachine.db.iapi.types.TypeId.CHAR_ID;
 import static com.splicemachine.db.iapi.types.TypeId.VARCHAR_DB2_COMPATIBLE_ID;
-
 /**
  * DataTypeDescriptor describes a runtime SQL type.
  * It consists of a catalog type (TypeDescriptor)
@@ -77,6 +76,7 @@ public class DataTypeDescriptor implements Formatable{
     // DO NOT CHANGE OR REMOVE THIS WITHOUT PROVIDING AN UPDATE SCRIPT
     // it is needed for ObjectStreamClass.getDeclaredSUID. see DB-10665
     public static final long serialVersionUID = 804804029538241393l;
+    private boolean isDB2CompatibleVarchar;
 
     /********************************************************
      **
@@ -476,8 +476,10 @@ public class DataTypeDescriptor implements Formatable{
         //all the attributes of CD's TDI. So, if the CD is for a user table's
         //character type column, then this call by RC.init should have CD's
         //collation attributes copied into RC along with other attributes.
-        if (DB2Compatible && source.getTypeId().getTypeFormatId() == StoredFormatIds.VARCHAR_TYPE_ID)
+        if (DB2Compatible && source.getTypeId().getTypeFormatId() == StoredFormatIds.VARCHAR_TYPE_ID) {
             this.typeId = VARCHAR_DB2_COMPATIBLE_ID;
+            this.isDB2CompatibleVarchar = true;
+        }
         else
             this.typeId=source.typeId;
         typeDescriptor=new TypeDescriptorImpl(source.typeDescriptor,
@@ -1679,6 +1681,7 @@ public class DataTypeDescriptor implements Formatable{
         CatalogMessage.TypeDescriptorImpl typeDescriptorImpl = dataTypeDescriptor.getTypeDescriptor();
         typeDescriptor = ProtobufUtils.fromProtobuf(typeDescriptorImpl);
         collationDerivation = dataTypeDescriptor.getCollationDerivation();
+        isDB2CompatibleVarchar = dataTypeDescriptor.getIsDB2CompatibleVarchar();
         init();
     }
 
@@ -1692,7 +1695,10 @@ public class DataTypeDescriptor implements Formatable{
 
 
         String typeName=this.getTypeName();
-        typeId=TypeId.getBuiltInTypeId(typeName);
+        if (isDB2CompatibleVarchar)
+            typeId = VARCHAR_DB2_COMPATIBLE_ID;
+        else
+            typeId=TypeId.getBuiltInTypeId(typeName);
         if(typeId==null && typeName!=null){
             /*
              * This is a User-defined TypeId, which we serialize. For whatever reason,
@@ -1738,6 +1744,7 @@ public class DataTypeDescriptor implements Formatable{
         CatalogMessage.DataTypeDescriptor dataTypeDescriptor = CatalogMessage.DataTypeDescriptor.newBuilder()
                 .setTypeDescriptor(typeDescriptorImpl)
                 .setCollationDerivation(getCollationDerivation())
+                .setIsDB2CompatibleVarchar(isDB2CompatibleVarchar)
                 .build();
         return dataTypeDescriptor;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueFactoryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataValueFactoryImpl.java
@@ -1344,6 +1344,7 @@ public abstract class DataValueFactoryImpl implements DataValueFactory, ModuleCo
                         case StoredFormatIds.TIMESTAMP_TYPE_ID: return new SQLTimestamp();
                         case StoredFormatIds.TINYINT_TYPE_ID: return new SQLTinyint();
                         case StoredFormatIds.VARCHAR_TYPE_ID: return new SQLVarchar();
+                        case StoredFormatIds.VARCHAR_DB2_COMPATIBLE_TYPE_ID: return new SQLVarcharDB2Compatible();
                         case StoredFormatIds.LONGVARCHAR_TYPE_ID: return new SQLLongvarchar();
                         case StoredFormatIds.VARBIT_TYPE_ID: return new SQLVarbit();
                         case StoredFormatIds.LONGVARBIT_TYPE_ID: return new SQLLongVarbit();

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/TypeId.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/TypeId.java
@@ -263,6 +263,7 @@ public class TypeId{
     private static final TypeId NUMERIC_ID=new TypeId(StoredFormatIds.DECIMAL_TYPE_ID,new DecimalTypeIdImpl(true));
     public static final TypeId DECFLOAT_ID=create(StoredFormatIds.DECFLOAT_TYPE_ID,StoredFormatIds.DECFLOAT_TYPE_ID_IMPL);
     private static final TypeId VARCHAR_ID=create(StoredFormatIds.VARCHAR_TYPE_ID,StoredFormatIds.VARCHAR_TYPE_ID_IMPL);
+    public static final TypeId VARCHAR_DB2_COMPATIBLE_ID=create(StoredFormatIds.VARCHAR_DB2_COMPATIBLE_TYPE_ID,StoredFormatIds.VARCHAR_TYPE_ID_IMPL);
     private static final TypeId ARRAY_ID=create(StoredFormatIds.ARRAY_TYPE_ID,StoredFormatIds.ARRAY_TYPE_ID_IMPL);
     private static final TypeId DATE_ID=create(StoredFormatIds.DATE_TYPE_ID,StoredFormatIds.DATE_TYPE_ID_IMPL);
     private static final TypeId TIME_ID=create(StoredFormatIds.TIME_TYPE_ID,StoredFormatIds.TIME_TYPE_ID_IMPL);
@@ -865,6 +866,7 @@ public class TypeId{
                 break;
 
             case StoredFormatIds.VARCHAR_TYPE_ID:
+            case StoredFormatIds.VARCHAR_DB2_COMPATIBLE_TYPE_ID:
                 typePrecedence=VARCHAR_PRECEDENCE;
                 javaTypeName="java.lang.String";
                 maxMaxWidth=TypeId.VARCHAR_MAXWIDTH;
@@ -1486,6 +1488,9 @@ public class TypeId{
             case StoredFormatIds.VARCHAR_TYPE_ID:
                 return new SQLVarchar();
 
+            case StoredFormatIds.VARCHAR_DB2_COMPATIBLE_TYPE_ID:
+                return new SQLVarcharDB2Compatible();
+
             case StoredFormatIds.XML_TYPE_ID:
                 return new XML();
 
@@ -1555,6 +1560,9 @@ public class TypeId{
 
             case StoredFormatIds.VARCHAR_TYPE_ID:
                 return new SQLVarchar("");
+
+            case StoredFormatIds.VARCHAR_DB2_COMPATIBLE_TYPE_ID:
+                return new SQLVarcharDB2Compatible("");
 
             case StoredFormatIds.DATE_TYPE_ID:
             case StoredFormatIds.TIME_TYPE_ID:
@@ -1647,6 +1655,7 @@ public class TypeId{
 
             case StoredFormatIds.VARCHAR_TYPE_ID:
             case StoredFormatIds.LONGVARCHAR_TYPE_ID:
+            case StoredFormatIds.VARCHAR_DB2_COMPATIBLE_TYPE_ID:
                 // Return 200 if maximum width is max int
                 if(dts.getMaximumWidth()==Integer.MAX_VALUE){
                     return 200;
@@ -1747,6 +1756,7 @@ public class TypeId{
             case StoredFormatIds.DECIMAL_TYPE_ID:
             case StoredFormatIds.CHAR_TYPE_ID:
             case StoredFormatIds.VARCHAR_TYPE_ID:
+            case StoredFormatIds.VARCHAR_DB2_COMPATIBLE_TYPE_ID:
             case StoredFormatIds.BLOB_TYPE_ID:
             case StoredFormatIds.CLOB_TYPE_ID:
                 return true;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParameterNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParameterNode.java
@@ -31,12 +31,14 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
+import com.splicemachine.db.catalog.types.TypeDescriptorImpl;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.ClassName;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.classfile.VMOpcode;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.context.ContextManager;
+import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.store.access.Qualifier;
@@ -49,6 +51,8 @@ import java.sql.Types;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
+
+import static com.splicemachine.db.impl.sql.compile.CharTypeCompiler.getDB2CompatibilityModeStatic;
 
 /**
  * This node type represents a ? parameter.
@@ -177,14 +181,21 @@ public class ParameterNode extends ValueNode
 
     public void setType(DataTypeDescriptor descriptor) throws StandardException
     {
+        boolean isDB2CompatibilityMode =
+            descriptor.getTypeId().getTypeFormatId() == StoredFormatIds.VARCHAR_TYPE_ID ?
+                getDB2CompatibilityModeStatic() : false;
+
         /* Make sure the type is nullable. */
 
         /*
          ** Generate a new descriptor with all the same properties as
          ** the given one, except that it is nullable.
          */
-        descriptor = descriptor.getNullabilityType(true);
-
+        if (isDB2CompatibilityMode) {
+            descriptor = new DataTypeDescriptor(descriptor, true, true);
+        }
+        else
+            descriptor = descriptor.getNullabilityType(true);
 
         if (userParameterTypes != null)
             userParameterTypes[parameterNumber] = descriptor;

--- a/db-engine/src/main/protobuf/Derby.proto
+++ b/db-engine/src/main/protobuf/Derby.proto
@@ -81,6 +81,7 @@ message ReferencedColumnsDescriptorImpl {
 message DataTypeDescriptor {
   optional TypeDescriptorImpl typeDescriptor = 1;
   optional int32 collationDerivation = 2;
+  optional bool isDB2CompatibleVarchar = 3;
 }
 message DDdependableFinder {
   extensions 1000 to 1100;

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
@@ -117,6 +117,15 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
                         row(1, "a    "),
                         row(1, "a      ")))
                 .create();
+        new TableCreator(conn)
+                .withCreate("create table a ( v1 varchar(10) not null default '', v2 varchar(10) not null default '')")
+                .withIndex("create index idx1 on a (v2)")
+                .withIndex("create index idx2 on a (v2, v1)")
+                .withIndex("create index idx3 on a (v1)")
+                .withInsert("insert into a values(?,?)")
+                .withRows(rows(
+                        row("hello", "there")))
+                .create();
     }
 
     @BeforeClass
@@ -451,6 +460,47 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
                  methodWatcher.prepareStatement(sqlText)) {
             loadParamsAndRun(ps, skipParamTwo, skipParamThree, sqlText, expected);
         }
+    }
+
+    private void testPreparedQuery2(String sqlTemplate,
+                                    String expected) throws Exception  {
+        String sqlText = format(sqlTemplate, "IDX1");
+        try (PreparedStatement ps =
+                 methodWatcher.prepareStatement(sqlText)) {
+            loadParamsAndRun2(ps, sqlText, expected);
+        }
+
+        sqlText = format(sqlTemplate, "IDX2");
+        try (PreparedStatement ps =
+                 methodWatcher.prepareStatement(sqlText)) {
+            loadParamsAndRun2(ps, sqlText, expected);
+        }
+        sqlText = format(sqlTemplate, "IDX3");
+        try (PreparedStatement ps =
+                 methodWatcher.prepareStatement(sqlText)) {
+            loadParamsAndRun2(ps, sqlText, expected);
+        }
+    }
+    private void loadParamsAndRun2(PreparedStatement ps,
+                                  String sqlText,
+                                  String expected) throws Exception {
+            ps.setString(1, "there ");
+            try (ResultSet rs = ps.executeQuery()) {
+                assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+            }
+    }
+
+    @Test
+    public void testParameterizedIndexLookup() throws Exception {
+        String sqlTemplate = "select v1 from a --splice-properties useSpark=" + useSpark.toString() +
+                             ", index=%s\n" +
+                             "where v2=?";
+        String expected =
+            "V1   |\n" +
+            "-------\n" +
+            "hello |";
+
+        testPreparedQuery2(sqlTemplate, expected);
     }
 
     @Test


### PR DESCRIPTION
## Short Description
Queries involving a varchar index and IndexLookup step return wrong results with database property splice.db2.varchar.compatible = true.

## Long Description
In non-parameterized queries, a SQLVarcharDB2Compatible object is created in the gen phase (query compilation) for the value used in an index lookup (as opposed to the normal SQLVarchar).  For parameterized queries, we built an array of DataTypeDescriptors and end up calling DataTypeDescriptor.getNull() which checks the column data type and builds a null SQLVarchar.  

The fix is to introduce a new data type, VARCHAR_DB2_COMPATIBLE_TYPE_ID, to be used in place of VARCHAR_TYPE_ID in the parameter row data types array.  It will be used for internal purposes only.  The only usage of the parameter data types is to get a new null, so it should not require updating the code to support VARCHAR_DB2_COMPATIBLE_TYPE_ID wherever VARCHAR_TYPE_ID is used.

## How to test

```
call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', true);
drop schema DB_11552 cascade;
create schema DB_11552;
set schema DB_11552;
create table a ( v1 varchar(10) not null default '', v2 varchar(10) not null default '');
create index idx1 on a (v2);
create index idx2 on a (v2, v1);
create index idx3 on a (v1);

insert into a values ('hello', 'there');

prepare f1 as 'select v1 from a --splice-properties index=IDX1
    where v2=?';
-- Should return 'hello', before fix returned nothing
execute f1 using 'values (''there '')';

prepare f2 as 'select v1 from a --splice-properties index=IDX3
    where v2=?';
-- Should return 'hello', before fix returned nothing
execute f2 using 'values (''there '')';
```
