### PR TITLE
DB-11564 Support hinting cursor '?' 

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
@@ -44,6 +44,7 @@ import com.splicemachine.db.iapi.sql.depend.Dependent;
 import com.splicemachine.db.iapi.sql.depend.Provider;
 import com.splicemachine.db.iapi.sql.depend.ProviderList;
 
+import com.splicemachine.db.iapi.types.DataType;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 
 import com.splicemachine.db.iapi.store.access.StoreCostController;
@@ -738,6 +739,10 @@ public interface CompilerContext extends Context
     void setSecondFunctionCompatibilityMode(String mode);
 
     void setFloatingPointNotation(int floatingPointNotation);
+
+    void setCursorUntypedExpressionType(DataTypeDescriptor type);
+
+    DataTypeDescriptor getCursorUntypedExpressionType();
 
     String getTimestampFormat();
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -46,8 +46,10 @@ import com.splicemachine.db.iapi.sql.depend.Dependency;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
 import com.splicemachine.db.iapi.sql.execute.ExecutionContext;
+import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.FloatingPointDataType;
 import com.splicemachine.db.iapi.types.SQLTimestamp;
+import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.util.ByteArray;
 import com.splicemachine.db.iapi.util.InterruptStatus;
 import com.splicemachine.db.impl.ast.JsonTreeBuilderVisitor;
@@ -67,6 +69,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Timestamp;
+import java.sql.Types;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -491,6 +494,7 @@ public class GenericStatement implements Statement{
         setSecondFunctionCompatibilityMode(lcc, cc);
         setFloatingPointNotation(lcc, cc);
         setOuterJoinFlatteningDisabled(lcc, cc);
+        setCursorUntypedExpressionType(lcc, cc);
 
         if (!cc.isSparkVersionInitialized()) {
             setSparkVersion(cc);
@@ -765,6 +769,15 @@ public class GenericStatement implements Statement{
                 timestampFormatString = CompilerContext.DEFAULT_TIMESTAMP_FORMAT;
             }
             cc.setTimestampFormat(timestampFormatString);
+        }
+    }
+
+    private void setCursorUntypedExpressionType(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        String type = PropertyUtil.getCachedDatabaseProperty(lcc, Property.CURSOR_UNTYPED_EXPRESSION_TYPE);
+        if(type != null && "varchar".equals(type.toLowerCase())) {
+            cc.setCursorUntypedExpressionType(DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, true, 254));
+        } else {
+            cc.setCursorUntypedExpressionType(null);
         }
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
@@ -317,6 +317,11 @@ public class CompilerContextImpl extends ContextImpl
         floatingPointNotation = value;
     }
 
+    public void setCursorUntypedExpressionType(DataTypeDescriptor type)
+    {
+        cursorUntypedExpressionType = type;
+    }
+
     public int getCurrentTimestampPrecision() {
         return currentTimestampPrecision;
     }
@@ -331,6 +336,10 @@ public class CompilerContextImpl extends ContextImpl
 
     public int getFloatingPointNotation() {
         return floatingPointNotation;
+    }
+
+    public DataTypeDescriptor getCursorUntypedExpressionType() {
+        return cursorUntypedExpressionType;
     }
 
     public boolean isOuterJoinFlatteningDisabled() {
@@ -1208,6 +1217,7 @@ public class CompilerContextImpl extends ContextImpl
     private       String                              timestampFormat                              = DEFAULT_TIMESTAMP_FORMAT;
     private       int                                 floatingPointNotation                        = DEFAULT_FLOATING_POINT_NOTATION;
     private       String                              secondFunctionCompatibilityMode              = DEFAULT_SECOND_FUNCTION_COMPATIBILITY_MODE;
+    private       DataTypeDescriptor                  cursorUntypedExpressionType                  = null;
     // Used to track the flattened half outer joins.
     private       int                                 nextOJLevel                                  = 1;
     private       boolean                             outerJoinFlatteningDisabled;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CursorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CursorNode.java
@@ -125,10 +125,10 @@ public class CursorNode extends DMLStatementNode{
         this.updateMode=(Integer)updateMode;
         this.updatableColumns=(Vector)updatableColumns;
 
-		/*
+        /*
         ** This is a sanity check and not an error since the parser
-		** controls setting updatableColumns and updateMode.
-		*/
+        ** controls setting updatableColumns and updateMode.
+        */
         if(SanityManager.DEBUG)
             SanityManager.ASSERT(this.updatableColumns==null ||
                             this.updatableColumns.isEmpty() || this.updateMode==UPDATE,
@@ -211,8 +211,8 @@ public class CursorNode extends DMLStatementNode{
                     getNodeFactory().doJoinOrderOptimization(),
                     getContextManager());
 
-			/* Check for ? parameters directly under the ResultColums */
-            resultSet.rejectParameters();
+            /* Check for ? parameters directly under the ResultColums */
+            resultSet.assumeVarcharForUnknownParameters();
 
             // Bind and Optimize Real Time Views (OK, That is a made up name).
             bindAndOptimizeRealTimeViews();
@@ -231,7 +231,7 @@ public class CursorNode extends DMLStatementNode{
             // define how we bind these out, so we don't allow it.
             resultSet.rejectXMLValues();
 
-			/* Verify that all underlying ResultSets reclaimed their FromList */
+            /* Verify that all underlying ResultSets reclaimed their FromList */
             if(SanityManager.DEBUG){
                 SanityManager.ASSERT(fromList.isEmpty(),
                         "fromList.size() is expected to be 0, not "
@@ -391,25 +391,25 @@ public class CursorNode extends DMLStatementNode{
 
         super.optimizeStatement();
 
-		/* we need to generate a new ResultSetNode to enable the scrolling
-		 * on top of the tree before modifying the access paths.
-		 */
+        /* we need to generate a new ResultSetNode to enable the scrolling
+         * on top of the tree before modifying the access paths.
+         */
         ResultSetNode siChild = resultSet;
 
-		/* We get a shallow copy of the ResultColumnList and its
-		 * ResultColumns.  (Copy maintains ResultColumn.expression for now.)
-		 */
+        /* We get a shallow copy of the ResultColumnList and its
+         * ResultColumns.  (Copy maintains ResultColumn.expression for now.)
+         */
         ResultColumnList siRCList = resultSet.getResultColumns();
         ResultColumnList childRCList = siRCList.copyListAndObjects();
         resultSet.setResultColumns(childRCList);
 
-		/* Replace ResultColumn.expression with new VirtualColumnNodes
-		 * in the ScrollInsensitiveResultSetNode's ResultColumnList.  (VirtualColumnNodes include
-		 * pointers to source ResultSetNode, this, and source ResultColumn.)
-		 */
+        /* Replace ResultColumn.expression with new VirtualColumnNodes
+         * in the ScrollInsensitiveResultSetNode's ResultColumnList.  (VirtualColumnNodes include
+         * pointers to source ResultSetNode, this, and source ResultColumn.)
+         */
         siRCList.genVirtualColumnNodes(resultSet, childRCList);
 
-		/* Finally, we create the new ScrollInsensitiveResultSetNode */
+        /* Finally, we create the new ScrollInsensitiveResultSetNode */
         resultSet = (ResultSetNode) getNodeFactory().getNode(
                         C_NodeTypes.SCROLL_INSENSITIVE_RESULT_SET_NODE,
                         resultSet,
@@ -452,13 +452,13 @@ public class CursorNode extends DMLStatementNode{
         // this will generate an expression that will be a ResultSet
         resultSet.generate(acb,mb);
 
-		/*
-		** Generate the position code if this cursor is updatable.  This
-		** involves generating methods to get the cursor result set, and
-		** the target result set (which is for the base row).  Also,
-		** generate code to store the cursor result set in a generated
-		** field.
-		*/
+        /*
+        ** Generate the position code if this cursor is updatable.  This
+        ** involves generating methods to get the cursor result set, and
+        ** the target result set (which is for the base row).  Also,
+        ** generate code to store the cursor result set in a generated
+        ** field.
+        */
         if(needTarget){
             // PUSHCOMPILE - could be put into a single method
             acb.rememberCursor(mb);
@@ -487,8 +487,8 @@ public class CursorNode extends DMLStatementNode{
     /**
      * Returns whether or not this Statement requires a set/clear savepoint
      * around its execution.  The following statement "types" do not require them:
-     * Cursor	- unnecessary and won't work in a read only environment
-     * Xact	- savepoint will get blown away underneath us during commit/rollback
+     * Cursor    - unnecessary and won't work in a read only environment
+     * Xact    - savepoint will get blown away underneath us during commit/rollback
      *
      * @return boolean    Whether or not this Statement requires a set/clear savepoint
      */
@@ -681,15 +681,15 @@ public class CursorNode extends DMLStatementNode{
 
         updateTable=resultSet.getCursorTargetTable();
 
-		/* Tell the table that it is the cursor target */
+        /* Tell the table that it is the cursor target */
         if(updateTable.markAsCursorTargetTable()){
-			/* Cursor is updatable - remember to generate the position code */
+            /* Cursor is updatable - remember to generate the position code */
             needTarget=true;
 
-			/* We must generate the target column list at bind time
-			 * because the optimizer may transform the FromBaseTable from
-			 * a table scan into an index scan.
-			 */
+            /* We must generate the target column list at bind time
+             * because the optimizer may transform the FromBaseTable from
+             * a table scan into an index scan.
+             */
             genTargetResultColList();
         }
         return UPDATE;
@@ -719,14 +719,14 @@ public class CursorNode extends DMLStatementNode{
     private ResultColumnDescriptor[] genTargetResultColList() throws StandardException{
         ResultColumnList newList;
 
-		/*
-		   updateTable holds the FromTable that is the target.
-		   copy its ResultColumnList, making BaseColumn references
-		   for use in the CurrentOfNode, which behaves as if it had
-		   base columns for the statement it is in.
+        /*
+           updateTable holds the FromTable that is the target.
+           copy its ResultColumnList, making BaseColumn references
+           for use in the CurrentOfNode, which behaves as if it had
+           base columns for the statement it is in.
 
-			updateTable is null if the cursor is not updatable.
-		 */
+            updateTable is null if the cursor is not updatable.
+         */
         if(updateTable==null) return null;
 
         if(targetColumnDescriptors!=null) return targetColumnDescriptors;
@@ -756,7 +756,7 @@ public class CursorNode extends DMLStatementNode{
                     newNode,
                     getContextManager());
 
-			/* Build the ResultColumnList to return */
+            /* Build the ResultColumnList to return */
             newList.addResultColumn(newCol);
         }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CursorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CursorNode.java
@@ -42,6 +42,7 @@ import com.splicemachine.db.iapi.sql.conn.Authorizer;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.sql.execute.ConstantAction;
+import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.impl.sql.CursorInfo;
 import com.splicemachine.db.impl.sql.CursorTableReference;
@@ -212,7 +213,12 @@ public class CursorNode extends DMLStatementNode{
                     getContextManager());
 
             /* Check for ? parameters directly under the ResultColums */
-            resultSet.assumeVarcharForUnknownParameters();
+            DataTypeDescriptor untypedExpressionType = getCompilerContext().getCursorUntypedExpressionType();
+            if (untypedExpressionType == null) {
+                resultSet.rejectParameters();
+            } else {
+                resultSet.setUnknownParameterType(untypedExpressionType);
+            }
 
             // Bind and Optimize Real Time Views (OK, That is a made up name).
             bindAndOptimizeRealTimeViews();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
@@ -49,6 +49,7 @@ import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.db.iapi.util.StringUtil;
 import org.apache.spark.sql.types.StructField;
 
+import java.sql.Types;
 import java.util.Collections;
 import java.util.List;
 
@@ -1508,6 +1509,13 @@ public class ResultColumn extends ValueNode
     {
         if ((expression != null) && (expression.isParameterNode()))
             throw StandardException.newException(SQLState.LANG_PARAM_IN_SELECT_LIST);
+    }
+
+    void assumeVarcharForUnknownParameters() throws StandardException
+    {
+        if (expression != null && expression.isParameterNode()) {
+            expression.setType(DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, 254));
+        }
     }
 
     /*

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
@@ -1511,10 +1511,10 @@ public class ResultColumn extends ValueNode
             throw StandardException.newException(SQLState.LANG_PARAM_IN_SELECT_LIST);
     }
 
-    void assumeVarcharForUnknownParameters() throws StandardException
+    void setUnknownParameterType(DataTypeDescriptor type) throws StandardException
     {
         if (expression != null && expression.isParameterNode()) {
-            expression.setType(DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, 254));
+            expression.setType(type);
         }
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumnList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumnList.java
@@ -1846,9 +1846,9 @@ public class ResultColumnList extends QueryTreeNodeVector<ResultColumn>{
         }
     }
 
-    void assumeVarcharForUnknownParameters() throws StandardException{
+    void setUnknownParameterType(DataTypeDescriptor type) throws StandardException{
         for (ResultColumn rc: this) {
-            rc.assumeVarcharForUnknownParameters();
+            rc.setUnknownParameterType(type);
         }
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumnList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumnList.java
@@ -1846,6 +1846,12 @@ public class ResultColumnList extends QueryTreeNodeVector<ResultColumn>{
         }
     }
 
+    void assumeVarcharForUnknownParameters() throws StandardException{
+        for (ResultColumn rc: this) {
+            rc.assumeVarcharForUnknownParameters();
+        }
+    }
+
     /**
      * Check for (and reject) XML values directly under the ResultColumns.
      * This is done for SELECT/VALUES statements.  We reject values

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultSetNode.java
@@ -725,9 +725,9 @@ public abstract class ResultSetNode extends QueryTreeNode{
         }
     }
 
-    public void assumeVarcharForUnknownParameters() throws StandardException {
+    public void setUnknownParameterType(DataTypeDescriptor type) throws StandardException {
         if (resultColumns!= null) {
-            resultColumns.assumeVarcharForUnknownParameters();
+            resultColumns.setUnknownParameterType(type);
         }
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultSetNode.java
@@ -725,6 +725,12 @@ public abstract class ResultSetNode extends QueryTreeNode{
         }
     }
 
+    public void assumeVarcharForUnknownParameters() throws StandardException {
+        if (resultColumns!= null) {
+            resultColumns.assumeVarcharForUnknownParameters();
+        }
+    }
+
     /**
      * Check for (and reject) XML values directly under the ResultColumns.
      * This is done for SELECT/VALUES statements.  We reject values

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1157,6 +1157,8 @@ public interface Property {
     String FLOATING_POINT_NOTATION = "splice.function.floatingPointNotation";
     String PRESERVE_LINE_ENDINGS = "splice.function.preserveLineEndings";
 
+    String CURSOR_UNTYPED_EXPRESSION_TYPE = "splice.bind.cursorUntypedExpressionType";
+
     String OUTERJOIN_FLATTENING_DISABLED = "derby.database.outerJoinFlatteningDisabled";
 
     String SSQ_FLATTENING_FOR_UPDATE_DISABLED = "derby.database.ssqFlatteningForUpdateDisabled";


### PR DESCRIPTION
## Short Description
Introduced `splice.bind.cursorUntypedExpressionType` to hint `select ?`'s type.
(e.g. short description of the PR)

## Long Description
This PR introduces a new global database property: `splice.bind.cursorUntypedExpressionType`.
As of now, the only supported value (beside null) for that parameter is `'varchar'`.
If that parameter is set, we assume the type of a '?' at top select level to be `VARCHAR(254)`.
This is a workaround introduced until we provide proper deferred prepare statement support, at which point, this parameter can be discontinued once DB-11582 is addressed.

## How to test
```
splice> call syscs_util.syscs_set_global_database_property('splice.bind.cursorUntypedExpressionType', null);
name                |value
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PROPERTY_NAME       |splice.bind.cursorUntypedExpressionType
NEW VALUE           |NULL
PREVIOUS VALUE      |varchar
INFO                |

4 rows selected
ELAPSED TIME = 27 milliseconds
splice> prepare foo as 'select ?';
ERROR 42X34: There is a ? parameter in the select list.  This is not allowed.


splice> call syscs_util.syscs_set_global_database_property('splice.bind.cursorUntypedExpressionType', 'varchar');
name                |value
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PROPERTY_NAME       |splice.bind.cursorUntypedExpressionType
NEW VALUE           |varchar
PREVIOUS VALUE      |int
INFO                |

4 rows selected
ELAPSED TIME = 43 milliseconds
splice> prepare foo as 'select ?';
ELAPSED TIME = 6 milliseconds
splice> execute foo using 'values ''abc''';
Splice WARNING: Autocommit may close using result set
1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
abc

1 row selected
ELAPSED TIME = 11 milliseconds       

```
