### PR TITLE
DB-10258 Create parameter to disallow multidatabase creation

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -45,11 +45,7 @@ import com.splicemachine.db.iapi.sql.ParameterValueSet;
 import com.splicemachine.db.iapi.sql.PreparedStatement;
 import com.splicemachine.db.iapi.sql.compile.*;
 import com.splicemachine.db.iapi.sql.depend.Provider;
-import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
-import com.splicemachine.db.iapi.sql.dictionary.DatabaseDescriptor;
-import com.splicemachine.db.iapi.sql.dictionary.SPSDescriptor;
-import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
-import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
+import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ConstantAction;
 import com.splicemachine.db.iapi.sql.execute.CursorActivation;
 import com.splicemachine.db.iapi.sql.execute.ExecPreparedStatement;
@@ -494,6 +490,8 @@ public interface LanguageConnectionContext extends Context {
      * @return String the authorization id
      */
     String getCurrentUserId(Activation a);
+
+    UserDescriptor getCurrentUserDescriptor(Activation a) throws StandardException;
 
     void setCurrentUser(Activation a, String userName);
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -2358,4 +2358,6 @@ public interface DataDictionary{
     DatabaseDescriptor createNewDatabase(String name, String dbOwner) throws StandardException;
 
     UUID createNewDatabaseAndDatabaseOwner(String name, String dbOwner, String dbPassword) throws StandardException;
+
+    void enableMultiDatabase(boolean value) throws StandardException;
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -656,7 +656,6 @@ public interface DataDictionary{
      * Indicate whether there is anything in the
      * particular database.
      * Checks for schemas, users, roles in the the database
-     * XXX(arnaud multidb) check for other objects in the DB?
      *
      * @param dd database descriptor
      * @return true/false
@@ -2352,9 +2351,9 @@ public interface DataDictionary{
 
     void createDbOwnerSchema(TransactionController tc, UUID databaseUuid, String dbOwner) throws StandardException;
 
-    DatabaseDescriptor createNewDatabase(String name, String dbOwner) throws StandardException;
+    UUID createNewDatabaseAndDatabaseOwner(TransactionController tc, String name, String dbOwner, String dbPassword) throws StandardException;
 
-    UUID createNewDatabaseAndDatabaseOwner(String name, String dbOwner, String dbPassword) throws StandardException;
+    UUID createNewDatabaseAndDatabaseOwner(TransactionController tc, String dbName, UserDescriptor dbOwner) throws StandardException;
 
     void enableMultiDatabase(boolean value) throws StandardException;
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/UserDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/UserDescriptor.java
@@ -121,17 +121,25 @@ public final class  UserDescriptor extends TupleDescriptor
         return _databaseId;
     }
 
-    public boolean isDbOwner(DataDictionary dd) {
-        String dbo = dd.getAuthorizationDatabaseOwner(_databaseId);
+    public void setDatabaseId(UUID dbId) {
+        _databaseId = dbId;
+    }
+
+    private boolean isDbOwner() {
+        String dbo = dataDictionary.getAuthorizationDatabaseOwner(_databaseId);
 
         return dbo.equals(this._userName);
+    }
+
+    UserDescriptor cloneForOtherDatabase(UUID otherDbUUID) {
+        return new UserDescriptor(dataDictionary, _userName, _hashingScheme, getAndZeroPassword(), _lastModified, otherDbUUID);
     }
 
     public void drop(LanguageConnectionContext lcc, boolean dropIfOwner) throws StandardException {
         DataDictionary dd=lcc.getDataDictionary();
 
         // you can't drop the credentials of the dbo
-        if (!dropIfOwner && isDbOwner(dd)) {
+        if (!dropIfOwner && isDbOwner()) {
             throw StandardException.newException(SQLState.CANT_DROP_DBO);
         }
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/AccessFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/AccessFactory.java
@@ -272,4 +272,8 @@ public interface AccessFactory
     TransactionController getReadOnlyTransaction(ContextManager cm, long txnId) throws StandardException;
 
     void elevateRawTransaction(byte[] writeTable) throws StandardException;
+
+    boolean isMultiDatabaseEnabled();
+
+    void enableMultiDatabase(boolean value);
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection.java
@@ -352,6 +352,9 @@ public abstract class EmbedConnection implements EngineConnection
                         );
                     }
                 } catch (StandardException se) {
+                    if (se.getSQLState().equals(SQLState.LANG_MULTIDATABASE_NOT_ENABLED)) {
+                        throw se;
+                    }
                     throw new SQLException(SQLState.BOOT_DATABASE_FAILED, se);
                 }
             }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection.java
@@ -346,7 +346,7 @@ public abstract class EmbedConnection implements EngineConnection
                     TransactionController tc = af.getTransaction(ContextService.getCurrentContextManager());
                     if (dd.getDatabaseDescriptor(getDBName(), tc, false) == null) {
                         af.elevateRawTransaction(Bytes.toBytes("boot"));
-                        dd.createNewDatabaseAndDatabaseOwner(getDBName(),
+                        dd.createNewDatabaseAndDatabaseOwner(tc, getDBName(),
                                 info.getProperty(Attribute.USERNAME_ATTR),
                                 info.getProperty(Attribute.PASSWORD_ATTR)
                         );

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/BaseDataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/BaseDataDictionary.java
@@ -58,6 +58,7 @@ public abstract class BaseDataDictionary implements DataDictionary, ModuleContro
     protected static final String        CFG_SYSDATABASES_ID = "SysdatabasesIdentifier";
     protected static final String        CFG_SYSDATABASES_INDEX1_ID = "SysdatabasesIndex1Identifier";
     protected static final String        CFG_SYSDATABASES_INDEX2_ID = "SysdatabasesIndex2Identifier";
+    public static final String           CFG_ALLOW_MULTIDATABASE = "AllowMultidatabase";
     protected static final int           SYSCONGLOMERATES_CORE_NUM = 0;
     protected static final int           SYSTABLES_CORE_NUM = 1;
     protected static final int           SYSCOLUMNS_CORE_NUM = 2;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -716,31 +716,39 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
         authorizationDatabasesOwner.put(databaseID, authorizationId);
     }
 
-    public UUID createNewDatabaseAndDatabaseOwner(String name, String dbOwner, String dbPassword) throws StandardException {
-        dbOwner = IdUtil.getUserAuthorizationId(dbOwner);
-        DatabaseDescriptor dbDesc = createNewDatabase(name, dbOwner);
-        UUID dbId = dbDesc.getUUID();
-        TransactionController tc = af.getTransaction(ContextService.getCurrentContextManager());
+    private void assertTcElevated(TransactionController tc, String caller) throws StandardException {
         if (!tc.isElevated()) {
-            throw StandardException.plainWrapException(new IOException("addStoreDependency: not writeable"));
+            throw StandardException.plainWrapException(new IOException(caller + ": not writeable"));
         }
-        UserDescriptor desc = dataDescriptorGenerator.makeUserDescriptor(tc, dbOwner, dbPassword, dbId);
-        addDescriptor(desc, null, SYSUSERS_CATALOG_NUM, false, tc, false);
-        authorizationDatabasesOwner.put(dbId, IdUtil.getUserAuthorizationId(dbOwner));
+    }
+
+    public UUID createNewDatabaseAndDatabaseOwner(TransactionController tc, String dbName, String dbOwner, String dbPassword) throws StandardException {
+        assertTcElevated(tc, "createNewDatabaseAndDatabaseOwner");
+        dbOwner = IdUtil.getUserAuthorizationId(dbOwner);
+        UserDescriptor dbOwnerDesc = dataDescriptorGenerator.makeUserDescriptor(tc, dbOwner, dbPassword, null);
+        return createNewDatabaseAndDatabaseOwner(tc, dbName, dbOwnerDesc);
+    }
+
+    public UUID createNewDatabaseAndDatabaseOwner(TransactionController tc, String dbName, UserDescriptor dbOwner) throws StandardException {
+        if (!af.isMultiDatabaseEnabled()) {
+            throw StandardException.newException(SQLState.LANG_MULTIDATABASE_NOT_ENABLED);
+        }
+        assertTcElevated(tc, "createNewDatabaseAndDatabaseOwner");
+        DatabaseDescriptor dbDesc = createNewDatabase(dbName, dbOwner.getUserName());
+        UUID dbId = dbDesc.getUUID();
+        dbOwner.setDatabaseId(dbId);
+        addDescriptor(dbOwner, null, SYSUSERS_CATALOG_NUM, false, tc, false);
+        authorizationDatabasesOwner.put(dbId, dbOwner.getUserName());
         createDbSpecificSystemSchemas(tc, dbDesc);
         return dbId;
     }
 
-    // XXX(arnaud multidb) remove that one. We should not be able to create a db without an owner
-    public DatabaseDescriptor createNewDatabase(String name, String dbOwner) throws StandardException {
+    private DatabaseDescriptor createNewDatabase(String name, String dbOwner) throws StandardException {
         dbOwner = IdUtil.getUserAuthorizationId(dbOwner);
         ContextService.getFactory();
         TransactionController tc = af.getTransaction(ContextService.getCurrentContextManager());
         if (!tc.isElevated()) {
-            throw StandardException.plainWrapException(new IOException("addStoreDependency: not writeable"));
-        }
-        if (!af.isMultiDatabaseEnabled()) {
-            throw StandardException.newException(SQLState.LANG_MULTIDATABASE_NOT_ENABLED, name);
+            throw StandardException.plainWrapException(new IOException("createNewDatabase: not writeable"));
         }
 
         UUID uuid = getUUIDFactory().createUUID();
@@ -6525,7 +6533,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
     @Override
     public void dropDependentsStoredDependencies(UUID dependentsUUID,TransactionController tc) throws StandardException{
         if (!tc.isElevated()) {
-            StandardException.plainWrapException(new IOException("addStoreDependency: not writeable"));
+            StandardException.plainWrapException(new IOException("dropDependentsStoredDependencies: not writeable"));
         }
 
         dropDependentsStoredDependencies(dependentsUUID,tc,true);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -160,7 +160,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
 
     public DataDescriptorGenerator dataDescriptorGenerator;
     protected DataValueFactory dvf;
-    AccessFactory af;
+    protected AccessFactory af;
     //DataDictionaryContext                ddc;
 
     protected ExecutionFactory exFactory;
@@ -738,6 +738,9 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
         TransactionController tc = af.getTransaction(ContextService.getCurrentContextManager());
         if (!tc.isElevated()) {
             throw StandardException.plainWrapException(new IOException("addStoreDependency: not writeable"));
+        }
+        if (!af.isMultiDatabaseEnabled()) {
+            throw StandardException.newException(SQLState.LANG_MULTIDATABASE_NOT_ENABLED, name);
         }
 
         UUID uuid = getUUIDFactory().createUUID();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryOperatorNode.java
@@ -71,8 +71,8 @@ public class UnaryOperatorNode extends OperatorNode
      */
     private int operatorType;
 
-    String		resultInterfaceType;
-    String		receiverInterfaceType;
+    String        resultInterfaceType;
+    String        receiverInterfaceType;
 
     // At the time of adding XML support, it was decided that
     // we should avoid creating new OperatorNodes where possible.
@@ -108,14 +108,14 @@ public class UnaryOperatorNode extends OperatorNode
     };
 
     static final String[] UnaryResultTypes = {
-            ClassName.XMLDataValue, 		// XMLParse
-            ClassName.StringDataValue,		// XMLSerialize
-            ClassName.StringDataValue	    // DIGITS
+            ClassName.XMLDataValue,         // XMLParse
+            ClassName.StringDataValue,        // XMLSerialize
+            ClassName.StringDataValue        // DIGITS
     };
 
     static final String[] UnaryArgTypes = {
-            ClassName.StringDataValue,		// XMLParse
-            ClassName.XMLDataValue,			// XMLSerialize
+            ClassName.StringDataValue,        // XMLParse
+            ClassName.XMLDataValue,            // XMLSerialize
             ClassName.NumberDataValue       // DIGITS
     };
 
@@ -131,13 +131,6 @@ public class UnaryOperatorNode extends OperatorNode
      */
     protected int operandMatchIndexExpr = -1;
 
-    /* The following four fields record operand matches for
-     * which conglomerate and which column. These values
-     * are reset and valid only for the current access path.
-     * They should not be used beyond cost estimation.
-     */
-    //ConglomerateDescriptor operandMatchIndexExprConglomDesc = null;
-
     // 0-based index column position
     protected int operandMatchIndexExprColumnPosition = -1;
 
@@ -145,10 +138,10 @@ public class UnaryOperatorNode extends OperatorNode
      * Initializer for a UnaryOperatorNode.
      *
      * <ul>
-     * @param operand	The operand of the node
-     * @param operatorOrOpType	Either 1) the name of the operator,
+     * @param operand    The operand of the node
+     * @param operatorOrOpType    Either 1) the name of the operator,
      *  OR 2) an Integer holding the operatorType for this operator.
-     * @param methodNameOrAddedArgs	Either 1) name of the method
+     * @param methodNameOrAddedArgs    Either 1) name of the method
      *  to call for this operator, or 2) an array of Objects
      *  from which primitive method parameters can be
      *  retrieved.
@@ -156,9 +149,9 @@ public class UnaryOperatorNode extends OperatorNode
 
     @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "DB-9407")
     public void init(
-            Object	operand,
-            Object		operatorOrOpType,
-            Object		methodNameOrAddedArgs)
+            Object    operand,
+            Object        operatorOrOpType,
+            Object        methodNameOrAddedArgs)
     {
         operands = new ArrayList<>(Collections.singletonList((ValueNode) operand));
         if (operatorOrOpType instanceof String)  {
@@ -191,9 +184,9 @@ public class UnaryOperatorNode extends OperatorNode
     /**
      * Initializer for a UnaryOperatorNode
      *
-     * @param operand	The operand of the node
+     * @param operand    The operand of the node
      */
-    public void init(Object	operand)
+    public void init(Object    operand)
     {
         this.operands = new ArrayList<>(Collections.singletonList((ValueNode) operand));
         this.operatorType = -1;
@@ -208,7 +201,7 @@ public class UnaryOperatorNode extends OperatorNode
     /**
      * Set the operator.
      *
-     * @param operator	The operator.
+     * @param operator    The operator.
      */
     void setOperator(String operator)
     {
@@ -219,7 +212,7 @@ public class UnaryOperatorNode extends OperatorNode
     /**
      * Set the methodName.
      *
-     * @param methodName	The methodName.
+     * @param methodName    The methodName.
      */
     void setMethodName(String methodName)
     {
@@ -230,7 +223,7 @@ public class UnaryOperatorNode extends OperatorNode
     /**
      * Get the operand of this unary operator.
      *
-     * @return	The operand of this unary operator.
+     * @return    The operand of this unary operator.
      */
     public ValueNode getOperand()
     {
@@ -245,7 +238,7 @@ public class UnaryOperatorNode extends OperatorNode
      * This gets called when ParameterNode is needed to get parameter
      * specific information like getDefaultValue(), getParameterNumber() etc
      *
-     * @return	The parameter operand of this unary operator else null.
+     * @return    The parameter operand of this unary operator else null.
      */
     public ParameterNode getParameterOperand() throws StandardException
     {
@@ -267,19 +260,19 @@ public class UnaryOperatorNode extends OperatorNode
      * Sub-classes need to implement their own bindExpression() method
      * for their own specific rules.
      *
-     * @param fromList		The FROM list for the query this
-     *				expression is in, for binding columns.
-     * @param subqueryList		The subquery list being built as we find SubqueryNodes
-     * @param aggregateVector	The aggregate vector being built as we find AggregateNodes
+     * @param fromList        The FROM list for the query this
+     *                expression is in, for binding columns.
+     * @param subqueryList        The subquery list being built as we find SubqueryNodes
+     * @param aggregateVector    The aggregate vector being built as we find AggregateNodes
      *
-     * @return	The new top of the expression tree.
+     * @return    The new top of the expression tree.
      *
-     * @exception StandardException		Thrown on error
+     * @exception StandardException        Thrown on error
      */
     @Override
     public ValueNode bindExpression( FromList fromList,
                                      SubqueryList subqueryList,
-                                     List<AggregateNode>	aggregateVector) throws StandardException {
+                                     List<AggregateNode>    aggregateVector) throws StandardException {
         bindOperand(fromList, subqueryList, aggregateVector);
         if (operatorType == XMLPARSE_OP)
             bindXMLParse();
@@ -298,7 +291,7 @@ public class UnaryOperatorNode extends OperatorNode
      */
     protected void bindOperand(FromList fromList,
                                SubqueryList subqueryList,
-                               List<AggregateNode>	aggregateVector) throws StandardException {
+                               List<AggregateNode>    aggregateVector) throws StandardException {
         bindOperands(fromList, subqueryList, aggregateVector);
 
         if (getOperand().requiresTypeFromContext()) {
@@ -484,7 +477,7 @@ public class UnaryOperatorNode extends OperatorNode
      * will not be pushed down.
      *
      * For example, in:
-     *		select * from (select 1 from s) a (x) where x = 1
+     *        select * from (select 1 from s) a (x) where x = 1
      * we will not push down x = 1.
      * NOTE: It would be easy to handle the case of a constant, but if the
      * inner SELECT returns an arbitrary expression, then we would have to copy
@@ -492,17 +485,17 @@ public class UnaryOperatorNode extends OperatorNode
      * subqueries and method calls.
      * RESOLVE - revisit this issue once we have views.
      *
-     * @param referencedTabs	JBitSet with bit map of referenced FromTables
+     * @param referencedTabs    JBitSet with bit map of referenced FromTables
      * @param referencedColumns  An object which maps tableNumber to the columns
      *                           from that table which are present in the predicate.
-     * @param simplePredsOnly	Whether or not to consider method
-     *							calls, field references and conditional nodes
-     *							when building bit map
+     * @param simplePredsOnly    Whether or not to consider method
+     *                            calls, field references and conditional nodes
+     *                            when building bit map
      *
-     * @return boolean		Whether or not source.expression is a ColumnReference
-     *						or a VirtualColumnNode.
+     * @return boolean        Whether or not source.expression is a ColumnReference
+     *                        or a VirtualColumnNode.
      *
-     * @exception StandardException			Thrown on error
+     * @exception StandardException            Thrown on error
      */
     public boolean categorize(JBitSet referencedTabs, ReferencedColumnsMap referencedColumns, boolean simplePredsOnly)
             throws StandardException
@@ -514,12 +507,12 @@ public class UnaryOperatorNode extends OperatorNode
      * By default unary operators don't accept ? parameters as operands.
      * This can be over-ridden for particular unary operators.
      *
-     *	We throw an exception if the parameter doesn't have a datatype
-     *	assigned to it yet.
+     *    We throw an exception if the parameter doesn't have a datatype
+     *    assigned to it yet.
      *
-     * @exception StandardException		Thrown if ?  parameter doesn't
-     *									have a type bound to it yet.
-     *									? parameter where it isn't allowed.
+     * @exception StandardException        Thrown if ?  parameter doesn't
+     *                                    have a type bound to it yet.
+     *                                    ? parameter where it isn't allowed.
      */
 
     void bindParameter() throws StandardException
@@ -579,11 +572,11 @@ public class UnaryOperatorNode extends OperatorNode
     /**
      * Do code generation for this unary operator.
      *
-     * @param acb	The ExpressionClassBuilder for the class we're generating
-     * @param mb	The method the expression will go into
+     * @param acb    The ExpressionClassBuilder for the class we're generating
+     * @param mb    The method the expression will go into
      *
      *
-     * @exception StandardException		Thrown on error
+     * @exception StandardException        Thrown on error
      */
 
     public void generateExpression(ExpressionClassBuilder acb,
@@ -594,9 +587,6 @@ public class UnaryOperatorNode extends OperatorNode
                 (operatorType == -1)
                         ? getTypeCompiler().interfaceName()
                         : resultInterfaceType;
-
-        // System.out.println("resultTypeName " + resultTypeName + " method " + methodName);
-        // System.out.println("isBooleanTypeId() " + getTypeId().isBooleanTypeId());
 
         boolean needField = !getTypeId().isBooleanTypeId();
 
@@ -633,7 +623,7 @@ public class UnaryOperatorNode extends OperatorNode
              ** Store the result of the method call in the field, so we can re-use
              ** the object.
              */
-//			mb.putField(field);
+//            mb.putField(field);
         } else {
             mb.callMethod(VMOpcode.INVOKEINTERFACE, (String) null,
                     methodName, resultTypeName, 0);
@@ -647,7 +637,7 @@ public class UnaryOperatorNode extends OperatorNode
      * Override in nodes that use methods on super-interfaces of
      * the receiver's interface, such as comparisons.
      *
-     * @exception StandardException		Thrown on error
+     * @exception StandardException        Thrown on error
      */
     public String getReceiverInterfaceName() throws StandardException {
         if (SanityManager.DEBUG)
@@ -740,7 +730,6 @@ public class UnaryOperatorNode extends OperatorNode
     public void setMatchIndexExpr(int tableNumber, int columnPosition, ConglomerateDescriptor conglomDesc) {
         this.operandMatchIndexExpr = tableNumber;
         this.operandMatchIndexExprColumnPosition = columnPosition;
-        //this.operandMatchIndexExprConglomDesc = conglomDesc;
     }
 
     public void castOperandAndBindCast(DataTypeDescriptor type) throws StandardException {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryOperatorNode.java
@@ -136,7 +136,7 @@ public class UnaryOperatorNode extends OperatorNode
      * are reset and valid only for the current access path.
      * They should not be used beyond cost estimation.
      */
-    ConglomerateDescriptor operandMatchIndexExprConglomDesc = null;
+    //ConglomerateDescriptor operandMatchIndexExprConglomDesc = null;
 
     // 0-based index column position
     protected int operandMatchIndexExprColumnPosition = -1;
@@ -740,7 +740,7 @@ public class UnaryOperatorNode extends OperatorNode
     public void setMatchIndexExpr(int tableNumber, int columnPosition, ConglomerateDescriptor conglomDesc) {
         this.operandMatchIndexExpr = tableNumber;
         this.operandMatchIndexExprColumnPosition = columnPosition;
-        this.operandMatchIndexExprConglomDesc = conglomDesc;
+        //this.operandMatchIndexExprConglomDesc = conglomDesc;
     }
 
     public void castOperandAndBindCast(DataTypeDescriptor type) throws StandardException {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -3503,6 +3503,11 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     }
 
     @Override
+    public UserDescriptor getCurrentUserDescriptor(Activation a) throws StandardException {
+        return getDataDictionary().getUser(getCurrentDatabase(a).getUUID(), getCurrentUserId(a));
+    }
+
+    @Override
     public void setCurrentUser(Activation a, String userName) {
         getCurrentSQLSessionContext(a).setUser(userName);
     }

--- a/db-engine/src/test/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImplTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImplTest.java
@@ -61,6 +61,10 @@ public class DataDictionaryImplTest {
         }
 
         @Override
+        public void enableMultiDatabase(boolean value) {
+        }
+
+        @Override
         protected void setDependencyManager() {
 
         }

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -998,6 +998,7 @@ public interface SQLState {
     String LANG_NO_METHOD_MATCHING_ALIAS                               = "42Y16";
     // String LANG_DROP_SYSTEM_TABLE_ATTEMPTED                         = "42Y17"; -- replaced by 42X62
     String LANG_DATABASE_DOES_NOT_EXIST                                = "42Y18";
+    String LANG_MULTIDATABASE_NOT_ENABLED                              = "42Y19";
     String LANG_INVALID_CAST                                           = "42846";
     String LANG_INVALID_CAST_TO_CHAR_WITH_LENGTH_NOT_FROM_CHAR             = "42846.A";
     String LANG_INVALID_CAST_TO_CHAR_WITH_FORMAT_NOT_FROM_DATE             = "42846.B";

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -2532,6 +2532,11 @@ Guide.
             </msg>
 
             <msg>
+                <name>42Y19</name>
+                <text>Multidatabase is disabled</text>
+            </msg>
+
+            <msg>
                 <name>42Y22</name>
                 <text>Aggregate {0} cannot operate on type {1}.</text>
                 <arg>aggregateType</arg>

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -25,8 +25,6 @@ import com.splicemachine.access.configuration.SIConfigurations;
 import com.splicemachine.access.configuration.SQLConfiguration;
 import com.splicemachine.client.SpliceClient;
 import com.splicemachine.db.catalog.AliasInfo;
-import com.splicemachine.db.catalog.Dependable;
-import com.splicemachine.db.catalog.DependableFinder;
 import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.catalog.types.SynonymAliasInfo;
 import com.splicemachine.db.iapi.error.StandardException;
@@ -36,7 +34,6 @@ import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.services.monitor.Monitor;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
-import com.splicemachine.db.iapi.sql.depend.Dependent;
 import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.sql.execute.ScanQualifier;
@@ -73,8 +70,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.function.Function;
-
-import static com.splicemachine.db.impl.sql.catalog.SYSTABLESRowFactory.SYSTABLES_VIEW_IN_SYSIBM;
 
 /**
  * @author Scott Fines
@@ -551,6 +546,11 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
     @Override
     protected SystemAggregateGenerator getSystemAggregateGenerator(){
         return new SpliceSystemAggregatorGenerator(this);
+    }
+
+    @Override
+    public void enableMultiDatabase(boolean value) {
+        this.af.enableMultiDatabase(value);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -1109,6 +1109,20 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .varchar("VALUE", Limits.DB2_VARCHAR_MAXWIDTH)
                 .build());
 
+        procedures.add(Procedure.newBuilder().name("SYSCS_ENABLE_MULTIDATABASE")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .sqlControl(RoutineAliasInfo.MODIFIES_SQL_DATA).returnType(null).isDeterministic(false)
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_DISABLE_MULTIDATABASE")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .sqlControl(RoutineAliasInfo.MODIFIES_SQL_DATA).returnType(null).isDeterministic(false)
+                .build());
+
         /*
          * Procedure to empty the statement caches on all region servers in the cluster.
          * Essentially a wrapper around the Derby version of SYSCS_EMPTY_STATEMENT_CACHE

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateDatabaseConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateDatabaseConstantOperation.java
@@ -18,6 +18,7 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
+import com.splicemachine.db.iapi.sql.dictionary.UserDescriptor;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.impl.sql.execute.DDLConstantAction;
 import com.splicemachine.db.shared.common.reference.SQLState;
@@ -93,14 +94,14 @@ public class CreateDatabaseConstantOperation extends DDLConstantAction {
          * the transaction.
          */
         LanguageConnectionContext lcc = activation.getLanguageConnectionContext();
-        lcc.getDataDictionary().startWriting(lcc);
-        lcc.getDataDictionary().createNewDatabase(dbName, null); // XXX(arnaud multidb) should we really allow no owner for a DB?
+        DataDictionary dd = lcc.getDataDictionary();
+        UserDescriptor currentUser = lcc.getCurrentUserDescriptor(activation);
+        dd.startWriting(lcc);
+        dd.createNewDatabaseAndDatabaseOwner(tc, dbName, currentUser);
 
         if (!isDatabasePresent(activation)) {
             throw StandardException.newException(SQLState.CREATE_DATABASE_FAILED, dbName);
         }
-
-        // XXX (arnaud multidb) create owner of DB with some syntax here?
     }
 
     public String getScopeName() {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceAccessManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceAccessManager.java
@@ -19,6 +19,8 @@ import java.io.Serializable;
 import java.util.*;
 
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
+import com.splicemachine.db.impl.sql.catalog.BaseDataDictionary;
+import com.splicemachine.derby.impl.sql.catalog.SpliceDataDictionary;
 import com.splicemachine.utils.Pair;
 import splice.com.google.common.base.Preconditions;
 import com.splicemachine.derby.impl.db.SpliceDatabase;
@@ -760,5 +762,12 @@ public class SpliceAccessManager implements AccessFactory, CacheableFactory, Mod
         this.database = database;
     }
 
+    public boolean isMultiDatabaseEnabled() {
+        return Boolean.parseBoolean(serviceProperties.getProperty(BaseDataDictionary.CFG_ALLOW_MULTIDATABASE));
+    }
+
+    public void enableMultiDatabase(boolean value) {
+        serviceProperties.setProperty(BaseDataDictionary.CFG_ALLOW_MULTIDATABASE, Boolean.toString(value));
+    }
 }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/SpliceAdmin.java
@@ -1449,6 +1449,23 @@ public class SpliceAdmin extends BaseAdminProcedures{
         }
     }
 
+    private static void SYSCS_ENABLE_MULTIDABASE(boolean value) throws SQLException {
+        try {
+            LanguageConnectionContext lcc = ConnectionUtil.getCurrentLCC();
+            lcc.getDataDictionary().enableMultiDatabase(value);
+        } catch (Exception e) {
+            throw PublicAPI.wrapStandardException(Exceptions.parseException(e));
+        }
+    }
+
+    public static void SYSCS_ENABLE_MULTIDATABASE() throws SQLException {
+        SYSCS_ENABLE_MULTIDABASE(true);
+    }
+
+    public static void SYSCS_DISABLE_MULTIDATABASE() throws SQLException {
+        SYSCS_ENABLE_MULTIDABASE(false);
+    }
+
     public static void SYSCS_EMPTY_GLOBAL_STATEMENT_CACHE() throws SQLException{
         List<HostAndPort> servers;
         try {

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiDatabaseIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiDatabaseIT.java
@@ -20,6 +20,7 @@ import org.apache.log4j.Logger;
 import org.junit.*;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
+import org.junit.runner.Description;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -34,7 +35,6 @@ import static org.junit.Assert.*;
  * Tests around creating schemas
  */
 public class MultiDatabaseIT extends SpliceUnitTest {
-    protected static SpliceWatcher classWatcher = new SpliceWatcher();
     private static final Logger LOG = Logger.getLogger(MultiDatabaseIT.class);
     private static String OTHER_DB = MultiDatabaseIT.class.getSimpleName().toUpperCase();
     private static String OTHER_DB_OWNER_NOT_SPLICE = MultiDatabaseIT.class.getSimpleName().toUpperCase() + "2";
@@ -45,6 +45,29 @@ public class MultiDatabaseIT extends SpliceUnitTest {
     private static String SEQUENCE = "SEQUENCE_" + MultiDatabaseIT.class.getSimpleName().toUpperCase();
 
 
+    protected static SpliceWatcher classWatcher = new SpliceWatcher() {
+        @Override
+        protected void starting(Description description) {
+            super.starting(description);
+            try {
+                createConnection().execute("CALL SYSCS_UTIL.SYSCS_ENABLE_MULTIDATABASE()");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        protected void finished(Description description) {
+            try {
+                createConnection().execute("CALL SYSCS_UTIL.SYSCS_DISABLE_MULTIDATABASE()");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            super.finished(description);
+        }
+
+
+    };
     protected static SpliceDatabaseWatcher otherDbOwnerNotSpliceWatcher = new SpliceDatabaseWatcher(OTHER_DB_OWNER_NOT_SPLICE, OTHER_DB_OWNER_NOT_SPLICE);
     protected static SpliceDatabaseWatcher otherDbWatcher = new SpliceDatabaseWatcher(OTHER_DB);
     protected static SpliceSchemaWatcher spliceDbSchemaWatcher = new SpliceSchemaWatcher(null, SCHEMA);


### PR DESCRIPTION
## Short Description
This disables multidatabase as a default and introduces a new system procedure to enable it.

## Long Description
This introduces two new system procedures: 
```
SYSCS_UTIL.SYSCS_ENABLE_MULTIDATABASE()
SYSCS_UTIL.SYSCS_DISABLE_MULTIDATABASE()
```
Creating a new database is forbidden if multidatabase is disabled. Disabling multidatabase after the creation of a new database does not destroy that database, but only prevents the creation of new ones.
This parameter is persisted in zookeeper, because we need to be able to access during connection time.

 
## How to test
```
splice> show databases;
DATABASENAME
------------------------------------
SPLICEDB
splice> connect 'jdbc:splice://localhost:1527/splicedb3;user=foo;password=pass;create=true';
ERROR 42Y19: DERBY SQL error: SQLCODE: -1, SQLSTATE: 42Y19, SQLERRMC: Multidatabase is disabled
splice> call syscs_util.syscs_enable_multidatabase();
Statement executed.
ELAPSED TIME = 190 milliseconds
splice> connect 'jdbc:splice://localhost:1527/splicedb3;user=foo;password=pass;create=true';
ELAPSED TIME = 67 milliseconds
splice> show databases;
DATABASENAME
------------------------------------
SPLICEDB
SPLICEDB3
```
