### PR TITLE
DB-11592 CREATE DATABASE FOODB creates dbOwner based on current user

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -45,11 +45,7 @@ import com.splicemachine.db.iapi.sql.ParameterValueSet;
 import com.splicemachine.db.iapi.sql.PreparedStatement;
 import com.splicemachine.db.iapi.sql.compile.*;
 import com.splicemachine.db.iapi.sql.depend.Provider;
-import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
-import com.splicemachine.db.iapi.sql.dictionary.DatabaseDescriptor;
-import com.splicemachine.db.iapi.sql.dictionary.SPSDescriptor;
-import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
-import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
+import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ConstantAction;
 import com.splicemachine.db.iapi.sql.execute.CursorActivation;
 import com.splicemachine.db.iapi.sql.execute.ExecPreparedStatement;
@@ -494,6 +490,8 @@ public interface LanguageConnectionContext extends Context {
      * @return String the authorization id
      */
     String getCurrentUserId(Activation a);
+
+    UserDescriptor getCurrentUserDescriptor(Activation a) throws StandardException;
 
     void setCurrentUser(Activation a, String userName);
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -659,7 +659,6 @@ public interface DataDictionary{
      * Indicate whether there is anything in the
      * particular database.
      * Checks for schemas, users, roles in the the database
-     * XXX(arnaud multidb) check for other objects in the DB?
      *
      * @param dd database descriptor
      * @return true/false
@@ -2355,9 +2354,9 @@ public interface DataDictionary{
 
     void createDbOwnerSchema(TransactionController tc, UUID databaseUuid, String dbOwner) throws StandardException;
 
-    DatabaseDescriptor createNewDatabase(String name, String dbOwner) throws StandardException;
+    UUID createNewDatabaseAndDatabaseOwner(TransactionController tc, String name, String dbOwner, String dbPassword) throws StandardException;
 
-    UUID createNewDatabaseAndDatabaseOwner(String name, String dbOwner, String dbPassword) throws StandardException;
+    UUID createNewDatabaseAndDatabaseOwner(TransactionController tc, String dbName, UserDescriptor dbOwner) throws StandardException;
 
     void enableMultiDatabase(boolean value) throws StandardException;
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/UserDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/UserDescriptor.java
@@ -121,17 +121,25 @@ public final class  UserDescriptor extends TupleDescriptor
         return _databaseId;
     }
 
-    public boolean isDbOwner(DataDictionary dd) {
-        String dbo = dd.getAuthorizationDatabaseOwner(_databaseId);
+    public void setDatabaseId(UUID dbId) {
+        _databaseId = dbId;
+    }
+
+    private boolean isDbOwner() {
+        String dbo = dataDictionary.getAuthorizationDatabaseOwner(_databaseId);
 
         return dbo.equals(this._userName);
+    }
+
+    UserDescriptor cloneForOtherDatabase(UUID otherDbUUID) {
+        return new UserDescriptor(dataDictionary, _userName, _hashingScheme, getAndZeroPassword(), _lastModified, otherDbUUID);
     }
 
     public void drop(LanguageConnectionContext lcc, boolean dropIfOwner) throws StandardException {
         DataDictionary dd=lcc.getDataDictionary();
 
         // you can't drop the credentials of the dbo
-        if (!dropIfOwner && isDbOwner(dd)) {
+        if (!dropIfOwner && isDbOwner()) {
             throw StandardException.newException(SQLState.CANT_DROP_DBO);
         }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection.java
@@ -346,7 +346,7 @@ public abstract class EmbedConnection implements EngineConnection
                     TransactionController tc = af.getTransaction(ContextService.getCurrentContextManager());
                     if (dd.getDatabaseDescriptor(getDBName(), tc, false) == null) {
                         af.elevateRawTransaction(Bytes.toBytes("boot"));
-                        dd.createNewDatabaseAndDatabaseOwner(getDBName(),
+                        dd.createNewDatabaseAndDatabaseOwner(tc, getDBName(),
                                 info.getProperty(Attribute.USERNAME_ATTR),
                                 info.getProperty(Attribute.PASSWORD_ATTR)
                         );

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -3497,6 +3497,11 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     }
 
     @Override
+    public UserDescriptor getCurrentUserDescriptor(Activation a) throws StandardException {
+        return getDataDictionary().getUser(getCurrentDatabase(a).getUUID(), getCurrentUserId(a));
+    }
+
+    @Override
     public void setCurrentUser(Activation a, String userName) {
         getCurrentSQLSessionContext(a).setUser(userName);
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateDatabaseConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateDatabaseConstantOperation.java
@@ -18,6 +18,7 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
+import com.splicemachine.db.iapi.sql.dictionary.UserDescriptor;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.impl.sql.execute.DDLConstantAction;
 import com.splicemachine.db.shared.common.reference.SQLState;
@@ -93,14 +94,14 @@ public class CreateDatabaseConstantOperation extends DDLConstantAction {
          * the transaction.
          */
         LanguageConnectionContext lcc = activation.getLanguageConnectionContext();
-        lcc.getDataDictionary().startWriting(lcc);
-        lcc.getDataDictionary().createNewDatabase(dbName, null); // XXX(arnaud multidb) should we really allow no owner for a DB?
+        DataDictionary dd = lcc.getDataDictionary();
+        UserDescriptor currentUser = lcc.getCurrentUserDescriptor(activation);
+        dd.startWriting(lcc);
+        dd.createNewDatabaseAndDatabaseOwner(tc, dbName, currentUser);
 
         if (!isDatabasePresent(activation)) {
             throw StandardException.newException(SQLState.CREATE_DATABASE_FAILED, dbName);
         }
-
-        // XXX (arnaud multidb) create owner of DB with some syntax here?
     }
 
     public String getScopeName() {

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiDatabaseIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiDatabaseIT.java
@@ -293,4 +293,31 @@ public class MultiDatabaseIT extends SpliceUnitTest {
         assertFailed(otherDbConn, "select * from sys.sysdatabases", "42Y07");
         assertFailed(otherDbOwnerNotSpliceConn, "select * from sys.sysdatabases", "42Y07");
     }
+
+    @Test
+    public void testCreateDatabase() throws Exception {
+        spliceDbConn.execute("create database CREATE_DATABASE_SPLICE_DB_CONN");
+        otherDbConn.execute("create database CREATE_DATABASE_OTHER_DB_CONN");
+        otherDbOwnerNotSpliceConn.execute("create database CREATE_DATABASE_OTHER_DB_OWNER_NOT_SPLICE_CONN");
+
+        String sql = "select d.authorizationid, d.databasename " +
+                "from sys.sysdatabases d, sys.sysusers u " +
+                "where d.databaseid = u.databaseid and d.authorizationid = u.username and d.databasename like 'CREATE_DATABASE_%_CONN' " +
+                "order by 2";
+
+        try {
+            String expected = "AUTHORIZATIONID |                 DATABASENAME                  |\n" +
+                    "------------------------------------------------------------------\n" +
+                    "MULTIDATABASEIT2 |CREATE_DATABASE_OTHER_DB_OWNER_NOT_SPLICE_CONN |\n" +
+                    "     SPLICE      |         CREATE_DATABASE_OTHER_DB_CONN         |\n" +
+                    "     SPLICE      |        CREATE_DATABASE_SPLICE_DB_CONN         |";
+            testQuery(sql, expected, spliceDbConn);
+        } finally {
+            spliceDbConn.execute("drop database CREATE_DATABASE_SPLICE_DB_CONN cascade");
+            otherDbConn.execute("drop database CREATE_DATABASE_OTHER_DB_CONN cascade");
+            otherDbOwnerNotSpliceConn.execute("drop database CREATE_DATABASE_OTHER_DB_OWNER_NOT_SPLICE_CONN cascade");
+            String expected = "";
+            testQuery(sql, expected, spliceDbConn);
+        }
+    }
 }


### PR DESCRIPTION
## Short Description
`CREATE DATABASE FOODB` now properly creates a database, and duplicates `CURRENT USER` to be its owner.
## Long Description
Up until now, the only way to create a new database and its owner was to connect via the jdbc connection string and append create=true to it. For example:
```
connect 'jdbc:splice://localhost:1527/foodb;user=foouser;password=bar;create=true';
```
This PR makes it possible to create a new DB with the simple command:
```
CREATE DATABASE FOODB;
```
If the current user is `foouser`, the new database owner of `FOODB` will be a brand new `foouser` (with the same password), residing in the newly created database.

## How to test
```
splice> select current database, user, current database admin;
1               |2                   |3
----------------------------------------------------------
SPLICEDB        |SPLICE              |SPLICE

1 row selected
ELAPSED TIME = 6 milliseconds

splice> call syscs_util.syscs_enable_multidatabase();
Statement executed.
ELAPSED TIME = 2 milliseconds

splice> create database FOODB;
0 rows inserted/updated/deleted
ELAPSED TIME = 112 milliseconds

splice> show databases;
DATABASENAME
------------------------------------
FOODB
SPLICEDB

splice> connect 'jdbc:splice://localhost:1527/foodb;user=splice;password=admin';
ELAPSED TIME = 6 milliseconds

splice> select current database, user, current database admin;
1               |2                   |3
----------------------------------------------------------
FOODB           |SPLICE              |SPLICE
```