### PR TITLE
DB-11119 Support TRANSLATE with one parameter

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SimpleStringOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SimpleStringOperatorNode.java
@@ -31,6 +31,7 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
+import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 
 import com.splicemachine.db.iapi.error.StandardException;
@@ -53,15 +54,10 @@ import java.util.List;
 @SuppressFBWarnings(value = "HE_INHERITS_EQUALS_USE_HASHCODE", justification="DB-9277")
 public class SimpleStringOperatorNode extends UnaryOperatorNode
 {
-    /**
-     * Initializer for a SimpleOperatorNode
-     *
-     * @param operand        The operand
-     * @param methodName    The method name
-     */
 
-    public void init(Object operand, Object methodName)
-    {
+    public SimpleStringOperatorNode(ValueNode operand, String methodName, ContextManager cm) {
+        setContextManager(cm);
+        setNodeType(C_NodeTypes.SIMPLE_STRING_OPERATOR_NODE);
         super.init(operand, methodName, methodName);
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TranslateFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TranslateFunctionNode.java
@@ -103,11 +103,6 @@ public class TranslateFunctionNode extends OperatorNode {
             throw StandardException.newException(SQLState.NOT_IMPLEMENTED, "TRANSLATE(op, outputTranslationTable) not implemented");
         }
 
-        for (int i = 0; i < 3; ++i) {
-            if (operands.get(i).requiresTypeFromContext()) {
-                castOperandAndBindCast(i, DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR));
-            }
-        }
         for (int i = 1; i < 3; ++i) {
             if (operands.get(i).getTypeId().isBitTypeId()) {
                 castOperandAndBindCast(i, DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, operands.get(i).getTypeServices().getMaximumWidth()));

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TranslateFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TranslateFunctionNode.java
@@ -16,18 +16,10 @@ package com.splicemachine.db.impl.sql.compile;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.ClassName;
 import com.splicemachine.db.iapi.reference.SQLState;
-import com.splicemachine.db.iapi.services.classfile.VMOpcode;
-import com.splicemachine.db.iapi.services.compiler.LocalField;
-import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.context.ContextManager;
-import com.splicemachine.db.iapi.services.io.StoredFormatIds;
-import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
-import com.splicemachine.db.iapi.types.DataTypeUtilities;
-import com.splicemachine.db.iapi.types.TypeId;
 
-import java.lang.reflect.Modifier;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -83,6 +75,34 @@ public class TranslateFunctionNode extends OperatorNode {
                                     List<AggregateNode> aggregateVector) throws StandardException {
         bindOperands(fromList, subqueryList, aggregateVector);
 
+        for (int i = 0; i < 4; ++i) {
+            if (operands.get(i) != null && operands.get(i).requiresTypeFromContext()) {
+                castOperandAndBindCast(i, DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR));
+            }
+        }
+
+        if (operands.get(0).getTypeId().isBitTypeId()) {
+            throw StandardException.newException(SQLState.NOT_IMPLEMENTED, "TRANSLATE on BIT DATA types not yet implemented");
+        }
+
+        if (!operands.get(0).getTypeId().isCharOrVarChar()) {
+            castOperandAndBindCast(0, DataTypeDescriptor.getBuiltInDataTypeDescriptor(
+                    Types.VARCHAR,
+                    operands.get(0).getTypeServices().isNullable(),
+                    operands.get(0).getTypeCompiler().getCastToCharWidth(operands.get(0).getTypeServices(), getCompilerContext())));
+        }
+
+        // Only one operand: TRANSLATE is equivalent to UPPER
+        if (operands.get(1) == null) {
+            ValueNode upper = new SimpleStringOperatorNode(operands.get(0), "upper", getContextManager());
+            return upper.bindExpression(fromList, subqueryList, aggregateVector);
+        }
+
+        // output but no input table: currently not supported
+        if (operands.get(2) == null) {
+            throw StandardException.newException(SQLState.NOT_IMPLEMENTED, "TRANSLATE(op, outputTranslationTable) not implemented");
+        }
+
         for (int i = 0; i < 3; ++i) {
             if (operands.get(i).requiresTypeFromContext()) {
                 castOperandAndBindCast(i, DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR));
@@ -114,7 +134,7 @@ public class TranslateFunctionNode extends OperatorNode {
             }
         }
         setType(DataTypeDescriptor.getBuiltInDataTypeDescriptor(
-                Types.VARCHAR,
+                operands.get(0).getTypeId().getJDBCTypeId(),
                 operands.stream().anyMatch(op -> op != null && op.getTypeServices().isNullable()),
                 operands.get(0).getTypeServices().getMaximumWidth()));
         return this;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -53,79 +53,9 @@ import org.apache.commons.lang3.mutable.MutableInt;
 import com.splicemachine.db.iapi.sql.Statement;
 import com.splicemachine.db.iapi.sql.StatementType;
 
-/* aggregates */
-import com.splicemachine.db.impl.sql.compile.CountAggregateDefinition;
-import com.splicemachine.db.impl.sql.compile.MaxMinAggregateDefinition;
-import com.splicemachine.db.impl.sql.compile.SumAvgAggregateDefinition;
-import com.splicemachine.db.impl.sql.compile.StringAggregateDefinition;
-
-import com.splicemachine.db.impl.sql.compile.AggregateNode;
-import com.splicemachine.db.impl.sql.compile.BinaryOperatorNode;
-import com.splicemachine.db.impl.sql.compile.BlobFunctionNode;
-import com.splicemachine.db.impl.sql.compile.CallStatementNode;
-import com.splicemachine.db.impl.sql.compile.CharConstantNode;
-import com.splicemachine.db.impl.sql.compile.CastNode;
-import com.splicemachine.db.impl.sql.compile.ColumnDefinitionNode;
-import com.splicemachine.db.impl.sql.compile.ColumnReference;
-import com.splicemachine.db.impl.sql.compile.CreateAliasNode;
-import com.splicemachine.db.impl.sql.compile.CreateTableNode;
-import com.splicemachine.db.impl.sql.compile.CursorNode;
-import com.splicemachine.db.impl.sql.compile.DaysFunctionNode;
+import com.splicemachine.db.impl.sql.compile.*;
 import com.splicemachine.db.impl.sql.compile.ExplainNode.SparkExplainKind;
-import com.splicemachine.db.impl.sql.compile.FromBaseTable;
-import com.splicemachine.db.impl.sql.compile.FromList;
-import com.splicemachine.db.impl.sql.compile.FromSubquery;
-import com.splicemachine.db.impl.sql.compile.FromTable;
-import com.splicemachine.db.impl.sql.compile.GroupByList;
-import com.splicemachine.db.impl.sql.compile.HasNodeVisitor;
-import com.splicemachine.db.impl.sql.compile.IndexExpression;
-import com.splicemachine.db.impl.sql.compile.JavaToSQLValueNode;
-import com.splicemachine.db.impl.sql.compile.JoinNode;
-import com.splicemachine.db.impl.sql.compile.MethodCallNode;
-import com.splicemachine.db.impl.sql.compile.QueryTreeNode;
-import com.splicemachine.db.impl.sql.compile.ReplaceAggregatesWithCRVisitor;
-import com.splicemachine.db.impl.sql.compile.ResultColumnList;
-import com.splicemachine.db.impl.sql.compile.ResultColumn;
-import com.splicemachine.db.impl.sql.compile.OrderByList;
-import com.splicemachine.db.impl.sql.compile.OrderByColumn;
-import com.splicemachine.db.impl.sql.compile.ResultSetNode;
-import com.splicemachine.db.impl.sql.compile.SelectNode;
-import com.splicemachine.db.impl.sql.compile.SubqueryNode;
-import com.splicemachine.db.impl.sql.compile.TableName;
-import com.splicemachine.db.impl.sql.compile.TernaryOperatorNode;
-import com.splicemachine.db.impl.sql.compile.ParameterNode;
-import com.splicemachine.db.impl.sql.compile.PrivilegeNode;
-import com.splicemachine.db.impl.sql.compile.ConstraintDefinitionNode;
-import com.splicemachine.db.impl.sql.compile.DMLModStatementNode;
-import com.splicemachine.db.impl.sql.compile.RoutineDesignator;
-import com.splicemachine.db.impl.sql.compile.SecondFunctionNode;
-import com.splicemachine.db.impl.sql.compile.StatementListNode;
-import com.splicemachine.db.impl.sql.compile.StatementNode;
-import com.splicemachine.db.impl.sql.compile.TableElementList;
-import com.splicemachine.db.impl.sql.compile.TableElementNode;
-import com.splicemachine.db.impl.sql.compile.TableOperatorNode;
-import com.splicemachine.db.impl.sql.compile.BasicPrivilegesNode;
-import com.splicemachine.db.impl.sql.compile.TransactionStatementNode;
-import com.splicemachine.db.impl.sql.compile.TranslateFunctionNode;
-import com.splicemachine.db.impl.sql.compile.TriggerReferencingStruct;
-import com.splicemachine.db.impl.sql.compile.UnionNode;
-import com.splicemachine.db.impl.sql.compile.IntersectOrExceptNode;
-import com.splicemachine.db.impl.sql.compile.UnaryOperatorNode;
-import com.splicemachine.db.impl.sql.compile.UntypedNullConstantNode;
-import com.splicemachine.db.impl.sql.compile.UpdateNode;
-import com.splicemachine.db.impl.sql.compile.UserTypeConstantNode;
-import com.splicemachine.db.impl.sql.compile.ValueNode;
-import com.splicemachine.db.impl.sql.compile.ValueNodeList;
-import com.splicemachine.db.impl.sql.compile.GroupByColumn;
-import com.splicemachine.db.impl.sql.compile.CurrentDatetimeOperatorNode;
-import com.splicemachine.db.impl.sql.compile.DDLStatementNode;
-import com.splicemachine.db.impl.sql.compile.AlterTableNode;
 
-import com.splicemachine.db.impl.sql.compile.ParseException;
-import com.splicemachine.db.impl.sql.compile.Token;
-import com.splicemachine.db.impl.sql.compile.TokenMgrError;
-import com.splicemachine.db.impl.sql.compile.SQLParserConstants;
-import com.splicemachine.db.impl.sql.compile.CharStream;
 import com.splicemachine.db.impl.sql.execute.BasicPrivilegeInfo;
 import com.splicemachine.db.impl.sql.execute.TablePrivilegeInfo;
 import com.splicemachine.db.impl.sql.execute.SchemaPrivilegeInfo;
@@ -6610,15 +6540,15 @@ escapedValueFunction() throws StandardException :
 ValueNode translateFunctionNode() throws StandardException:
 {
     ValueNode stringExpression;
-    ValueNode toString;
-    ValueNode fromString;
+    ValueNode toString = null;
+    ValueNode fromString = null;
     ValueNode pad = null;
 }
 {
     <LEFT_PAREN>
         stringExpression = additiveExpression(null, 0)
-    <COMMA> toString = additiveExpression(null, 0)
-    <COMMA> fromString = additiveExpression(null, 0)
+    [ <COMMA> toString = additiveExpression(null, 0) ]
+    [ <COMMA> fromString = additiveExpression(null, 0) ]
     [ <COMMA> pad = additiveExpression(null, 0) ]
 
     <RIGHT_PAREN>
@@ -7098,11 +7028,10 @@ characterValueFunction() throws StandardException :
     {
         if (locale == null)
         {
-            return (ValueNode) nodeFactory.getNode(
-                    C_NodeTypes.SIMPLE_STRING_OPERATOR_NODE,
-                    value,
-                    (upperTok != null) ? "upper" : "lower",
-                    getContextManager());
+            return new SimpleStringOperatorNode(
+                value,
+                (upperTok != null) ? "upper" : "lower",
+                getContextManager());
         }
         else
         {
@@ -7120,11 +7049,10 @@ characterValueFunction() throws StandardException :
     {
         if (locale == null)
         {
-            return (ValueNode) nodeFactory.getNode(
-                    C_NodeTypes.SIMPLE_STRING_OPERATOR_NODE,
-                    value,
-                    (upperTok != null) ? "upper" : "lower",
-                    getContextManager());
+            return new SimpleStringOperatorNode(
+                value,
+                (upperTok != null) ? "upper" : "lower",
+                getContextManager());
         }
         else
         {

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
@@ -1149,11 +1149,11 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
                 methodWatcher.connectionBuilder().useOLAP(true).useNativeSpark(true).build()
         };
         for (TestConnection conn: conns) {
-            checkStringExpression("translate(lower(a)) from testTranslate", "ABCDEFG", conn);
-            checkStringExpression("translate(a, b, c) from testTranslate", "aBcDeFG", conn);
-            checkStringExpression("translate(a, 'ac', c, 'U') from testTranslate", "aBcDUFG", conn);
             try (PreparedStatement ps = conn.prepareStatement("" +
                     "select id," +
+                    "translate(lower(a)), " +
+                    "translate(a,b,c), " +
+                    "translate(a,'ac', c, 'U'), " +
                     "translate(?)," +
                     "translate(?)," +
                     "translate(?, b, c)," +
@@ -1170,12 +1170,12 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
                 ps.setString(8, "321");
                 try (ResultSet rs = ps.executeQuery()) {
                     Assert.assertEquals(
-                            "ID | 2  | 3 |   4    |   5    |   6    | 7  |\n" +
-                                    "---------------------------------------------\n" +
-                                    " 1 |ABC | 1 |aBcDeFG |aBcDeFG |aBcDeFG |674 |\n" +
-                                    " 2 |ABC | 1 |aBcDeFG | NULL   | NULL   |674 |\n" +
-                                    " 3 |ABC | 1 | NULL   |aBcDeFG | NULL   |674 |\n" +
-                                    " 4 |ABC | 1 | NULL   | NULL   |aBcDeFG |674 |",
+                            "ID |   2    |   3    |   4    | 5  | 6 |   7    |   8    |   9    |10  |\n" +
+                                    "------------------------------------------------------------------------\n" +
+                                    " 1 |ABCDEFG |aBcDeFG |aBcDUFG |ABC | 1 |aBcDeFG |aBcDeFG |aBcDeFG |674 |\n" +
+                                    " 2 | NULL   | NULL   | NULL   |ABC | 1 |aBcDeFG | NULL   | NULL   |674 |\n" +
+                                    " 3 |ABCDEFG | NULL   |aBcDUFG |ABC | 1 | NULL   |aBcDeFG | NULL   |674 |\n" +
+                                    " 4 |ABCDEFG | NULL   | NULL   |ABC | 1 | NULL   | NULL   |aBcDeFG |674 |",
                             TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
                 }
             }


### PR DESCRIPTION
## Short Description
TRANSLATE('abc') should parse properly and return 'ABC'

## Long Description
We now supports TRANSLATE with only one parameter. It should be equivalent to UPPER and return a new uppercased string.
We currently do not support TRANSLATE on BIT DATA TYPES.
Running TRANSLATE on any other type will cast the first operand to VARCHAR.

## How to test
```
splice> select translate('abc');
1
---
ABC

1 row selected
ELAPSED TIME = 4 milliseconds
splice> select translate(1E1);
1
------------------------------------------------------
10.0

1 row selected
ELAPSED TIME = 4 milliseconds
splice> select translate(1.0976);
1
-------
1.0976

1 row selected
ELAPSED TIME = 6 milliseconds

splice> select translate(cast('test translate' as varchar(30)))
> ;
1
------------------------------
TEST TRANSLATE

1 row selected
ELAPSED TIME = 16 milliseconds

```