### PR TITLE
DB-11570 Use SQLDB2Varchar in SQLChar.getNewVarchar when applicable

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLChar.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLChar.java
@@ -191,6 +191,8 @@ public class SQLChar extends DataType implements StringDataValue, StreamStorable
     /* Locale info (for International support) */
     private LocaleFinder localeFinder;
 
+    private boolean ignoreTrailingWhitespacesInVarcharComparison = false;
+
 
     /**************************************************************************
      * Constructors for This class:
@@ -3600,7 +3602,11 @@ public class SQLChar extends DataType implements StringDataValue, StreamStorable
      */
     protected StringDataValue getNewVarchar() throws StandardException
     {
-        return new SQLVarchar();
+        if (ignoreTrailingWhitespacesInVarcharComparison) {
+            return new SQLVarcharDB2Compatible();
+        } else {
+            return new SQLVarchar();
+        }
     }
 
     protected void setLocaleFinder(LocaleFinder localeFinder)
@@ -3786,5 +3792,11 @@ public class SQLChar extends DataType implements StringDataValue, StreamStorable
     public void setValueForSbcsData(DataValueDescriptor dvd) throws StandardException
     {
         setValue(dvd.getBytes()==null?null:new String(dvd.getBytes(), StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public void setIgnoreTrailingWhitespacesInVarcharComparison(boolean value)
+    {
+        ignoreTrailingWhitespacesInVarcharComparison = value;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/StringDataValue.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/StringDataValue.java
@@ -39,230 +39,230 @@ import java.text.RuleBasedCollator;
 
 public interface StringDataValue extends ConcatableDataValue
 {
-	// TRIM() types
-	int BOTH		= 0;
-	int TRAILING	= 1;
-	int LEADING		= 2;
+    // TRIM() types
+    int BOTH        = 0;
+    int TRAILING    = 1;
+    int LEADING        = 2;
 
-	/**
-	  For a character string type, the collation derivation should always be
-	  "explicit"(not possible in Derby 10.3), "implicit" or "none". We will
-	  start by setting it to "implicit" in TypeDescriptorImpl. At runtime, only
-	  character string types which are results of aggregate methods dealing
-	  with operands with different collation types should have a collation
-	  derivation of "none". All the other character string types should have
-	  their collation derivation set to "implicit".
-	 */
-	int COLLATION_DERIVATION_NONE = 0;
-	/** @see StringDataValue#COLLATION_DERIVATION_NONE */
-	int COLLATION_DERIVATION_IMPLICIT = 1;
-	/** @see StringDataValue#COLLATION_DERIVATION_NONE */
-	int COLLATION_DERIVATION_EXPLICIT = 2;
-	/**
-	 * In Derby 10.3, it is possible to have database with one of the following
-	 * two configurations
-	 * 1)all the character columns will have a collation type of UCS_BASIC.
-	 * This is same as what we do in Derby 10.2 release.
-	 * 2)all the character string columns belonging to system tables will have
-	 * collation type of UCS_BASIC but all the character string columns
-	 * belonging to user tables will have collation type of TERRITORY_BASED.
-	 *
-	 * Data types will start with collation type defaulting to UCS_BASIC in
-	 * TypeDescriptorImpl. This collation type of course makes sense for
-	 * character string types only. It will be ignored for the rest of the
-	 * types. If a character's collation type should be TERRITORY_BASED, then
-	 * DTD.setCollationType can be called to change the default of UCS_BASIC.
-	 *
-	 * The collation types TERRITORY_BASED:PRIMARY through TERRITORY_BASED:IDENTICAL
-	 * are variants of the TERRITORY_BASED type, with explicit collation strength.
-	 */
-	int COLLATION_TYPE_UCS_BASIC = 0;
-	/** @see StringDataValue#COLLATION_TYPE_UCS_BASIC */
-	int COLLATION_TYPE_TERRITORY_BASED = 1;
-	int COLLATION_TYPE_TERRITORY_BASED_PRIMARY = 2;
-	int COLLATION_TYPE_TERRITORY_BASED_SECONDARY = 3;
-	int COLLATION_TYPE_TERRITORY_BASED_TERTIARY = 4;
-	int COLLATION_TYPE_TERRITORY_BASED_IDENTICAL = 5;
+    /**
+      For a character string type, the collation derivation should always be
+      "explicit"(not possible in Derby 10.3), "implicit" or "none". We will
+      start by setting it to "implicit" in TypeDescriptorImpl. At runtime, only
+      character string types which are results of aggregate methods dealing
+      with operands with different collation types should have a collation
+      derivation of "none". All the other character string types should have
+      their collation derivation set to "implicit".
+     */
+    int COLLATION_DERIVATION_NONE = 0;
+    /** @see StringDataValue#COLLATION_DERIVATION_NONE */
+    int COLLATION_DERIVATION_IMPLICIT = 1;
+    /** @see StringDataValue#COLLATION_DERIVATION_NONE */
+    int COLLATION_DERIVATION_EXPLICIT = 2;
+    /**
+     * In Derby 10.3, it is possible to have database with one of the following
+     * two configurations
+     * 1)all the character columns will have a collation type of UCS_BASIC.
+     * This is same as what we do in Derby 10.2 release.
+     * 2)all the character string columns belonging to system tables will have
+     * collation type of UCS_BASIC but all the character string columns
+     * belonging to user tables will have collation type of TERRITORY_BASED.
+     *
+     * Data types will start with collation type defaulting to UCS_BASIC in
+     * TypeDescriptorImpl. This collation type of course makes sense for
+     * character string types only. It will be ignored for the rest of the
+     * types. If a character's collation type should be TERRITORY_BASED, then
+     * DTD.setCollationType can be called to change the default of UCS_BASIC.
+     *
+     * The collation types TERRITORY_BASED:PRIMARY through TERRITORY_BASED:IDENTICAL
+     * are variants of the TERRITORY_BASED type, with explicit collation strength.
+     */
+    int COLLATION_TYPE_UCS_BASIC = 0;
+    /** @see StringDataValue#COLLATION_TYPE_UCS_BASIC */
+    int COLLATION_TYPE_TERRITORY_BASED = 1;
+    int COLLATION_TYPE_TERRITORY_BASED_PRIMARY = 2;
+    int COLLATION_TYPE_TERRITORY_BASED_SECONDARY = 3;
+    int COLLATION_TYPE_TERRITORY_BASED_TERTIARY = 4;
+    int COLLATION_TYPE_TERRITORY_BASED_IDENTICAL = 5;
 
-	/**
-	 * The SQL concatenation '||' operator.
-	 *
-	 * @param leftOperand	String on the left hand side of '||'
-	 * @param rightOperand	String on the right hand side of '||'
-	 * @param result	The result of a previous call to this method,
-	 *					null if not called yet.
-	 *
-	 * @return	A ConcatableDataValue containing the result of the '||'
-	 *
-	 * @exception StandardException		Thrown on error
-	 */
-	StringDataValue concatenate(
-			StringDataValue leftOperand,
-			StringDataValue rightOperand,
-			StringDataValue result)
-		throws StandardException;
+    /**
+     * The SQL concatenation '||' operator.
+     *
+     * @param leftOperand    String on the left hand side of '||'
+     * @param rightOperand    String on the right hand side of '||'
+     * @param result    The result of a previous call to this method,
+     *                    null if not called yet.
+     *
+     * @return    A ConcatableDataValue containing the result of the '||'
+     *
+     * @exception StandardException        Thrown on error
+     */
+    StringDataValue concatenate(
+            StringDataValue leftOperand,
+            StringDataValue rightOperand,
+            StringDataValue result)
+        throws StandardException;
 
-	public StringDataValue repeat(
-			StringDataValue leftOperand,
-			NumberDataValue repeatedTimes,
-			StringDataValue result)
-		throws StandardException;
+    public StringDataValue repeat(
+            StringDataValue leftOperand,
+            NumberDataValue repeatedTimes,
+            StringDataValue result)
+        throws StandardException;
 
-	/**
-	 * The SQL like() function with out escape clause.
-	 *
-	 * @param pattern	the pattern to use
-	 *
-	 * @return	A BooleanDataValue containing the result of the like
-	 *
-	 * @exception StandardException		Thrown on error
-	 */
-	BooleanDataValue like(DataValueDescriptor pattern)
-							throws StandardException;
+    /**
+     * The SQL like() function with out escape clause.
+     *
+     * @param pattern    the pattern to use
+     *
+     * @return    A BooleanDataValue containing the result of the like
+     *
+     * @exception StandardException        Thrown on error
+     */
+    BooleanDataValue like(DataValueDescriptor pattern)
+                            throws StandardException;
 
-	/**
-	 * The SQL like() function WITH escape clause.
-	 *
-	 * @param pattern	the pattern to use
-	 * @param escape	the escape character
-	 *
-	 * @return	A BooleanDataValue containing the result of the like
-	 *
-	 * @exception StandardException		Thrown on error
-	 */
-	BooleanDataValue like(DataValueDescriptor pattern,
-						  DataValueDescriptor escape)
-							throws StandardException;
+    /**
+     * The SQL like() function WITH escape clause.
+     *
+     * @param pattern    the pattern to use
+     * @param escape    the escape character
+     *
+     * @return    A BooleanDataValue containing the result of the like
+     *
+     * @exception StandardException        Thrown on error
+     */
+    BooleanDataValue like(DataValueDescriptor pattern,
+                          DataValueDescriptor escape)
+                            throws StandardException;
 
-	/**
-	 * right() function.
-	 * @param length Number of characters to take.
-	 * @param result The result of this method.
-	 * @return A StringDataValue containing the result of the right().
-	 * @throws StandardException
-	 */
-	StringDataValue right(
-			NumberDataValue length,
-			StringDataValue result)
-		throws StandardException;
-	/**
-	 * left() function.
-	 * @param length Number of characters to take.
-	 * @param result The result of this method.
-	 * @return A StringDataValue containing the result of the left().
-	 * @throws StandardException
-	 */
-	StringDataValue left(
-			NumberDataValue length,
-			StringDataValue result)
-		throws StandardException;
+    /**
+     * right() function.
+     * @param length Number of characters to take.
+     * @param result The result of this method.
+     * @return A StringDataValue containing the result of the right().
+     * @throws StandardException
+     */
+    StringDataValue right(
+            NumberDataValue length,
+            StringDataValue result)
+        throws StandardException;
+    /**
+     * left() function.
+     * @param length Number of characters to take.
+     * @param result The result of this method.
+     * @return A StringDataValue containing the result of the left().
+     * @throws StandardException
+     */
+    StringDataValue left(
+            NumberDataValue length,
+            StringDataValue result)
+        throws StandardException;
 
-	/**
-	 * The SQL Ansi trim function.
+    /**
+     * The SQL Ansi trim function.
 
-	 * @param trimType type of trim. Possible values are {@link #LEADING}, {@link #TRAILING}
-	 *        or {@link #BOTH}.
-	 * @param trimChar  The character to trim from <em>this</em>
-	 * @param result The result of a previous call to this method,
-	 *					null if not called yet.
-	 * @return A StringDataValue containing the result of the trim().
-	 * @throws StandardException
-	 */
-	StringDataValue ansiTrim(
-			int trimType,
-			StringDataValue trimChar,
-			StringDataValue result)
-		throws StandardException;
+     * @param trimType type of trim. Possible values are {@link #LEADING}, {@link #TRAILING}
+     *        or {@link #BOTH}.
+     * @param trimChar  The character to trim from <em>this</em>
+     * @param result The result of a previous call to this method,
+     *                    null if not called yet.
+     * @return A StringDataValue containing the result of the trim().
+     * @throws StandardException
+     */
+    StringDataValue ansiTrim(
+            int trimType,
+            StringDataValue trimChar,
+            StringDataValue result)
+        throws StandardException;
 
-	// Same as ansiTrim, but allow a trimString longer than a single character.
-	StringDataValue db2Trim(
-			int trimType,
-			StringDataValue trimString,
-			StringDataValue result)
-		throws StandardException;
+    // Same as ansiTrim, but allow a trimString longer than a single character.
+    StringDataValue db2Trim(
+            int trimType,
+            StringDataValue trimString,
+            StringDataValue result)
+        throws StandardException;
 
-	/**
-	 * Convert the string to upper case.
-	 *
-	 * @param result	The result (reusable - allocate if null).
-	 *
-	 * @return	The string converted to upper case.
-	 *
-	 * @exception StandardException		Thrown on error
-	 */
-	StringDataValue upper(StringDataValue result)
-							throws StandardException;
+    /**
+     * Convert the string to upper case.
+     *
+     * @param result    The result (reusable - allocate if null).
+     *
+     * @return    The string converted to upper case.
+     *
+     * @exception StandardException        Thrown on error
+     */
+    StringDataValue upper(StringDataValue result)
+                            throws StandardException;
 
-	/**
-	 * Covert the string to upper case with specified locale.
-	 * @param str The string
-	 * @param locale  The locale
-	 * @param result the result
-	 * @return The string converted to upper case
-	 * @throws StandardException Thrown on error
-	 */
-	StringDataValue upperWithLocale(StringDataValue str, StringDataValue locale, StringDataValue result)
-							throws StandardException;
+    /**
+     * Covert the string to upper case with specified locale.
+     * @param str The string
+     * @param locale  The locale
+     * @param result the result
+     * @return The string converted to upper case
+     * @throws StandardException Thrown on error
+     */
+    StringDataValue upperWithLocale(StringDataValue str, StringDataValue locale, StringDataValue result)
+                            throws StandardException;
 
-	/**
-	 * Find the position of the searchString in an expressionString
-	 * @param expressionString The string to search
-	 * @param searchString  The substring to search for
-	 * @return 0 if not found,
-	 *         null if either operand is null,
-	 *         otherwise the 1-based position of the first character in the match
-	 * @throws StandardException Thrown on error
-	 */
+    /**
+     * Find the position of the searchString in an expressionString
+     * @param expressionString The string to search
+     * @param searchString  The substring to search for
+     * @return 0 if not found,
+     *         null if either operand is null,
+     *         otherwise the 1-based position of the first character in the match
+     * @throws StandardException Thrown on error
+     */
     NumberDataValue positionOfString(StringDataValue expressionString, StringDataValue searchString,
                                      NumberDataValue result) throws StandardException;
-	/**
-	 * Covert the string to lower case with specified locale.
-	 * @param str The string
-	 * @param locale  The locale
-	 * @param result the result
-	 * @return The string converted to lower case
-	 * @throws StandardException Thrown on error
-	 */
-	StringDataValue lowerWithLocale(StringDataValue str, StringDataValue locale, StringDataValue result)
-			throws StandardException;
+    /**
+     * Covert the string to lower case with specified locale.
+     * @param str The string
+     * @param locale  The locale
+     * @param result the result
+     * @return The string converted to lower case
+     * @throws StandardException Thrown on error
+     */
+    StringDataValue lowerWithLocale(StringDataValue str, StringDataValue locale, StringDataValue result)
+            throws StandardException;
 
-	/**
-	 * Convert the string to lower case.
-	 *
-	 * @param result	The result (reusable - allocate if null).
-	 *
-	 * @return	The string converted to lower case.
-	 *
-	 * @exception StandardException		Thrown on error
-	 */
-	StringDataValue lower(StringDataValue result)
-							throws StandardException;
+    /**
+     * Convert the string to lower case.
+     *
+     * @param result    The result (reusable - allocate if null).
+     *
+     * @return    The string converted to lower case.
+     *
+     * @exception StandardException        Thrown on error
+     */
+    StringDataValue lower(StringDataValue result)
+                            throws StandardException;
 
 
-	/**
-	 * Get a char array.  Typically, this is a simple
-	 * getter that is cheaper than getString() because
-	 * we always need to create a char array when
-	 * doing I/O.  Use this instead of getString() where
-	 * reasonable.
-	 * <p>
-	 * <b>WARNING</b>: may return a character array that has spare
-	 * characters at the end.  MUST be used in conjunction
-	 * with getLength() to be safe.
-	 *
-	 * @exception StandardException		Thrown on error
-	 */
-	char[] getCharArray() throws StandardException;
+    /**
+     * Get a char array.  Typically, this is a simple
+     * getter that is cheaper than getString() because
+     * we always need to create a char array when
+     * doing I/O.  Use this instead of getString() where
+     * reasonable.
+     * <p>
+     * <b>WARNING</b>: may return a character array that has spare
+     * characters at the end.  MUST be used in conjunction
+     * with getLength() to be safe.
+     *
+     * @exception StandardException        Thrown on error
+     */
+    char[] getCharArray() throws StandardException;
 
-	/**
-	 * Gets either SQLChar/SQLVarchar/SQLLongvarchar/SQLClob(base classes) or
-	 * CollatorSQLChar/CollatorSQLVarchar/CollatorSQLLongvarch/CollatorSQLClob
-	 * (subclasses). Whether this method returns the base class or the subclass
-	 * depends on the value of the RuleBasedCollator. If RuleBasedCollator is
-	 * null, then the object returned would be baseclass otherwise it would be
-	 * subcalss.
-	 */
-	StringDataValue getValue(RuleBasedCollator collatorForComparison);
+    /**
+     * Gets either SQLChar/SQLVarchar/SQLLongvarchar/SQLClob(base classes) or
+     * CollatorSQLChar/CollatorSQLVarchar/CollatorSQLLongvarch/CollatorSQLClob
+     * (subclasses). Whether this method returns the base class or the subclass
+     * depends on the value of the RuleBasedCollator. If RuleBasedCollator is
+     * null, then the object returned would be baseclass otherwise it would be
+     * subcalss.
+     */
+    StringDataValue getValue(RuleBasedCollator collatorForComparison);
 
     /**
      * Returns the stream header generator for the string data value.
@@ -276,7 +276,7 @@ public interface StringDataValue extends ConcatableDataValue
      * set explicitly.
      * @see #setStreamHeaderFormat
      */
-	StreamHeaderGenerator getStreamHeaderGenerator();
+    StreamHeaderGenerator getStreamHeaderGenerator();
 
     /**
      * Tells the data value descriptor which CLOB stream header format to use.
@@ -285,7 +285,7 @@ public interface StringDataValue extends ConcatableDataValue
      *      prior to version 10.5, {@code false} if the version is 10.5 or
      *      newer, and {@code null} if unknown at this time
      */
-	void setStreamHeaderFormat(Boolean usePreTenFiveHdrFormat);
+    void setStreamHeaderFormat(Boolean usePreTenFiveHdrFormat);
 
     /**
      * Returns a descriptor for the input stream for this data value.
@@ -299,30 +299,32 @@ public interface StringDataValue extends ConcatableDataValue
      * @throws StandardException if obtaining the descriptor fails, or if the
      *      value isn't represented as a stream.
      */
-	CharacterStreamDescriptor getStreamWithDescriptor()
+    CharacterStreamDescriptor getStreamWithDescriptor()
             throws StandardException;
 
 
-	/**
-	 * Stuff a StringDataValue with a Clob.
-	 */
-	void setValue(Clob value)
-		throws StandardException;
+    /**
+     * Stuff a StringDataValue with a Clob.
+     */
+    void setValue(Clob value)
+        throws StandardException;
 
-	/**
-	 * The SQL split_part() is used to split a given string based on a delimiter and pick out the desired field from the string, start from the left of the string.
-	 *
-	 * @param delimiter the delimiter of the defined string
-	 * @param fieldNumber number of a result field
-	 * @param result The result of a previous call to this method, null if not called yet.
-	 *
-	 * @return  A StringDataValue containing the result of the split_part()
-	 *
-	 * @exception StandardException     Thrown on error
-	 */
-	public StringDataValue split_part(
-			StringDataValue delimiter,
-			NumberDataValue fieldNumber,
-			StringDataValue result)
-			throws StandardException;
+    /**
+     * The SQL split_part() is used to split a given string based on a delimiter and pick out the desired field from the string, start from the left of the string.
+     *
+     * @param delimiter the delimiter of the defined string
+     * @param fieldNumber number of a result field
+     * @param result The result of a previous call to this method, null if not called yet.
+     *
+     * @return  A StringDataValue containing the result of the split_part()
+     *
+     * @exception StandardException     Thrown on error
+     */
+    public StringDataValue split_part(
+            StringDataValue delimiter,
+            NumberDataValue fieldNumber,
+            StringDataValue result)
+            throws StandardException;
+
+    void setIgnoreTrailingWhitespacesInVarcharComparison(boolean value);
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorNode.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.ClassName;
 import com.splicemachine.db.iapi.services.classfile.VMOpcode;
 import com.splicemachine.db.iapi.services.compiler.LocalField;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
@@ -481,5 +482,14 @@ public abstract class OperatorNode extends ValueNode
         mb.getField(field);
 
         mb.callMethod(VMOpcode.INVOKEINTERFACE, resultInterfaceType, methodName, resultInterfaceType, operands.size());
+    }
+
+    public void generateSetIgnoreTrailingWhitespacesInVarcharComparison(int operandIndex, MethodBuilder mb) throws StandardException {
+        if (getCompilerContext().getVarcharDB2CompatibilityMode()) {
+            mb.dup();
+            mb.push(true);
+            mb.callMethod(VMOpcode.INVOKEINTERFACE, ClassName.StringDataValue,
+                    "setIgnoreTrailingWhitespacesInVarcharComparison", "void", 1);
+        }
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TranslateFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TranslateFunctionNode.java
@@ -119,4 +119,27 @@ public class TranslateFunctionNode extends OperatorNode {
                 operands.get(0).getTypeServices().getMaximumWidth()));
         return this;
     }
+
+    @Override
+    public void generateExpression(ExpressionClassBuilder acb, MethodBuilder mb) throws StandardException {
+        /* Allocate an object for re-use to hold the result of the operator */
+        LocalField field = acb.newFieldDeclaration(Modifier.PRIVATE, resultInterfaceType);
+        operands.get(0).generateExpression(acb, mb);
+        mb.upCast(interfaceTypes.get(0));
+        generateSetIgnoreTrailingWhitespacesInVarcharComparison(0, mb);
+        for (int i = 1; i < operands.size(); ++i) {
+            if (operands.get(i) != null)
+            {
+                operands.get(i).generateExpression(acb, mb);
+                mb.upCast(interfaceTypes.get(i));
+            }
+            else
+            {
+                mb.pushNull(interfaceTypes.get(i));
+            }
+        }
+        mb.getField(field);
+
+        mb.callMethod(VMOpcode.INVOKEINTERFACE, resultInterfaceType, methodName, resultInterfaceType, operands.size());
+    }
 }

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
@@ -17,6 +17,7 @@ package com.splicemachine.db.impl.sql.compile;
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.derby.test.framework.TestConnection;
 import com.splicemachine.homeless.TestUtils;
 import com.splicemachine.test.SerialTest;
 import com.splicemachine.test_tools.TableCreator;
@@ -592,6 +593,13 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
                     "----------------\n" +
                     " 1 | a | 1 | a |";
             Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        }
+    }
+
+    @Test
+    public void testDB_11570() throws Exception {
+        try (TestConnection conn = methodWatcher.getOrCreateConnection()){
+            checkBooleanExpression("'abcdefgh            '=strip(replace(TRANSLATE('abcdefgh            ',' ',X'00'),' ',''))", true, conn);
         }
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceStringFunctionsIT.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.derby.utils;
 
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.derby.test.framework.*;
 import com.splicemachine.homeless.TestUtils;
@@ -41,7 +42,7 @@ import static org.junit.Assert.*;
  * @author Walt Koetke
  */
 public class SpliceStringFunctionsIT extends SpliceUnitTest {
-	
+
     private static final String CLASS_NAME = SpliceStringFunctionsIT.class.getSimpleName().toUpperCase();
     private static SpliceWatcher classWatcher = new SpliceWatcher(CLASS_NAME);
 
@@ -53,15 +54,15 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
 
     // Table for INSTR testing.
     private static final SpliceTableWatcher tableWatcherB = new SpliceTableWatcher(
-    	"B", schemaWatcher.schemaName, "(a int, b varchar(30), c varchar(30), d int)");
+        "B", schemaWatcher.schemaName, "(a int, b varchar(30), c varchar(30), d int)");
 
     // Table for INITCAP testing.
     private static final SpliceTableWatcher tableWatcherC = new SpliceTableWatcher(
-    	"C", schemaWatcher.schemaName, "(a varchar(30), b varchar(30))");
+        "C", schemaWatcher.schemaName, "(a varchar(30), b varchar(30))");
 
     // Table for CONCAT testing.
     private static final SpliceTableWatcher tableWatcherD = new SpliceTableWatcher(
-    	"D", schemaWatcher.schemaName, "(a varchar(30), b varchar(30), c varchar(30))");
+        "D", schemaWatcher.schemaName, "(a varchar(30), b varchar(30), c varchar(30))");
 
     // Table for CHR testing.
     private static final SpliceTableWatcher tableWatcherE = new SpliceTableWatcher(
@@ -372,10 +373,10 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
     @Test
     public void testInstrFunction() throws Exception {
         int count = 0;
-	    String sCell1 = null;
-	    String sCell2 = null;
+        String sCell1 = null;
+        String sCell2 = null;
 
-	    try (ResultSet rs = methodWatcher.executeQuery("SELECT INSTR(b, c), d from " + tableWatcherB)) {
+        try (ResultSet rs = methodWatcher.executeQuery("SELECT INSTR(b, c), d from " + tableWatcherB)) {
             count = 0;
             while (rs.next()) {
                 sCell1 = rs.getString(1);
@@ -388,13 +389,13 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
     }
 
     private void runRTrimTests(boolean useSpark) throws Exception {
-	    String sCell1 = null;
-	    String sCell2 = null;
+        String sCell1 = null;
+        String sCell2 = null;
         int count = 0;
 
-	    // Use a join so we can test native spark execution.
-	    try (ResultSet rs = methodWatcher.executeQuery(
-	            "SELECT RTRIM(a.a,a.b), a.c from " + tableWatcherK + " a --splice-properties joinStrategy=nestedloop,useSpark=" + useSpark +
+        // Use a join so we can test native spark execution.
+        try (ResultSet rs = methodWatcher.executeQuery(
+                "SELECT RTRIM(a.a,a.b), a.c from " + tableWatcherK + " a --splice-properties joinStrategy=nestedloop,useSpark=" + useSpark +
                     "\n, " + tableWatcherK + " b where a.a = b.a and a.b = b.b")) {
 
             while (rs.next()) {
@@ -404,7 +405,7 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
                 count++;
             }
         }
-	    Assert.assertEquals("Incorrect row count", 13, count);
+        Assert.assertEquals("Incorrect row count", 13, count);
     }
 
     @Test
@@ -414,12 +415,12 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
     }
 
     private void runRTrimSysFunTests(boolean useSpark, String expected) throws Exception {
-	    String sCell1 = null;
-	    String sCell2 = null;
+        String sCell1 = null;
+        String sCell2 = null;
         int count = 0;
 
-	    // Use a join so we can test native spark execution.
-	    String sqlText = "SELECT SYSFUN.RTRIM(a.a) from " + tableWatcherK + " a --splice-properties useSpark=" + useSpark +
+        // Use a join so we can test native spark execution.
+        String sqlText = "SELECT SYSFUN.RTRIM(a.a) from " + tableWatcherK + " a --splice-properties useSpark=" + useSpark +
                     "\n, " + tableWatcherK + " b where a.a = b.a and a.b = b.b";
 
         testQuery(sqlText, expected, methodWatcher);
@@ -452,10 +453,10 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
 
     @Test
     public void testInitcapFunction() throws Exception {
-	    String sCell1 = null;
-	    String sCell2 = null;
+        String sCell1 = null;
+        String sCell2 = null;
 
-	    try (ResultSet rs = methodWatcher.executeQuery("SELECT INITCAP(a), b from " + tableWatcherC)) {
+        try (ResultSet rs = methodWatcher.executeQuery("SELECT INITCAP(a), b from " + tableWatcherC)) {
             while (rs.next()) {
                 sCell1 = rs.getString(1);
                 sCell2 = rs.getString(2);
@@ -472,43 +473,43 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
             testPosStrFunctionHelper(true, join);
         }
 
-	    String query = "Values(POSSTR(cast(null as char(3)), ''))";
-	    String expected = "1  |\n" +
+        String query = "Values(POSSTR(cast(null as char(3)), ''))";
+        String expected = "1  |\n" +
                             "------\n" +
                             "NULL |";
         testQuery(query, expected, methodWatcher);
-	    query = "Values(POSSTR(cast(null as char(3)), cast(null as char(3))))";
+        query = "Values(POSSTR(cast(null as char(3)), cast(null as char(3))))";
         testQuery(query, expected, methodWatcher);
-	    query = "Values(POSSTR('', cast(null as char(3))))";
+        query = "Values(POSSTR('', cast(null as char(3))))";
         testQuery(query, expected, methodWatcher);
 
         expected = "1 |\n" +
                     "----\n" +
                     " 2 |";
-	    query = "Values(POSSTR('123', 2))";
+        query = "Values(POSSTR('123', 2))";
         testQuery(query, expected, methodWatcher);
 
         expected = "1 |\n" +
                     "----\n" +
                     " 0 |";
-	    query = "Values(POSSTR('123', 1234))";
+        query = "Values(POSSTR('123', 1234))";
         testQuery(query, expected, methodWatcher);
 
         expected = "1 |\n" +
                     "----\n" +
                     " 3 |";
-	    query = "Values(POSSTR('  \t', '\t'))";
+        query = "Values(POSSTR('  \t', '\t'))";
         testQuery(query, expected, methodWatcher);
 
         expected = "1 |\n" +
                     "----\n" +
                     " 6 |";
-	    query = "Values(POSSTR('bcabCabc', 'abc'))";
+        query = "Values(POSSTR('bcabCabc', 'abc'))";
         testQuery(query, expected, methodWatcher);
     }
 
     private void testPosStrFunctionHelper(boolean useSpark, String strategy) throws Exception {
-	    String expected = "B        |     C      |  3  |\n" +
+        String expected = "B        |     C      |  3  |\n" +
                         "------------------------------------\n" +
                         "    Bam Bam     |Bam Bam Bam |  0  |\n" +
                         " Barney Rubble  |   Wilma    |  0  |\n" +
@@ -520,9 +521,9 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
                         "Fred Flintstone |  stoner    |  0  |\n" +
                         "     NULL       |   NULL     |NULL |";
 
-	    String query = "SELECT a.b, a.c, POSSTR(a.b, a.c) from " + tableWatcherB + format(" a --splice-properties joinStrategy=%s,useSpark=", strategy) + useSpark +
+        String query = "SELECT a.b, a.c, POSSTR(a.b, a.c) from " + tableWatcherB + format(" a --splice-properties joinStrategy=%s,useSpark=", strategy) + useSpark +
                     "\n, " + tableWatcherB + " b where a.a = b.a";
-	    testQuery(query, expected, methodWatcher);
+        testQuery(query, expected, methodWatcher);
 
         expected = "A   |  C   | 3 |\n" +
                     "-------------------\n" +
@@ -540,17 +541,17 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
                     " abc g |abc g | 1 |\n" +
                     "abcabc |      | 1 |";
 
-	    query = "SELECT a.a, a.c, POSSTR(a.a, a.c) from " + tableWatcherK + format(" a --splice-properties joinStrategy=%s,useSpark=", strategy) + useSpark +
+        query = "SELECT a.a, a.c, POSSTR(a.a, a.c) from " + tableWatcherK + format(" a --splice-properties joinStrategy=%s,useSpark=", strategy) + useSpark +
                     "\n, " + tableWatcherK + " b where a.a = b.a and a.b = b.b";
-	    testQuery(query, expected, methodWatcher);
+        testQuery(query, expected, methodWatcher);
     }
 
     @Test
     public void testConcatFunction() throws Exception {
-	    String sCell1 = null;
-	    String sCell2 = null;
+        String sCell1 = null;
+        String sCell2 = null;
 
-	    try (ResultSet rs = methodWatcher.executeQuery("SELECT CONCAT(a, b), c from " + tableWatcherD)) {
+        try (ResultSet rs = methodWatcher.executeQuery("SELECT CONCAT(a, b), c from " + tableWatcherD)) {
             while (rs.next()) {
                 sCell1 = rs.getString(1);
                 sCell2 = rs.getString(2);
@@ -561,10 +562,10 @@ public class SpliceStringFunctionsIT extends SpliceUnitTest {
 
     @Test
     public void testConcatAliasFunction() throws Exception {
-	    String sCell1 = null;
-	    String sCell2 = null;
+        String sCell1 = null;
+        String sCell2 = null;
 
-	    try (ResultSet rs = methodWatcher.executeQuery("SELECT a CONCAT b, c from " + tableWatcherD)) {
+        try (ResultSet rs = methodWatcher.executeQuery("SELECT a CONCAT b, c from " + tableWatcherD)) {
             while (rs.next()) {
                 sCell1 = rs.getString(1);
                 sCell2 = rs.getString(2);


### PR DESCRIPTION
## Short Description
When `splice.db2.varchar.compatible` is set to true, SQLChar.{replace,strip,etc.} should return a `SQLDB2Varchar`


## Long Description
Functions in SQLChar (substring, split_part, right, left, replace, translate, ansiTrim, db2Trim) need to create a new `SQLVarchar` to store the result. If `splice.db2.varchar.compatible` is set to true, we should make sure that the result will be stored in a `SQLVarcharDB2Compatible` instead.

Comparisons done on `replace(SQLChar)` would not behave according to that parameter before that change.


## How to test
```
call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', false);
values 'abcdefgh            '=strip(replace(TRANSLATE('abcdefgh            ',' ',X'00'),' ',''));
1
-----
false

call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', true);
values 'abcdefgh            '=strip(replace(TRANSLATE('abcdefgh            ',' ',X'00'),' ',''));
1
-----
true


```