### PR TITLE
DB-11567 Add FK_COLNAMES and PK_COLNAMES to SYSCAT.REFERENCES

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSFOREIGNKEYSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSFOREIGNKEYSRowFactory.java
@@ -297,6 +297,12 @@ public class SYSFOREIGNKEYSRowFactory extends CatalogRowFactory
 				new ColumnDescriptor("UPDATERULE",9,9,
 						DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.CHAR, false, 1),
 						null,null,view,viewId,0,0,0),
+				new ColumnDescriptor("FK_COLNAMES",10,5,
+						DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, false, 640),
+						null,null,view,viewId,0,0,0),
+				new ColumnDescriptor("PK_COLNAMES",11,6,
+						DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, false, 640),
+						null,null,view,viewId,0,0,0),
 			});
 		return cdsl;
 	}
@@ -365,37 +371,132 @@ public class SYSFOREIGNKEYSRowFactory extends CatalogRowFactory
 	}
 
     public static String SYSCAT_REFERENCES_VIEW_SQL = "create view REFERENCES as \n" +
-			"SELECT CC.CONSTRAINTNAME AS CONSTNAME\n" +
-			"     , VC.SCHEMANAME AS TABSCHEMA\n" +
-			"     , TC.TABLENAME AS TABNAME\n" +
-			"     , CP.CONSTRAINTNAME AS REFKEYNAME\n" +
-			"     , VP.SCHEMANAME AS REFTABSCHEMA\n" +
-			"     , TP.TABLENAME AS REFTABNAME\n" +
-			"     , CAST(C.DESCRIPTOR.numberOfOrderedColumns() AS SMALLINT) AS COLCOUNT\n" +
-			"     , (CASE FK.DELETERULE \n" +
-			"          WHEN 'R' THEN 'A'\n" +
-			"          WHEN 'S' THEN 'R'\n" +
-			"          WHEN 'C' THEN 'C'\n" +
-			"          WHEN 'U' THEN 'N'\n" +
-			"        END) AS DELETERULE\n" +
-			"     , (CASE FK.UPDATERULE\n" +
-			"          WHEN 'R' THEN 'A'\n" +
-			"          WHEN 'S' THEN 'R'\n" +
-			"        END) AS UPDATERULE\n" +
-			"FROM --splice-properties joinOrder=fixed\n" +
-			"     SYS.SYSFOREIGNKEYS FK\n" +
-			"   , SYS.SYSCONSTRAINTS CC\n" +
-			"   , SYS.SYSCONSTRAINTS CP\n" +
-			"   , SYS.SYSTABLES TC\n" +
-			"   , SYS.SYSTABLES TP\n" +
-			"   , SYSVW.SYSSCHEMASVIEW VC\n" +
-			"   , SYSVW.SYSSCHEMASVIEW VP\n" +
-			"   , SYS.SYSCONGLOMERATES C\n" +
-			"WHERE FK.CONSTRAINTID = CC.CONSTRAINTID\n" +
-			"  AND CC.TABLEID = TC.TABLEID\n" +
-			"  AND CC.SCHEMAID = VC.SCHEMAID\n" +
-			"  AND FK.KEYCONSTRAINTID = CP.CONSTRAINTID\n" +
-			"  AND CP.TABLEID = TP.TABLEID\n" +
-			"  AND CP.SCHEMAID = VP.SCHEMAID\n" +
-			"  AND FK.CONGLOMERATEID = C.CONGLOMERATEID";
+			"SELECT X.CONSTNAME\n" +
+			"     , X.TABSCHEMA\n" +
+			"     , X.TABNAME\n" +
+			"     , X.REFKEYNAME\n" +
+			"     , X.REFTABSCHEMA\n" +
+			"     , X.REFTABNAME\n" +
+			"     , X.COLCOUNT\n" +
+			"     , X.DELETERULE\n" +
+			"     , X.UPDATERULE\n" +
+			"     , CAST(X.FK_COLNAMES AS VARCHAR(640)) AS FK_COLNAMES\n" +
+			"     , CAST(STRING_AGG(X.PK_COLNAME, ',') AS VARCHAR(640)) AS PK_COLNAMES\n" +
+			"FROM (\n" +
+			"    SELECT W.CONSTNAME\n" +
+			"         , W.TABSCHEMA\n" +
+			"         , W.TABNAME\n" +
+			"         , W.REFKEYNAME\n" +
+			"         , W.REFTABSCHEMA\n" +
+			"         , W.REFTABNAME\n" +
+			"         , W.COLCOUNT\n" +
+			"         , W.DELETERULE\n" +
+			"         , W.UPDATERULE\n" +
+			"         , W.FK_COLNAMES\n" +
+			"         , COLSP.COLUMNNAME AS PK_COLNAME\n" +
+			"         , CONGLOMSP.DESCRIPTOR.getKeyColumnPosition(COLSP.COLUMNNUMBER) AS PKCOLS_ORD\n" +
+			"    FROM --splice-properties joinOrder=fixed\n" +
+			"    (\n" +
+			"        SELECT V.CONSTNAME\n" +
+			"             , V.TABSCHEMA\n" +
+			"             , V.TABNAME\n" +
+			"             , V.REFKEYNAME\n" +
+			"             , V.REFTABSCHEMA\n" +
+			"             , V.REFTABNAME\n" +
+			"             , V.COLCOUNT\n" +
+			"             , V.DELETERULE\n" +
+			"             , V.UPDATERULE\n" +
+			"             , V.PK_TABLEID\n" +
+			"             , V.PK_CONSTRAINTID\n" +
+			"             , STRING_AGG(V.FK_COLNAME, ',') AS FK_COLNAMES\n" +
+			"        FROM (\n" +
+			"            SELECT U.CONSTNAME\n" +
+			"                 , U.TABSCHEMA\n" +
+			"                 , U.TABNAME\n" +
+			"                 , U.REFKEYNAME\n" +
+			"                 , U.REFTABSCHEMA\n" +
+			"                 , U.REFTABNAME\n" +
+			"                 , CAST(CONGLOMSC.DESCRIPTOR.numberOfOrderedColumns() AS SMALLINT) AS COLCOUNT\n" +
+			"                 , U.DELETERULE\n" +
+			"                 , U.UPDATERULE\n" +
+			"                 , COLSC.COLUMNNAME AS FK_COLNAME\n" +
+			"                 , CONGLOMSC.DESCRIPTOR.getKeyColumnPosition(COLSC.COLUMNNUMBER) AS FKCOLS_ORD\n" +
+			"                 , U.PK_TABLEID\n" +
+			"                 , U.PK_CONSTRAINTID\n" +
+			"            FROM --splice-properties joinOrder=fixed\n" +
+			"            (\n" +
+			"                  SELECT CC.CONSTRAINTNAME AS CONSTNAME\n" +
+			"                       , VC.SCHEMANAME AS TABSCHEMA\n" +
+			"                       , TC.TABLENAME AS TABNAME\n" +
+			"                       , CP.CONSTRAINTNAME AS REFKEYNAME\n" +
+			"                       , VP.SCHEMANAME AS REFTABSCHEMA\n" +
+			"                       , TP.TABLENAME AS REFTABNAME\n" +
+			"                       , (CASE FK.DELETERULE \n" +
+			"                            WHEN 'R' THEN 'A'\n" +
+			"                            WHEN 'S' THEN 'R'\n" +
+			"                            WHEN 'C' THEN 'C'\n" +
+			"                            WHEN 'U' THEN 'N'\n" +
+			"                          END) AS DELETERULE\n" +
+			"                       , (CASE FK.UPDATERULE\n" +
+			"                            WHEN 'R' THEN 'A'\n" +
+			"                            WHEN 'S' THEN 'R'\n" +
+			"                          END) AS UPDATERULE\n" +
+			"                       , CAST(NULL AS TIMESTAMP) AS CREATE_TIME\n" +
+			"                       , FK.CONGLOMERATEID as FK_CONGLOMID\n" +
+			"                       , CC.TABLEID as FK_TABLEID\n" +
+			"                       , CP.TABLEID as PK_TABLEID\n" +
+			"                       , FK.KEYCONSTRAINTID as PK_CONSTRAINTID\n" +
+			"                  FROM --splice-properties joinOrder=fixed\n" +
+			"                       SYS.SYSFOREIGNKEYS FK\n" +
+			"                     , SYS.SYSCONSTRAINTS CC\n" +
+			"                     , SYS.SYSCONSTRAINTS CP\n" +
+			"                     , SYS.SYSTABLES TC\n" +
+			"                     , SYS.SYSTABLES TP\n" +
+			"                     , SYSVW.SYSSCHEMASVIEW VC\n" +
+			"                     , SYSVW.SYSSCHEMASVIEW VP\n" +
+			"                  WHERE FK.CONSTRAINTID = CC.CONSTRAINTID\n" +
+			"                    AND CC.TABLEID = TC.TABLEID\n" +
+			"                    AND CC.SCHEMAID = VC.SCHEMAID\n" +
+			"                    AND FK.KEYCONSTRAINTID = CP.CONSTRAINTID\n" +
+			"                    AND CP.TABLEID = TP.TABLEID\n" +
+			"                    AND CP.SCHEMAID = VP.SCHEMAID\n" +
+			"                ) U\n" +
+			"              , SYS.SYSCONGLOMERATES CONGLOMSC\n" +
+			"              , SYS.SYSCOLUMNS COLSC\n" +
+			"            WHERE U.FK_CONGLOMID = CONGLOMSC.CONGLOMERATEID\n" +
+			"              AND U.FK_TABLEID = COLSC.REFERENCEID\n" +
+			"              AND CASE WHEN CONGLOMSC.DESCRIPTOR IS NULL THEN FALSE ELSE (CONGLOMSC.DESCRIPTOR.getKeyColumnPosition(COLSC.COLUMNNUMBER) > 0) END\n" +
+			"            ORDER BY U.CONSTNAME, FKCOLS_ORD\n" +
+			"            ) V\n" +
+			"        GROUP BY V.CONSTNAME\n" +
+			"               , V.TABSCHEMA\n" +
+			"               , V.TABNAME\n" +
+			"               , V.REFKEYNAME\n" +
+			"               , V.REFTABSCHEMA\n" +
+			"               , V.REFTABNAME\n" +
+			"               , V.COLCOUNT\n" +
+			"               , V.DELETERULE\n" +
+			"               , V.UPDATERULE\n" +
+			"               , V.PK_TABLEID\n" +
+			"               , V.PK_CONSTRAINTID\n" +
+			"        ) W\n" +
+			"      , SYS.SYSPRIMARYKEYS PK\n" +
+			"      , SYS.SYSCONGLOMERATES CONGLOMSP\n" +
+			"      , SYS.SYSCOLUMNS COLSP\n" +
+			"    WHERE W.PK_CONSTRAINTID = PK.CONSTRAINTID\n" +
+			"      AND PK.CONGLOMERATEID = CONGLOMSP.CONGLOMERATEID\n" +
+			"      AND W.PK_TABLEID = COLSP.REFERENCEID\n" +
+			"      AND CASE WHEN CONGLOMSP.DESCRIPTOR IS NULL THEN FALSE ELSE (CONGLOMSP.DESCRIPTOR.getKeyColumnPosition(COLSP.COLUMNNUMBER) > 0) END\n" +
+			"    ORDER BY W.CONSTNAME, PKCOLS_ORD\n" +
+			"    ) X\n" +
+			"GROUP BY X.CONSTNAME\n" +
+			"       , X.TABSCHEMA\n" +
+			"       , X.TABNAME\n" +
+			"       , X.REFKEYNAME\n" +
+			"       , X.REFTABSCHEMA\n" +
+			"       , X.REFTABNAME\n" +
+			"       , X.COLCOUNT\n" +
+			"       , X.DELETERULE\n" +
+			"       , X.UPDATERULE\n" +
+			"       , X.FK_COLNAMES";
 }

--- a/db-engine/src/main/resources/com/splicemachine/db/impl/sql/catalog/syscat_references_view.sql
+++ b/db-engine/src/main/resources/com/splicemachine/db/impl/sql/catalog/syscat_references_view.sql
@@ -1,0 +1,131 @@
+CREATE VIEW REFERENCES AS
+SELECT X.CONSTNAME
+     , X.TABSCHEMA
+     , X.TABNAME
+--     , CAST(NULL AS VARCHAR(128)) AS OWNER
+--     , CAST(NULL AS CHAR(1)) AS OWNERTYPE
+     , X.REFKEYNAME
+     , X.REFTABSCHEMA
+     , X.REFTABNAME
+     , X.COLCOUNT
+     , X.DELETERULE
+     , X.UPDATERULE
+     , CAST(X.FK_COLNAMES AS VARCHAR(640)) AS FK_COLNAMES
+     , CAST(STRING_AGG(X.PK_COLNAME, ',') AS VARCHAR(640)) AS PK_COLNAMES
+FROM (
+    SELECT W.CONSTNAME
+         , W.TABSCHEMA
+         , W.TABNAME
+         , W.REFKEYNAME
+         , W.REFTABSCHEMA
+         , W.REFTABNAME
+         , W.COLCOUNT
+         , W.DELETERULE
+         , W.UPDATERULE
+         , W.FK_COLNAMES
+         , COLSP.COLUMNNAME AS PK_COLNAME
+         , CONGLOMSP.DESCRIPTOR.getKeyColumnPosition(COLSP.COLUMNNUMBER) AS PKCOLS_ORD
+    FROM --splice-properties joinOrder=fixed
+    (
+        SELECT V.CONSTNAME
+             , V.TABSCHEMA
+             , V.TABNAME
+             , V.REFKEYNAME
+             , V.REFTABSCHEMA
+             , V.REFTABNAME
+             , V.COLCOUNT
+             , V.DELETERULE
+             , V.UPDATERULE
+             , V.PK_TABLEID
+             , V.PK_CONSTRAINTID
+             , STRING_AGG(V.FK_COLNAME, ',') AS FK_COLNAMES
+        FROM (
+            SELECT U.CONSTNAME
+                 , U.TABSCHEMA
+                 , U.TABNAME
+                 , U.REFKEYNAME
+                 , U.REFTABSCHEMA
+                 , U.REFTABNAME
+                 , CAST(CONGLOMSC.DESCRIPTOR.numberOfOrderedColumns() AS SMALLINT) AS COLCOUNT
+                 , U.DELETERULE
+                 , U.UPDATERULE
+                 , COLSC.COLUMNNAME AS FK_COLNAME
+                 , CONGLOMSC.DESCRIPTOR.getKeyColumnPosition(COLSC.COLUMNNUMBER) AS FKCOLS_ORD
+                 , U.PK_TABLEID
+                 , U.PK_CONSTRAINTID
+            FROM --splice-properties joinOrder=fixed
+            (
+                  SELECT CC.CONSTRAINTNAME AS CONSTNAME
+                       , VC.SCHEMANAME AS TABSCHEMA
+                       , TC.TABLENAME AS TABNAME
+                       , CP.CONSTRAINTNAME AS REFKEYNAME
+                       , VP.SCHEMANAME AS REFTABSCHEMA
+                       , TP.TABLENAME AS REFTABNAME
+                       , (CASE FK.DELETERULE
+                            WHEN 'R' THEN 'A'
+                            WHEN 'S' THEN 'R'
+                            WHEN 'C' THEN 'C'
+                            WHEN 'U' THEN 'N'
+                          END) AS DELETERULE
+                       , (CASE FK.UPDATERULE
+                            WHEN 'R' THEN 'A'
+                            WHEN 'S' THEN 'R'
+                          END) AS UPDATERULE
+                       , CAST(NULL AS TIMESTAMP) AS CREATE_TIME
+                       , FK.CONGLOMERATEID as FK_CONGLOMID
+                       , CC.TABLEID as FK_TABLEID
+                       , CP.TABLEID as PK_TABLEID
+                       , FK.KEYCONSTRAINTID as PK_CONSTRAINTID
+                  FROM --splice-properties joinOrder=fixed
+                       SYS.SYSFOREIGNKEYS FK
+                     , SYS.SYSCONSTRAINTS CC
+                     , SYS.SYSCONSTRAINTS CP
+                     , SYS.SYSTABLES TC
+                     , SYS.SYSTABLES TP
+                     , SYSVW.SYSSCHEMASVIEW VC
+                     , SYSVW.SYSSCHEMASVIEW VP
+                  WHERE FK.CONSTRAINTID = CC.CONSTRAINTID
+                    AND CC.TABLEID = TC.TABLEID
+                    AND CC.SCHEMAID = VC.SCHEMAID
+                    AND FK.KEYCONSTRAINTID = CP.CONSTRAINTID
+                    AND CP.TABLEID = TP.TABLEID
+                    AND CP.SCHEMAID = VP.SCHEMAID
+                ) U
+              , SYS.SYSCONGLOMERATES CONGLOMSC
+              , SYS.SYSCOLUMNS COLSC
+            WHERE U.FK_CONGLOMID = CONGLOMSC.CONGLOMERATEID
+              AND U.FK_TABLEID = COLSC.REFERENCEID
+              AND CASE WHEN CONGLOMSC.DESCRIPTOR IS NULL THEN FALSE ELSE (CONGLOMSC.DESCRIPTOR.getKeyColumnPosition(COLSC.COLUMNNUMBER) > 0) END
+            ORDER BY U.CONSTNAME, FKCOLS_ORD
+            ) V
+        GROUP BY V.CONSTNAME
+               , V.TABSCHEMA
+               , V.TABNAME
+               , V.REFKEYNAME
+               , V.REFTABSCHEMA
+               , V.REFTABNAME
+               , V.COLCOUNT
+               , V.DELETERULE
+               , V.UPDATERULE
+               , V.PK_TABLEID
+               , V.PK_CONSTRAINTID
+        ) W
+      , SYS.SYSPRIMARYKEYS PK
+      , SYS.SYSCONGLOMERATES CONGLOMSP
+      , SYS.SYSCOLUMNS COLSP
+    WHERE W.PK_CONSTRAINTID = PK.CONSTRAINTID
+      AND PK.CONGLOMERATEID = CONGLOMSP.CONGLOMERATEID
+      AND W.PK_TABLEID = COLSP.REFERENCEID
+      AND CASE WHEN CONGLOMSP.DESCRIPTOR IS NULL THEN FALSE ELSE (CONGLOMSP.DESCRIPTOR.getKeyColumnPosition(COLSP.COLUMNNUMBER) > 0) END
+    ORDER BY W.CONSTNAME, PKCOLS_ORD
+    ) X
+GROUP BY X.CONSTNAME
+       , X.TABSCHEMA
+       , X.TABNAME
+       , X.REFKEYNAME
+       , X.REFTABSCHEMA
+       , X.REFTABNAME
+       , X.COLCOUNT
+       , X.DELETERULE
+       , X.UPDATERULE
+       , X.FK_COLNAMES

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -117,6 +117,7 @@ public class SpliceCatalogUpgradeScripts{
         addUpgradeScript(baseVersion4, 2001, new UpgradeScriptToAddColumnsViewInSYSCAT(sdd, tc));
         addUpgradeScript(baseVersion4, 2001, new UpgradeScriptForChangingGetKeyColumnPosition(sdd, tc));
         addUpgradeScript(baseVersion4, BaseDataDictionary.SERDE_UPGRADE_SPRINT, new UpgradeStoredObjects(sdd, tc));
+        addUpgradeScript(baseVersion4, 2004, new UpgradeScriptToAddReferencesViewInSYSCAT(sdd, tc));
         // remember to add your script to SpliceCatalogUpgradeScriptsTest too, otherwise test fails
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
@@ -35,7 +35,8 @@ public class SpliceCatalogUpgradeScriptsTest {
             "VERSION4.2001: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptForTableColumnViewInSYSIBM\n" +
             "VERSION4.2001: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToAddColumnsViewInSYSCAT\n" +
             "VERSION4.2001: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptForChangingGetKeyColumnPosition\n" +
-            "VERSION4.2003: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeStoredObjects\n";
+            "VERSION4.2003: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeStoredObjects\n" +
+            "VERSION4.2004: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToAddReferencesViewInSYSCAT\n";
 
     // see DB-11296, UpgradeConglomerateTable must run before other upgrade scripts
     String s3 = "VERSION4.1996: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeConglomerateTable\n";

--- a/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKeyMetadataIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKeyMetadataIT.java
@@ -159,27 +159,27 @@ public class ForeignKeyMetadataIT {
 
     @Test
     public void testReferencesAndSysKeyColUseViews() throws Exception {
-        methodWatcher.executeUpdate("create table if not exists SELF_REF (c int, d int, " +
-                "constraint SRPK primary key (c), constraint SRFK foreign key (c) references SELF_REF(c))");
+        methodWatcher.executeUpdate("create table if not exists SELF_REF (a int, b int, " +
+                "constraint SRPK primary key (a, b), constraint SRFK foreign key (a, b) references SELF_REF(a, b))");
         methodWatcher.executeUpdate("create table if not exists TBL1_REF (c int, d int, " +
-                "constraint TRFK1 foreign key (c) references SELF_REF(c) ON DELETE SET NULL)");
+                "constraint TRFK1 foreign key (c, d) references SELF_REF(a, b) ON DELETE SET NULL)");
         methodWatcher.executeUpdate("create table if not exists TBL2_REF (c int, d int, " +
-                "constraint TRFK2 foreign key (c) references SELF_REF(c) ON DELETE CASCADE)");
+                "constraint TRFK2 foreign key (d, c) references SELF_REF(a, b) ON DELETE CASCADE)");
         methodWatcher.executeUpdate("create table if not exists TBL3_REF (c int, d int, " +
-                "constraint TRFK3 foreign key (c) references SELF_REF(c) ON DELETE RESTRICT)");
+                "constraint TRFK3 foreign key (c, d) references SELF_REF(a, b) ON DELETE RESTRICT)");
         methodWatcher.executeUpdate("create table if not exists TBL4_REF (c int, d int, " +
-                "constraint TRFK4 foreign key (c) references SELF_REF(c) ON UPDATE RESTRICT)");
+                "constraint TRFK4 foreign key (d, c) references SELF_REF(a, b) ON UPDATE RESTRICT)");
 
         String query = "select * from syscat.references r where r.tabname like '%_REF%'";
 
         String expected =
-                "CONSTNAME |      TABSCHEMA      | TABNAME |REFKEYNAME |    REFTABSCHEMA     |REFTABNAME |COLCOUNT |DELETERULE |UPDATERULE |\n" +
-                "----------------------------------------------------------------------------------------------------------------------------\n" +
-                "   SRFK    |FOREIGNKEYMETADATAIT |SELF_REF |   SRPK    |FOREIGNKEYMETADATAIT | SELF_REF  |    1    |     A     |     A     |\n" +
-                "   TRFK1   |FOREIGNKEYMETADATAIT |TBL1_REF |   SRPK    |FOREIGNKEYMETADATAIT | SELF_REF  |    1    |     N     |     A     |\n" +
-                "   TRFK2   |FOREIGNKEYMETADATAIT |TBL2_REF |   SRPK    |FOREIGNKEYMETADATAIT | SELF_REF  |    1    |     C     |     A     |\n" +
-                "   TRFK3   |FOREIGNKEYMETADATAIT |TBL3_REF |   SRPK    |FOREIGNKEYMETADATAIT | SELF_REF  |    1    |     R     |     A     |\n" +
-                "   TRFK4   |FOREIGNKEYMETADATAIT |TBL4_REF |   SRPK    |FOREIGNKEYMETADATAIT | SELF_REF  |    1    |     A     |     R     |";
+                "CONSTNAME |      TABSCHEMA      | TABNAME |REFKEYNAME |    REFTABSCHEMA     |REFTABNAME |COLCOUNT |DELETERULE |UPDATERULE | FK_COLNAMES | PK_COLNAMES |\n" +
+                "--------------------------------------------------------------------------------------------------------------------------------------------------------\n" +
+                "   SRFK    |FOREIGNKEYMETADATAIT |SELF_REF |   SRPK    |FOREIGNKEYMETADATAIT | SELF_REF  |    2    |     A     |     A     |     A,B     |     A,B     |\n" +
+                "   TRFK1   |FOREIGNKEYMETADATAIT |TBL1_REF |   SRPK    |FOREIGNKEYMETADATAIT | SELF_REF  |    2    |     N     |     A     |     C,D     |     A,B     |\n" +
+                "   TRFK2   |FOREIGNKEYMETADATAIT |TBL2_REF |   SRPK    |FOREIGNKEYMETADATAIT | SELF_REF  |    2    |     C     |     A     |     D,C     |     A,B     |\n" +
+                "   TRFK3   |FOREIGNKEYMETADATAIT |TBL3_REF |   SRPK    |FOREIGNKEYMETADATAIT | SELF_REF  |    2    |     R     |     A     |     C,D     |     A,B     |\n" +
+                "   TRFK4   |FOREIGNKEYMETADATAIT |TBL4_REF |   SRPK    |FOREIGNKEYMETADATAIT | SELF_REF  |    2    |     A     |     R     |     D,C     |     A,B     |";
         try(ResultSet rs = methodWatcher.executeQuery(query)) {
             Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
         }
@@ -201,7 +201,8 @@ public class ForeignKeyMetadataIT {
 
         expected = "NAME | COLNO | CONSTNAME | CONSTNAME |\n" +
                 "--------------------------------------\n" +
-                "  C  |   0   |   SRFK    |   SRPK    |";
+                "  A  |   0   |   SRFK    |   SRPK    |\n" +
+                "  B  |   1   |   SRFK    |   SRPK    |";
         try(ResultSet rs = methodWatcher.executeQuery(query)) {
             Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
         }


### PR DESCRIPTION
## Short Description
This change adds `FK_COLNAMES` and `PK_COLNAMES` columns to system view `SYSCAT.REFERENCES`.

## Long Description
DB2 drops columns `FK_COLNAMES` and `PK_COLNAMES` in the latest version. However, customer has queries that rely on these columns. For compatibility, we want to add them to the view, too.

The column data types are `VARCHAR(640)` as of DB2 LUW 9.7.0.

Values in these columns are:
`FK_COLNAMES`: foreign key column names of a foreign key constraint concatenated with comma as separator.
`PK_COLNAMES`: primary key column names of a primary key constraint concatenated with comma as separator.

## How to test
`ForeignKeyMetadataIT.testReferencesAndSysKeyColUseViews` is updated to reflect this change.
