### PR TITLE
DB-9588 Get out of infinite loop if we hit timeout

### DIFF
--- a/hbase_storage/src/main/java/com/splicemachine/storage/HLock.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HLock.java
@@ -15,6 +15,7 @@
 package com.splicemachine.storage;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.hadoop.hbase.exceptions.TimeoutIOException;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -62,7 +63,9 @@ public class HLock implements Lock{
         try{
             delegate = region.getRowLock(key); // Null Lock Delegate means not run...
             return delegate!=null;
-        }catch(IOException e){
+        } catch(TimeoutIOException te) {
+            throw new RuntimeException(te);
+        } catch(IOException e){
             return false;
         }
     }


### PR DESCRIPTION
## Short Description
Get out of infinite loop if we hit timeout taking a lock
## Long Description
In SIObserver.prePut() there's a chance we enter an infinite loop if we hit a lock timeout. We'll report NOT_RUN for the affected rows and we'll retry again thinking we failed to take the lock due to a concurrent write, but since we hit a timeout we'll always return NOT_RUN. 
The change raises an exception in this case so that we can deal with it at a different layer.

## How to test
I tested it manually with breakpoints, this is almost impossible to test programatically.

I tested:
* Conflict case, two concurrent transactions try to modify the same row, one takes the lock the other retries a few times
* Timeout case, operation expires and lock times out, we raise an exception to the user
