### PR TITLE
DB-10382 fix exception paths (3.1)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/error/StandardException.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/error/StandardException.java
@@ -67,7 +67,7 @@ public class StandardException extends Exception
 	 * Exception State
 	 */
 	private Object[] arguments;
-	private int severity;
+	private int severity = ExceptionSeverity.NO_APPLICABLE_SEVERITY;
 	private String textMessage;
 	private String sqlState;
 	private transient int report;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementPermission.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/StatementPermission.java
@@ -144,7 +144,6 @@ public abstract class StatementPermission {
         throws StandardException
 	{
 		DataDictionary dd = lcc.getDataDictionary();
-		TransactionController tc = lcc.getTransactionExecute();
 		ExecPreparedStatement ps = activation.getPreparedStatement();
 		List<String> currentGroupuserlist = lcc.getCurrentGroupUser(activation);
 


### PR DESCRIPTION
## Bug Symptoms

Under some circumstances, the Server Connection gets in an erroneous state, and the connection to the client is dropped. Symptoms are one of the following:

When executing a query through sqlshell (or other JDBC shells):

- `ERROR 08006: Insufficient data while reading from the network - expected a minimum of 6 bytes and received only 0 bytes.  The connection has been terminated.`
- `ERROR 08006: A network protocol error was encountered and the connection has been terminated: the requested command encountered an unarchitected and implementation-specific condition for which there was no architected message (additional information may be available in the derby.log file on the server)`
- `ERROR 08003: DERBY SQL error: SQLCODE: -1, SQLSTATE: 08003, SQLERRMC: No current connection.`

## Fix

This fix will add catches for all `Throwable` and convert them into wrapped `SQLException` at all necessary places, and quite early up from `DRADConnThread`/`DRDAStatement` so that also unexpected Exceptions should not “escape” the connection thread.

The actual code that is dropping the connection is in `EmbedConnectionContext.cleanupOnError`, which is calling `conn.setInactive()` for all non-StandardExceptions, causing the DRDA Connection Stream to not continue, send results or follow-up messages, so that the client side might see a connection drop while still expecting data (hence the "insufficient data"). We now prevent this from happening for all cases except `ThreadDeath`.

Note this does NOT fix the actual cause of the exceptions, but rather display them correctly and prevent them from closing the connection.

## How to test

As this is about unexpected exceptions being thrown, this is quite hard to test by QA. See this [comment](https://splicemachine.atlassian.net/browse/DB-11470?focusedCommentId=74662) about how to force an unexpected exception in a SELECT query; 

On some versions `SELECT * SYS.SYSCOLUMNSTATS` runs into an error, see [DB-11267](https://splicemachine.atlassian.net/browse/DB-11267) , but this is not reliable.