### PR TITLE
DB-11476 Apply computeSqrtLevel selectivity to the correct level

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/PredicateUtils.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/PredicateUtils.java
@@ -47,7 +47,7 @@ public class PredicateUtils {
         @Override
         public boolean apply(Predicate p) {
             return p != null &&
-                    p.isJoinPredicate() &&
+                    p.isHashableJoinPredicate() &&
                     p.getAndNode().getLeftOperand().isBinaryEqualsOperatorNode();
         }
     };

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DefaultPredicateSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DefaultPredicateSelectivity.java
@@ -32,6 +32,7 @@
 package com.splicemachine.db.impl.sql.compile;
 
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.compile.AccessPath;
 import com.splicemachine.db.iapi.sql.compile.Optimizable;
 import com.splicemachine.db.impl.ast.RSUtils;
 
@@ -63,8 +64,15 @@ public class DefaultPredicateSelectivity extends AbstractSelectivityHolder {
         return
             getNumReferencedTables() < 2             ||
             baseTable.getCurrentAccessPath() == null ||
-            RSUtils.isNLJ(baseTable.getCurrentAccessPath());
+            canPushJoinPredAsInnerTablePred(baseTable.getCurrentAccessPath());
     }
+
+    private boolean canPushJoinPredAsInnerTablePred(AccessPath accessPath) {
+        if (accessPath == null)
+            return false;
+        return accessPath.getJoinStrategy().getJoinStrategyType().isAllowsJoinPredicatePushdown();
+    }
+
 
     public Predicate getPredicate() { return p; }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -981,7 +981,7 @@ public class FromBaseTable extends FromTable {
                     if(baseTableRestrictionList.isRedundantPredicate(i)) continue;
                 }
 
-                if(!p.isJoinPredicate()&& !p.isFullJoinPredicate() || currentJoinStrategy.allowsJoinPredicatePushdown()) //skip join predicates unless they support predicate pushdown
+                if(!p.isHashableJoinPredicate()&& !p.isFullJoinPredicate() || currentJoinStrategy.allowsJoinPredicatePushdown()) //skip join predicates unless they support predicate pushdown
                     scf.addPredicate(p, defaultSelectivityFactor);
             }
             scf.generateCost();
@@ -3447,7 +3447,7 @@ public class FromBaseTable extends FromTable {
 
     private boolean areAllJoinPredicates(List<Predicate> predList) {
         for (Predicate predicate : predList) {
-            if (!predicate.isJoinPredicate() && !predicate.isFullJoinPredicate()) {
+            if (!predicate.isHashableJoinPredicate() && !predicate.isFullJoinPredicate()) {
                 return false;
             }
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
@@ -200,7 +200,7 @@ public abstract class HashableJoinStrategy extends BaseJoinStrategy {
                 // no join predicates.
                 for (int i = 0; i < predList.size(); i++) {
                     pred = (Predicate)predList.getOptPredicate(i);
-                    if (pred.isJoinPredicate()) {
+                    if (pred.isHashableJoinPredicate()) {
                         ap.setMissingHashKeyOK(true);
 
                         AndNode andNode = pred.getAndNode();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
@@ -1979,7 +1979,7 @@ public class JoinNode extends TableOperatorNode{
             if(table!=null){
                 for(int i=table.nonStoreRestrictionList.size()-1;i>=0;i--){
                     Predicate op=(Predicate)table.nonStoreRestrictionList.getOptPredicate(i);
-                    if(op.isJoinPredicate() || op.getPulled() || op.isFullJoinPredicate()){
+                    if(op.isHashableJoinPredicate() || op.getPulled() || op.isFullJoinPredicate()){
                         table.nonStoreRestrictionList.removeOptPredicate(i);
                     }
                 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
@@ -841,7 +841,7 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
      * pushed into subqueries.
      */
     protected boolean pushableToSubqueries() throws StandardException{
-        if(!isJoinPredicate(false))
+        if(!isHashableJoinPredicate(false))
             return false;
 
         // isJoinPredicate() only treats BinaryRelationalOperatorNode as JoinPredicate, so when we get it
@@ -878,18 +878,18 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
 
     }
 
-    public boolean isJoinPredicate(){
-        return isJoinPredicate(true);
+    public boolean isHashableJoinPredicate(){
+        return isHashableJoinPredicate(true);
     }
 
     /**
-     * Is this predicate a join predicate?  In order to be so,
+     * Is this predicate a hashable join predicate?  In order to be so,
      * it must be a binary relational operator node that has either
      * a column reference or an index expression on both sides.
      *
      * @return Whether or not this is a join predicate.
      */
-    public boolean isJoinPredicate(boolean checkScope){
+    public boolean isHashableJoinPredicate(boolean checkScope){
         // If the predicate isn't a binary relational operator,
         // then it's not a join predicate.
         if(!(getAndNode().getLeftOperand() instanceof BinaryRelationalOperatorNode)){

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
@@ -1373,7 +1373,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                 ** Is it just one more than the previous position?
                 */
                 if((thisIndexPosition-currentStartPosition)> numColsInStartPred ||
-                        !considerJoinPredicateAsKey && thisPred.isJoinPredicate()){
+                        !considerJoinPredicateAsKey && thisPred.isHashableJoinPredicate()){
                     /*
                     ** There's a gap in the start positions.  Don't mark any
                     ** more predicates as start predicates.
@@ -1418,7 +1418,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
             /* Same as above, except for stop keys */
             if(currentStopPosition + numColsInStopPred <= thisIndexPosition || thisIndexPosition == -1){
                 if((thisIndexPosition-currentStopPosition)> numColsInStopPred ||
-                        !considerJoinPredicateAsKey && thisPred.isJoinPredicate()){
+                        !considerJoinPredicateAsKey && thisPred.isHashableJoinPredicate()){
                     gapInStopPositions=true;
                 }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ScanCostFunction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ScanCostFunction.java
@@ -666,10 +666,13 @@ public class ScanCostFunction{
      * @throws StandardException
      */
     public static double computeSelectivity(double selectivity, List<SelectivityHolder> holders) throws StandardException {
+        int level = 0;
         for (int i = 0; i< holders.size();i++) {
             // Do not include join predicates unless join strategy is nested loop.
-            if (holders.get(i).shouldApplySelectivity())
-                selectivity = computeSqrtLevel(selectivity,i,holders.get(i));
+            if (holders.get(i).shouldApplySelectivity()) {
+                selectivity = computeSqrtLevel(selectivity, level, holders.get(i));
+                level++;
+            }
         }
         return selectivity;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectivityUtil.java
@@ -84,7 +84,10 @@ public class SelectivityUtil {
 
 
     private static boolean isTheRightJoinPredicate(Predicate p, JoinPredicateType predicateType) {
-        if (p == null || !p.isJoinPredicate())
+        if (p == null || predicateType != JoinPredicateType.ALL && !p.isHashableJoinPredicate())
+            return false;
+
+        if (p.referencedSet.cardinality() < 2)
             return false;
 
         // only equality join conditions can be used for hashable joins to search for matching rows
@@ -298,7 +301,7 @@ public class SelectivityUtil {
     // Look for equality predicate that is not a join predicate
     private static boolean existsNonJoinPredicate(List<Predicate> predList) {
         for (Predicate predicate : predList) {
-            if (!predicate.isJoinPredicate() && !predicate.isFullJoinPredicate()) {
+            if (!predicate.isHashableJoinPredicate() && !predicate.isFullJoinPredicate()) {
                 return true;
             }
         }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeJoinStrategy.java
@@ -200,7 +200,7 @@ public class MergeJoinStrategy extends HashableJoinStrategy{
     private boolean isOuterTableEmpty(Optimizable innerTable, OptimizablePredicateList predList) throws StandardException{
         for (int i = 0; i < predList.size(); i++) {
             Predicate p = (Predicate) predList.getOptPredicate(i);
-            if (!p.isJoinPredicate()) continue;
+            if (!p.isHashableJoinPredicate()) continue;
             BinaryRelationalOperatorNode bron = (BinaryRelationalOperatorNode)p.getAndNode().getLeftOperand();
             ColumnReference outerColumn = null;
             if (bron.getLeftOperand() instanceof ColumnReference) {
@@ -239,7 +239,7 @@ public class MergeJoinStrategy extends HashableJoinStrategy{
         BitSet outerColumns = new BitSet(keyAscending.length);
         for(int p = 0;p<predList.size();p++){
             Predicate pred = (Predicate)predList.getOptPredicate(p);
-            if(pred.isJoinPredicate()) continue; //we'll deal with these later
+            if(pred.isHashableJoinPredicate()) continue; //we'll deal with these later
             RelationalOperator relop=pred.getRelop();
             if(!(relop instanceof BinaryRelationalOperatorNode)) continue;
             if(relop.getOperator()==RelationalOperator.EQUALS_RELOP) {
@@ -286,7 +286,7 @@ public class MergeJoinStrategy extends HashableJoinStrategy{
 
             for(int p=0;p<predList.size();p++){
                 Predicate pred = (Predicate)predList.getOptPredicate(p);
-                if(!pred.isJoinPredicate()) continue; //we've already dealt with those
+                if(!pred.isHashableJoinPredicate()) continue; //we've already dealt with those
                 RelationalOperator relop=pred.getRelop();
                 assert relop instanceof BinaryRelationalOperatorNode:
                         "Programmer error: RelationalOperator of type "+ relop.getClass()+" detected";

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SelectivityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/SelectivityIT.java
@@ -830,17 +830,17 @@ public class SelectivityIT extends SpliceUnitTest {
         rowContainsQuery(5,"explain select * from t11 a, t11 b, t11 c where a.a = b.a and b.a = c.a and a.a = c.a " +
                                               "and a.b = b.b and a.b = c.b","outputRows=3,",methodWatcher);
 
-        rowContainsQuery(2,"explain select * from t11 a, t11 b, t11 c where a.a = b.a and (a.b+a.a)/2 = b.a and a.a = c.a","outputRows=10,",methodWatcher);
+        rowContainsQuery(2,"explain select * from t11 a, t11 b, t11 c where a.a = b.a and (a.b+a.a)/2 = b.a and a.a = c.a","outputRows=8,",methodWatcher);
         rowContainsQuery(2,"explain select * from t11 a --splice-properties joinStrategy=nestedloop\n" +
                             ", t11 b --splice-properties joinStrategy=nestedloop\n" +
                             ", t11 c --splice-properties joinStrategy=nestedloop\n" +
                              "where a.a = b.a and (a.b+a.a)/2 = b.a and a.a = c.a","outputRows=10,",methodWatcher);
-        rowContainsQuery(2,"explain select * from t11 a, t11 b, t11 c where a.a = b.a and (a.b+a.a)/2 between b.a-1 and b.a+1 and a.a = c.a","outputRows=10,",methodWatcher);
+        rowContainsQuery(2,"explain select * from t11 a, t11 b, t11 c where a.a = b.a and (a.b+a.a)/2 between b.a-1 and b.a+1 and a.a = c.a","outputRows=8,",methodWatcher);
         rowContainsQuery(2,"explain select * from t11 a --splice-properties joinStrategy=nestedloop\n" +
                             ", t11 b --splice-properties joinStrategy=nestedloop\n" +
                             ", t11 c --splice-properties joinStrategy=nestedloop\n" +
                             "where a.a = b.a and (a.b+a.a)/2 between b.a-1 and b.a+1 and a.a = c.a","outputRows=10,",methodWatcher);
-        rowContainsQuery(2,"explain select * from t11 a, t11 b, t11 c where a.a = b.a and (c.a+a.a)/2 <> b.a and a.a = c.a","outputRows=10,",methodWatcher);
+        rowContainsQuery(2,"explain select * from t11 a, t11 b, t11 c where a.a = b.a and (c.a+a.a)/2 <> b.a and a.a = c.a","outputRows=8,",methodWatcher);
         rowContainsQuery(2,"explain select * from t11 a --splice-properties joinStrategy=nestedloop\n" +
                             ", t11 b --splice-properties joinStrategy=nestedloop\n" +
                             ", t11 c --splice-properties joinStrategy=nestedloop\n" +


### PR DESCRIPTION
## Short Description
A cross join of two tables is picking the large table as the right table and broadcasting it, leading to out of memory errors or query execution that runs seemingly forever.

## Long Description
Broadcast costs are dominating the execution of cross join when the broadcast table is large, but the cost formula estimates that the join costs are 3 orders of magnitude larger than remote cost of doing the broadcast.  

Remote cost formula:
> remoteCost = openLatency + closeLatency + totalRowCount * totalSelectivity * remoteLatency * (1+colSizeFactor/1024d)
remoteLatency is 10.0.

Join row cost formula:
> joiningRowCost = numOfJoinedRows * localLatency;
localLatency is 1.0, but the number of joined rows is so high that joiningRowCost dominates.

For a query of the form:

> select count(*) from
>        t1 BH, t1 BU
>        WHERE (BH.b='h' or BH.c='h') and
>              (BH.b=BU.b OR BH.c=BU.b)
>          AND BU.b <> 'h';

The join condition "(BH.b=BU.b OR BH.c=BU.b)" is included part of BH when considering (BU join BH), and as part of BU when considering (BH join BU).  When calculating scan selectivity, ScanCostFunction.computeSelectivity calls shouldApplySelectivity and correctly skips the join condition, however the argument to parameter "level" is passed as a value 1 higher than when BU is the inner table because we have one extra predicate:

>         for (int i = 0; i< holders.size();i++) {
>             // Do not include join predicates unless join strategy is nested loop.
>             if (holders.get(i).shouldApplySelectivity()) {
>                 selectivity = computeSqrtLevel(selectivity, i, holders.get(i));
>             }
>         }

This affects the exponential backoff in computeSqrtLevel and BU join BH appears to have more join rows than BH join BU.  Since the joiningRowCost dominates costs, we pick the join permutation that appears to join less rows, and end up broadcasting the large table.  The long-term solution may be to adjust the cost formulas to more accurately estimate broadcast costs.  The solution to this Jira is to fix exponential backoff to ignore levels that don't have their selectivity applied:
>             if (holders.get(i).shouldApplySelectivity()) {
>                 selectivity = computeSqrtLevel(selectivity, level, holders.get(i));
>                 level++;
>             }

Also, a change is made in isTheRightJoinPredicate when picking join predicates in estimateJoinSelectivity.  It currently skips predicates of type JoinPredicateType.ALL, probably because these predicates used to be counted as part of the scan selectivity.  But since we skip them in scan selectivity estimates now, they must be counted as part of join selectivity.  Function isJoinPredicate is renamed to isHashableJoinPredicate as it is applicable to hash-based joins for calls where JoinPredicateType is MERGE_SEARCH or HASH_SEARCH.  When JoinPredicateType is ALL, isTheRightJoinPredicate returns true if more than one table is referenced in the predicate (the opposite of the shouldApplySelectivity check in scan selectivity estimation).


## How to test

> drop table t1;
> create table t1 (a int, b varchar(10), c varchar(10));
> 
> insert into t1 values (1, 'a', 'a');
> insert into t1 values (1, 'a', 'a');
> insert into t1 values (1, 'a', 'a');
> insert into t1 values (1, 'a', 'a');
> insert into t1 values (1, 'a', 'a');
> insert into t1 values (1, 'a', 'a');
> insert into t1 values (1, 'a', 'a');
> insert into t1 values (1, 'a', 'a');
> insert into t1 values (1, 'a', 'a');
> insert into t1 values (1, 'a', 'a');
> 
> insert into t1 select * from t1;
> insert into t1 select * from t1;
> insert into t1 select * from t1;
> insert into t1 select * from t1;
> insert into t1 select * from t1;
> insert into t1 select * from t1;
> insert into t1 select * from t1;
> insert into t1 select * from t1;
> insert into t1 select * from t1;
> insert into t1 select * from t1;
> insert into t1 select * from t1;
> insert into t1 select * from t1;
> insert into t1 select * from t1;
> insert into t1 select * from t1;
> insert into t1 select * from t1;
> insert into t1 select * from t1;
> insert into t1 select * from t1;
> insert into t1 select * from t1;
> analyze table t1;
> explain
> select count(*) from
>        t1 BH, t1 BU
>        WHERE (BH.b='h' or BH.c='h') and
>              (BH.b=BU.b OR BH.c=BU.b)
>          AND BU.b <> 'h';
> 
The explain should pick BH as the right table:
> Plan
> ----
> Cursor(n=9,rows=1,updateMode=READ_ONLY (1),engine=OLAP (session hint))
>   ->  ScrollInsensitive(n=9,totalCost=3436036397.562,outputRows=1,outputHeapSize=0 B,partitions=1,parallelTasks=1)
>     ->  ProjectRestrict(n=8,totalCost=3435996965.562,outputRows=1,outputHeapSize=0 B,partitions=1,parallelTasks=1)
>       ->  GroupBy(n=7,totalCost=3435996965.562,outputRows=1,outputHeapSize=0 B,partitions=1,parallelTasks=1)
>         ->  ProjectRestrict(n=6,totalCost=3435992564.653,outputRows=2123366,outputHeapSize=12.15 MB,partitions=1,parallelTasks=1)
>           ->  CrossJoin(n=4,totalCost=3435992564.653,outputRows=2123366,outputHeapSize=12.15 MB,partitions=1,parallelTasks=1,preds=[((BH.B[4:2] = BU.B[4:1]) or ((BH.C[4:3] = BU.B[4:1]) or false))])
>             ->  TableScan[T1(2672)](n=2,totalCost=2782.726,scannedRows=2621440,outputRows=1310720,outputHeapSize=12.15 MB,partitions=1,parallelTasks=1,preds=[((BH.B[2:1] = h) or ((BH.C[2:2] = h) or false))])
>             ->  TableScan[T1(2672)](n=0,totalCost=2782.726,scannedRows=2621440,outputRows=2621440,outputHeapSize=5 MB,partitions=1,parallelTasks=1,preds=[(BU.B[0:1] <> h)])

