### PR TITLE
DB-11133: persist DDL demarcation point to zookeeper

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/AsynchronousDDLWatcher.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/AsynchronousDDLWatcher.java
@@ -76,6 +76,7 @@ public class AsynchronousDDLWatcher implements DDLWatcher,CommunicationListener{
         if(!checker.initialize(this))
             return; //we aren't a server, so do nothing further
 
+        refresher.initDemarcationPoint();
         try {
             // run refresh() synchronously the first time
             if (!refresher.refreshDDL(ddlListeners)) return;

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatchChecker.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatchChecker.java
@@ -34,4 +34,10 @@ public interface DDLWatchChecker{
     void notifyProcessed(Collection<Pair<DDLChange,String>> processedChanges) throws IOException;
 
     void killDDLTransaction(String key);
+
+    default void assignDDLDemarcationPoint(long txnId) throws Exception{}
+
+    default long initDemarcationPoint() throws IOException {
+        return 0;
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
This PR fixes an issue only happens if a region server restarts and lost most recent DDL demarcation point. The workload initiated(from a different region server) before  most recent DDL demarcation point may try to use data dictionary cache and read data that's not supposed to be visible to it.

## Long Description


For every DDL, we set a DDL demarcation point(transaction id) in DDL refresher. Any txns started earlier than this demarcation point is forbidden from reading/writing data dictionary cache, because the DDL may have changed data dictionary. The data dictionary cache can only contain data that's visible after demarcation point. However, demarcation point is not persisted. If a region server restarts, it loses the most recent DDL transaction id.

We have found in a rare case, a truncated, insert and region server restart can cause the write workload to be written to old base table and new index, thus causing a data inconsistency.

In the following case, a table is hosted by RS2. A insert was executed after the table is truncated from a different region server.

     
1  (RS1)insert into table 
2  (RS1)truncate a table with index                   (RS2) Restart

3   (RS1) keep retrying insert

4                                                                     (RS2)Restarted

5                                                                     (RS2)another workload queries the table. Table descriptor is read into  cache 

6                                                                     (RS2)write pipeline receives insert workload, queries cache, and sees new descriptor

At timeline 6, no demarcation point for truncate DDL was lost, so write pipeline uses data dictionary cache to find out indexes of the table. However, the descriptor in cache is for the table/index after truncate. In normal case without a restart, write pipeline can check demarcation point to find itself started earlier than most recent DDL, and decide to read data dictionary table(not cache).

This PR addresses this issue by persisting the most recent DDL transaction ID in ZooKeeper. If a region server restarts, it fetches the transaction ID from zookeeper.

## How to test
Extremely hard to reproduce manually. Please run Dmitry's test suite on srv056 repetitively to confirm this is fixed. Turn on debug trace for ZooKeeperDDLWatchChecker to confirm DDL demarcation point is set in zookeeper and retrieved every time a region server restarts.
