### PR TITLE
DB-11620 improve error message for missing ORDER BY in RANK

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RankFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RankFunctionNode.java
@@ -38,6 +38,7 @@ import java.util.List;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.types.TypeId;
+import com.splicemachine.db.shared.common.reference.SQLState;
 
 /**
  * Class that represents a call to the RANK() window function.
@@ -57,7 +58,7 @@ public final class RankFunctionNode extends WindowFunctionNode  {
         // the columns with which to create the ranking function node.
         List<OrderedColumn> orderByList = ((WindowDefinitionNode)arg2).getOrderByList();
         if (orderByList == null || orderByList.isEmpty()) {
-            SanityManager.THROWASSERT("Missing required ORDER BY clause for ranking window function.");
+            throw StandardException.newException(SQLState.LANG_SYNTAX_ERROR, "RANK requires an ORDER BY clause");
         }
 
         super.init(orderByList.get(0).getColumnExpression(), arg1, Boolean.FALSE, "RANK", arg2);

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WindowFunctionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/WindowFunctionIT.java
@@ -14,11 +14,14 @@
 
 package com.splicemachine.derby.impl.sql.execute.operations;
 
+import com.splicemachine.db.shared.common.reference.SQLState;
 import com.splicemachine.derby.test.framework.*;
 import com.splicemachine.homeless.TestUtils;
 import com.splicemachine.test.LongerThanTwoMinutes;
 import com.splicemachine.test_dao.TableDAO;
 import com.splicemachine.test_tools.TableCreator;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -43,6 +46,10 @@ import static org.junit.Assert.*;
  *
  * Created by jyuan on 7/30/14.
  */
+@SuppressFBWarnings({
+        "VA_FORMAT_STRING_USES_NEWLINE",
+        "RV_RETURN_VALUE_IGNORED" // todo: fix this
+})
 @SuppressWarnings("unchecked")
 @RunWith(Parameterized.class)
 @Category(LongerThanTwoMinutes.class)
@@ -1019,7 +1026,7 @@ public class WindowFunctionIT extends SpliceUnitTest {
     });
 
     @ClassRule
-    public static SpliceWatcher methodWatcher = new SpliceWatcher();
+    final public static SpliceWatcher methodWatcher = new SpliceWatcher();
 
 
     @Test
@@ -5443,4 +5450,20 @@ public class WindowFunctionIT extends SpliceUnitTest {
         assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         rs.close();
     }
+
+    @Test
+    public void testRankWithoutOrderByErrorMessage() throws Exception {
+        String sqlText = String.format("SELECT rank_col, rank() over (partition by rn/10) rnk from %s", this.getTableReference(EMPTAB));
+
+        try {
+            methodWatcher.execute(sqlText);
+            Assert.fail("expect exception");
+        }
+        catch(SQLException e) {
+            Assert.assertEquals("Syntax error: RANK requires an ORDER BY clause.", e.getMessage());
+            Assert.assertEquals(SQLState.LANG_SYNTAX_ERROR, e.getSQLState());
+        }
+    }
+
+
 }


### PR DESCRIPTION
## Description
This improves the error message if RANK is used without an ORDER BY clause.

## How to test

```
DROP TABLE WINDOW_RANK_BI_S.RANK_BIGINT_table;
CREATE TABLE WINDOW_RANK_BI_S.RANK_BIGINT_table (column_1 BIGINT, column_2 BIGINT);
INSERT INTO WINDOW_RANK_BI_S.RANK_BIGINT_table (column_2, column_1) values (-1820363457914885439, 2365922364770649437);

SELECT column_1, RANK() OVER () from WINDOW_RANK_BI_S.RANK_BIGINT_table ORDER BY 1 NULLS FIRST, 2 NULLS FIRST;
```

This should return an error like `ERROR 42X01: Syntax error: RANK requires an ORDER BY clause`