### PR TITLE
DB-11620 improve error message for missing ORDER BY in RANK (2.8)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RankFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RankFunctionNode.java
@@ -39,10 +39,12 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.shared.common.reference.SQLState;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Class that represents a call to the RANK() window function.
  */
+@SuppressFBWarnings(value="HE_INHERITS_EQUALS_USE_HASHCODE", justification = ".")
 public final class RankFunctionNode extends WindowFunctionNode  {
     /**
      * Initializer. QueryTreeNode override.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RankFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RankFunctionNode.java
@@ -38,6 +38,7 @@ import java.util.List;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.types.TypeId;
+import com.splicemachine.db.shared.common.reference.SQLState;
 
 /**
  * Class that represents a call to the RANK() window function.
@@ -57,7 +58,7 @@ public final class RankFunctionNode extends WindowFunctionNode  {
         // the columns with which to create the ranking function node.
         List<OrderedColumn> orderByList = ((WindowDefinitionNode)arg2).getOrderByList();
         if (orderByList == null || orderByList.isEmpty()) {
-            SanityManager.THROWASSERT("Missing required ORDER BY clause for ranking window function.");
+            throw StandardException.newException(SQLState.LANG_SYNTAX_ERROR, "RANK requires an ORDER BY clause");
         }
 
         super.init(orderByList.get(0).getColumnExpression(), arg1, Boolean.FALSE, "RANK", arg2);


### PR DESCRIPTION
## Description
This fixes `Types 'XXX' and 'CHAR' are not type compatible` error when using `select case when COND then X1 else X2 end` and **X1** or **X2** are `null`. 

## How to test
The following query should not fail after the fix:
```
CREATE TABLE T_CASE_WHEN_NULL (i INTEGER);
select * from T_CASE_WHEN_NULL where case when i > 0 then 2 else null end > 4 ;
select * from T_CASE_WHEN_NULL where case when i > 0 then null else 2 end > 4 ;
```
