### PR TITLE
DB-11639 Native spark cross join for DB2 mode

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
@@ -926,6 +926,11 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     @Override
     public DataSet<V> crossJoin(OperationContext context, DataSet<V> rightDataSet, Broadcast type) {
         try {
+            String varcharDB2CompatibilityModeString =
+                PropertyUtil.getCachedDatabaseProperty(context.getActivation().getLanguageConnectionContext(),
+                                                       Property.SPLICE_DB2_VARCHAR_COMPATIBLE);
+            boolean varcharDB2CompatibilityMode = Boolean.parseBoolean(varcharDB2CompatibilityModeString);
+
             Dataset<Row> leftDF = dataset;
             Dataset<Row> rightDF;
             if (rightDataSet instanceof NativeSparkDataSet) {
@@ -938,12 +943,48 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
             Column expr = null;
             int[] rightJoinKeys = ((JoinOperation)context.getOperation()).getRightHashKeys();
             int[] leftJoinKeys = ((JoinOperation)context.getOperation()).getLeftHashKeys();
+
+            List<String> extraColNamesLeft = new ArrayList<>();
+            List<Column> extraColumnsLeft = new ArrayList<>();
+            List<String> extraColNamesRight = new ArrayList<>();
+            List<Column> extraColumnsRight = new ArrayList<>();
             if ( leftJoinKeys!=null || rightJoinKeys!=null ) {
                 assert rightJoinKeys != null && leftJoinKeys != null && rightJoinKeys.length == leftJoinKeys.length : "Join Keys Have Issues";
+
+                Tuple2<String, String>[] leftColTypes = leftDF.dtypes();
+                Tuple2<String, String>[] rightColTypes = rightDF.dtypes();
+                String leftColNames[] = new String[rightJoinKeys.length];
+                String rightColNames[] = new String[rightJoinKeys.length];
+                boolean leftAdded = false;
+                boolean rightAdded = false;
+                // Add new rtrimmed join key columns for string types
+                // if using DB2 compatibility mode.
                 for (int i = 0; i < rightJoinKeys.length; i++) {
-                    Column joinEquality = (leftDF.col(ValueRow.getNamedColumn(leftJoinKeys[i]))
-                            .equalTo(rightDF.col(ValueRow.getNamedColumn(rightJoinKeys[i]))));
+                    leftColNames[i] = ValueRow.getNamedColumn(leftJoinKeys[i]);
+                    if (varcharDB2CompatibilityMode && leftColTypes[leftJoinKeys[i]]._2().equals("StringType")) {
+                        extraColumnsLeft.add(rtrim(col(leftColNames[i])));
+                        leftColNames[i] = leftColNames[i] + "_rtrimmed";
+                        extraColNamesLeft.add(leftColNames[i]);
+                        leftAdded = true;
+                    }
+                    rightColNames[i] = ValueRow.getNamedColumn(rightJoinKeys[i]);
+                    if (varcharDB2CompatibilityMode && rightColTypes[rightJoinKeys[i]]._2().equals("StringType")) {
+                        extraColumnsRight.add(rtrim(col(rightColNames[i])));
+                        rightColNames[i] = rightColNames[i] + "_rtrimmed";
+                        extraColNamesRight.add(rightColNames[i]);
+                        rightAdded = true;
+                    }
+                }
+                if (leftAdded)
+                    leftDF = NativeSparkUtils.withColumns(extraColNamesLeft, extraColumnsLeft, leftDF);
+                if (rightAdded)
+                    rightDF = NativeSparkUtils.withColumns(extraColNamesRight, extraColumnsRight, rightDF);
+
+                for (int i = 0; i < rightJoinKeys.length; i++) {
+                    Column joinEquality = (leftDF.col(leftColNames[i]).equalTo(rightDF.col(rightColNames[i])));
                     expr = i != 0 ? expr.and(joinEquality) : joinEquality;
+                    leftDF = leftDF.filter(leftColNames[i] + " IS NOT NULL");
+                    rightDF = rightDF.filter(rightColNames[i] + " IS NOT NULL");
                 }
             }
             Dataset<Row> joinedDF;
@@ -962,6 +1003,11 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
             if (expr != null) {
                 joinedDF = joinedDF.filter(expr);
             }
+            if (!extraColNamesLeft.isEmpty())
+                joinedDF = joinedDF.drop(extraColNamesLeft.toArray(new String[0]));
+            if (!extraColNamesRight.isEmpty())
+                joinedDF = joinedDF.drop(extraColNamesRight.toArray(new String[0]));
+
             DataSet joinedSet = new NativeSparkDataSet(joinedDF, context);
             NativeSparkDataSet nds = (NativeSparkDataSet)joinedSet;
             SpliceOperation op = context.getOperation();

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkDataSet.java
@@ -22,6 +22,7 @@ import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.impl.sql.compile.ExplainNode;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
 import com.splicemachine.derby.impl.SpliceSpark;
+import com.splicemachine.derby.impl.sql.execute.operations.CrossJoinOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.DMLWriteOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.MultiProbeTableScanOperation;
 import com.splicemachine.derby.impl.sql.execute.operations.export.ExportExecRowWriter;
@@ -68,6 +69,8 @@ import java.io.OutputStream;
 import java.util.*;
 import java.util.concurrent.Future;
 import java.util.zip.GZIPOutputStream;
+
+import static org.apache.spark.api.java.StorageLevels.*;
 
 /**
  *

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/DB2VarcharCompatibilityIT.java
@@ -179,6 +179,8 @@ public class DB2VarcharCompatibilityIT extends SpliceUnitTest {
         testQuery(sqlText, expected, methodWatcher);
         sqlText = format(sqlTemplate, "SORTMERGE");
         testQuery(sqlText, expected, methodWatcher);
+        sqlText = format(sqlTemplate, "CROSS");
+        testQuery(sqlText, expected, methodWatcher);
         sqlText = format(sqlTemplate2, "NESTEDLOOP", "NESTEDLOOP");
         testQuery(sqlText, expected, methodWatcher);
     }


### PR DESCRIPTION
## Short Description
Implements native spark cross join for DB2 varchar compatibility mode.

## Long Description
When cross join cannot run natively in spark it has a broadcast join implementation to fill the gap.  This implementation does not honor the flag indicating the right table should not be cached.  Previously, when splice.db2.varchar.compatible is set to true, a cross join selected by the optimizer does not qualify for native spark, so if the join planner ever mistakenly picks the large table as the right table of cross join we can hit an out of memory condition if the table is too large to be broadcast.

Fix:
Implement native spark cross join for DB2 mode by adding trimmed join columns so trailing spaces are ignored.  Also add IS NOT NULL conditions on the left and right join keys.  The remaining case that can't use native spark cross join is equijoin on columns of the REAL data type.  Possibly this case could be handled in native spark in the future as well, and the non-native spark path can be eliminated entirely. 

## How to test
Create different tables with varchar columns and join the together with the following property enabled:
> call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', true);

Check for incorrect results.