### PR TITLE
DB-11605 fix using NULL in case when/else (3.0)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CastNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CastNode.java
@@ -127,36 +127,12 @@ public class CastNode extends ValueNode
                     DataTypeDescriptor castTarget,
                     ContextManager cm) throws StandardException {
         super(cm);
+        setNodeType(C_NodeTypes.CAST_NODE);
         this.castOperand = castOperand;
         setType(castTarget);
     }
 
-    /**
-     * Constructor for a CastNode
-     *
-     * @param castOperand    The operand of the node
-     * @param charType        CHAR or VARCHAR JDBC type as target
-     * @param charLength    target type length
-     * @param cm            The context manager
-     *
-     * @exception StandardException        Thrown on error
-     */
-
-    public CastNode(ValueNode castOperand,
-                    int charType,
-                    int charLength,
-                    ContextManager cm) throws StandardException {
-        super(cm);
-        this.castOperand = castOperand;
-        targetCharType = charType;
-        if (charLength < 0)    // unknown, figure out later
-            return;
-        requestedStringLength = charLength;
-        setType(DataTypeDescriptor.getBuiltInDataTypeDescriptor(targetCharType, charLength));
-    }
-
     public CastNode() {
-
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLGrammarImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLGrammarImpl.java
@@ -1314,4 +1314,14 @@ class SQLGrammarImpl {
         }
         return buf.toString();
     }
+
+    ValueNode getNullForCase() throws StandardException {
+
+        ValueNode untypedNullConstantNode = (ValueNode) nodeFactory.getNode(C_NodeTypes.UNTYPED_NULL_CONSTANT_NODE, cm);
+        DataTypeDescriptor type = DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.CHAR, 1);
+        ValueNode value = new CastNode(untypedNullConstantNode, type, cm);
+        ((CastNode) value).setForExternallyGeneratedCASTnode();
+        ((CastNode) value).setForNullsInConditionalNode();
+        return value;
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/sqlgrammar.jj
@@ -14993,15 +14993,7 @@ caseInnerExpression(ValueNode compareTo) throws StandardException :
 {
     <END>
     {
-        ValueNode value = (ValueNode) nodeFactory.getNode(
-                                        C_NodeTypes.CAST_NODE,
-                                        (ValueNode) nodeFactory.getNode(C_NodeTypes.UNTYPED_NULL_CONSTANT_NODE,
-                                                                        getContextManager()),
-                                        DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.CHAR, 1),
-                                        getContextManager());
-        ((CastNode) value).setForExternallyGeneratedCASTnode();
-        ((CastNode) value).setForNullsInConditionalNode();
-        return value;
+        return getNullForCase();
     }
 |
     <ELSE> expr = thenElseExpression() <END>
@@ -15063,14 +15055,7 @@ thenElseExpression() throws StandardException :
     LOOKAHEAD ( {getToken(1).kind == NULL} )
     <NULL>
     {
-        ValueNode value = (ValueNode) nodeFactory.getNode(
-                                        C_NodeTypes.CAST_NODE,
-                                        (ValueNode) nodeFactory.getNode(C_NodeTypes.UNTYPED_NULL_CONSTANT_NODE,
-                                                                        getContextManager()),
-                                        DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.CHAR, 1),
-                                        getContextManager());
-        ((CastNode) value).setForExternallyGeneratedCASTnode();
-        return value;
+        return getNullForCase();
     }
 |
     expr = additiveExpression(null, 0)

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NullPredicateIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NullPredicateIT.java
@@ -273,4 +273,13 @@ public class NullPredicateIT extends SpliceUnitTest {
             Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         }
     }
+
+    @Test // DB-11605
+    public void testNullInCaseWhen() throws Exception {
+        String res = "A | B  |\n" +
+                "---------\n" +
+                " 1 |aaa |";
+        methodWatcher.assertStrResult(res, "select * from t where case when a < 0 then null else 2 end > 0", false);
+        methodWatcher.assertStrResult(res, "select * from t where case when a > 0 then 2 else null end > 0", false);
+    }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceWatcher.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.derby.test.framework;
 
+import com.splicemachine.homeless.TestUtils;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.rules.TestWatcher;
@@ -336,7 +337,7 @@ public class SpliceWatcher extends TestWatcher implements AutoCloseable {
             return s.executeUpdate(sql);
         }
     }
-    
+
     public boolean execute(String sql) throws Exception {
         try(Statement s = getOrCreateConnection().createStatement()) {
             return s.execute(sql);
@@ -435,6 +436,14 @@ public class SpliceWatcher extends TestWatcher implements AutoCloseable {
         {
             Assert.assertTrue(rs.next());
             return rs.getString(index);
+        }
+    }
+
+    public void assertStrResult(String res, String query, Boolean sort) throws Exception {
+        try(ResultSet rs = executeQuery(query)) {
+            String out = sort ? TestUtils.FormattedResult.ResultFactory.toString(rs) :
+                    TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
+            Assert.assertEquals(res, out);
         }
     }
 }


### PR DESCRIPTION
## Description
This fixes `Types 'XXX' and 'CHAR' are not type compatible` error when using `select case when COND then X1 else X2 end` and **X1** or **X2** are `null`. 

## How to test
The following query should not fail after the fix:
```
CREATE TABLE T_CASE_WHEN_NULL (i INTEGER);
select * from T_CASE_WHEN_NULL where case when i > 0 then 2 else null end > 4 ;
select * from T_CASE_WHEN_NULL where case when i > 0 then null else 2 end > 4 ;
```
