### PR TITLE
DB-11445 skip checking older versions once row accumulation is complete.

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/scanner/SITableScanner.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/scanner/SITableScanner.java
@@ -207,7 +207,7 @@ public class SITableScanner<Data> implements StandardIterator<ExecRow>,AutoClose
             }else{
                 DataCell currentKeyValue = keyValues.get(0);
                 if(template.nColumns()>0){
-                    if(!filterRowKey(currentKeyValue)||!filterRow(filter,keyValues)){
+                    if(!(filterRowKey(currentKeyValue) && filterRow(filter,keyValues))){
                         //filter the row first, then filter the row key
                         filterCounter.increment();
                         continue;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/scanner/SITableScanner.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/scanner/SITableScanner.java
@@ -326,7 +326,12 @@ public class SITableScanner<Data> implements StandardIterator<ExecRow>,AutoClose
                              * This logic tries to avoid performing transactional resolution when we are not actually interested
                              * in the value anyway. In some cases we read a column which the accumulator is not interested in
                              * but we have to transactionally resolve anyway, for instance if the field we are actually interested
-                             * in is on the rowkey.
+                             * in is on the rowkey, i.e. in SITableScanner#next() we do the following:
+                             *      if(!(filterRowKey(currentKeyValue) && filterRow(filter,keyValues))){
+                             *          // filter out the row
+                             *      }
+                             * filterRowKey does not perform SI delegating it to filterRow which ends up calling this method,
+                             * so even if the accumulator finished, we still want to SI in this case.
                              */
                             if (keyValue.dataType() == CellType.USER_DATA  && (!accumulator.isInteresting(keyValue) || accumulator.isFinished()) && keyIncluded){
                                 return ReturnCode.INCLUDE;

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/filter/PackedTxnFilter.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/filter/PackedTxnFilter.java
@@ -98,17 +98,24 @@ public class PackedTxnFilter implements TxnFilter, SIFilter{
         }
     }
 
-    public DataFilter.ReturnCode accumulate(DataCell data) throws IOException{
-        if(!accumulator.isFinished() && !excludeRow && accumulator.isInteresting(data)){
-            if(!accumulator.accumulateCell(data)){
-                excludeRow=true;
+    public DataFilter.ReturnCode accumulate(DataCell data) throws IOException {
+        boolean isFinished = accumulator.isFinished();
+        boolean isInteresting = accumulator.isInteresting(data);
+        // no need to proceed further investigating previous versions, we're done.
+        if (isFinished && !isInteresting) {
+            return DataFilter.ReturnCode.NEXT_ROW;
+        }
+        if (!isFinished && !excludeRow && isInteresting) {
+            if (!accumulator.accumulateCell(data)) {
+                excludeRow = true;
             }
         }
-        if(lastValidCell==null){
-            lastValidCell=data;
+        if (lastValidCell == null) {
+            lastValidCell = data;
             return DataFilter.ReturnCode.INCLUDE;
-        }else
+        } else {
             return DataFilter.ReturnCode.SKIP;
+        }
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
Skip checking older versions of a row once accumulating its columns finishes

## Long Description
When we do an index scan, we do two things:
1. Scan hbase index conglomerate to identify affected index row(s).
2. For each index row, we look it up in the base table to add any missing columns.

In the second step, we were unnecessarily scanning all base table user_data versions, if the number of updates is relatively small, this is OK since the user_data versions is not too big, however if we are doing too many updates in a table with min. retention period (MRP) defined -effectively preventing flushes- it could become very costly to go through previous versions.

## How to test
Create a table with a large amount of updates:

```
call SYSCS_UTIL.SET_MIN_RETENTION_PERIOD('SPLICE',null, 604800);
drop table t2 if exists;
create table t2(col1 int, col2 varchar(20), col3 varchar(20));
create index i2 on t2(col2, col3);
insert into t2 values (1,'a','a');
insert into t2 values (1,'a','a');
insert into t2 values (1,'a','a');
insert into t2 values (1,'a','a');
insert into t2 values (1,'a','a');
insert into t2 values (1,'a','a');
insert into t2 values (1,'a','a');
insert into t2 values (1,'a','a');
insert into t2 values (1,'a','a');
insert into t2 values (1,'a','a');
update t2 set col2 = 'z', col3 = 'y', col1 = 1 ;
update t2 set col2 = 'z', col3 = 'y', col1 = 2 ;
update t2 set col2 = 'z', col3 = 'y', col1 = 3 ;
update t2 set col2 = 'z', col3 = 'y', col1 = 4 ;
-- maybe thousands of these updates
-- ..
update t2 set col2 = 'z', col3 = 'y', col1 = 5000 ;
-- following select takes seconds in master but only few ms with this PR
select * from t2 --splice-properties index=i2 -- [1]
; 
```

I ran the benchmark on master and DB-11445 and got the following results, we measure the time needed for index scan statement ([1] in script above), all times are in milliseconds.

<table>
<tr>
	<td>#updates
	<td>master
	<td>DB-11445
<tr>
	<td>1000
	<td>45.3
	<td>38.3
<tr>
	<td>2000
	<td>403.3
	<td>191.3
<tr>
	<td>3000
	<td>8164.7
	<td>206
<tr>
	<td>4000
	<td>17479
	<td>245.7
</table>