### PR TITLE
DB-11636: fix avg aggregator regression

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/ProtobufUtils.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/ProtobufUtils.java
@@ -10,8 +10,7 @@ import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.util.ByteArray;
 import com.splicemachine.db.impl.services.uuid.BasicUUID;
 import com.splicemachine.db.impl.sql.*;
-import com.splicemachine.db.impl.sql.execute.FKInfo;
-import com.splicemachine.db.impl.sql.execute.TriggerInfo;
+import com.splicemachine.db.impl.sql.execute.*;
 import com.splicemachine.utils.ByteSlice;
 
 import java.io.IOException;
@@ -362,6 +361,22 @@ public class ProtobufUtils {
             case BaseTypeIdImpl:
             default:
                 return new BaseTypeIdImpl(baseTypeId);
+        }
+    }
+
+    public static SumAggregator toSumAggregator(CatalogMessage.SystemAggregator ag) throws IOException, ClassNotFoundException {
+        CatalogMessage.SystemAggregator.Type t = ag.getType();
+        switch (t) {
+            case SumAggregator:
+                return new SumAggregator(ag);
+            case DecimalBufferedSumAggregator:
+                return new DecimalBufferedSumAggregator(ag);
+            case DoubleBufferedSumAggregator:
+                return new DoubleBufferedSumAggregator(ag);
+            case LongBufferedSumAggregator:
+                return new LongBufferedSumAggregator(ag);
+            default:
+                throw new RuntimeException("Unexpected type " + t);
         }
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/AvgAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/AvgAggregator.java
@@ -36,10 +36,7 @@ import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 import com.splicemachine.db.iapi.services.loader.ClassFactory;
 import com.splicemachine.db.iapi.sql.execute.ExecAggregator;
-import com.splicemachine.db.iapi.types.DataTypeDescriptor;
-import com.splicemachine.db.iapi.types.DataValueDescriptor;
-import com.splicemachine.db.iapi.types.NumberDataValue;
-import com.splicemachine.db.iapi.types.TypeId;
+import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.db.impl.sql.CatalogMessage;
 
 import java.io.IOException;
@@ -339,6 +336,6 @@ public final class AvgAggregator extends OrderableAggregator
 		count = avgAggregator.getCount();
 		scale = avgAggregator.getScale();
 		CatalogMessage.SystemAggregator ag = avgAggregator.getSumAggregator();
-		aggregator = new SumAggregator(ag);
+		aggregator = ProtobufUtils.toSumAggregator(ag);
 	}
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DecimalBufferedSumAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DecimalBufferedSumAggregator.java
@@ -56,17 +56,21 @@ public class DecimalBufferedSumAggregator extends SumAggregator {
 
 	private BigDecimal sum = BigDecimal.ZERO;
 	private boolean isNull = true;
+	private int bufferSize;
 
 	public DecimalBufferedSumAggregator() { // SERDE
 
 	}
 
 	public DecimalBufferedSumAggregator(CatalogMessage.SystemAggregator agg) throws IOException, ClassNotFoundException {
-		this(64);
 		init(agg);
 	}
 
 	public DecimalBufferedSumAggregator(int bufferSize) {
+		init(bufferSize);
+	}
+
+	private void init(int bufferSize) {
 		int s = 1;
 		while(s<bufferSize){
 			s<<=1;
@@ -74,8 +78,8 @@ public class DecimalBufferedSumAggregator extends SumAggregator {
 		buffer = new BigDecimal[s];
 		this.length = s-1;
 		position = 0;
+		this.bufferSize = bufferSize;
 	}
-
 	@Override
 	protected void accumulate(DataValueDescriptor addend) throws StandardException {
 		buffer[position] = getBigDecimal(addend);
@@ -145,6 +149,7 @@ public class DecimalBufferedSumAggregator extends SumAggregator {
 					CatalogMessage.DecimalBufferedSumAggregator.newBuilder()
 							.setIsNull(isNull)
 							.setSum(ByteString.copyFrom(bs))
+							.setBufferSize(bufferSize)
 							.build();
 
 			CatalogMessage.SystemAggregator.Builder builder = super.toProtobufBuilder();
@@ -165,6 +170,7 @@ public class DecimalBufferedSumAggregator extends SumAggregator {
 			 ObjectInputStream ois = new ObjectInputStream(bis)) {
 			this.sum =	(BigDecimal)ois.readObject();
 		}
+		init(aggregator.getBufferSize());
 	}
 
 	@Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DecimalBufferedSumAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DecimalBufferedSumAggregator.java
@@ -61,6 +61,11 @@ public class DecimalBufferedSumAggregator extends SumAggregator {
 
 	}
 
+	public DecimalBufferedSumAggregator(CatalogMessage.SystemAggregator agg) throws IOException, ClassNotFoundException {
+		this(64);
+		init(agg);
+	}
+
 	public DecimalBufferedSumAggregator(int bufferSize) {
 		int s = 1;
 		while(s<bufferSize){

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DoubleBufferedSumAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DoubleBufferedSumAggregator.java
@@ -57,17 +57,21 @@ public class DoubleBufferedSumAggregator extends SumAggregator{
 
 	private java.util.TreeMap<Integer, MutableDouble> sumTree;
 	private boolean isNull = true;
+    private int bufferSize;
 
 	public DoubleBufferedSumAggregator() {}
 	public DoubleBufferedSumAggregator(int bufferSize) {
 		this(bufferSize, null);
 	}
 	public DoubleBufferedSumAggregator(CatalogMessage.SystemAggregator agg) throws IOException, ClassNotFoundException {
-		this(64);
 		init(agg);
 	}
 
 	public DoubleBufferedSumAggregator(int bufferSize, TreeMap<Integer, MutableDouble> tree) {
+		init(bufferSize, tree);
+	}
+
+	private void init(int bufferSize, TreeMap<Integer, MutableDouble> tree) {
 		if (tree == null)
 			sumTree = new TreeMap<>();
 		else
@@ -79,6 +83,7 @@ public class DoubleBufferedSumAggregator extends SumAggregator{
 		buffer = new double[s];
 		this.length = s-1;
 		position = 0;
+		this.bufferSize = bufferSize;
 	}
 
 	@Override
@@ -158,6 +163,7 @@ public class DoubleBufferedSumAggregator extends SumAggregator{
 					CatalogMessage.DoubleBufferedSumAggregator.newBuilder()
 							.setIsNull(isNull)
 							.setSumTree(ByteString.copyFrom(bs))
+							.setBufferSize(bufferSize)
 							.build();
 			CatalogMessage.SystemAggregator.Builder builder = super.toProtobufBuilder();
 			builder.setType(CatalogMessage.SystemAggregator.Type.DoubleBufferedSumAggregator)
@@ -178,6 +184,7 @@ public class DoubleBufferedSumAggregator extends SumAggregator{
 			 ObjectInputStream ois = new ObjectInputStream(bis)) {
 			this.sumTree =	(TreeMap<Integer, MutableDouble>)ois.readObject();
 		}
+		init(aggregator.getBufferSize(), null);
 	}
 
 	@Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DoubleBufferedSumAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DoubleBufferedSumAggregator.java
@@ -62,6 +62,11 @@ public class DoubleBufferedSumAggregator extends SumAggregator{
 	public DoubleBufferedSumAggregator(int bufferSize) {
 		this(bufferSize, null);
 	}
+	public DoubleBufferedSumAggregator(CatalogMessage.SystemAggregator agg) throws IOException, ClassNotFoundException {
+		this(64);
+		init(agg);
+	}
+
 	public DoubleBufferedSumAggregator(int bufferSize, TreeMap<Integer, MutableDouble> tree) {
 		if (tree == null)
 			sumTree = new TreeMap<>();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/LongBufferedSumAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/LongBufferedSumAggregator.java
@@ -57,10 +57,16 @@ public class LongBufferedSumAggregator extends SumAggregator {
 	private long sum = 0;
 	private boolean isNull = true; //set to false when elements are added
 
+	private int bufferSize;
+
 	public LongBufferedSumAggregator() {
 
 	}
 	public LongBufferedSumAggregator(int bufferSize) {
+		init(bufferSize);
+	}
+
+	private void init(int bufferSize) {
 		int s = 1;
 		while(s<bufferSize){
 			s<<=1;
@@ -68,10 +74,10 @@ public class LongBufferedSumAggregator extends SumAggregator {
 		buffer = new long[s];
 		this.length = s-1;
 		position = 0;
+		this.bufferSize = bufferSize;
 	}
 
 	public LongBufferedSumAggregator(CatalogMessage.SystemAggregator agg) throws IOException, ClassNotFoundException {
-		this(64);
 		init(agg);
 	}
 
@@ -142,6 +148,7 @@ public class LongBufferedSumAggregator extends SumAggregator {
 				CatalogMessage.LongBufferedSumAggregator.newBuilder()
 						.setIsNull(isNull)
 						.setSum(sum)
+						.setBufferSize(bufferSize)
 						.build();
 		builder.setType(CatalogMessage.SystemAggregator.Type.LongBufferedSumAggregator)
 				.setExtension(CatalogMessage.LongBufferedSumAggregator.longBufferedSumAggregator, aggregator);
@@ -155,6 +162,7 @@ public class LongBufferedSumAggregator extends SumAggregator {
 				systemAggregator.getExtension(CatalogMessage.LongBufferedSumAggregator.longBufferedSumAggregator);
 		this.isNull = aggregator.getIsNull();
 		this.sum = aggregator.getSum();
+		init(aggregator.getBufferSize());
 	}
 
 	@Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/LongBufferedSumAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/LongBufferedSumAggregator.java
@@ -70,6 +70,11 @@ public class LongBufferedSumAggregator extends SumAggregator {
 		position = 0;
 	}
 
+	public LongBufferedSumAggregator(CatalogMessage.SystemAggregator agg) throws IOException, ClassNotFoundException {
+		this(64);
+		init(agg);
+	}
+
 	@Override
 	protected void accumulate(DataValueDescriptor addend) throws StandardException {
 		buffer[position] = addend.getLong();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/MaxMinAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/MaxMinAggregator.java
@@ -105,7 +105,7 @@ public final class MaxMinAggregator extends OrderableAggregator {
 	@Override
 	protected void writeExternalOld(ObjectOutput out) throws IOException {
 		out.writeBoolean(isMax);
-		super.writeExternal(out);
+		super.writeExternalOld(out);
 	}
 
 	/**
@@ -141,7 +141,7 @@ public final class MaxMinAggregator extends OrderableAggregator {
 		CatalogMessage.MaxMinAggregator aggregator =
 				systemAggregator.getExtension(CatalogMessage.MaxMinAggregator.maxMinAggregator);
 		isMax = aggregator.getIsMax();
-		value = ProtobufUtils.fromProtobuf(aggregator.getValue());
+		value = aggregator.hasValue() ? ProtobufUtils.fromProtobuf(aggregator.getValue()) : null;
 	}
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/SumAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/SumAggregator.java
@@ -51,7 +51,7 @@ public  class SumAggregator extends OrderableAggregator
 	public SumAggregator() {}
 
 	public SumAggregator(CatalogMessage.SystemAggregator systemAggregator) throws IOException, ClassNotFoundException  {
-	    super.init(systemAggregator);
+	    init(systemAggregator);
 	}
 
 	@Override
@@ -171,13 +171,20 @@ public  class SumAggregator extends OrderableAggregator
 
 	@Override
 	protected CatalogMessage.SystemAggregator.Builder toProtobufBuilder() throws IOException{
+		CatalogMessage.SumAggregator.Builder sumAggregatorBuilder = CatalogMessage.SumAggregator.newBuilder();
+		if (value != null) {
+			sumAggregatorBuilder.setValue(value.toProtobuf());
+		}
 		CatalogMessage.SystemAggregator.Builder builder = super.toProtobufBuilder();
-		builder.setType(CatalogMessage.SystemAggregator.Type.SumAggregator);
+		builder.setType(CatalogMessage.SystemAggregator.Type.SumAggregator)
+				.setExtension(CatalogMessage.SumAggregator.sumAggregator, sumAggregatorBuilder.build());
 		return builder;
 	}
 
 	@Override
 	protected void init(CatalogMessage.SystemAggregator systemAggregator) throws IOException, ClassNotFoundException {
 		super.init(systemAggregator);
+		CatalogMessage.SumAggregator sumAggregator = systemAggregator.getExtension(CatalogMessage.SumAggregator.sumAggregator);
+		value = sumAggregator.hasValue() ? ProtobufUtils.fromProtobuf(sumAggregator.getValue()) : null;
 	}
 }

--- a/db-engine/src/main/protobuf/Derby.proto
+++ b/db-engine/src/main/protobuf/Derby.proto
@@ -202,6 +202,7 @@ message DecimalBufferedSumAggregator {
   }
   optional bool isNull = 1;
   optional bytes sum = 2;
+  optional int32 bufferSize = 3;
 }
 
 message DoubleBufferedSumAggregator {
@@ -211,6 +212,7 @@ message DoubleBufferedSumAggregator {
   }
   optional bool isNull = 1;
   optional bytes sumTree = 2;
+  optional int32 bufferSize = 3;
 }
 
 message LongBufferedSumAggregator {
@@ -220,6 +222,7 @@ message LongBufferedSumAggregator {
   }
   optional bool isNull = 1;
   optional int64 sum = 2;
+  optional int32 bufferSize = 3;
 }
 
 message MaxMinAggregator {

--- a/db-engine/src/main/protobuf/Derby.proto
+++ b/db-engine/src/main/protobuf/Derby.proto
@@ -245,6 +245,7 @@ message SumAggregator {
   {
     required SumAggregator sumAggregator = 1007;
   }
+  optional DataValueDescriptor value = 1;
 }
 
 message CursorTableReference {


### PR DESCRIPTION
## Short Description
A regression due to serialization changes to avg aggregator

## Long Description
The SumAggregator included in a AvgAggregator can be one of LongBufferedSumAggregator, DecimalBufferedSumAggregator, or DoubleBufferedSumAggregator. When it is deserialized, we should find out its correct data type and construct the right aggregator.

## How to test
This is only reproducible if a grouped aggregation is executed a normal spark processor (not native spark). To disable native spark, set the following database property

```
call syscs_util.syscs_set_global_database_property('splice.execution.nativeSparkAggregationMode', 'off');
create table AG (a int, b real, c bigint, d decimal(15,2));
insert into AG values(1, 1, 2, 3);
insert into AG values(2, 1, 2, 3);
insert into AG values(3, 1, 2, 3);

insert into AG select a, b+1, c+1, d+1 from AG
insert into AG select a, b+1, c+1, d+1 from AG
insert into AG select a, b+1, c+1, d+1 from AG
insert into AG select a, b+1, c+1, d+1 from AG
```

This query should not fail with NPE
```
select a, avg(b), avg(c), avg(d) from ag --splice-properties useSpark=true
group by a order by a;
```