### PR TITLE
DB-11610 fix broken SYSCAT.INDEXCOLUSE

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSCONGLOMERATESRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSCONGLOMERATESRowFactory.java
@@ -441,6 +441,7 @@ public class SYSCONGLOMERATESRowFactory extends CatalogRowFactory
     }
 
     final public static Pair<Integer, String> SYSCAT_INDEXCOLUSE_VIEW_SQL = new Pair<>(1,
+            "create view INDEXCOLUSE as \n" +
             "    SELECT  \n" +
             "           S.SCHEMANAME AS INDSCHEMA, \n" +
             "           CONGLOMS.CONGLOMERATENAME AS INDNAME, \n" +

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ViewIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ViewIT.java
@@ -131,6 +131,12 @@ public class ViewIT {
         finally {
             methodWatcher.execute("DROP SEQUENCE ViewIT_SEQUENCE RESTRICT");
         }
+    }
 
+    @Test
+    public void testINDEXCOLUSE() throws Exception {
+        try ( ResultSet rs = methodWatcher.executeQuery("select * from syscat.indexcoluse")) {
+            Assert.assertTrue(TestUtils.FormattedResult.ResultFactory.toString(rs).contains("SYSALIASES_INDEX1"));
+        }
     }
 }


### PR DESCRIPTION
## Description
DB-11610 broke SYSCAT.INDEXCOLUSE, this fixes it.

## How to test
`select * from syscat.indexcoluse` should execute normally (added IT now).