### PR TITLE
DB-11622 Fix cost accumulation and NLJ cost function

### DIFF
--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/IndexPrefixIterationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/IndexPrefixIterationIT.java
@@ -237,7 +237,8 @@ public class IndexPrefixIterationIT  extends SpliceUnitTest {
             "----\n" +
             " 1 |";
 
-        containedStrings = Arrays.asList("IndexScan", "T11_IX4", "IndexPrefixIteratorMode(129 values)", "scannedRows=1");
+        String indexName = useSpark ? "T11_IX4" : "T11_IX1";
+        containedStrings = Arrays.asList("IndexScan", indexName, "IndexPrefixIteratorMode(129 values)", "scannedRows=1");
         testQuery(query, expected, methodWatcher);
         testExplainContains(query, methodWatcher, containedStrings, notContainedStrings);
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/JoinOrderJumpModeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/JoinOrderJumpModeIT.java
@@ -247,7 +247,7 @@ public class JoinOrderJumpModeIT extends SpliceUnitTest {
                 new String[] {"Join"},                                                        // 14
                 new String[] {"Scan["},                                                       // 16, IndexScan on mem but TableScan on cdh
                 new String[] {"Join"},                                                        // 17
-                new String[] {"TableScan[TABLE_5", "scannedRows=800,outputRows=800"},         // 18
+                new String[] {"TableScan[TABLE_5", "scannedRows=1,outputRows=1"},             // 18
                 new String[] {"Join"},                                                        // 19
                 new String[] {"TableScan[TABLE_4", "scannedRows=1,outputRows=1"},             // 20
                 new String[] {"Join"},                                                        // 21


### PR DESCRIPTION
## Short Description
This change fixes performance regression of the query reported in DB-11622.

## Long Description
Before this change, we have two issues in cost estimation:
1. Cost accumulation is generally done as per parallel task except for the first table access, from which total cost is accumulated.
2. NLJ cost function always multiply outer rows by inner total cost. Essentially, this means we believe inner table access can be perfectly parallelized in case of broadcast join, sort merge join, and merge join, but not NLJ and cross join. When inner table access cost is high and number of parallelism is also high, this difference makes NLJ lose immediately.

In this change, 1 is fixed by accumulating per task cost for the first table access. 2 is improved by making NLJ uses inner table per task cost so that its cost is estimated under the same assumption as other join strategies.

## How to test
On 1TB data set, DB-11622 query should finish within 2 s after the fix. Without the fix and on optimizer branch, the query doesn't finish in 7 hours.
