### PR TITLE
DB-11625 Support both operands of concat to be parameters

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryComparisonOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryComparisonOperatorNode.java
@@ -155,6 +155,12 @@ public abstract class BinaryComparisonOperatorNode extends BinaryOperatorNode
         TypeId leftTypeId = getLeftOperand().getTypeId();
         TypeId rightTypeId = getRightOperand().getTypeId();
 
+        if (leftTypeId.isStringTypeId() && rightTypeId.isStringTypeId() &&
+                (leftTypeId.isLongVarcharTypeId() || rightTypeId.isLongVarcharTypeId())) {
+            castLeftOperandAndBindCast(DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, true));
+            castRightOperandAndBindCast(DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, true));
+        }
+
         if (! leftTypeId.isStringTypeId() && rightTypeId.isStringTypeId())
         {
             setRightOperand(addCastNodeForStringToNonStringComparison(getLeftOperand(), getRightOperand()));

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorNode.java
@@ -454,12 +454,21 @@ public abstract class OperatorNode extends ValueNode
     }
 
     public void castOperandAndBindCast(int operandIndex, DataTypeDescriptor type) throws StandardException {
+        castOperandAndBindCast(operandIndex, type, false);
+    }
+
+    public void castOperandAndBindCast(int operandIndex, DataTypeDescriptor type, boolean implicit) throws StandardException {
         operands.set(operandIndex,
                 (ValueNode) getNodeFactory().getNode(
                         C_NodeTypes.CAST_NODE,
                         operands.get(operandIndex),
                         type,
                         getContextManager()));
+        if (implicit) {
+            // DERBY-2910 - Match current schema collation for implicit cast as we do for
+            // explicit casts per SQL Spec 6.12 (10)
+            operands.get(operandIndex).setCollationUsingCompilationSchema();
+        }
         ((CastNode) operands.get(operandIndex)).bindCastNodeOnly();
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/PreparedStatementIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/PreparedStatementIT.java
@@ -625,4 +625,31 @@ public class PreparedStatementIT extends SpliceUnitTest {
             methodWatcher.execute("call syscs_util.syscs_set_global_database_property('splice.bind.cursorUntypedExpressionType', null)");
         }
     }
+
+    @Test
+    public void testConcatUnknownParameters() throws Exception {
+        testParamsHelper("select ? || ?",
+                new Object[] {"abc", "def"},
+                "1   |\n" +
+                        "--------\n" +
+                        "abcdef |");
+
+        testParamsHelper("select ? || ? = ? || ?",
+                new Object[] {"abc", "def", "abc", "def"},
+                "1  |\n" +
+                        "------\n" +
+                        "true |");
+
+        testParamsHelper("select varchar('abc' || 'def') = ? || ?",
+                new Object[] {"abc", "def"},
+                "1  |\n" +
+                        "------\n" +
+                        "true |");
+
+        testParamsHelper("select char('abc' || 'def') = ? || ?",
+                new Object[] {"abc", "def"},
+                "1  |\n" +
+                        "------\n" +
+                        "true |");
+    }
 }


### PR DESCRIPTION
## Short Description

Assume operands types of `? || ?` to be VARCHAR

## Long Description

Two things are introduced by this PR:
1. We assume both operands of the concatenation operator to be VARCHAR if they are both unkwnon
2. We cast LONG VARCHAR back to VARCHAR when trying to compare LONG VARCHAR to another string type

The second point is necessary because the result of `? || ?` is of type LONG VARCHAR

## How to test

```
prepare foo as 'select ? || ?';
execute foo using 'values (''abc'', ''def'')';
1
-
abcdef

prepare foo as 'select ''abcdef'' = ? || ?';
execute foo using 'values (''abc'', ''def'')';
1
-
true
```