### PR TITLE
DB-11613 Fix NPE in aggregate queries with repeated predicates

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/ast/ISpliceVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/ast/ISpliceVisitor.java
@@ -49,11 +49,11 @@ public interface ISpliceVisitor {
     boolean stopTraversal();
     boolean skipChildren(Visitable node);
 
-	/**
-	 * Return the low-level Visitor instead of the wrapper class
-	 * in case this is an ASTVisitor.
-	 */
-	default ISpliceVisitor getVisitor() { return this; }
+    /**
+     * Return the low-level Visitor instead of the wrapper class
+     * in case this is an ASTVisitor.
+     */
+    default ISpliceVisitor getVisitor() { return this; }
 
     Visitable defaultVisit(Visitable node) throws StandardException;
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/ast/ISpliceVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/ast/ISpliceVisitor.java
@@ -34,6 +34,7 @@ package com.splicemachine.db.iapi.ast;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.compile.CompilationPhase;
 import com.splicemachine.db.iapi.sql.compile.Visitable;
+import com.splicemachine.db.iapi.sql.compile.Visitor;
 import com.splicemachine.db.impl.sql.compile.*;
 
 /**
@@ -47,6 +48,12 @@ public interface ISpliceVisitor {
     boolean isPostOrder();
     boolean stopTraversal();
     boolean skipChildren(Visitable node);
+
+	/**
+	 * Return the low-level Visitor instead of the wrapper class
+	 * in case this is an ASTVisitor.
+	 */
+	default ISpliceVisitor getVisitor() { return this; }
 
     Visitable defaultVisit(Visitable node) throws StandardException;
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Visitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Visitor.java
@@ -31,6 +31,7 @@
 
 package	com.splicemachine.db.iapi.sql.compile;
 
+import com.splicemachine.db.iapi.ast.ISpliceVisitor;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.impl.sql.compile.QueryTreeNode;
 
@@ -116,4 +117,10 @@ public interface Visitor
 	 * @return true/false
 	 */
 	boolean skipChildren(Visitable node) throws StandardException;
+
+	/**
+	 * Return the low-level Visitor instead of the wrapper class
+	 * in case this is an ASTVisitor.
+	 */
+	default ISpliceVisitor getBaseVisitor() { return null; }
 }	

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/SpliceDerbyVisitorAdapter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/SpliceDerbyVisitorAdapter.java
@@ -37,6 +37,7 @@ import com.splicemachine.db.iapi.reference.MessageId;
 import com.splicemachine.db.iapi.sql.compile.ASTVisitor;
 import com.splicemachine.db.iapi.sql.compile.CompilationPhase;
 import com.splicemachine.db.iapi.sql.compile.Visitable;
+import com.splicemachine.db.iapi.sql.compile.Visitor;
 import com.splicemachine.db.impl.sql.compile.QueryTreeNode;
 import org.apache.log4j.Logger;
 import splice.com.google.common.cache.Cache;
@@ -136,4 +137,7 @@ public class SpliceDerbyVisitorAdapter implements ASTVisitor {
     public boolean skipChildren(Visitable node) throws StandardException {
         return v.skipChildren(node);
     }
+
+    @Override
+    public ISpliceVisitor getBaseVisitor() { return v.getVisitor(); }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
@@ -47,6 +47,7 @@ import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.impl.ast.CollectingVisitor;
 import com.splicemachine.db.impl.ast.ColumnCollectingVisitor;
 import com.splicemachine.db.impl.ast.LimitOffsetVisitor;
+import com.splicemachine.db.impl.ast.RepeatedPredicateVisitor;
 import splice.com.google.common.base.Predicates;
 
 import java.sql.Types;
@@ -2156,13 +2157,25 @@ public class SelectNode extends ResultSetNode{
             fromList=(FromList)fromList.accept(v, this);
         }
         if(whereClause!=null){
+            if (v.getBaseVisitor() instanceof RepeatedPredicateVisitor)
+                ((RepeatedPredicateVisitor)v.getBaseVisitor()).setAggregateVector(whereAggregates);
+
             whereClause=(ValueNode)whereClause.accept(v, this);
+
+            if (v.getBaseVisitor() instanceof RepeatedPredicateVisitor)
+                ((RepeatedPredicateVisitor)v.getBaseVisitor()).setAggregateVector(null);
         }
         if(wherePredicates!=null){
             wherePredicates=(PredicateList)wherePredicates.accept(v, this);
         }
         if(havingClause!=null){
+            if (v.getBaseVisitor() instanceof RepeatedPredicateVisitor)
+                ((RepeatedPredicateVisitor)v.getBaseVisitor()).setAggregateVector(havingAggregates);
+
             havingClause=(ValueNode)havingClause.accept(v, this);
+
+            if (v.getBaseVisitor() instanceof RepeatedPredicateVisitor)
+                ((RepeatedPredicateVisitor)v.getBaseVisitor()).setAggregateVector(null);
         }
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
@@ -2157,13 +2157,7 @@ public class SelectNode extends ResultSetNode{
             fromList=(FromList)fromList.accept(v, this);
         }
         if(whereClause!=null){
-            if (v.getBaseVisitor() instanceof RepeatedPredicateVisitor)
-                ((RepeatedPredicateVisitor)v.getBaseVisitor()).setAggregateVector(whereAggregates);
-
             whereClause=(ValueNode)whereClause.accept(v, this);
-
-            if (v.getBaseVisitor() instanceof RepeatedPredicateVisitor)
-                ((RepeatedPredicateVisitor)v.getBaseVisitor()).setAggregateVector(null);
         }
         if(wherePredicates!=null){
             wherePredicates=(PredicateList)wherePredicates.accept(v, this);

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/GroupedAggregateOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/GroupedAggregateOperationIT.java
@@ -265,4 +265,36 @@ public class GroupedAggregateOperationIT extends SpliceUnitTest {
         rs.close();
     }
 
+    @Test()
+    public void testAggregateWithRepeatedPredicate() throws Exception {
+        String sqlText = format("SELECT\n" +
+                                "A.C1, SUM(A.DIFFERENZ)\n" +
+                                "FROM ( SELECT A1.C1,C2+1 AS DIFFERENZ FROM %s WHERE A1.C1 = 'A100001' ) A,\n" +
+                                "%s B\n" +
+                                "WHERE A.C1 = B.C1\n" +
+                                "GROUP BY A.C1\n" +
+                                "HAVING\n" +
+                                "(\n" +
+                                "(\n" +
+                                "SUM(DIFFERENZ) >= 4999\n" +
+                                "AND A.C1 <> 'A100001'\n" +
+                                ")\n" +
+                                "OR\n" +
+                                "(\n" +
+                                "SUM(DIFFERENZ) >= 4999\n" +
+                                "AND A.C1 = 'A100001'\n" +
+                                "AND '10' = '10'\n" +
+                                ")\n" +
+                                "OR ( SUM(DIFFERENZ) <= 1000 AND A.C1 = 'A100001' AND '10' <> '10')\n" +
+                                ")",spliceTableWatcher3,spliceTableWatcher3);
+
+        try (ResultSet rs = methodWatcher.executeQuery(sqlText)) {
+            String expected =
+            "C1    |      2       |\n" +
+            "------------------------\n" +
+            "A100001 |6000001511955 |";
+            assertEquals("\n" + sqlText + "\n", expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        }
+    }
+
 }


### PR DESCRIPTION
## Short Description
Fixes NullPointerException in aggregate queries with repeated predicates;

## Long Description
For a query such as:

```
EXPLAIN SELECT
    A.C1, SUM(A.DIFFERENZ)
    FROM ( SELECT A1.C1,C2+1 AS "DIFFERENZ" FROM A1 WHERE A1.C1 = '' ) A, A1 B
    WHERE A.C1 = B.C1
    GROUP BY A.C1
    HAVING ((SUM(DIFFERENZ) <= 4999 AND A.C1 <> '') OR
            (SUM(DIFFERENZ) <= 4999 AND A.C1 = '' AND '10' = '10') OR
            (SUM(DIFFERENZ) <= 1000 AND A.C1 = '' AND '10' <> '10'));
```

The predicate SUM(DIFFERENZ) <= 4999 is repeated, and ends up getting factored out of the OR'ed predicates by RepeatedPredicateVisitor and replaced with a new predicate instance in a top-level AND.  

Root cause:
When processing a SelectNode we pass aggregate vector "havingAggregates" to bindExpression in the binding phase:
`havingClause.bindExpression(fromListParam,havingSubquerys,havingAggregates);`

... which adds all found AggregateNodes to havingAggregates.
Then in post-binding phase RepeatedPredicateVisitor is called and the havingClause is rewritten with new predicates.  havingAggregates now contains AggregateNodes not present in the havingClause because they were referenced in predicates that were pruned out.

In the optimizer phase we replace the AggregateNodes with new column references:

>         if(havingClause!=null){
>             // replace aggregates in the having clause with column references.
>             replaceAggsVisitor=new ReplaceAggregatesWithCRVisitor((ResultColumnList)getNodeFactory().getNode(
>                     C_NodeTypes.RESULT_COLUMN_LIST,
>                     getContextManager()),
>                     ((FromTable)childResult).getTableNumber());
>             havingClause.accept(replaceAggsVisitor);
>             // make having clause a restriction list in the parent
>             // project restrict node.
>             ProjectRestrictNode parentPRSN=(ProjectRestrictNode)parent;
>             parentPRSN.setRestriction(havingClause);
>         } 
... which updates the AggregateNode with the replacement ColumnReference to use:

>             generatedRef = (ColumnReference) getNodeFactory().getNode(
>                     C_NodeTypes.COLUMN_REFERENCE,
>                     generatedRC.getName(),
>                     null,
>                     getContextManager());

We then look in the SelectNode's aggregate vectors and build the projection of each of the AggregateNodes.  Any AggregateNodes that were pruned out by RepeatedPredicateVisitor were never visited and never got generatedRef set, so this field is null.
Then when trying to access generatedRef, we get a null value and attempt to dereference it: 

>             /*
>             ** Set the column reference to point to
>             ** this.
>             */
>             newColumnRef=aggregate.getGeneratedRef();
>             newColumnRef.setSource(tmpRC);

The fix is to create a new Visitor, AggregateVectorCleaner, which will remove any AggregateNodes lying under pruned predicates from the appopriate aggregate vector.  The replacement nodes are scanned for the new AggregateNode to use, and it is added to the aggregate vector.

## How to test
The following query should not error out:

```
drop table t1;
create table t1 (a int, b dec(18,3), c dec(18,3));

EXPLAIN SELECT A.A, SUM(A.DIFFERENZ)
    FROM ( SELECT T1.A,B-C+1 AS "DIFFERENZ" FROM T1 WHERE T1.A = 1 ) A, T1 B
    WHERE A.A = B.A
    GROUP BY A.A
    HAVING ( (SUM(DIFFERENZ) <= 4999 AND A.A <> 1) OR
             (SUM(DIFFERENZ) <= 4999 AND A.A = 1 AND '10' = '10') OR
             (SUM(DIFFERENZ) <= 1000 AND A.A = 1 AND '10' <> '10')
           );
```

