### PR TITLE
DB-11676: recover from data dictionary serialization upgrade failure

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/TransactionController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/TransactionController.java
@@ -1730,4 +1730,6 @@ public interface TransactionController
 	void closeMe(ScanController scan);
 
 	void rewritePropertyConglomerate() throws StandardException;
+
+	void recoverPropertyConglomerateIfNecessary() throws StandardException;
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/db/BasicDatabase.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/db/BasicDatabase.java
@@ -511,6 +511,10 @@ public class BasicDatabase implements ModuleControl, ModuleSupportable, Property
         TransactionController tc = af.getTransaction(
                 ContextService.getFactory().getCurrentContextManager());
 
+        // If a pre-2003 build failed to upgraded to a post-2003 build, property conglomerate may be in an
+        // inconsistent state. Restore it before trying to retrieve database properties.
+        tc.recoverPropertyConglomerateIfNecessary();
+
         String  upgradeID = null;
         UUID    databaseID;
 

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/PartitionAdmin.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/PartitionAdmin.java
@@ -15,11 +15,13 @@
 package com.splicemachine.access.api;
 
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.impl.sql.compile.HashableJoinStrategy;
 import com.splicemachine.storage.Partition;
 import com.splicemachine.storage.PartitionServer;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -58,7 +60,7 @@ public interface PartitionAdmin extends AutoCloseable{
     void deleteSnapshot(String snapshotName) throws IOException;
 
     default Set<String> listSnapshots() throws IOException {
-        throw new RuntimeException("Not implemented");
+        return new HashSet();
     }
 
     void restoreSnapshot(String snapshotName) throws IOException;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -142,10 +142,16 @@ public class SpliceCatalogUpgradeScripts{
         return scripts;
     }
 
-    public static void runAllScripts(List<VersionAndUpgrade> upgradeNeeded) throws StandardException {
+    public static void runAllScripts(List<VersionAndUpgrade> upgradeNeeded,
+                                     SpliceDataDictionary sdd,
+                                     TransactionController tc) throws StandardException {
         if( upgradeNeeded.size() == 0 ) {
             LOG.info("No upgrade needed.");
             return;
+        }
+        if (sdd != null) {
+            // Recover from previous failed upgrade from pre-2003 to post-2003 release
+            UpgradeUtils.recoverFromPreviousFailedUpgrade(sdd, tc);
         }
         LOG.info("Running " + upgradeNeeded.size() + " upgrade scripts:");
         for( VersionAndUpgrade el : upgradeNeeded ) {
@@ -167,7 +173,7 @@ public class SpliceCatalogUpgradeScripts{
             currentVersion=new Splice_DD_Version(null,configuration.getUpgradeForcedFrom());
         }
         try {
-            runAllScripts(getScriptsToUpgrade(scripts, currentVersion));
+            runAllScripts(getScriptsToUpgrade(scripts, currentVersion), sdd, tc);
         }
         catch (StandardException e) {
             if (UpgradeConglomerateTable.isTableCreated()) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeConglomerateTable.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeConglomerateTable.java
@@ -8,8 +8,6 @@ import com.splicemachine.derby.impl.sql.catalog.SpliceDataDictionary;
 import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.utils.SpliceLogUtils;
 
-import java.io.IOException;
-
 public class UpgradeConglomerateTable extends UpgradeScriptBase {
 
     private static boolean tableCreated = false;
@@ -23,12 +21,13 @@ public class UpgradeConglomerateTable extends UpgradeScriptBase {
         PartitionAdmin admin = null;
         try {
             admin = SIDriver.driver().getTableFactory().getAdmin();
-            if (!admin.tableExists(HBaseConfiguration.CONGLOMERATE_SI_TABLE_NAME)) {
-                admin.createSITable(HBaseConfiguration.CONGLOMERATE_SI_TABLE_NAME);
-                admin.setCatalogVersion(HBaseConfiguration.CONGLOMERATE_SI_TABLE_NAME, "1");
-                UpgradeUtils.initializeConglomerateSITable(tc);
-                tableCreated = true;
+            if (admin.tableExists(HBaseConfiguration.CONGLOMERATE_SI_TABLE_NAME)){
+                admin.deleteTable(HBaseConfiguration.CONGLOMERATE_SI_TABLE_NAME);
             }
+            admin.createSITable(HBaseConfiguration.CONGLOMERATE_SI_TABLE_NAME);
+            admin.setCatalogVersion(HBaseConfiguration.CONGLOMERATE_SI_TABLE_NAME, "1");
+            UpgradeUtils.initializeConglomerateSITable(tc);
+            tableCreated = true;
         }
         catch (Exception e) {
             // If upgrade fails for some reasons, roll back CONGLOMERATE_SI table and throw an exception

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/PropertyConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/PropertyConglomerate.java
@@ -726,7 +726,7 @@ public class PropertyConglomerate {
             }
         }
 
-        tc.snapshot(propertiesConglomId + "_snapshot", Long.toString(propertiesConglomId));
+        tc.snapshot(propertiesConglomId + "_upgrade", Long.toString(propertiesConglomId));
         tc.truncate(Long.toString(propertiesConglomId));
 
         try (ConglomerateController cc =
@@ -736,11 +736,22 @@ public class PropertyConglomerate {
                              TransactionController.OPENMODE_FORUPDATE,
                              TransactionController.MODE_TABLE,
                              TransactionController.ISOLATION_SERIALIZABLE)) {
+
             for (DataValueDescriptor[] row : rows) {
                 ExecRow vRow = new ValueRow();
                 vRow.setRowArray(row);
                 cc.insert(vRow);
             }
+        }
+    }
+
+    public void recoverPropertyConglomerateIfNecessary(TransactionController tc) throws StandardException {
+        Set<String> snapshots = tc.listSnapshots();
+        String snapshotName = propertiesConglomId + "_upgrade";
+        if (snapshots.contains(snapshotName)) {
+            tc.truncate(Long.toString(propertiesConglomId));
+            tc.cloneSnapshot(snapshotName, Long.toString(propertiesConglomId));
+            tc.deleteSnapshot(snapshotName);
         }
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransactionManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransactionManager.java
@@ -2034,4 +2034,9 @@ public class SpliceTransactionManager implements XATransactionController,
     public void rewritePropertyConglomerate() throws StandardException {
         accessmanager.getTransactionalProperties().rewritePropertyConglomerate(this);
     }
+
+    @Override
+    public void recoverPropertyConglomerateIfNecessary() throws StandardException {
+        accessmanager.getTransactionalProperties().recoverPropertyConglomerateIfNecessary(this);
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/ConglomerateUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/ConglomerateUtils.java
@@ -79,7 +79,11 @@ public class ConglomerateUtils{
         try {
             PartitionAdmin partitionAdmin = SIDriver.driver().getTableFactory().getAdmin();
             if (partitionAdmin.tableExists(HBaseConfiguration.CONGLOMERATE_SI_TABLE_NAME)) {
-                return readConglomerate(conglomId, instanceClass, txn, HBaseConfiguration.CONGLOMERATE_SI_TABLE_NAME);
+                try {
+                    return readConglomerate(conglomId, instanceClass, txn, HBaseConfiguration.CONGLOMERATE_SI_TABLE_NAME);
+                } catch (Exception e) {
+                    return readConglomerate(conglomId, instanceClass, txn, HBaseConfiguration.CONGLOMERATE_TABLE_NAME);
+                }
             }
             else {
                 return readConglomerate(conglomId, instanceClass, txn, HBaseConfiguration.CONGLOMERATE_TABLE_NAME);

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
@@ -115,7 +115,7 @@ public class SpliceCatalogUpgradeScriptsTest {
         Assert.assertEquals( 0, SpliceCatalogUpgradeScripts.getScriptsToUpgrade(list,
                 new Splice_DD_Version(null, 4,0,0, 0)).size() );
 
-        SpliceCatalogUpgradeScripts.runAllScripts(list);
+        SpliceCatalogUpgradeScripts.runAllScripts(list, null, null);
         Assert.assertEquals(4, counter[0]);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
If upgrade from pre-2003 to post-2003 aborts abruptly, system tables are left in an inconsistent state. This PR roll back previous upgrade in next startup

## Long Description

If upgrade from pre-2003 to post-2003 aborts abruptly, system tables are left in an inconsistent state - some system tables are encoded in new serialization format, while others are still in old format. For next restart, master server will have problem reading objects from system tables.

This PR address this problem by rolling back the previous failed upgrade. All tables that has been rewritten using new serialization format are truncated. The backup tables that are still in old serialization format are restored. The upgrade process will start from scratch.

## How to test
During an upgrade from pre-2003 to post-2003 release, tail master server log. The following logging messages mark the beginning and end of upgrade.

Start upgrading data dictionary serialization format.
...
Finished upgrading data dictionary serialization format successfully.

Stop master server in between and start again. Upgrade should succeed in next restart.
