### PR TITLE
DB-11267 add SYSVW.SYSTRIGGERSVIEW

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSALIASESRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSALIASESRowFactory.java
@@ -119,9 +119,9 @@ public class SYSALIASESRowFactory extends CatalogRowFactory {
 
     private ColumnDescriptor[] getSYSALIAS_TO_TABLE_VIEW_SQL(TableDescriptor view, UUID viewId) {
         return new ColumnDescriptor[]{
-                getCD(view, viewId, "SCHEMANAME", Types.VARCHAR, 1, false, 128),
-                getCD(view, viewId, "ALIAS", Types.VARCHAR, 2, false, 128),
-                getCD(view, viewId, "BASETABLE", Types.VARCHAR, 3, false, 256)
+                getCD(view, viewId, "SCHEMANAME", 1, Types.VARCHAR, false, 128),
+                getCD(view, viewId, "ALIAS",      2, Types.VARCHAR, false, 128),
+                getCD(view, viewId, "BASETABLE",  3, Types.VARCHAR, false, 256)
         };
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSALIASESRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSALIASESRowFactory.java
@@ -134,7 +134,7 @@ public class SYSALIASESRowFactory extends CatalogRowFactory {
                 "ALIASTYPE,\n" +
                 "NAMESPACE,\n" +
                 "SYSTEMALIAS,\n" +
-                "cast(ALIASINFO AS VARCHAR(32)) AS ALIASINFO,\n" +
+                "cast(ALIASINFO AS LONG VARCHAR) AS ALIASINFO,\n" +
                 "SPECIFICNAME\n" +
                 "FROM SYS.SYSALIASES");
 
@@ -146,9 +146,9 @@ public class SYSALIASESRowFactory extends CatalogRowFactory {
                 getCD(view, viewId, "JAVACLASSNAME", 4, Types.LONGVARCHAR, false),
                 getCD(view, viewId, "ALIASTYPE",     5, Types.CHAR, false, 1),
                 getCD(view, viewId, "NAMESPACE",     6, Types.CHAR, false, 1),
-                getCD(view, viewId, "SYSTEMALIAS",   7, Types.BOOLEAN, false, 1),
-                getCD(view, viewId, "ALIASINFO",     8, Types.VARCHAR, true, 1),
-                getCD(view, viewId, "SPECIFICNAME",  9, Types.VARCHAR, false, 36)
+                getCD(view, viewId, "SYSTEMALIAS",   7, Types.BOOLEAN, false),
+                getCD(view, viewId, "ALIASINFO",     8, Types.LONGVARCHAR, true),
+                getCD(view, viewId, "SPECIFICNAME",  9, Types.VARCHAR, false, 128)
         };
     }
 
@@ -412,7 +412,7 @@ public class SYSALIASESRowFactory extends CatalogRowFactory {
                 SystemColumnImpl.getUUIDColumn(ALIASID, false),
                 SystemColumnImpl.getIdentifierColumn(ALIAS, false),
                 SystemColumnImpl.getUUIDColumn(SCHEMAID, true),
-                SystemColumnImpl.getColumn(JAVACLASSNAME, java.sql.Types.LONGVARCHAR, false, Integer.MAX_VALUE),
+                SystemColumnImpl.getColumn(JAVACLASSNAME, java.sql.Types.LONGVARCHAR, true, Integer.MAX_VALUE),
                 SystemColumnImpl.getIndicatorColumn(ALIASTYPE),
                 SystemColumnImpl.getIndicatorColumn(NAMESPACE),
                 SystemColumnImpl.getColumn(SYSTEMALIAS, Types.BOOLEAN, false),

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSALIASESRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSALIASESRowFactory.java
@@ -40,6 +40,7 @@ import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.sql.execute.ExecutionFactory;
 import com.splicemachine.db.iapi.types.*;
+import com.splicemachine.utils.Pair;
 
 import java.sql.Types;
 import java.util.ArrayList;
@@ -105,14 +106,51 @@ public class SYSALIASESRowFactory extends CatalogRowFactory {
                     , "c013800d-00d7-ddbe-c4e1-000a0a411400"    // SYSALIASES_INDEX2
                     , "c013800d-00d7-ddbe-34ae-000a0a411400"    // SYSALIASES_INDEX3
             };
-    public static String SYSALIAS_TO_TABLE_VIEW_SQL = "create view SYSALIASTOTABLEVIEW as \n" +
+
+    final public static Pair<Integer, String> SYSALIAS_TO_TABLE_VIEW_SQL = new Pair<>(0,
+            "create view SYSALIASTOTABLEVIEW as \n" +
             "SELECT S.SCHEMANAME, A.alias as ALIAS, cast(A.ALIASINFO as varchar(256)) as BASETABLE \n" +
             "FROM \n" +
             "SYS.SYSALIASES A, SYS.SYSTABLES T, SYSVW.SYSSCHEMASVIEW S \n" +
             "WHERE A.ALIASTYPE = 'S' AND \n" +
             "S.SCHEMAID = T.SCHEMAID AND \n" +
             "A.SCHEMAID = T.SCHEMAID AND \n" +
-            "A.ALIAS = T.TABLENAME";
+            "A.ALIAS = T.TABLENAME");
+
+    private ColumnDescriptor[] getSYSALIAS_TO_TABLE_VIEW_SQL(TableDescriptor view, UUID viewId) {
+        return new ColumnDescriptor[]{
+                getCD(view, viewId, "SCHEMANAME", Types.VARCHAR, 1, false, 128),
+                getCD(view, viewId, "ALIAS", Types.VARCHAR, 2, false, 128),
+                getCD(view, viewId, "BASETABLE", Types.VARCHAR, 3, false, 256)
+        };
+    }
+
+    final public static Pair<Integer, String> SYSALIASESVIEW_SQL = new Pair<>(1,
+            "CREATE VIEW SYSALIASESVIEW AS SELECT\n" +
+                "ALIASID,\n" +
+                "ALIAS,\n" +
+                "SCHEMAID,\n" +
+                "JAVACLASSNAME,\n" +
+                "ALIASTYPE,\n" +
+                "NAMESPACE,\n" +
+                "SYSTEMALIAS,\n" +
+                "cast(ALIASINFO AS VARCHAR(32)) AS ALIASINFO,\n" +
+                "SPECIFICNAME\n" +
+                "FROM SYS.SYSALIASES");
+
+    private ColumnDescriptor[] getSYSALIASESVIEW_SQL(TableDescriptor view, UUID viewId) {
+        return new ColumnDescriptor[]{
+                getCD(view, viewId, "ALIASID",       1, Types.CHAR, false, 36),
+                getCD(view, viewId, "ALIAS",         2, Types.VARCHAR, false, 128),
+                getCD(view, viewId, "SCHEMAID",      3, Types.CHAR, true, 36),
+                getCD(view, viewId, "JAVACLASSNAME", 4, Types.LONGVARCHAR, false),
+                getCD(view, viewId, "ALIASTYPE",     5, Types.CHAR, false, 1),
+                getCD(view, viewId, "NAMESPACE",     6, Types.CHAR, false, 1),
+                getCD(view, viewId, "SYSTEMALIAS",   7, Types.BOOLEAN, false, 1),
+                getCD(view, viewId, "ALIASINFO",     8, Types.VARCHAR, true, 1),
+                getCD(view, viewId, "SPECIFICNAME",  9, Types.VARCHAR, false, 36)
+        };
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     //
@@ -386,18 +424,10 @@ public class SYSALIASESRowFactory extends CatalogRowFactory {
     public List<ColumnDescriptor[]> getViewColumns(TableDescriptor view, UUID viewId) throws StandardException {
 
         List<ColumnDescriptor[]> cdsl = new ArrayList<>();
-        cdsl.add(
-                new ColumnDescriptor[]{
-                        new ColumnDescriptor("SCHEMANAME", 1, 1,
-                                DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, false, 128),
-                                null, null, view, viewId, 0, 0, 0),
-                        new ColumnDescriptor("ALIAS", 2, 2,
-                                DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, false, 128),
-                                null, null, view, viewId, 0, 0, 0),
-                        new ColumnDescriptor("BASETABLE", 3, 3,
-                                DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, false, 256),
-                                null, null, view, viewId, 0, 0, 0)
-                });
+        assert SYSALIAS_TO_TABLE_VIEW_SQL.getFirst() == cdsl.size();
+        cdsl.add(getSYSALIAS_TO_TABLE_VIEW_SQL(view, viewId));
+        assert SYSALIASESVIEW_SQL.getFirst() == cdsl.size();
+        cdsl.add( getSYSALIASESVIEW_SQL(view, viewId) );
         return cdsl;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTRIGGERSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTRIGGERSRowFactory.java
@@ -549,7 +549,7 @@ public class SYSTRIGGERSRowFactory extends CatalogRowFactory {
                 getCD(view, viewId, "OLDREFERENCINGNAME",    16, Types.VARCHAR, true, 128),
                 getCD(view, viewId, "NEWREFERENCINGNAME",    17, Types.VARCHAR, true, 128),
                 getCD(view, viewId, "WHENCLAUSETEXT",        18, Types.LONGVARCHAR, true),
-                getCD(view, viewId, "TRIGGERDEFINITIONLIST", 19, Types.VARCHAR, true, 64),
+                getCD(view, viewId, "TRIGGERDEFINITIONLIST", 19, Types.LONGVARCHAR, true),
                 getCD(view, viewId, "ACTIONSTMTIDLIST",      20, Types.VARCHAR, true, 64),
         };
     }
@@ -574,7 +574,7 @@ public class SYSTRIGGERSRowFactory extends CatalogRowFactory {
                     "OLDREFERENCINGNAME,\n" +
                     "NEWREFERENCINGNAME,\n" +
                     "WHENCLAUSETEXT,\n" +
-                    "cast(TRIGGERDEFINITIONLIST AS VARCHAR(64)) AS TRIGGERDEFINITIONLIST,\n" +
+                    "cast(TRIGGERDEFINITIONLIST AS LONG VARCHAR) AS TRIGGERDEFINITIONLIST,\n" +
                     "cast(ACTIONSTMTIDLIST AS VARCHAR(64)) AS ACTIONSTMTIDLIST\n" +
                     "FROM sys.SYSTRIGGERS");
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTRIGGERSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTRIGGERSRowFactory.java
@@ -42,6 +42,7 @@ import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.sql.execute.ExecutionFactory;
 import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.db.impl.sql.execute.TriggerEventDML;
+import com.splicemachine.utils.Pair;
 
 import java.sql.Timestamp;
 import java.sql.Types;
@@ -519,4 +520,61 @@ public class SYSTRIGGERSRowFactory extends CatalogRowFactory {
             return true;
         }
     }
+
+    public List<ColumnDescriptor[]> getViewColumns(TableDescriptor view, UUID viewId) throws StandardException {
+
+        List<ColumnDescriptor[]> cdsl = new ArrayList<>();
+        assert cdsl.size() == SYSVW_SYSTRIGGERSVIEW_SQL.getFirst();
+        cdsl.add( getSYSVW_SYSTRIGGERSVIEW_SQL_ColumnDescriptor(view, viewId) );
+        return cdsl;
+    }
+
+    private ColumnDescriptor[] getSYSVW_SYSTRIGGERSVIEW_SQL_ColumnDescriptor(TableDescriptor view, UUID viewId) {
+        return new ColumnDescriptor[]{
+                getCD(view, viewId, "TRIGGERID",             1, Types.CHAR, false, 36),
+                getCD(view, viewId, "TRIGGERNAME",           2, Types.VARCHAR, false, 128),
+                getCD(view, viewId, "SCHEMAID",              3, Types.CHAR, false, 36),
+                getCD(view, viewId, "CREATIONTIMESTAMP",     4, Types.TIMESTAMP, false),
+                getCD(view, viewId, "EVENT",                 5, Types.CHAR, false, 1),
+                getCD(view, viewId, "FIRINGTIME",            6, Types.CHAR, false, 1),
+                getCD(view, viewId, "TYPE",                  7, Types.CHAR, false, 1),
+                getCD(view, viewId, "STATE",                 8, Types.CHAR, false, 1),
+                getCD(view, viewId, "TABLEID",               9, Types.CHAR, false, 36),
+                getCD(view, viewId, "WHENSTMTID",            10, Types.CHAR, true, 36),
+                getCD(view, viewId, "ACTIONSTMTID",          11, Types.CHAR, true, 36),
+                getCD(view, viewId, "REFERENCEDCOLUMNS",     12, Types.VARCHAR, true, 64),
+                getCD(view, viewId, "TRIGGERDEFINITION",     13, Types.LONGVARCHAR, true),
+                getCD(view, viewId, "REFERENCINGOLD",        14, Types.BOOLEAN, true),
+                getCD(view, viewId, "REFERENCINGNEW",        15, Types.BOOLEAN, true),
+                getCD(view, viewId, "OLDREFERENCINGNAME",    16, Types.VARCHAR, true, 128),
+                getCD(view, viewId, "NEWREFERENCINGNAME",    17, Types.VARCHAR, true, 128),
+                getCD(view, viewId, "WHENCLAUSETEXT",        18, Types.LONGVARCHAR, true),
+                getCD(view, viewId, "TRIGGERDEFINITIONLIST", 19, Types.VARCHAR, true, 64),
+                getCD(view, viewId, "ACTIONSTMTIDLIST",      20, Types.VARCHAR, true, 64),
+        };
+    }
+
+    final public static Pair<Integer, String> SYSVW_SYSTRIGGERSVIEW_SQL = new Pair<>(0,
+            "create view SYSTRIGGERSVIEW as SELECT\n" +
+                    "TRIGGERID,\n" +
+                    "TRIGGERNAME,\n" +
+                    "SCHEMAID,\n" +
+                    "CREATIONTIMESTAMP,\n" +
+                    "EVENT,\n" +
+                    "FIRINGTIME,\n" +
+                    "TYPE,\n" +
+                    "STATE,\n" +
+                    "TABLEID,\n" +
+                    "WHENSTMTID,\n" +
+                    "ACTIONSTMTID,\n" +
+                    "cast(REFERENCEDCOLUMNS AS VARCHAR(64)) AS REFERENCEDCOLUMNS,\n" +
+                    "TRIGGERDEFINITION,\n" +
+                    "REFERENCINGOLD,\n" +
+                    "REFERENCINGNEW,\n" +
+                    "OLDREFERENCINGNAME,\n" +
+                    "NEWREFERENCINGNAME,\n" +
+                    "WHENCLAUSETEXT,\n" +
+                    "cast(TRIGGERDEFINITIONLIST AS VARCHAR(64)) AS TRIGGERDEFINITIONLIST,\n" +
+                    "cast(ACTIONSTMTIDLIST AS VARCHAR(64)) AS ACTIONSTMTIDLIST\n" +
+                    "FROM sys.SYSTRIGGERS");
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -278,6 +278,7 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
         createOrUpdateSystemView(tc, "SYSVW", "SYSCONGLOMERATEINSCHEMAS");
         createOrUpdateSystemView(tc, "SYSVW", "SYSTABLESVIEW");
         createOrUpdateSystemView(tc, "SYSVW", "SYSCOLUMNSVIEW");
+        createOrUpdateSystemView(tc, "SYSVW", "SYSTRIGGERSVIEW");
 
         SpliceLogUtils.info(LOG, "Views in SYSVW created!");
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -278,7 +278,6 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
         createOrUpdateSystemView(tc, "SYSVW", "SYSCONGLOMERATEINSCHEMAS");
         createOrUpdateSystemView(tc, "SYSVW", "SYSTABLESVIEW");
         createOrUpdateSystemView(tc, "SYSVW", "SYSCOLUMNSVIEW");
-        createOrUpdateSystemView(tc, "SYSVW", "SYSTRIGGERSVIEW");
 
         SpliceLogUtils.info(LOG, "Views in SYSVW created!");
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/ViewDefinitions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/ViewDefinitions.java
@@ -61,7 +61,7 @@ class SystemViewDefinitions {
         views.put(new Pair<>("SYSVW", "SYSROUTINEPERMSVIEW"), new ViewInfo(DataDictionary.SYSROUTINEPERMS_CATALOG_NUM, 0, SYSROUTINEPERMSRowFactory.SYSROUTINEPERMS_VIEW_SQL));
         views.put(new Pair<>("SYSVW", "SYSPERMSVIEW"), new ViewInfo(DataDictionary.SYSPERMS_CATALOG_NUM, 0, SYSPERMSRowFactory.SYSPERMS_VIEW_SQL));
         views.put(new Pair<>("SYSVW", "SYSALIASTOTABLEVIEW"), new ViewInfo(DataDictionary.SYSALIASES_CATALOG_NUM, SYSALIASESRowFactory.SYSALIAS_TO_TABLE_VIEW_SQL));
-        views.put(new Pair<>("SYSVW", "SYSALIASTOTABLEVIEW"), new ViewInfo(DataDictionary.SYSALIASES_CATALOG_NUM, SYSALIASESRowFactory.SYSALIASESVIEW_SQL));
+        views.put(new Pair<>("SYSVW", "SYSALIASESVIEW"), new ViewInfo(DataDictionary.SYSALIASES_CATALOG_NUM, SYSALIASESRowFactory.SYSALIASESVIEW_SQL));
         views.put(new Pair<>("SYSVW", "SYSCONGLOMERATESVIEW"), new ViewInfo(DataDictionary.SYSCONGLOMERATES_CATALOG_NUM, SYSCONGLOMERATESRowFactory.SYSVW_SYSCONGLOMERATES_SQL));
         views.put(new Pair<>("SYSVW", "SYSDEPENDSVIEW"), new ViewInfo(DataDictionary.SYSDEPENDS_CATALOG_NUM, SYSDEPENDSRowFactory.SYSVW_SYSDEPENDS_SQL));
         views.put(new Pair<>("SYSVW", "SYSSEQUENCESVIEW"), new ViewInfo(DataDictionary.SYSSEQUENCES_CATALOG_NUM, SYSSEQUENCESRowFactory.SYSVW_SYSSEQUENCESVIEW_SQL));

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/ViewDefinitions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/ViewDefinitions.java
@@ -60,10 +60,12 @@ class SystemViewDefinitions {
         views.put(new Pair<>("SYSVW", "SYSCOLPERMSVIEW"), new ViewInfo(DataDictionary.SYSCOLPERMS_CATALOG_NUM, 0, SYSCOLPERMSRowFactory.SYSCOLPERMS_VIEW_SQL));
         views.put(new Pair<>("SYSVW", "SYSROUTINEPERMSVIEW"), new ViewInfo(DataDictionary.SYSROUTINEPERMS_CATALOG_NUM, 0, SYSROUTINEPERMSRowFactory.SYSROUTINEPERMS_VIEW_SQL));
         views.put(new Pair<>("SYSVW", "SYSPERMSVIEW"), new ViewInfo(DataDictionary.SYSPERMS_CATALOG_NUM, 0, SYSPERMSRowFactory.SYSPERMS_VIEW_SQL));
-        views.put(new Pair<>("SYSVW", "SYSALIASTOTABLEVIEW"), new ViewInfo(DataDictionary.SYSALIASES_CATALOG_NUM, 0, SYSALIASESRowFactory.SYSALIAS_TO_TABLE_VIEW_SQL));
+        views.put(new Pair<>("SYSVW", "SYSALIASTOTABLEVIEW"), new ViewInfo(DataDictionary.SYSALIASES_CATALOG_NUM, SYSALIASESRowFactory.SYSALIAS_TO_TABLE_VIEW_SQL));
+        views.put(new Pair<>("SYSVW", "SYSALIASTOTABLEVIEW"), new ViewInfo(DataDictionary.SYSALIASES_CATALOG_NUM, SYSALIASESRowFactory.SYSALIASESVIEW_SQL));
         views.put(new Pair<>("SYSVW", "SYSCONGLOMERATESVIEW"), new ViewInfo(DataDictionary.SYSCONGLOMERATES_CATALOG_NUM, SYSCONGLOMERATESRowFactory.SYSVW_SYSCONGLOMERATES_SQL));
         views.put(new Pair<>("SYSVW", "SYSDEPENDSVIEW"), new ViewInfo(DataDictionary.SYSDEPENDS_CATALOG_NUM, SYSDEPENDSRowFactory.SYSVW_SYSDEPENDS_SQL));
         views.put(new Pair<>("SYSVW", "SYSSEQUENCESVIEW"), new ViewInfo(DataDictionary.SYSSEQUENCES_CATALOG_NUM, SYSSEQUENCESRowFactory.SYSVW_SYSSEQUENCESVIEW_SQL));
+        views.put(new Pair<>("SYSVW", "SYSTRIGGERSVIEW"), new ViewInfo(DataDictionary.SYSTRIGGERS_CATALOG_NUM, SYSTRIGGERSRowFactory.SYSVW_SYSTRIGGERSVIEW_SQL));
 
         views.put(new Pair<>("SYSIBM", "SYSCOLUMNS"), new ViewInfo(DataDictionary.SYSCOLUMNS_CATALOG_NUM, 1, SYSCOLUMNSRowFactory.SYSCOLUMNS_VIEW_IN_SYSIBM));
         views.put(new Pair<>("SYSIBM", "SYSTABLES"), new ViewInfo(DataDictionary.SYSTABLES_CATALOG_NUM, 1, SYSTABLESRowFactory.SYSTABLES_VIEW_IN_SYSIBM));
@@ -82,6 +84,7 @@ class SystemViewDefinitions {
     void createOrUpdateView(TransactionController tc, SpliceDataDictionary dd, String schemaName, String viewName) throws StandardException {
         SchemaDescriptor schemaDesc = dd.getSystemWideSchemaDescriptor(schemaName);
         ViewInfo info = views.get(new Pair<>(schemaName, viewName));
+        assert info != null;
         // Runtime handling for sysschemasview:
         String viewSql = (schemaName.equals("SYSVW") && viewName.equals("SYSSCHEMASVIEW")) ? dd.getSchemaViewSQL() : info.viewSql;
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/security/MetaDataAccessControlIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/security/MetaDataAccessControlIT.java
@@ -227,12 +227,12 @@ public class MetaDataAccessControlIT {
     public void testShowTableWithAccessControl() throws Exception {
         ResultSet rs = user1Conn.query("call SYSIBM.SQLTABLES(null,null,null,null,null)");
         /* expected 19 tables: 16 sysvw views, and 2 user tables t1, and t2, and 1 alias AS1 */
-        assertEquals("Expected to have 19 tables", 19, resultSetSize(rs));
+        assertEquals("Expected to have 21 tables", 21, resultSetSize(rs));
         rs.close();
 
         /* expected just 16 sysvw views */
         rs = user2Conn.query("call SYSIBM.SQLTABLES(null,null,null,null,null)");
-        assertEquals("Expected to have 16 tables", 16, resultSetSize(rs));
+        assertEquals("Expected to have 18 tables", 18, resultSetSize(rs));
         rs.close();
 
     }


### PR DESCRIPTION
## Short Description
- DB-11267 added SYSVW.SYSTRIGGERSVIEW
- DB-11267 added SYSVW.SYSALIASESVIEW
- DB-11688 fix SYSINDEXCOLUSE in SYSALIASES

## Long Description
added SYSVW.SYSTRIGGERSVIEW and SYSVW.SYSALIASESVIEW since SYS.SYSTRIGGERS and SYS.SYSALIASES can not be directly queried over JDBC due to marshal problems.

## How to test

### test SYSINDEXCOLUSE in SYSALIASES
Execute this query without error (with sqlshell from spliceengine)
```
select * from SYS.SYSALIASES WHERE ALIAS = 'SYSINDEXCOLUSE';
```

### test SYSALIASESVIEW
Execute this query without error (with ext. sqlshell)
```
select * from SYSVW.SYSALIASESVIEW WHERE ALIAS = 'SYSINDEXCOLUSE';
```

### test SYSTRIGGERSVIEW
make sure `SYSVW.SYSTRIGGERSVIEW` would return at least one line by creating an example table+trigger:
```
CREATE TABLE T1(A VARCHAR(5), B VARCHAR(5));
CREATE TRIGGER mytrigger BEFORE INSERT
   ON t1 REFERENCING NEW AS N
   FOR EACH ROW
   BEGIN ATOMIC
      SET N.a = 'hello', N.b = 'goodbye';
   END;
```
Now with this PR, the following should return a valid result and no error (with ext. sqlshell).
```
SELECT * FROM SYSVW.SYSTRIGGERSVIEW;
```
