### PR TITLE
DB-11687 Improve NE+Range estimates

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NotEqualsSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NotEqualsSelectivity.java
@@ -41,7 +41,7 @@ import com.splicemachine.db.iapi.types.DataValueDescriptor;
  *
  */
 public class NotEqualsSelectivity extends AbstractSelectivityHolder {
-    private final DataValueDescriptor value;
+    public final DataValueDescriptor value;
     private final StoreCostController storeCost;
     private final double selectivityFactor;
     private final boolean useExtrapolation;


### PR DESCRIPTION
## Short Description
This change boost the performance of query with hash `SGgiYFr5`.

## Long Description
Three issues:
* Index XPFVEZUASERLZP is not picked up probably because high number of estimated output rows. Currently working on this.
* Join between VE and VZ is not NLJ probably due to the same issue above.
* We don’t have bitmap IXAND.

To improve the first two points, this change improves the following:
* A not equal predicate and a range predicate are combined if the not equal value equals to an inclusive boundary value of the range predicate.

## How to test
`SGgiYFr5` should have plan on OLTP after this change. It's execution time should below 30 seconds on a k8s cluster. Before this change, the plan is on OLAP and takes at least 350 seconds.
