### PR TITLE
DB-11675 Fix NPE in IndexLookup: SPLICE-2399 regression

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -1536,6 +1536,8 @@ public interface LanguageConnectionContext extends Context {
 
     boolean alwaysAllowIndexPrefixIteration();
 
+    boolean favorIndexPrefixIteration();
+
     void setupLocalSPSCache(boolean fromSparkExecution,
                             SPSDescriptor fromTableDmlSpsDescriptor) throws StandardException;
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/SessionProperties.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/SessionProperties.java
@@ -59,7 +59,8 @@ public interface SessionProperties {
         CURRENTFUNCTIONPATH(15),
         DISABLEPREDSFORINDEXORPKACCESSPATH(16),
         ALWAYSALLOWINDEXPREFIXITERATION(17),
-        OLAPALWAYSPENALIZENLJ(18);
+        OLAPALWAYSPENALIZENLJ(18),
+        FAVORINDEXPREFIXITERATION(19);
 
         public static final int COUNT = PROPERTYNAME.values().length;
 
@@ -93,7 +94,7 @@ public interface SessionProperties {
             property = SessionProperties.PROPERTYNAME.valueOf(propertyNameString);
         } catch (IllegalArgumentException e) {
             throw StandardException.newException(SQLState.LANG_INVALID_SESSION_PROPERTY,propertyNameString,
-                "useOLAP, useSpark (deprecated), defaultSelectivityFactor, skipStats, olapQueue, recursiveQueryIterationLimit, tableLimitForExhaustiveSearch, minPlanTimeout, currentFunctionPath, disablePredsForIndexOrPkAccessPath, alwaysAllowIndexPrefixIteration, olapAlwaysPenalizeNLJ");
+                "useOLAP, useSpark (deprecated), defaultSelectivityFactor, skipStats, olapQueue, recursiveQueryIterationLimit, tableLimitForExhaustiveSearch, minPlanTimeout, currentFunctionPath, disablePredsForIndexOrPkAccessPath, alwaysAllowIndexPrefixIteration, olapAlwaysPenalizeNLJ, favorIndexPrefixIteration");
         }
 
         String valString = pair.getSecond();
@@ -109,6 +110,7 @@ public interface SessionProperties {
             case OLAPALWAYSPENALIZENLJ:
             case DISABLEPREDSFORINDEXORPKACCESSPATH:
             case ALWAYSALLOWINDEXPREFIXITERATION:
+            case FAVORINDEXPREFIXITERATION:
                 try {
                     Boolean.parseBoolean(valString);
                 } catch (Exception e) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -910,6 +910,9 @@ public class FromBaseTable extends FromTable {
         // the first index column not used by any useful predicates
         // versus scanning all rows in the conglomerate.
         // Choose the cheapest of the two access paths.
+        LanguageConnectionContext lcc = getLanguageConnectionContext();
+        if (lcc.favorIndexPrefixIteration())
+            return finalCostEstimate;
         if (currentAccessPath.getNumUnusedLeadingIndexFields() > 0) {
             finalCostEstimate = firstPassCostEstimate = firstPassCostEstimate.cloneMe();
             AccessPath firstPassAccessPath = new AccessPathImpl(optimizer);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
@@ -1424,6 +1424,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
         int numColsInStopPred = 1;
 
         currentStartPosition += firstColumnIdx;
+        currentStopPosition += firstColumnIdx;
         for(int i=0;i<usefulCount;i++){
             Predicate thisPred=usefulPredicates[i];
             int thisIndexPosition=thisPred.getIndexPosition();
@@ -1450,6 +1451,8 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                     ** more predicates as start predicates.
                     */
                     if (indexPrefixIterationAllowed &&
+                        !rowIdScan                  &&
+                        currentStartPosition == (firstColumnIdx - 1) &&
                         (!thisPred.isHashableJoinPredicate() || considerJoinPredicateAsKey) &&
                          (thisIndexPosition-currentStartPosition) == numColsInStartPred + 1) {
                         accessPath.setNumUnusedLeadingIndexFields(1);
@@ -1502,6 +1505,8 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                     ** more predicates as start predicates.
                     */
                     if (indexPrefixIterationAllowed &&
+                        !rowIdScan                  &&
+                        currentStopPosition == (firstColumnIdx - 1) &&
                         (!thisPred.isHashableJoinPredicate() || considerJoinPredicateAsKey) &&
                          (thisIndexPosition-currentStopPosition) == numColsInStopPred + 1) {
                         accessPath.setNumUnusedLeadingIndexFields(1);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -512,6 +512,11 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
                     alwaysAllowIndexPrefixIteration.equalsIgnoreCase("true")) {
                 this.sessionProperties.setProperty(SessionProperties.PROPERTYNAME.ALWAYSALLOWINDEXPREFIXITERATION, "TRUE".toString());
             }
+            String favorIndexPrefixIteration = connectionProperties.getProperty(Property.CONNECTION_FAVOR_INDEX_PREFIX_ITERATION);
+            if (favorIndexPrefixIteration != null &&
+                    favorIndexPrefixIteration.equalsIgnoreCase("true")) {
+                this.sessionProperties.setProperty(SessionProperties.PROPERTYNAME.FAVORINDEXPREFIXITERATION, "TRUE".toString());
+            }
         }
         if (type.isSessionHinted()) {
             this.sessionProperties.setProperty(SessionProperties.PROPERTYNAME.USEOLAP, type.isOlap());
@@ -4107,6 +4112,16 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         Boolean alwaysAllowIndexPrefixIteration = (Boolean) getSessionProperties().getProperty(SessionProperties.PROPERTYNAME.ALWAYSALLOWINDEXPREFIXITERATION);
         if (alwaysAllowIndexPrefixIteration != null) {
             return alwaysAllowIndexPrefixIteration;
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean favorIndexPrefixIteration() {
+        Boolean favorIndexPrefixIteration = (Boolean) getSessionProperties().getProperty(SessionProperties.PROPERTYNAME.FAVORINDEXPREFIXITERATION);
+        if (favorIndexPrefixIteration != null) {
+            return favorIndexPrefixIteration;
         }
 
         return false;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/SessionPropertiesImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/SessionPropertiesImpl.java
@@ -128,6 +128,10 @@ public class SessionPropertiesImpl implements SessionProperties {
                 boolean alwaysAllowIndexPrefixIteration = Boolean.parseBoolean(valString);
                 properties[ALWAYSALLOWINDEXPREFIXITERATION.getId()] = alwaysAllowIndexPrefixIteration;
                 break;
+            case FAVORINDEXPREFIXITERATION:
+                boolean favorIndexPrefixIteration = Boolean.parseBoolean(valString);
+                properties[FAVORINDEXPREFIXITERATION.getId()] = favorIndexPrefixIteration;
+                break;
             default:
                 assert false;
         }

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1265,6 +1265,12 @@ public interface Property {
     String CONNECTION_ALWAYS_ALLOW_INDEX_PREFIX_ITERATION = "alwaysAllowIndexPrefixIteration";
 
     /**
+     * If true, causes the optimizer to choose IndexPrefixIteratorMode for a given
+     * index, if it is legal.
+     */
+    String CONNECTION_FAVOR_INDEX_PREFIX_ITERATION = "favorIndexPrefixIteration";
+
+    /**
      * If true, disable IndexPrefixIteratorMode access paths.  All index or primary key access
      * that uses a start key or stop key must then specify the first column of the index
      * in an equality of IN list predicate.

--- a/splice_machine/src/test/test-data/subquery/IndexPrefixIterationTestTables.sql
+++ b/splice_machine/src/test/test-data/subquery/IndexPrefixIterationTestTables.sql
@@ -17,6 +17,26 @@ create table t11 (a1 bigint,
                  g1 bigint,
                  h1 timestamp, primary key(a1, b1, c1, d1, e1, f1, g1, h1));
 
+CREATE TABLE Table1 (
+COL1 CHAR(36) NOT NULL
+,COL2 CHAR(5) NOT NULL DEFAULT ''
+,COL3 TIMESTAMP NOT NULL
+,COL4 CHAR(1) NOT NULL DEFAULT ''
+,COL5 CHAR(1) NOT NULL DEFAULT ''
+,COL6 TIMESTAMP NOT NULL
+,COL7 CHAR(8) NOT NULL DEFAULT ''
+,COL8 CHAR(36) NOT NULL
+,COL9 CHAR(36) NOT NULL
+,COL10 VARCHAR(3560) NOT NULL DEFAULT ''
+, CONSTRAINT MY_PK PRIMARY KEY("COL1")
+);
+
+create index Table1_Idx1 on Table1 (COL2, COL5, COL3, COL8, COL9);
+
+insert into Table1 values ('a', 'ABCDE', timestamp('2010-12-31 15:59:59.3211111'), 'b', 'c', timestamp('1969-12-31 15:59:59.000001'), 'd', 'e', 'f', 'g');
+
+analyze table Table1;
+
 insert into t1 values(1,1,1,1,1,1,1, timestamp('2018-12-31 15:59:59.3211111'));
 insert into t1 values(1,1,1,1,1,1,1, timestamp('1969-12-31 15:59:59.3211111'));
 insert into t1 values(1,1,1,1,1,1,1, timestamp('1969-12-31 15:59:59.9999999'));


### PR DESCRIPTION
## Short Description
During index lookup the wrong base table field is used to locate the column side of the predicate and no matching column is found, leading to NPE.

## Long Description
In `PredicateList.orderUsefulPredicates`, when an index access is identified as not using the first index column AccessPath.numUnusedLeadingIndexFields is set to 1.  The logic should only kick in when examining the first column position of an index, but it sometimes gets invoked after the first index column is already found:

>                     if (indexPrefixIterationAllowed &&
>                         (!thisPred.isHashableJoinPredicate() || considerJoinPredicateAsKey) &&
>                          (thisIndexPosition-currentStartPosition) == numColsInStartPred + 1) {
>                         accessPath.setNumUnusedLeadingIndexFields(1);
>                     }

currentStartPosition is zero at this point (it starts out as -1, and is set to the first index column position:
> currentStartPosition=thisIndexPosition;

The condition:
> (thisIndexPosition-currentStartPosition) == numColsInStartPred + 1) 

is not sufficient to limit the logic to only kick in on the first index column.

Since currentStartPosition is initialized to firstColumnIdx - 1 by this line:
> currentStartPosition += firstColumnIdx;

The first is to add a test for that condition:
>                     if (indexPrefixIterationAllowed &&
>                         !rowIdScan                  &&
>                         currentStartPosition == (firstColumnIdx - 1) &&   <<<-----------
>                         (!thisPred.isHashableJoinPredicate() || considerJoinPredicateAsKey) &&
>                          (thisIndexPosition-currentStartPosition) == numColsInStartPred + 1) {
>                         accessPath.setNumUnusedLeadingIndexFields(1);
>                     }

A new session property is added to force selection of indexPrefixIteration mode, if legal, for a given index, to allow more test coverage of SPLICE-2399:
> set session_property favorIndexPrefixIteration=true;

Statistics are required for SPLICE-2399 to be active, but for testing purposes, the following session property can bypass this requirement:
> set session_property alwaysAllowIndexPrefixIteration=true;

## How to test
The following test case should not hit a NullPointerException:
```
CREATE TABLE Table1 (
"COL1" CHAR(36) NOT NULL
,"COL2" CHAR(5) NOT NULL DEFAULT ''
,"COL3" TIMESTAMP NOT NULL
,"COL4" CHAR(1) NOT NULL DEFAULT ''
,"COL5" CHAR(1) NOT NULL DEFAULT ''
,"COL6" TIMESTAMP NOT NULL
,"COL7" CHAR(8) NOT NULL DEFAULT ''
,"COL8" CHAR(36) NOT NULL
,"COL9" CHAR(36) NOT NULL
,"COL10" VARCHAR(3560) NOT NULL DEFAULT ''
, CONSTRAINT MY_PK PRIMARY KEY("COL1")
);
create index Table1_Idx1 on Table1 (COL2, COL5, COL3, COL8, COL9);

analyze table Table1;

set session_property favorIndexPrefixIteration=true;

explain SELECT DP.COL1,
       DP.COL3,
       DP.COL9,
       DP.COL8,
--       GF.sprache,
       DP.COL10
FROM --splice-properties joinOrder=fixed
       Table1 DP --splice-properties index=Table1_Idx1
WHERE
       DP.COL2 = 'ABCDE'
   AND DP.COL5 ^= 'J'
   AND DP.COL3 < '2011-11-01'
                    || '-00.00.00.000000'
ORDER BY DP.COL1;
```


