### PR TITLE
DB-11693 Skip purging in memstore flushes if region is closing 

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/compactions/SpliceDefaultFlusher.java
+++ b/hbase_sql/src/main/java/com/splicemachine/compactions/SpliceDefaultFlusher.java
@@ -58,7 +58,8 @@ public class SpliceDefaultFlusher extends DefaultStoreFlusher {
         long txnLowWatermark = SIConstants.OLDEST_TIME_TRAVEL_TX;
         if(SIDriver.driver().isEngineStarted() &&
                 SpliceCompactionUtils.needsSI(store.getTableName()) &&
-                !SIDriver.driver().lifecycleManager().isRestoreMode()) {
+                !SIDriver.driver().lifecycleManager().isRestoreMode() &&
+                !store.getHRegion().isClosing()) {
             try {
                 txnLowWatermark = SpliceCompactionUtils.getTxnLowWatermark(store);
             } catch (Exception e) {

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/FlushDeadlockWhenRegionInClosingStateIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/FlushDeadlockWhenRegionInClosingStateIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.splicemachine.hbase;
+
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.derby.utils.SpliceAdmin;
+import com.splicemachine.test.HBaseTestUtils;
+import com.splicemachine.test.SerialTest;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.log4j.Logger;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+@Category(value = {SerialTest.class})
+public class FlushDeadlockWhenRegionInClosingStateIT extends SpliceUnitTest {
+    private static final Logger LOG = Logger.getLogger(FlushDeadlockWhenRegionInClosingStateIT.class);
+    private static final String SCHEMA = FlushDeadlockWhenRegionInClosingStateIT.class.getSimpleName().toUpperCase();
+    private static final SpliceWatcher spliceClassWatcher = new SpliceWatcher(SCHEMA);
+    private static final SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(SCHEMA);
+
+
+    @ClassRule
+    public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
+          .around(spliceSchemaWatcher);
+
+    @Rule
+    public final SpliceWatcher methodWatcher = new SpliceWatcher(SCHEMA);
+
+
+    @Test(timeout = 60000)
+    public void testNoDeadlock() throws Exception {
+        String table = "testNoDeadlock";
+        long[] conglomerates = SpliceAdmin.getConglomNumbers(methodWatcher.getOrCreateConnection(), "SYS", "SYSTABLES");
+        methodWatcher.execute(format("create table %s.%s (a int)", SCHEMA, table));
+        methodWatcher.executeUpdate("CALL SYSCS_UTIL.INVALIDATE_GLOBAL_DICTIONARY_CACHE()");
+
+        try (Admin admin = ConnectionFactory.createConnection(new Configuration()).getAdmin()) {
+            /*
+             * Disabling SYS.SYSTABLES will trigger a flush as part of closing the region and will end up in a bad state
+             * if we do not account for the region closing in SpliceDefaultFlusher
+             * See DB-11639
+             */
+            HBaseTestUtils.disable(admin, TableName.valueOf("splice:" + conglomerates[0]), LOG);
+            HBaseTestUtils.enable(admin, TableName.valueOf("splice:" + conglomerates[0]), LOG);
+        }
+    }
+}

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/FlushDeadlockWhenRegionInClosingStateIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/FlushDeadlockWhenRegionInClosingStateIT.java
@@ -60,7 +60,7 @@ public class FlushDeadlockWhenRegionInClosingStateIT extends SpliceUnitTest {
             /*
              * Disabling SYS.SYSTABLES will trigger a flush as part of closing the region and will end up in a bad state
              * if we do not account for the region closing in SpliceDefaultFlusher
-             * See DB-11639
+             * See DB-11693
              */
             HBaseTestUtils.disable(admin, TableName.valueOf("splice:" + conglomerates[0]), LOG);
             HBaseTestUtils.enable(admin, TableName.valueOf("splice:" + conglomerates[0]), LOG);


### PR DESCRIPTION
## Short description

We should not try to purge any data when flushing the memstore if the region being flushed is closing

## Long description

When flushing the memstore to disk, we call `getTxnLowWatermark` to understand what can be purged. 
If a region that is necessary for `getTxnLowWatermark` is closing, we will hang until that region is back online. However, if that region is the very one we try to flush, this will result in a deadlock.

We now make sure that a region isn't closing before trying to call `getTxnLowWatermark`

## How to test

An easy way to reproduce in standalone is:

```
create table a(i int); -- add some data to SYSTABLES
CALL SYSCS_UTIL.INVALIDATE_GLOBAL_DICTIONARY_CACHE(); -- invalidate caches so we have to go to HBase to retrieve TableDescriptor
```

then from hbase shell

```
disable 'splice:48' # SYSTABLE conglomerate, trigger flush as part of closing the region
```
