### PR TITLE
DB-11697 Update pipeline source branch to main

### DIFF
--- a/pipelines/spliceengine-branch/Jenkinsfile
+++ b/pipelines/spliceengine-branch/Jenkinsfile
@@ -4,7 +4,7 @@ properties([
     parameters([
         gitParameter(branch: '',
                      branchFilter: 'origin/(.*)',
-                     defaultValue: 'master',
+                     defaultValue: 'main',
                      description: '',
                      name: 'BRANCH',
                      quickFilterEnabled: true,

--- a/pipelines/spliceengine-core/Jenkinsfile
+++ b/pipelines/spliceengine-core/Jenkinsfile
@@ -18,7 +18,7 @@ node('splice-standalone'){
                 // Get some code from a GitHub repository
                 checkout([  
                     $class: 'GitSCM', 
-                    branches: [[name: 'refs/heads/master']], 
+                    branches: [[name: 'refs/heads/main']], 
                     doGenerateSubmoduleConfigurations: false, 
                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine-ee']], 
                     submoduleCfg: [], 
@@ -26,7 +26,7 @@ node('splice-standalone'){
                 ])
                 checkout([  
                     $class: 'GitSCM', 
-                    branches: [[name: 'refs/heads/master']], 
+                    branches: [[name: 'refs/heads/main']], 
                     doGenerateSubmoduleConfigurations: false, 
                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine']], 
                     submoduleCfg: [], 
@@ -72,8 +72,8 @@ node('splice-standalone'){
                 jar=sh(returnStdout: true, script: "echo ${POM_VERSION} | grep '\\-SNAPSHOT'")
                 echo jar
                 if (env.jar != null) {
-                    build (job: '../PDImageBuilds/ssds', parameters: [[$class: 'choiceParam', name: 'Branch', value: 'master'], [$class: 'choiceParam', name: 'Platform', value: 'hdp3.1.5'], [$class: 'stringParam', name: 'Tag', value: version], [$class: 'choiceParam', name: 'Release', value: 'True']], propagate: false, wait: false)
-                    build (job: '../PDImageBuilds/ssds', parameters: [[$class: 'choiceParam', name: 'Branch', value: 'master'], [$class: 'choiceParam', name: 'Platform', value: 'cdh6.3.0'], [$class: 'stringParam', name: 'Tag', value: version], [$class: 'choiceParam', name: 'Release', value: 'True']], propagate: false, wait: false)
+                    build (job: '../PDImageBuilds/ssds', parameters: [[$class: 'choiceParam', name: 'Branch', value: 'main'], [$class: 'choiceParam', name: 'Platform', value: 'hdp3.1.5'], [$class: 'stringParam', name: 'Tag', value: version], [$class: 'choiceParam', name: 'Release', value: 'True']], propagate: false, wait: false)
+                    build (job: '../PDImageBuilds/ssds', parameters: [[$class: 'choiceParam', name: 'Branch', value: 'main'], [$class: 'choiceParam', name: 'Platform', value: 'cdh6.3.0'], [$class: 'stringParam', name: 'Tag', value: version], [$class: 'choiceParam', name: 'Release', value: 'True']], propagate: false, wait: false)
                 }
             }
         }

--- a/pipelines/spliceengine-hdp/Jenkinsfile
+++ b/pipelines/spliceengine-hdp/Jenkinsfile
@@ -26,7 +26,7 @@ def generateStage(platform,slackResponse) {
                 // Get some code from a GitHub repository
                 checkout([  
                     $class: 'GitSCM', 
-                    branches: [[name: 'refs/heads/master']], 
+                    branches: [[name: 'refs/heads/main']], 
                     doGenerateSubmoduleConfigurations: false, 
                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine-ee']], 
                     submoduleCfg: [], 
@@ -34,7 +34,7 @@ def generateStage(platform,slackResponse) {
                 ])
                 checkout([  
                     $class: 'GitSCM', 
-                    branches: [[name: 'refs/heads/master']], 
+                    branches: [[name: 'refs/heads/main']], 
                     doGenerateSubmoduleConfigurations: false, 
                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine']], 
                     submoduleCfg: [], 

--- a/pipelines/spliceengine-jdbc/Jenkinsfile
+++ b/pipelines/spliceengine-jdbc/Jenkinsfile
@@ -27,7 +27,7 @@ node('splice-standalone'){
                 // Get some code from a GitHub repository
                 checkout([  
                     $class: 'GitSCM', 
-                    branches: [[name: 'refs/heads/master']], 
+                    branches: [[name: 'refs/heads/main']], 
                     doGenerateSubmoduleConfigurations: false, 
                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine-ee']], 
                     submoduleCfg: [], 
@@ -35,7 +35,7 @@ node('splice-standalone'){
                 ])
                 checkout([  
                     $class: 'GitSCM', 
-                    branches: [[name: 'refs/heads/master']], 
+                    branches: [[name: 'refs/heads/main']], 
                     doGenerateSubmoduleConfigurations: false, 
                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine']], 
                     submoduleCfg: [], 

--- a/pipelines/spliceengine-mapr/Jenkinsfile
+++ b/pipelines/spliceengine-mapr/Jenkinsfile
@@ -26,7 +26,7 @@ def generateStage(platform,slackResponse) {
                 // Get some code from a GitHub repository
                 checkout([  
                     $class: 'GitSCM', 
-                    branches: [[name: 'refs/heads/master']], 
+                    branches: [[name: 'refs/heads/main']], 
                     doGenerateSubmoduleConfigurations: false, 
                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine-ee']], 
                     submoduleCfg: [], 
@@ -34,7 +34,7 @@ def generateStage(platform,slackResponse) {
                 ])
                 checkout([  
                     $class: 'GitSCM', 
-                    branches: [[name: 'refs/heads/master']], 
+                    branches: [[name: 'refs/heads/main']], 
                     doGenerateSubmoduleConfigurations: false, 
                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine']], 
                     submoduleCfg: [], 

--- a/pipelines/spliceengine-nsds/Jenkinsfile
+++ b/pipelines/spliceengine-nsds/Jenkinsfile
@@ -27,7 +27,7 @@ node('splice-standalone'){
                 // Get some code from a GitHub repository
                 checkout([  
                     $class: 'GitSCM', 
-                    branches: [[name: 'refs/heads/master']], 
+                    branches: [[name: 'refs/heads/main']], 
                     doGenerateSubmoduleConfigurations: false, 
                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine-ee']], 
                     submoduleCfg: [], 
@@ -35,7 +35,7 @@ node('splice-standalone'){
                 ])
                 checkout([  
                     $class: 'GitSCM', 
-                    branches: [[name: 'refs/heads/master']], 
+                    branches: [[name: 'refs/heads/main']], 
                     doGenerateSubmoduleConfigurations: false, 
                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine']], 
                     submoduleCfg: [], 

--- a/pipelines/spliceengine-parcel/Jenkinsfile
+++ b/pipelines/spliceengine-parcel/Jenkinsfile
@@ -26,7 +26,7 @@ def generateStage(platform,slackResponse) {
                 // Get some code from a GitHub repository
                 checkout([  
                     $class: 'GitSCM', 
-                    branches: [[name: 'refs/heads/master']], 
+                    branches: [[name: 'refs/heads/main']], 
                     doGenerateSubmoduleConfigurations: false, 
                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine-ee']], 
                     submoduleCfg: [], 
@@ -34,7 +34,7 @@ def generateStage(platform,slackResponse) {
                 ])
                 checkout([  
                     $class: 'GitSCM', 
-                    branches: [[name: 'refs/heads/master']], 
+                    branches: [[name: 'refs/heads/main']], 
                     doGenerateSubmoduleConfigurations: false, 
                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine']], 
                     submoduleCfg: [], 

--- a/pipelines/spliceengine-platform/Jenkinsfile
+++ b/pipelines/spliceengine-platform/Jenkinsfile
@@ -43,7 +43,7 @@ def generateStage(platform,slackResponse) {
                     // Get some code from a GitHub repository
                     checkout([  
                         $class: 'GitSCM', 
-                        branches: [[name: 'refs/heads/master']], 
+                        branches: [[name: 'refs/heads/main']], 
                         doGenerateSubmoduleConfigurations: false, 
                         extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine-ee']], 
                         submoduleCfg: [], 
@@ -51,7 +51,7 @@ def generateStage(platform,slackResponse) {
                     ])
                     checkout([  
                         $class: 'GitSCM', 
-                        branches: [[name: 'refs/heads/master']], 
+                        branches: [[name: 'refs/heads/main']], 
                         doGenerateSubmoduleConfigurations: false, 
                         extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine']], 
                         submoduleCfg: [], 

--- a/pipelines/spliceengine-sqlshell/Jenkinsfile
+++ b/pipelines/spliceengine-sqlshell/Jenkinsfile
@@ -27,7 +27,7 @@ node('splice-standalone'){
                 // Get some code from a GitHub repository
                 checkout([  
                     $class: 'GitSCM', 
-                    branches: [[name: 'refs/heads/master']], 
+                    branches: [[name: 'refs/heads/main']], 
                     doGenerateSubmoduleConfigurations: false, 
                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine-ee']], 
                     submoduleCfg: [], 
@@ -35,7 +35,7 @@ node('splice-standalone'){
                 ])
                 checkout([  
                     $class: 'GitSCM', 
-                    branches: [[name: 'refs/heads/master']], 
+                    branches: [[name: 'refs/heads/main']], 
                     doGenerateSubmoduleConfigurations: false, 
                     extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine']], 
                     submoduleCfg: [], 

--- a/pipelines/spot-bugs/Jenkinsfile
+++ b/pipelines/spot-bugs/Jenkinsfile
@@ -55,7 +55,7 @@ node('splice-standalone') {
                 } else if ( "$branch" == ".1" ) {
                     branch = "branch-3.1"
                 } else {
-                    branch = "master"
+                    branch = "main"
                 }
                 sh "cd .."
             }
@@ -87,7 +87,7 @@ node('splice-standalone') {
                     branch = "branch-3.1"
                 } else {
                     platforms = "cdh6.3.0"
-                    branch = "master"
+                    branch = "main"
                 }
                 sh "mvn -B clean install -Pcore -DskipTests"
                 sh """
@@ -119,7 +119,7 @@ node('splice-standalone') {
                 branch = "branch-3.1"
             } else {
                 platforms = "cdh6.3.0"
-                branch = "master"
+                branch = "main"
             }
 
           def errors = sh "./pipelines/spot-bugs/runSpotbugs.sh $platforms $branch"


### PR DESCRIPTION
## Short Description
Update pipelines to reference main instead of master

## Long Description
The PR updates the source branch references in the main branch to main instead of master. There also is some work needed to point to main in Jenkins whenever we cutover along with the other pipelines in the other repos, such as the weekly-build script. 