### PR TITLE
DB-10968 SYSCS_SET_GLOBAL_DATABASE_PROPERTY should be callable in functions

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/Procedure.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/Procedure.java
@@ -237,6 +237,10 @@ public class Procedure {
         return ads;
     }
 
+    public short getRoutineSqlControl() {
+        return routineSqlControl;
+    }
+
     public static class Builder{
         private List<Arg> args;
         private String name;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -246,7 +246,7 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .integer("mode")            // 0 = fetch all, 1 = fetch only props where value not same on all servers
                 .numOutputParams(0)
                 .numResultSets(1)
-                .modifiesSql() // restrict execution
+                .sqlControl(RoutineAliasInfo.NO_SQL)
                 .ownerClass(SpliceAdmin.class.getCanonicalName())
                 .build();
         procedures.add(getRegionServerConfig);
@@ -872,7 +872,7 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .numResultSets(0)
                 .varchar("loggerName", 128)
                 .varchar("loggerLevel", 128)
-                .modifiesSql() // restriction execution
+                .sqlControl(RoutineAliasInfo.NO_SQL)
                 .ownerClass(SpliceAdmin.class.getCanonicalName())
                 .build();
         procedures.add(setLoggerLevel);
@@ -882,7 +882,7 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .numResultSets(0)
                 .varchar("loggerName", 128)
                 .varchar("loggerLevel", 128)
-                .modifiesSql() // restriction execution
+                .sqlControl(RoutineAliasInfo.NO_SQL)
                 .ownerClass(SpliceAdmin.class.getCanonicalName())
                 .build();
         procedures.add(setLoggerLevelLocal);
@@ -1067,7 +1067,7 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .numOutputParams(0)
                 .numResultSets(1)
                 .ownerClass(SpliceAdmin.class.getCanonicalName())
-                .modifiesSql()
+                .sqlControl(RoutineAliasInfo.READS_SQL_DATA)
                 .returnType(null).isDeterministic(false)
                 .catalog("KEY")
                 .build());
@@ -1079,7 +1079,7 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .numOutputParams(0)
                 .numResultSets(1)
                 .ownerClass(SpliceAdmin.class.getCanonicalName())
-                .modifiesSql() // restrict execution
+                .sqlControl(RoutineAliasInfo.MODIFIES_SQL_DATA).returnType(null).isDeterministic(false)
                 .returnType(null).isDeterministic(false)
                 .catalog("KEY")
                 .varchar("VALUE", Limits.DB2_VARCHAR_MAXWIDTH)
@@ -1092,7 +1092,7 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .numOutputParams(0)
                 .numResultSets(1)
                 .ownerClass(SpliceAdmin.class.getCanonicalName())
-                .modifiesSql() // restrict execution
+                .sqlControl(RoutineAliasInfo.READS_SQL_DATA)
                 .returnType(null).isDeterministic(false)
                 .varchar("FILTER", Limits.DB2_VARCHAR_MAXWIDTH)
                 .arg("validate", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
@@ -1211,7 +1211,7 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .numOutputParams(0)
                 .numResultSets(0)
                 .ownerClass(SpliceAdmin.class.getCanonicalName())
-                .modifiesSql() // restriction execution
+                .sqlControl(RoutineAliasInfo.NO_SQL)
                 .returnType(null).isDeterministic(false)
                 .build());
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/security/PermissionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/security/PermissionIT.java
@@ -313,21 +313,4 @@ public class PermissionIT {
             adminConn.execute(format("drop view %s.v1", SCHEMA1));
         }
     }
-
-    void testPermissions(String sql) throws SQLException {
-        adminConn.execute(sql);
-        SpliceUnitTest.sqlExpectException(user1Conn, sql,
-                SQLState.AUTH_NO_GENERIC_PERMISSION, false);
-    }
-
-    @Test
-    public void testRestrictedMethods() throws Exception {
-        if( !SpliceUnitTest.isMemPlatform(methodWatcher) )
-            testPermissions("call SYSCS_UTIL.SYSCS_GET_REGION_SERVER_CONFIG_INFO(null, 0)");
-        testPermissions("call SYSCS_UTIL.SYSCS_SET_LOGGER_LEVEL('com.level.com', 'INFO')");
-        testPermissions("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY('test', 'test')");
-        testPermissions("call SYSCS_UTIL.SYSCS_GET_GLOBAL_DATABASE_PROPERTY('test')");
-        testPermissions("call SYSCS_UTIL.SYSCS_SET_LOGGER_LEVEL_LOCAL('test', 'INFO')");
-    }
-
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/ProcedureUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/ProcedureUnitTest.java
@@ -1,5 +1,6 @@
 package com.splicemachine.derby.utils;
 
+import com.splicemachine.db.catalog.types.RoutineAliasInfo;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.impl.sql.catalog.DefaultSystemProcedureGenerator;
@@ -177,4 +178,23 @@ public class ProcedureUnitTest {
         testProcedures(SpliceSystemProcedures.getSYSCSMProcedures());
     }
 
+    short getRoutineControl(List<Procedure> procedures, String name)
+    {
+        return procedures.stream().filter(p -> p.getName().equals(name)).findAny().get().getRoutineSqlControl();
+    }
+
+    @Test
+    public void testAllSysUtilProceduresExecutable()
+    {
+        List<Procedure> p = new ArrayList<>();
+        SpliceSystemProcedures.createSysUtilProcedures(p);
+        Assert.assertEquals(getRoutineControl(p, "SYSCS_GET_REGION_SERVER_CONFIG_INFO"), RoutineAliasInfo.NO_SQL);
+        Assert.assertEquals(getRoutineControl(p, "SYSCS_SET_LOGGER_LEVEL"),              RoutineAliasInfo.NO_SQL);
+        Assert.assertEquals(getRoutineControl(p, "SYSCS_SET_LOGGER_LEVEL_LOCAL"),        RoutineAliasInfo.NO_SQL);
+        Assert.assertEquals(getRoutineControl(p, "SYSCS_GET_GLOBAL_DATABASE_PROPERTY"),  RoutineAliasInfo.READS_SQL_DATA);
+        Assert.assertEquals(getRoutineControl(p, "SYSCS_SET_GLOBAL_DATABASE_PROPERTY"),  RoutineAliasInfo.MODIFIES_SQL_DATA);
+        Assert.assertEquals(getRoutineControl(p, "SYSCS_RESTORE_DATABASE_OWNER"),        RoutineAliasInfo.NO_SQL);
+        Assert.assertEquals(getRoutineControl(p, "SYSCS_SET_GLOBAL_DATABASE_PROPERTY"),  RoutineAliasInfo.MODIFIES_SQL_DATA);
+        testProcedures(p);
+    }
 }

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Exec_Stored_Proc_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Exec_Stored_Proc_IT.java
@@ -386,7 +386,7 @@ public class Trigger_Exec_Stored_Proc_IT  extends SpliceUnitTest {
         if (originalLevel.equals("INFO")) {
             newlevel = "WARN";
         }
-        tb.named("log_level_change").after().insert().on("S").statement().
+        tb.named("log_level_change").before().insert().on("S").statement().
             then("call SYSCS_UTIL.SYSCS_SET_LOGGER_LEVEL('com.splicemachine.tools.version.ManifestFinder', '"+newlevel+"')");
         createTrigger(tb);
 


### PR DESCRIPTION
## Description
SYSCS_SET_GLOBAL_DATABASE_PROPERTY should be callable in functions

## How to test
create a function, call SYSCS_SET_GLOBAL_DATABASE_PROPERTY.
This was wrongly fixed in DB-10968 before because of a misunderstanding of the permissions architecture.