### PR TITLE
DB-11695 force creating a new CC for generating code of explain plan.

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -938,7 +938,10 @@ public class GenericStatement implements Statement{
 
         // proceed to optimize and generate code for it
         StatementNode optimizedPlan = queryNode.fourPhasePrepare(lcc, null, new long[5], false, cc, null, cacheMe, true);
-
+        // mark the CC as in use so we use a new CC for the explain plan code generation.
+        if(!cc.getInUse()) {
+            cc.setInUse(true);
+        }
         // plug back the statement in the EXPLAIN plan, so we can proceed
         // with optimizing the EXPLAIN plan. The optimization of EXPLAIN
         // will bypass the underlying node since it is already optimized


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
Force creating a new CC when generating code for explain plan

## Long Description
We noticed that when running explain on some SQL statements and the same CC (which we use to generate the activation of the statement) is used again to generate the activation of the explain we might end up with an incorrect activation since the CC contains some state that belongs to other activation.

## How to test
This was noticed by the QA team when running some regression tests, please refer to their test plan for more information, what's interesting is that this error does not show up with sqlshell but only through JDBC driver.
