### PR TITLE
DB-11717 Increase default Spark row threshold to 80K

### DIFF
--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SQLConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SQLConfiguration.java
@@ -151,7 +151,7 @@ public class SQLConfiguration implements ConfigurationDefault {
      * Threshold in rows for using spark.  Default is 20000
      */
     public static final String DETERMINE_SPARK_ROW_THRESHOLD = "splice.optimizer.determineSparkRowThreshold";
-    private static final int DEFAULT_DETERMINE_SPARK_ROW_THRESHOLD = 20000;
+    private static final int DEFAULT_DETERMINE_SPARK_ROW_THRESHOLD = 80000;
 
     /**
      * The maximum number of Kryo objects to pool for reuse. This setting is generally

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/IndexPrefixIterationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/IndexPrefixIterationIT.java
@@ -237,7 +237,8 @@ public class IndexPrefixIterationIT  extends SpliceUnitTest {
             "----\n" +
             " 1 |";
 
-        containedStrings = Arrays.asList("IndexScan", "T11_IX4", "IndexPrefixIteratorMode(129 values)", "scannedRows=1");
+        String indexName = useSpark ? "T11_IX4" : "T11_IX1";
+        containedStrings = Arrays.asList("IndexScan", indexName, "IndexPrefixIteratorMode(129 values)", "scannedRows=1");
         testQuery(query, expected, methodWatcher);
         testExplainContains(query, methodWatcher, containedStrings, notContainedStrings);
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/JoinOrderJumpModeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/JoinOrderJumpModeIT.java
@@ -247,7 +247,7 @@ public class JoinOrderJumpModeIT extends SpliceUnitTest {
                 new String[] {"Join"},                                                        // 14
                 new String[] {"Scan["},                                                       // 16, IndexScan on mem but TableScan on cdh
                 new String[] {"Join"},                                                        // 17
-                new String[] {"TableScan[TABLE_5", "scannedRows=800,outputRows=800"},         // 18
+                new String[] {"TableScan[TABLE_5", "scannedRows=1,outputRows=1"},             // 18
                 new String[] {"Join"},                                                        // 19
                 new String[] {"TableScan[TABLE_4", "scannedRows=1,outputRows=1"},             // 20
                 new String[] {"Join"},                                                        // 21

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
@@ -329,7 +329,7 @@ public class ExplainPlanIT extends SpliceUnitTest  {
             Assert.assertTrue("expect explain plan contains engine=OLTP", rs.getString(1).contains("engine=OLTP"));
         }
 
-        sql = format("explain select * from %s.%s", CLASS_NAME, TABLE_NAME);
+        sql = format("explain select * from %s.%s --SPLICE-PROPERTIES usedefaultrowcount=90000", CLASS_NAME, TABLE_NAME);
         try (ResultSet rs  = methodWatcher.executeQuery(sql)) {
             Assert.assertTrue(rs.next());
             Assert.assertTrue("expect explain plan contains engine=OLAP", rs.getString(1).contains("engine=OLAP"));
@@ -411,12 +411,12 @@ public class ExplainPlanIT extends SpliceUnitTest  {
 
         // full table scan, we should go for spark path as all rows need to be accessed, even though the output row count
         // is small after applying the predicate
-        try (ResultSet rs = methodWatcher.executeQuery("explain select * from t4 where b4=10000")) {
+        try (ResultSet rs = methodWatcher.executeQuery("explain select * from t4 --splice-properties usedefaultrowcount=90000\n where b4=10000")) {
             Assert.assertTrue(rs.next());
             Assert.assertTrue("expect explain plan to pick spark path", rs.getString(1).contains("engine=OLAP"));
         }
 
-        // test join case, base table scan may not exceeds the rowcount limit of 20000, if the join result rowcount exceeds this
+        // test join case, base table scan may not exceeds the rowcount limit of 80000, if the join result rowcount exceeds this
         // limit, we still need to go for Spark path
         try (ResultSet rs = methodWatcher.executeQuery("explain select * from t4 as X, t4 as Y where X.a4>30000 and Y.a4 >30000 and X.b4=Y.b4")) {
             Assert.assertTrue(rs.next());
@@ -510,7 +510,7 @@ public class ExplainPlanIT extends SpliceUnitTest  {
         }
 
         /* Q3: test join case */
-        String engine3[] = {"OLAP", "OLAP", "OLAP", "OLTP", "OLTP", "OLTP", "OLTP", "OLTP"};
+        String engine3[] = {"OLAP", "OLAP", "OLTP", "OLTP", "OLTP", "OLTP", "OLTP", "OLTP"};
         int rowCount3[] = {1000000, 1000000, 854, 27, 1, 1, 1, 1};
         String join3[] = {"BroadcastJoin", "BroadcastJoin", "BroadcastJoin",
                 "NestedLoopJoin", "NestedLoopJoin", "NestedLoopJoin", "NestedLoopJoin", "NestedLoopJoin"};


### PR DESCRIPTION
## Short Description
This change increases `DEFAULT_DETERMINE_SPARK_ROW_THRESHOLD` to 80000.

## Long Description
20000 seems to be a small number for determining if a query should go to OLTP or OLAP. Several cases (`SVqKB1=#`, `S6IvIPML`, `SuOpWcwG`, ) indicate that scanning more than 20K rows and do joins on OLTP are actually still faster than in OLAP.

## How to test
The query hashes described above should now get a OLTP plan and run faster than before. Example:
`SuOpWcwG` should now run on OLTP and finish under 1 second. The same plan executed on OLAP would cost about 20 seconds.
