### PR TITLE
DB-11666 Timeout of testStatementTriggersRuntimeUnderLimit: 10s -> 15s

### DIFF
--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Performance_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Performance_IT.java
@@ -203,7 +203,7 @@ public class Trigger_Performance_IT extends SpliceUnitTest {
 
         long endTime = System.currentTimeMillis();
         long runTime = endTime - startTime;
-        assertTrue("Expected runtime to be less than 10 seconds.  Actual time: " + runTime + " milliseconds", runTime < 10000);
+        assertTrue("Expected runtime to be less than 15 seconds.  Actual time: " + runTime + " milliseconds", runTime < 15000);
 
     }
 


### PR DESCRIPTION
## Short Description
Increase statement trigger IT timeout

## Long Description
Increase the timeout of testStatementTriggersRuntimeUnderLimit from 10 seconds to 15 seconds.  ITs run much slower on colo clusters, and testStatementTriggersRuntimeUnderLimit runs well under 10 seconds on a laptop often takes 11 or 12 seconds on a colo system.

## How to test
Run testStatementTriggersRuntimeUnderLimit on a colo system and verify it passes.
