### PR TITLE
DB-11677:fix JDBC timeout

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/ResultSet.java
@@ -379,4 +379,11 @@ public interface ResultSet
 	default UUID getUuid() { return null; }
 
 	default void registerCloseable(AutoCloseable closeable) throws StandardException { }
+
+	default void cancel(){}
+
+	default boolean isCancelled(){
+		return false;
+	};
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/StatementContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/StatementContext.java
@@ -299,4 +299,6 @@ public interface StatementContext extends Context {
     boolean hasXPlainTableOrProcedure();
 
     void registerExpirable(Expirable expirable, Thread thread);
+
+    long getTimeoutMillis();
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedResultSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedResultSet.java
@@ -60,6 +60,7 @@ import java.sql.*;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.UUID;
+import java.util.concurrent.CancellationException;
 
 /* can't import these due to name overlap:
 import java.sql.ResultSet;
@@ -395,6 +396,10 @@ public abstract class EmbedResultSet extends ConnectionChild
 				 * on an error.
 				 * (Cache the LanguageConnectionContext)
 				 */
+				if (theResults.isCancelled()) {
+					throw new CancellationException("Operation was cancelled");
+				}
+
                 StatementContext statementContext =
                     lcc.pushStatementContext(isAtomic, 
 					     concurrencyOfThisResultSet==java.sql.ResultSet.CONCUR_READ_ONLY, 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BasicNoPutResultSetImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BasicNoPutResultSetImpl.java
@@ -1000,30 +1000,6 @@ implements NoPutResultSet
 		return false;
 	}
 
-    /**
-     * Checks whether the currently executing statement has been cancelled.
-     * This is done by checking the statement's allocated StatementContext
-     * object.
-     *
-     * @see StatementContext
-     */
-	public void checkCancellationFlag()
-        throws
-            StandardException
-	{
-        LanguageConnectionContext lcc = getLanguageConnectionContext();
-        StatementContext localStatementContext = lcc.getStatementContext();
-        if (localStatementContext == null) {
-            return;
-        }
-
-		InterruptStatus.throwIf(lcc);
-
-        if (localStatementContext.isCancelled()) {
-            throw StandardException.newException(SQLState.LANG_STATEMENT_CANCELLED_OR_TIMED_OUT);
-        }
-    }
-
 	public final void addWarning(SQLWarning w) {
 
 		if (isTopResultSet) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BasicNoPutResultSetImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BasicNoPutResultSetImpl.java
@@ -51,6 +51,7 @@ import com.splicemachine.db.iapi.sql.execute.NoPutResultSet;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.util.InterruptStatus;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Abstract ResultSet for for operations that return rows but
@@ -65,6 +66,7 @@ import com.splicemachine.db.iapi.util.InterruptStatus;
  * with its methods being public for exposure by its subtypes.
  * <p>
  */
+@SuppressFBWarnings("UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD")
 abstract class BasicNoPutResultSetImpl
 implements NoPutResultSet
 {
@@ -97,6 +99,7 @@ implements NoPutResultSet
 
 	// Set in the constructor and not modified
 	protected final Activation	    activation;
+	@SuppressFBWarnings("SS_SHOULD_BE_STATIC")
 	private final boolean				statisticsTimingOn = false;
 
 	ResultDescription resultDescription;
@@ -118,6 +121,7 @@ implements NoPutResultSet
 	 *	@param	optimizerEstimatedCost		The optimizer's estimated cost for
 	 *										this result set
 	 */
+	@SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
 	BasicNoPutResultSetImpl(ResultDescription resultDescription,
 							Activation activation,
 							double optimizerEstimatedRowCount,
@@ -457,7 +461,6 @@ implements NoPutResultSet
 	 */
 	public final ExecRow	getNextRow() throws StandardException 
 	{
-		LanguageConnectionContext lcc = getLanguageConnectionContext();
 		if ( ! isOpen ) {
 			throw StandardException.newException(SQLState.LANG_RESULT_SET_NOT_OPEN, NEXT);
 		}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
@@ -20,6 +20,8 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.io.FormatableArrayHolder;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
+import com.splicemachine.db.iapi.services.monitor.Monitor;
+import com.splicemachine.db.iapi.services.timer.TimerFactory;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.ResultColumnDescriptor;
 import com.splicemachine.db.iapi.sql.ResultDescription;
@@ -68,7 +70,6 @@ import java.sql.Timestamp;
 import java.util.*;
 
 import static com.splicemachine.db.shared.common.reference.SQLState.LANG_INTERNAL_ERROR;
-import static com.splicemachine.derby.stream.control.ControlUtils.checkCancellation;
 
 public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed, Externalizable{
     private static final long serialVersionUID=4l;
@@ -103,6 +104,8 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
     private volatile boolean isTimedout = false;
     private long startTime = System.nanoTime();
     private ExecRow currentBaseRow;
+    private CancelQueryTask cancelTask;
+    private volatile boolean cancelled = false;
 
     public SpliceBaseOperation(){
         super();
@@ -294,6 +297,12 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
         }catch(Exception e){
             throw Exceptions.parseException(e);
         }
+
+        if (cancelTask != null) {
+            cancelTask.cleanup();
+            cancelTask = null;
+        }
+
     }
 
     //	@Override
@@ -552,12 +561,24 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
     @Override
     public void openCore() throws StandardException{
         DataSetProcessor dsp = EngineDriver.driver().processorFactory().chooseProcessor(activation, this);
-        activation.getLanguageConnectionContext().getStatementContext().registerExpirable(this, Thread.currentThread());
+        setTimeout();
         if (dsp.getType() == DataSetProcessor.Type.SPARK && !(isOlapServer() && activation.isSubStatement()) && !SpliceClient.isClient()) {
             openDistributed();
         } else {
             openCore(dsp);
         }
+    }
+
+    private void setTimeout() {
+        long timeoutMillis = activation.getLanguageConnectionContext().getStatementContext().getTimeoutMillis();
+        if (timeoutMillis > 0) {
+            TimerFactory factory = Monitor.getMonitor().getTimerFactory();
+            Timer timer = factory.getCancellationTimer();
+            cancelTask = new CancelQueryTask(this);
+            cancelTask.registerExpirable(this, Thread.currentThread());
+            timer.schedule(cancelTask, timeoutMillis);
+        }
+
     }
 
     private void logExecutionStart(DataSetProcessor dsp) {
@@ -1054,7 +1075,7 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
     public void kill() throws StandardException {
         this.isKilled = true;
         // The cancel flag is checked during Control execution
-        getActivation().getLanguageConnectionContext().getStatementContext().cancel();
+        getActivation().getResultSet().cancel();
         if (remoteQueryClient != null) {
             try {
                 remoteQueryClient.interrupt();
@@ -1186,5 +1207,90 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
     @Override
     public ExecRow getCurrentBaseRow() throws StandardException {
         return currentBaseRow;
+    }
+
+    @Override
+    public void cancel() {
+        cancelled = true;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    private static class CancelQueryTask
+            extends
+            TimerTask
+    {
+        /**
+         * Reference to the StatementContext for the executing statement
+         * which might time out.
+         */
+        private Expirable expirable;
+        private Thread thread;
+        private ResultSet rs;
+        /**
+         * Initializes a new task for timing out a statement's execution.
+         * This does not schedule it for execution, the caller is
+         * responsible for calling Timer.schedule() with this object
+         * as parameter.
+         */
+        public CancelQueryTask(ResultSet rs)
+        {
+             this.rs = rs;
+        }
+
+        /**
+         * Invoked by a Timer class to cancel an executing statement.
+         * This method just sets a volatile flag in the associated
+         * StatementContext object by calling StatementContext.cancel();
+         * it is the responsibility of the thread executing the statement
+         * to check this flag regularly.
+         */
+        public void run()
+        {
+            synchronized (this) {
+                LOG.info("Wake up to cancel the query");
+                if (rs != null) {
+                    rs.cancel();
+                    LOG.info("Canceled the query");
+                }
+                if (expirable != null) {
+                    try {
+                        expirable.timeout();
+                    } catch (StandardException e) {
+                        // ignore
+                        LOG.error("Ignoring exception raised during cancellation due to a timeout", e);
+                    }
+                    thread.interrupt();
+                }
+            }
+
+        }
+
+        /**
+         * Stops this task and prevents it from cancelling a statement.
+         * Guarantees that after this method returns, the associated
+         * StatementContext object will not be tampered with by this task.
+         * Thus, the StatementContext object may safely be allocated to
+         * other executing statements.
+         */
+        public void cleanup() {
+            synchronized (this) {
+                expirable = null;
+                thread = null;
+            }
+            cancel();
+        }
+
+        public void registerExpirable(Expirable expirable, Thread thread) {
+            synchronized (this) {
+                if (this.expirable == null) {
+                    this.expirable = expirable;
+                    this.thread = thread;
+                }
+            }
+        }
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/control/ControlUtils.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.derby.stream.control;
 
+import com.splicemachine.db.iapi.sql.ResultSet;
 import com.splicemachine.db.iapi.sql.conn.ControlExecutionLimiter;
 import com.splicemachine.db.iapi.sql.conn.StatementContext;
 import com.splicemachine.derby.stream.function.AbstractSpliceFunction;
@@ -91,12 +92,12 @@ public class ControlUtils {
     public static <E> Iterator<E> checkCancellation(Iterator<E> iterator, OperationContext<?> opContext) {
         if (opContext == null)
             return iterator;
-        StatementContext context = opContext.getActivation().getLanguageConnectionContext().getStatementContext();
+        ResultSet rs = opContext.getActivation().getResultSet();
         return Iterators.transform(iterator, new Function<E, E>() {
             @Nullable
             @Override
             public E apply(@Nullable E v) {
-                if (context.isCancelled())
+                if (rs.isCancelled())
                     throw new CancellationException("Operation was cancelled");
                 return v;
             }


### PR DESCRIPTION
## Short Description
JDBC timeout is not respected by some queries.

## Long Description
JDBC query timeout is not respected by a query with many stages, because the timeout applies for a stage, not for the whole query. One example is select * query that runs on spark. If each spark task can complete within timeout, the query will succeed, even though it runs much longer than JDBC query timeout.

## How to test
Write a JDBC program and set query timeout to a small number. Run select * SQL on a big table. If the query runtime is expected to longer than timeout, it should fail.
