### PR TITLE
DB-10772 DB2-compatible getColumnDisplaySize() for decimals

### DIFF
--- a/db-client/src/main/java/com/splicemachine/db/client/am/ClientConnection.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ClientConnection.java
@@ -74,6 +74,7 @@ public abstract class ClientConnection
     protected final String user_;
     public boolean retrieveMessageText_;
     protected boolean jdbcReadOnly_;
+    protected boolean jdbcDb2CompatibleMode_ = false;
     /**
      * Holdabilty for created statements.
      * Only access through the holdability method
@@ -334,6 +335,8 @@ public abstract class ClientConnection
 
         principal = ClientDataSource.getClientPrincipal(properties);
         keytab =  ClientDataSource.getClientKeytab(properties);
+
+        jdbcDb2CompatibleMode_ = ClientDataSource.getJdbcDb2CompatibleMode(properties);
 
         agent_ = newAgent_(logWriter,
                 loginTimeout_,
@@ -1293,6 +1296,21 @@ public abstract class ClientConnection
                 agent_.logWriter_.traceExit(this, "isReadOnly", jdbcReadOnly_);
             }
             return false;
+        }
+        catch ( SqlException se )
+        {
+            throw se.getSQLException();
+        }
+    }
+
+    public boolean isDB2Compatible() throws SQLException {
+        try
+        {
+            checkForClosedConnection();
+            if (agent_.loggingEnabled()) {
+                agent_.logWriter_.traceExit(this, "isDB2Compatible", jdbcDb2CompatibleMode_);
+            }
+            return jdbcDb2CompatibleMode_;
         }
         catch ( SqlException se )
         {

--- a/db-client/src/main/java/com/splicemachine/db/client/am/ColumnMetaData.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/ColumnMetaData.java
@@ -39,6 +39,8 @@ public class ColumnMetaData implements java.sql.ResultSetMetaData {
 
     public boolean[] nullable_;
 
+    public boolean jdbcDb2CompatibleMode = false;
+
     // All of the following state data comes from the SQLDA reply.
 
     //Data from SQLDHGRP
@@ -302,13 +304,17 @@ public class ColumnMetaData implements java.sql.ResultSetMetaData {
                 return 22;
             case Types.DECIMAL:
             case java.sql.Types.NUMERIC:
-                // There are 3 possible cases with respect to finding the correct max width for DECIMAL type.
-                // 1. If scale = 0, only sign should be added to precision.
-                // 2. scale = precision, 3 should be added to precision for sign, decimal and an additional char '0'.
-                // 3. precision > scale > 0, 2 should be added to precision for sign and decimal.
-                int scale = getScale(column);
-                int precision = getPrecision(column);
-                return (scale == 0) ? (precision + 1) : ((scale == precision) ? (precision + 3) : (precision + 2));
+                if (jdbcDb2CompatibleMode) {
+                    return getPrecision(column) + 2;
+                } else {
+                    // There are 3 possible cases with respect to finding the correct max width for DECIMAL type.
+                    // 1. If scale = 0, only sign should be added to precision.
+                    // 2. scale = precision, 3 should be added to precision for sign, decimal and an additional char '0'.
+                    // 3. precision > scale > 0, 2 should be added to precision for sign and decimal.
+                    int scale = getScale(column);
+                    int precision = getPrecision(column);
+                    return (scale == 0) ? (precision + 1) : ((scale == precision) ? (precision + 3) : (precision + 2));
+                }
             case Types.DECFLOAT:
                 return 36;
             case Types.CHAR:
@@ -853,6 +859,10 @@ public class ColumnMetaData implements java.sql.ResultSetMetaData {
 
     public boolean columnIsNotInUnicode(int index) {
         return (sqlCcsid_[index] != 1208);
+    }
+
+    public void setJdbcDb2CompatibleMode(boolean value) {
+        jdbcDb2CompatibleMode = value;
     }
 
 }

--- a/db-client/src/main/java/com/splicemachine/db/client/am/Cursor.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/am/Cursor.java
@@ -36,6 +36,7 @@ import java.io.ObjectInputStream;
 import java.io.UnsupportedEncodingException;
 import java.sql.Date;
 import java.sql.Time;
+import java.text.DecimalFormat;
 import java.util.Calendar;
 
 // When we calculate column offsets make sure we calculate the correct offsets for double byte charactr5er data
@@ -1055,7 +1056,13 @@ public abstract class Cursor {
             case java.sql.Types.DECIMAL:
                 // We could get better performance here if we didn't materialize the BigDecimal,
                 // but converted directly from decimal bytes to a string.
-                return String.valueOf(get_DECIMAL(column));
+                if (agent_.connection_.isDB2Compatible()) {
+                    BigDecimal value = get_DECIMAL(column);
+                    String formatStr = "." + new String(new char[value.scale()]).replace('\0', '#');
+                    return new DecimalFormat(formatStr).format(value);
+                } else {
+                    return String.valueOf(get_DECIMAL(column));
+                }
             case com.splicemachine.db.iapi.reference.Types.DECFLOAT:
                 return String.valueOf(get_DECFLOAT(column));
             case java.sql.Types.DATE:

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetStatementReply.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetStatementReply.java
@@ -40,6 +40,7 @@ import com.splicemachine.db.client.am.Utils;
 import com.splicemachine.db.jdbc.ClientDriver;
 import com.splicemachine.db.shared.common.i18n.MessageUtil;
 import com.splicemachine.db.client.am.ClientMessageId;
+import com.splicemachine.db.shared.common.reference.Attribute;
 import com.splicemachine.db.shared.common.reference.SQLState;
 import com.splicemachine.db.shared.common.reference.MessageId;
 
@@ -134,6 +135,7 @@ public class NetStatementReply extends NetPackageReply implements StatementReply
                 netSqlca = parseSQLDARD(columnMetaData, true); // true means to skip the rest of SQLDARD bytes
             } else {
                 columnMetaData = ClientDriver.getFactory().newColumnMetaData(netAgent_.logWriter_);
+                columnMetaData.setJdbcDb2CompatibleMode(Boolean.parseBoolean(netAgent_.netConnection_.properties_.getProperty(Attribute.JDBC_DB2_COMPATIBLE_MODE)));
                 netSqlca = parseSQLDARD(columnMetaData, false); // false means do not skip SQLDARD bytes.
             }
 

--- a/db-client/src/main/java/com/splicemachine/db/client/net/NetStatementReply.java
+++ b/db-client/src/main/java/com/splicemachine/db/client/net/NetStatementReply.java
@@ -43,6 +43,7 @@ import com.splicemachine.db.client.am.ClientMessageId;
 import com.splicemachine.db.shared.common.reference.Attribute;
 import com.splicemachine.db.shared.common.reference.SQLState;
 import com.splicemachine.db.shared.common.reference.MessageId;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class NetStatementReply extends NetPackageReply implements StatementReplyInterface {
     NetStatementReply(NetAgent netAgent, int bufferSize) {
@@ -86,7 +87,7 @@ public class NetStatementReply extends NetPackageReply implements StatementReply
             buffer_ = longBufferForDecryption_;
             pos_ = longPosForDecryption_;
             count_ = longCountForDecryption_;
-            if (longBufferForDecryption_ != null && count_ > longBufferForDecryption_.length) {
+            if (count_ > longBufferForDecryption_.length) {
                 count_ = longBufferForDecryption_.length;
             }
             dssLength_ = 0;
@@ -193,6 +194,7 @@ public class NetStatementReply extends NetPackageReply implements StatementReply
     // Parse the reply for the Execute Immediate SQL Statement Command.
     // This method handles the parsing of all command replies and reply data
     // for the excsqlimm command.
+    @SuppressFBWarnings(value="SF_SWITCH_FALLTHROUGH", justification="intended")
     private void parseEXCSQLIMMreply(StatementCallbackInterface statement) throws DisconnectException {
         int peekCP = parseTypdefsOrMgrlvlovrs();
 
@@ -1551,6 +1553,7 @@ public class NetStatementReply extends NetPackageReply implements StatementReply
     //
     // Only called for generated secctions from a callable statement.
     //
+    @SuppressFBWarnings(value="DLS_DEAD_LOCAL_STORE", justification="intended")
     protected Object parsePKGNAMCSN(boolean skip) throws DisconnectException {
         parseLengthAndMatchCodePoint(CodePoint.PKGNAMCSN);
         if (skip) {
@@ -1599,7 +1602,7 @@ public class NetStatementReply extends NetPackageReply implements StatementReply
                     new DisconnectException(agent_,
                         new ClientMessageId(
                             SQLState.NET_SQLCDTA_INVALID_FOR_RDBNAM),
-                    new Integer(scldtaLen)));
+                            scldtaLen));
                 return null;
             }
             // read 2+scldtaLen number of bytes from the reply buffer into the pkgnamcsnBytes
@@ -1613,7 +1616,7 @@ public class NetStatementReply extends NetPackageReply implements StatementReply
             if (scldtaLen < 18 || scldtaLen > 255) {
                 agent_.accumulateChainBreakingReadExceptionAndThrow(new DisconnectException(agent_,
                     new ClientMessageId(SQLState.NET_SQLCDTA_INVALID_FOR_RDBCOLID),
-                    new Integer(scldtaLen)));
+                        scldtaLen));
                 return null;
             }
             // read 2+scldtaLen number of bytes from the reply buffer into the pkgnamcsnBytes
@@ -1626,7 +1629,7 @@ public class NetStatementReply extends NetPackageReply implements StatementReply
             if (scldtaLen < 18 || scldtaLen > 255) {
                 agent_.accumulateChainBreakingReadExceptionAndThrow(new DisconnectException(agent_,
                     new ClientMessageId(SQLState.NET_SQLCDTA_INVALID_FOR_PKGID),
-                    new Integer(scldtaLen)));
+                        scldtaLen));
                 return null; // To make compiler happy.
             }
             // read 2+scldtaLen number of bytes from the reply buffer into the pkgnamcsnBytes
@@ -1641,7 +1644,7 @@ public class NetStatementReply extends NetPackageReply implements StatementReply
         } else {
             agent_.accumulateChainBreakingReadExceptionAndThrow(new DisconnectException(agent_,
                 new ClientMessageId(SQLState.NET_PGNAMCSN_INVALID_AT_SQLAM),
-                new Integer(ddmLength), new Integer(netAgent_.targetSqlam_)));
+                    ddmLength, netAgent_.targetSqlam_));
             return null;  // To make compiler happy.
         }
 
@@ -2184,6 +2187,7 @@ public class NetStatementReply extends NetPackageReply implements StatementReply
     //   SQLXSCHEMA_s; PROTOCOL TYPE VCS; ENVLID 0x32; Length Override 255
     //   SQLXNAME_m; PROTOCOL TYPE VCM; ENVLID 0x3E; Length Override 255
     //   SQLXNAME_s; PROTOCOL TYPE VCS; ENVLID 0x32; Length Override 255
+    @SuppressFBWarnings(value="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", justification="might be a false-positive")
     private void parseSQLDXGRP(ColumnMetaData columnMetaData,
                                int column) throws DisconnectException {
         if (readFastUnsignedByte() == CodePoint.NULLDATA) {
@@ -2323,6 +2327,7 @@ public class NetStatementReply extends NetPackageReply implements StatementReply
     //   SQLRSNAME_m; PROTOCOL TYPE VCM; ENVLID 0x3E; Length Override 255
     //   SQLRSNAME_s; PROTOCOL TYPE VCS; ENVLID 0x32; Length Override 255
     //   SQLRSNUMROWS; PROTOCOL TYPE I4; ENVLID 0x02; Length Override 4
+    @SuppressFBWarnings(value="DLS_DEAD_LOCAL_STORE", justification="intended")
     private void parseSQLRSGRP(Section section) throws DisconnectException {
 
         int rsLocator = readInt();

--- a/db-client/src/main/java/com/splicemachine/db/jdbc/ClientBaseDataSource.java
+++ b/db-client/src/main/java/com/splicemachine/db/jdbc/ClientBaseDataSource.java
@@ -1217,4 +1217,8 @@ public abstract class ClientBaseDataSource implements Serializable, Referenceabl
     public static String getClientKeytab(Properties properties) {
         return properties.getProperty(Attribute.CLIENT_KERBEROS_KEYTAB);
     }
+
+    public static boolean getJdbcDb2CompatibleMode(Properties properties) {
+        return Boolean.parseBoolean(properties.getProperty(Attribute.JDBC_DB2_COMPATIBLE_MODE));
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection40.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection40.java
@@ -238,7 +238,7 @@ public class EmbedConnection40
      *
      * @param  interfaces a Class defining an interface
      * @return an object that implements the interface
-     * @throws java.sql.SQLExption if no object if found that implements the 
+     * @throws java.sql.SQLException if no object if found that implements the
      * interface
      */
     public <T> T unwrap(java.lang.Class<T> interfaces) 

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/Attribute.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/Attribute.java
@@ -294,6 +294,12 @@ public interface Attribute {
     */
     String SSL_ATTR = "ssl";
 
+    /**
+     * Attribute name to set JDBC work in DB2 compatible mode.
+     * Client driver attribute.
+     */
+    String JDBC_DB2_COMPATIBLE_MODE = "jdbcDb2CompatibleMode";
+
 }
 
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceNetConnection.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceNetConnection.java
@@ -34,6 +34,7 @@ public class SpliceNetConnection {
     public static final String PROPERTY_JDBC_CREATE = "splice.jdbc.create";
     public static final String PROPERTY_JDBC_SCHEMA = "splice.jdbc.schema";
     public static final String PROPERTY_JDBC_USEOLAP = "splice.jdbc.useolap";
+    public static final String PROPERTY_JDBC_DB2_COMPATIBLE = "splice.jdbc.db2compatible";
 
     public static final String URL_PREFIX = "jdbc:splice://";
     public static final String DEFAULT_HOST = "localhost";
@@ -52,6 +53,7 @@ public class SpliceNetConnection {
     private static String jdbcCreate = null;
     private static String jdbcSchema = null;
     private static String jdbcUseOLAP = null;
+    private static String jdbcJdbcDb2CompatibleMode = null;
 
     private static void separateUrlAndDatabase(String url) {
         int idx = url.lastIndexOf("/");
@@ -73,6 +75,7 @@ public class SpliceNetConnection {
                 final String PARAM_CREATE = "create=";
                 final String PARAM_USEOLAP = "useOLAP=";
                 final String PARAM_USESPARK = "useSpark=";
+                final String PARAM_JDBCDB2COMPATIBLE = "jdbcDb2CompatibleMode=";
 
                 separateUrlAndDatabase(url.substring(0, idx));
                 String args = url.substring(idx + 1);
@@ -106,6 +109,9 @@ public class SpliceNetConnection {
                     else if (arg.startsWith(PARAM_USESPARK)) {
                         jdbcUseOLAP = arg.substring(PARAM_USESPARK.length());
                     }
+                    else if (arg.startsWith(PARAM_JDBCDB2COMPATIBLE)) {
+                        jdbcJdbcDb2CompatibleMode = arg.substring(PARAM_JDBCDB2COMPATIBLE.length());
+                    }
                 }
             }
         }
@@ -121,6 +127,7 @@ public class SpliceNetConnection {
         jdbcCreate = System.getProperty(PROPERTY_JDBC_CREATE, jdbcCreate);
         jdbcSchema = System.getProperty(PROPERTY_JDBC_SCHEMA, jdbcSchema);
         jdbcUseOLAP = System.getProperty(PROPERTY_JDBC_USEOLAP, jdbcUseOLAP);
+        jdbcJdbcDb2CompatibleMode = System.getProperty(PROPERTY_JDBC_DB2_COMPATIBLE, jdbcJdbcDb2CompatibleMode);
     }
 
     public static class ConnectionBuilder implements Cloneable {
@@ -137,6 +144,7 @@ public class SpliceNetConnection {
         private String useNativeSpark;
         private String minPlanTimeout;
         private String currentFunctionPath;
+        private String jdbcDb2Compatible;
 
         @Override
         public ConnectionBuilder clone() throws CloneNotSupportedException {
@@ -195,6 +203,10 @@ public class SpliceNetConnection {
             this.currentFunctionPath = currentFunctionPath;
             return this;
         }
+        public ConnectionBuilder db2CompatibleMode(boolean db2Compatible) {
+            this.jdbcDb2Compatible = Boolean.toString(db2Compatible);
+            return this;
+        }
 
         public Connection build() throws SQLException {
             Properties info = new Properties();
@@ -216,6 +228,8 @@ public class SpliceNetConnection {
                 info.put("minPlanTimeout", minPlanTimeout);
             if (currentFunctionPath != null)
                 info.put("CurrentFunctionPath", currentFunctionPath);
+            if (jdbcDb2Compatible != null || jdbcJdbcDb2CompatibleMode != null)
+                info.put("jdbcDb2CompatibleMode", jdbcDb2Compatible != null ? jdbcDb2Compatible : jdbcJdbcDb2CompatibleMode);
             StringBuilder url = new StringBuilder();
             if (host != null || port != null) {
                 url.append(URL_PREFIX);


### PR DESCRIPTION
## Short Description
This change makes JDBC `getColumnDisplayWidth` method returns the same value as DB2 for decimal and numeric type columns.

## Long Description
Comparison of return values of `getColumnDisplayWidth` between splice and DB2:
|  | splice | splice example | DB2 | DB2 example |
|------|-------|-------|-------|-------|
| precision > scale > 0 | precision + 2 | -11.12 | precision + 2 | -11.12 |
| precision == scale | precision + 3 | -0.13 | precision + 2 | -.13 |
| scale == 0 | precision + 1 | -12 | precision + 2 | -12. |

Examples above show why `precision + 2` is always sufficient in DB2.

This change introduces a new JDBC connection attribute `jdbcDb2CompatibleMode=[true|false]` to set the JDBC `getColumnDisplayWidth` method.

Note that the string representation is purely a client thing. `getString()` of `SQLDecimal` is not modified. Decimal values are returned to client as they are. The difference can only be observed if
* client connects to database with a connection string that contains `jdbcDb2CompatibleMode=true`, and
* client calls `ResultSet.getString(int column)` on a decimal or numeric column.

The client can of course retrieve the original decimal values by calling `ResultSet.getBigDecimal(int column)` and perform its own string conversion.

## How to test
Setup:
```
create table test (dc1 decimal(4,2), dc2 decimal(2,0), dc3 decimal(2,2));
insert into test values (11.11, -12, -0.13);
```
On Java application side, do the following:
```
String dbUrl = "jdbc:splice://localhost:[port]/[dbName];user=[username];password=[password];jdbcDb2CompatibleMode=true";
try(Connection conn = DriverManager.getConnection(dbUrl)){
            try(Statement statement = conn.createStatement()){
                try (ResultSet rs = statement.executeQuery("select * from test")) {
                    for (int i = 1; i <= rs.getMetaData().getColumnCount(); i++) {
                        int colDispSize = rs.getMetaData().getColumnDisplaySize(i);
                        System.out.println(colDispSize);
                    }
                }
            }
```
The code snippet above should print 
```
6
4
4
```

Before this change, it should print
```
6
3
5
```
A new test `testJdbcDb2CompatibleMode` is added to JdbcApiIT.java.