### PR TITLE
DB-11637: abort broadcast join cache loading if spark task has been killed(3.0)

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinNoCacheLoader.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinNoCacheLoader.java
@@ -17,6 +17,7 @@ package com.splicemachine.derby.impl.sql.execute.operations;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.derby.impl.sql.JoinTable;
 import com.splicemachine.stream.Stream;
+import org.apache.spark.TaskContext;
 
 import java.util.concurrent.Callable;
 
@@ -30,14 +31,14 @@ public class BroadcastJoinNoCacheLoader implements Callable<JoinTable.Factory> {
     private final ExecRow outerTemplateRow;
     private final Callable<Stream<ExecRow>> streamLoader;
 
-    private final Long operationId;
+    private final TaskContext taskContext;
 
-    public BroadcastJoinNoCacheLoader(Long operationId,
+    public BroadcastJoinNoCacheLoader(TaskContext taskContext,
                   int[] innerHashKeys,
                   int[] outerHashKeys,
                   ExecRow outerTemplateRow,
                   Callable<Stream<ExecRow>> streamLoader){
-        this.operationId=operationId;
+        this.taskContext = taskContext;
         this.innerHashKeys=innerHashKeys;
         this.outerHashKeys=outerHashKeys;
         this.outerTemplateRow=outerTemplateRow;
@@ -46,6 +47,6 @@ public class BroadcastJoinNoCacheLoader implements Callable<JoinTable.Factory> {
 
     @Override
     public JoinTable.Factory call() throws Exception {
-        return tableLoader.load(streamLoader,innerHashKeys,outerHashKeys,outerTemplateRow);
+        return tableLoader.load(streamLoader,innerHashKeys,outerHashKeys,outerTemplateRow, taskContext);
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/IteratorUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/IteratorUtils.java
@@ -30,4 +30,11 @@ public class IteratorUtils {
         } else
             return it;
     }
+
+    public static <E> Iterator<E> asInterruptibleIterator(TaskContext context, Iterator<E> it) {
+        if (context != null) {
+            return (Iterator<E>) JavaConverters.asJavaIteratorConverter(new InterruptibleIterator(context, JavaConverters.asScalaIteratorConverter(it).asScala())).asJava();
+        } else
+            return it;
+    }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
(e.g. short description of the PR)

## Long Description
(e.g. why in detail, how, potential further work)

## How to test
(e.g. if bugfix: how to reproduce bug / impact)
(if feature: a easy example of how to check the feature)
(if feature is a configuration: an example to see different behavior with different configuration)
