### PR TITLE
DB-11637: abort broadcast join cache loading if spark task has been killed

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinNoCacheLoader.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinNoCacheLoader.java
@@ -17,6 +17,7 @@ package com.splicemachine.derby.impl.sql.execute.operations;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.derby.impl.sql.JoinTable;
 import com.splicemachine.stream.Stream;
+import org.apache.spark.TaskContext;
 
 import java.util.concurrent.Callable;
 
@@ -30,14 +31,14 @@ public class BroadcastJoinNoCacheLoader implements Callable<JoinTable.Factory> {
     private final ExecRow outerTemplateRow;
     private final Callable<Stream<ExecRow>> streamLoader;
 
-    private final Long operationId;
+    private final TaskContext taskContext;
 
-    public BroadcastJoinNoCacheLoader(Long operationId,
+    public BroadcastJoinNoCacheLoader(TaskContext taskContext,
                   int[] innerHashKeys,
                   int[] outerHashKeys,
                   ExecRow outerTemplateRow,
                   Callable<Stream<ExecRow>> streamLoader){
-        this.operationId=operationId;
+        this.taskContext = taskContext;
         this.innerHashKeys=innerHashKeys;
         this.outerHashKeys=outerHashKeys;
         this.outerTemplateRow=outerTemplateRow;
@@ -46,6 +47,6 @@ public class BroadcastJoinNoCacheLoader implements Callable<JoinTable.Factory> {
 
     @Override
     public JoinTable.Factory call() throws Exception {
-        return tableLoader.load(streamLoader,innerHashKeys,outerHashKeys,outerTemplateRow);
+        return tableLoader.load(streamLoader,innerHashKeys,outerHashKeys,outerTemplateRow, taskContext);
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/IteratorUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/IteratorUtils.java
@@ -30,4 +30,11 @@ public class IteratorUtils {
         } else
             return it;
     }
+
+    public static <E> Iterator<E> asInterruptibleIterator(TaskContext context, Iterator<E> it) {
+        if (context != null) {
+            return (Iterator<E>) JavaConverters.asJavaIteratorConverter(new InterruptibleIterator(context, JavaConverters.asScalaIteratorConverter(it).asScala())).asJava();
+        } else
+            return it;
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
If a broadcast join task is killed when it is loading the inner table to a cache, it does not terminate immediately. 

## Long Description
If a broadcast join task is killed when it is loading the inner table to a cache, it does not terminate immediately. Broadcast join does not check whether the task has been killed until it has completed cache loading. If the inner table is big, it will waste time and resources executing cache loading.

To fix the issue, the inner table rows are transformed to an InterruptibleIterator. When each row is read from the iterator, a task context is checked to find out whether the task has been killed. If so, an exception will be raised to terminate cache loading.

## How to test

Run TPCH1 query without using native spark dataset. Cancel the job during the 1st stage. The task should be terminated immediately. You will also find an exception raised from ValueRowMapTableLoader
