### PR TITLE
DB-11742: fix NPE that may prevent txn from committing

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/TransactionResourceImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/TransactionResourceImpl.java
@@ -354,7 +354,9 @@ public final class TransactionResourceImpl
     {
         try {
             // Session temp tables are cleaned up
-            lcc.resetFromPool();
+            if (lcc != null) {
+                lcc.resetFromPool();
+            }
         } catch (StandardException e) {
             // log but don't throw, closing
             Util.logSQLException(e);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
fix NPE that may prevent txn from committing

## Long Description
Backport a fix by @jpanko1 from master to branch-3.0. The NPE can cause a txn never commit or abort, preventing vacuum from cleaning up unused tables for ITs. ITs will eventually run out of memory and crash.

## How to test
This should improve ITs stability