### PR TITLE
DB-11690: backup metadata

### DIFF
--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -2023,6 +2023,7 @@ public interface SQLState {
     String NO_BACKUP_EXT_TABLE                      = "BR024";
     String EMPTY_SCHEMA                             = "BR025";
     String CANNOT_CONNECT_DURING_RESTORE            = "BR026";
+    String CANNOT_RESTORE_METADATA                  = "BR027";
     /**
      * Replication
      */

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -9301,6 +9301,10 @@ Shutting down instance {0} on database directory {1} with class loader {2} </tex
                <text>Cannot connect because database is being restored.</text>
            </msg>
            <msg>
+               <name>BR027</name>
+               <text>Cannot restore metadata from this backup.</text>
+           </msg>
+           <msg>
                <name>RPL001</name>
                <text>Incorrect replication role '{0}'</text>
                <arg>role</arg>

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupManager.java
@@ -16,6 +16,7 @@ package com.splicemachine.backup;
 
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.backup.BackupMessage.BackupJobStatus;
+import com.splicemachine.db.shared.common.reference.SQLState;
 
 import java.util.List;
 
@@ -54,4 +55,12 @@ public interface BackupManager{
 
     void restoreSchema(String destSchema, String sourceSchema, String directory,
                       long backupId, boolean validate) throws StandardException;
+
+    default long backupMetadata(String directory) throws StandardException{
+        throw StandardException.newException(SQLState.BACKUP_OPERATIONS_DISABLED);
+    }
+
+    default void restoreMetadata(String directory, long backupId, boolean validate) throws StandardException{
+        throw StandardException.newException(SQLState.BACKUP_OPERATIONS_DISABLED);
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupSystemProcedures.java
@@ -737,7 +737,6 @@ public class BackupSystemProcedures {
         } catch (Throwable t) {
             resultSets[0] = ProcedureUtils.generateResult("Error", t.getLocalizedMessage());
             SpliceLogUtils.error(LOG, "Database backup error", t);
-            t.printStackTrace();
         }
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/backup/BackupSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/backup/BackupSystemProcedures.java
@@ -722,4 +722,85 @@ public class BackupSystemProcedures {
             }
         }
     }
+
+    public static void SYSCS_BACKUP_METADATA(String directory, ResultSet[] resultSets)
+            throws StandardException, SQLException {
+        try {
+            // Check directory
+            if (directory == null || directory.isEmpty()) {
+                throw StandardException.newException(SQLState.INVALID_BACKUP_DIRECTORY, directory);
+            }
+
+            BackupManager backupManager = EngineDriver.driver().manager().getBackupManager();
+            backupManager.backupMetadata(directory);
+            resultSets[0] = ProcedureUtils.generateResult("Success", String.format("Metadata backup to %s", directory));
+        } catch (Throwable t) {
+            resultSets[0] = ProcedureUtils.generateResult("Error", t.getLocalizedMessage());
+            SpliceLogUtils.error(LOG, "Database backup error", t);
+            t.printStackTrace();
+        }
+    }
+
+    public static void SYSCS_RESTORE_METADATA(String directory, long backupId, boolean validate, ResultSet[] resultSets) throws StandardException, SQLException {
+        IteratorNoPutResultSet inprs = null;
+
+        Connection conn = SpliceAdmin.getDefaultConn();
+        LanguageConnectionContext lcc = conn.unwrap(EmbedConnection.class).getLanguageConnection();
+        try {
+            BackupManager backupManager = EngineDriver.driver().manager().getBackupManager();
+            // Check for ongoing backup...
+            BackupJobStatus[] backupJobStatuses = backupManager.getRunningBackups();
+            if (backupJobStatuses.length > 0) {
+                long runningBackupId = backupJobStatuses[0].getBackupId();
+                throw StandardException.newException(SQLState.NO_RESTORE_DURING_BACKUP, runningBackupId);
+            }
+            backupManager.restoreMetadata(directory, backupId,  validate);
+
+            // Print reboot statement
+            ResultColumnDescriptor[] rcds = {
+                    new GenericColumnDescriptor("result", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, 40)),
+                    new GenericColumnDescriptor("warnings", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, 1024))
+            };
+            ExecRow template = new ValueRow(2);
+            template.setRowArray(new DataValueDescriptor[]{new SQLVarchar(), new SQLVarchar()});
+            List<ExecRow> rows = Lists.newArrayList();
+
+            Activation activation = lcc.getLastActivation();
+            SQLWarning warning = activation.getWarnings();
+            if (warning != null) {
+                while (warning != null) {
+                    template.getColumn(1).setValue(warning.getSQLState());
+                    template.getColumn(2).setValue(warning.getLocalizedMessage());
+                    rows.add(template.getClone());
+                    warning = warning.getNextWarning();
+                }
+                template.getColumn(1).setValue("Found inconsistencies in backup");
+                template.getColumn(2).setValue("To force a restore, set valid to false");
+                rows.add(template.getClone());
+            } else {
+                template.getColumn(1).setValue("Restore completed");
+                template.getColumn(2).setValue("Database has to be rebooted");
+                rows.add(template.getClone());
+                LOG.info("Restore completed. Database reboot is required.");
+            }
+            inprs = new IteratorNoPutResultSet(rows, rcds, lcc.getLastActivation());
+            inprs.openCore();
+
+        } catch (Throwable t) {
+            ResultColumnDescriptor[] rcds = {
+                    new GenericColumnDescriptor("Error", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, t.getMessage().length()))};
+            ExecRow template = new ValueRow(1);
+            template.setRowArray(new DataValueDescriptor[]{new SQLVarchar()});
+            List<ExecRow> rows = Lists.newArrayList();
+            template.getColumn(1).setValue(t.getMessage());
+
+            rows.add(template.getClone());
+            inprs = new IteratorNoPutResultSet(rows, rcds, lcc.getLastActivation());
+            inprs.openCore();
+            SpliceLogUtils.error(LOG, "Error recovering backup", t);
+
+        } finally {
+            resultSets[0] = new EmbedResultSet40(conn.unwrap(EmbedConnection.class), inprs, false, null, true);
+        }
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -1689,6 +1689,18 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .ownerClass(UpgradeSystemProcedures.class.getCanonicalName())
                 .build();
         procedures.add(restartOlapServer);
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_BACKUP_METADATA")
+                .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                .varchar("directory", 32672)
+                .build());
+
+        procedures.add(Procedure.newBuilder().name("SYSCS_RESTORE_METADATA")
+                .numOutputParams(0).numResultSets(1).ownerClass(BackupSystemProcedures.class.getCanonicalName())
+                .varchar("directory", 32672)
+                .bigint("backupId")
+                .arg("validate", DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN).getCatalogType())
+                .build());
     }
 
     static public void getSYSFUN_PROCEDURES(List<Procedure> procedures)

--- a/splice_protocol/src/main/protobuf/Backup.proto
+++ b/splice_protocol/src/main/protobuf/Backup.proto
@@ -9,6 +9,7 @@ message BackupJobStatus {
         TABLE = 1;
         SCHEMA = 2;
         DATABASE = 3;
+        META = 4;
     }
 
     optional int64 backupId = 1;


### PR DESCRIPTION
## Short Description
Backup/restore data base except user data

## Long Description
This is a new feature to backup/restore splice system tables.
```
describe procedure syscs_util.syscs_backup_metadata;
COLUMN_NAME    |TYPE_NAME    |ORDINAL_POSITION
directory      |VARCHAR      |1               

describe procedure syscs_util.syscs_restore_metadata;
COLUMN_NAME    |TYPE_NAME    |ORDINAL_POSITION
directory      |VARCHAR      |1
backupId       |BIGINT       |2
validate       |BOOLEAN      |3           
```

Usage of `syscs_util.syscs_backup_metadata` and `syscs_util.syscs_restore_metadata` is very similar to database backup/restore system procedures.

## How to test 
Run `syscs_util.syscs_backup_metadata` and check the backup. User data should not be included.
Run `syscs_util.syscs_backup_metadata` for a backup, Restart splice machine and check user table does not have data
