### PR TITLE
DB-10592 StatisticsAdmin schema statistic in parallel 

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
@@ -1226,11 +1226,17 @@ public class StatisticsAdmin extends BaseAdminProcedures {
         public Iterable call() throws Exception {
             ContextManager cm = ContextService.getService().newContextManager(parent);
             ContextService.getService().setCurrentContextManager(cm);
-            statisticsOperation.openCore();
-            if (mergeStats) {
-                return getMergedStatistic(dataDictionary, tc, displayPair, statisticsOperation);
-            } else {
-                return getStatistic(dataDictionary, tc, displayPair, statisticsOperation);
+            try {
+                statisticsOperation.openCore();
+                if (mergeStats) {
+                    return getMergedStatistic(dataDictionary, tc, displayPair, statisticsOperation);
+                } else {
+                    return getStatistic(dataDictionary, tc, displayPair, statisticsOperation);
+                }
+            }
+            finally {
+                ContextService.getService().resetCurrentContextManager(cm);
+                ContextService.getService().removeContextManager(cm);
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
Schema statistic by tables is calculated in parallel

## Long Description
DB-10592 is changing the behavior of spark execution. Schema statistic is calculated sequentially, which can be blocked if some executors not ready, see more details in jira DB-10592. It can cause the timeout in COLLECT_SCHEMA_STATISTICS.  Changed to calculate in parallel.

## How to test
Execute ExportOperationIT, StatisticsAdminIT
