### PR TITLE
DB-11789 NSDS Bulk Import to Return Count of Imported Rows

### DIFF
--- a/splice_spark/src/main/spark2.2/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
+++ b/splice_spark/src/main/spark2.2/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
@@ -426,8 +426,8 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
     val sqlText = s"SELECT $columnList FROM ${schemaTableName}"
     df(sqlText).rdd
   }
-
-  private[this] def executeUpd(sql: String): Unit = {
+  
+  private[this] def executeUpd(sql: String): Int = {
     val st = internalConnection.createStatement()
     try {
       st.executeUpdate(sql)
@@ -735,9 +735,11 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
    * @param dataFrame input data
    * @param schemaTableName
    * @param options options to be passed to --splice-properties; bulkImportDirectory is required
+   *
+   * @return Number of records imported
    */
   def bulkImportHFile(dataFrame: DataFrame, schemaTableName: String,
-                      options: java.util.Map[String, String]): Unit =
+                      options: java.util.Map[String, String]): Int =
     bulkImportHFile(dataFrame, schemaTableName, options.asScala)
 
   /**
@@ -746,9 +748,11 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
     * @param dataFrame input data
     * @param schemaTableName
     * @param options options to be passed to --splice-properties; bulkImportDirectory is required
+    *
+    * @return Number of records imported
     */
   def bulkImportHFile(dataFrame: DataFrame, schemaTableName: String,
-                      options: scala.collection.mutable.Map[String, String]): Unit = {
+                      options: scala.collection.mutable.Map[String, String]): Int = {
 
     val bulkImportDirectory = options.get("bulkImportDirectory")
     if (bulkImportDirectory == null) {
@@ -774,9 +778,11 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
     * @param rdd input data
     * @param schemaTableName
     * @param options options to be passed to --splice-properties; bulkImportDirectory is required
+    *
+    * @return Number of records imported
     */
   def bulkImportHFile(rdd: JavaRDD[Row], schema: StructType, schemaTableName: String,
-                      options: scala.collection.mutable.Map[String, String]): Unit = {
+                      options: scala.collection.mutable.Map[String, String]): Int = {
 
     val bulkImportDirectory = options.get("bulkImportDirectory")
     if (bulkImportDirectory == null) {

--- a/splice_spark/src/main/spark2.3/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
+++ b/splice_spark/src/main/spark2.3/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
@@ -423,7 +423,7 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
     df(sqlText).rdd
   }
   
-  private[this] def executeUpd(sql: String): Unit = {
+  private[this] def executeUpd(sql: String): Int = {
     val st = internalConnection.createStatement()
     try {
       st.executeUpdate(sql)
@@ -731,9 +731,11 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
    * @param dataFrame input data
    * @param schemaTableName
    * @param options options to be passed to --splice-properties; bulkImportDirectory is required
+   *
+   * @return Number of records imported
    */
   def bulkImportHFile(dataFrame: DataFrame, schemaTableName: String,
-                      options: java.util.Map[String, String]): Unit =
+                      options: java.util.Map[String, String]): Int =
     bulkImportHFile(dataFrame, schemaTableName, options.asScala)
 
   /**
@@ -742,9 +744,11 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
     * @param dataFrame input data
     * @param schemaTableName
     * @param options options to be passed to --splice-properties; bulkImportDirectory is required
+    *
+    * @return Number of records imported
     */
   def bulkImportHFile(dataFrame: DataFrame, schemaTableName: String,
-                      options: scala.collection.mutable.Map[String, String]): Unit = {
+                      options: scala.collection.mutable.Map[String, String]): Int = {
 
     val bulkImportDirectory = options.get("bulkImportDirectory")
     if (bulkImportDirectory == null) {
@@ -770,9 +774,11 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
     * @param rdd input data
     * @param schemaTableName
     * @param options options to be passed to --splice-properties; bulkImportDirectory is required
+    *
+    * @return Number of records imported
     */
   def bulkImportHFile(rdd: JavaRDD[Row], schema: StructType, schemaTableName: String,
-                      options: scala.collection.mutable.Map[String, String]): Unit = {
+                      options: scala.collection.mutable.Map[String, String]): Int = {
 
     val bulkImportDirectory = options.get("bulkImportDirectory")
     if (bulkImportDirectory == null) {

--- a/splice_spark/src/main/spark2.4/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
+++ b/splice_spark/src/main/spark2.4/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
@@ -425,7 +425,7 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
     df(sqlText).rdd
   }
   
-  private[this] def executeUpd(sql: String): Unit = {
+  private[this] def executeUpd(sql: String): Int = {
     val st = internalConnection.createStatement()
     try {
       st.executeUpdate(sql)
@@ -733,9 +733,11 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
    * @param dataFrame input data
    * @param schemaTableName
    * @param options options to be passed to --splice-properties; bulkImportDirectory is required
+   *
+   * @return Number of records imported
    */
   def bulkImportHFile(dataFrame: DataFrame, schemaTableName: String,
-                      options: java.util.Map[String, String]): Unit =
+                      options: java.util.Map[String, String]): Int =
     bulkImportHFile(dataFrame, schemaTableName, options.asScala)
 
   /**
@@ -744,9 +746,11 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
     * @param dataFrame input data
     * @param schemaTableName
     * @param options options to be passed to --splice-properties; bulkImportDirectory is required
+    *
+    * @return Number of records imported
     */
   def bulkImportHFile(dataFrame: DataFrame, schemaTableName: String,
-                      options: scala.collection.mutable.Map[String, String]): Unit = {
+                      options: scala.collection.mutable.Map[String, String]): Int = {
 
     val bulkImportDirectory = options.get("bulkImportDirectory")
     if (bulkImportDirectory == null) {
@@ -772,9 +776,11 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
     * @param rdd input data
     * @param schemaTableName
     * @param options options to be passed to --splice-properties; bulkImportDirectory is required
+    *
+    * @return Number of records imported
     */
   def bulkImportHFile(rdd: JavaRDD[Row], schema: StructType, schemaTableName: String,
-                      options: scala.collection.mutable.Map[String, String]): Unit = {
+                      options: scala.collection.mutable.Map[String, String]): Int = {
 
     val bulkImportDirectory = options.get("bulkImportDirectory")
     if (bulkImportDirectory == null) {

--- a/splice_spark/src/main/spark3.0/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
+++ b/splice_spark/src/main/spark3.0/com/splicemachine/spark/splicemachine/SplicemachineContext.scala
@@ -423,7 +423,7 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
     df(sqlText).rdd
   }
   
-  private[this] def executeUpd(sql: String): Unit = {
+  private[this] def executeUpd(sql: String): Int = {
     val st = internalConnection.createStatement()
     try {
       st.executeUpdate(sql)
@@ -731,9 +731,11 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
    * @param dataFrame input data
    * @param schemaTableName
    * @param options options to be passed to --splice-properties; bulkImportDirectory is required
+   *
+   * @return Number of records imported
    */
   def bulkImportHFile(dataFrame: DataFrame, schemaTableName: String,
-                      options: java.util.Map[String, String]): Unit =
+                      options: java.util.Map[String, String]): Int =
     bulkImportHFile(dataFrame, schemaTableName, options.asScala)
 
   /**
@@ -742,9 +744,11 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
     * @param dataFrame input data
     * @param schemaTableName
     * @param options options to be passed to --splice-properties; bulkImportDirectory is required
+    *
+    * @return Number of records imported
     */
   def bulkImportHFile(dataFrame: DataFrame, schemaTableName: String,
-                      options: scala.collection.mutable.Map[String, String]): Unit = {
+                      options: scala.collection.mutable.Map[String, String]): Int = {
 
     val bulkImportDirectory = options.get("bulkImportDirectory")
     if (bulkImportDirectory == null) {
@@ -770,9 +774,11 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
     * @param rdd input data
     * @param schemaTableName
     * @param options options to be passed to --splice-properties; bulkImportDirectory is required
+    *
+    * @return Number of records imported
     */
   def bulkImportHFile(rdd: JavaRDD[Row], schema: StructType, schemaTableName: String,
-                      options: scala.collection.mutable.Map[String, String]): Unit = {
+                      options: scala.collection.mutable.Map[String, String]): Int = {
 
     val bulkImportDirectory = options.get("bulkImportDirectory")
     if (bulkImportDirectory == null) {

--- a/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceIT.scala
+++ b/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/DefaultSourceIT.scala
@@ -298,9 +298,10 @@ class DefaultSourceIT extends FunSuite with TestContext with BeforeAndAfter with
     val df = sqlContext.read.options(internalOptions).splicemachine
     val changedDF = df.withColumn("C6_INT", when(col("C6_INT").leq(10), col("C6_INT").plus(20)) )
 
-    splicemachineContext.bulkImportHFile(changedDF, internalTN, bulkImportOptions)
+    val returnedCount = splicemachineContext.bulkImportHFile(changedDF, internalTN, bulkImportOptions)
     val newDF = sqlContext.read.options(internalOptions).splicemachine
-    assert(newDF.count == 20)
+    org.junit.Assert.assertEquals("Incorrect row count in table", 20, newDF.count)
+    org.junit.Assert.assertEquals("Incorrect import count returned from function", 10, returnedCount)
   }
 
   test("bulkImportHFile using rdd") {  // DB-9394
@@ -320,9 +321,10 @@ class DefaultSourceIT extends FunSuite with TestContext with BeforeAndAfter with
     val df = sqlContext.read.options(internalOptions).splicemachine
     val changedDF = df.withColumn("C6_INT", when(col("C6_INT").leq(10), col("C6_INT").plus(20)) )
 
-    splicemachineContext.bulkImportHFile(changedDF.rdd, changedDF.schema, internalTN, bulkImportOptions)
+    val returnedCount = splicemachineContext.bulkImportHFile(changedDF.rdd, changedDF.schema, internalTN, bulkImportOptions)
     val newDF = sqlContext.read.options(internalOptions).splicemachine
-    assert(newDF.count == 20)
+    org.junit.Assert.assertEquals("Incorrect row count in table", 20, newDF.count)
+    org.junit.Assert.assertEquals("Incorrect import count returned from function", 10, returnedCount)
   }
 
 

--- a/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/SplicemachineContextIT.scala
+++ b/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/SplicemachineContextIT.scala
@@ -178,6 +178,15 @@ class SplicemachineContextIT extends FunSuite with TestContext with Matchers {
     dropCarTable
   }
 
+  test("Test Drop Table") {
+    if( ! splicemachineContext.tableExists(carSchemaTableName) ) {
+      createCarTable
+    }
+    org.junit.Assert.assertTrue( splicemachineContext.tableExists(carSchemaTableName) )
+    dropCarTable
+    org.junit.Assert.assertFalse( splicemachineContext.tableExists(carSchemaTableName) )
+  }
+
   test("Test Table Exists (One Param)") {
     createCarTable
     org.junit.Assert.assertTrue(
@@ -260,11 +269,12 @@ class SplicemachineContextIT extends FunSuite with TestContext with Matchers {
     val bulkImportDirectory = new File( System.getProperty("java.io.tmpdir")+s"/$module-SplicemachineContextIT/bulkImport" )
     bulkImportDirectory.mkdirs()
 
-    splicemachineContext.bulkImportHFile(internalTNDF, internalTN,
+    val returnedCount = splicemachineContext.bulkImportHFile(internalTNDF, internalTN,
       collection.mutable.Map("bulkImportDirectory" -> bulkImportDirectory.getAbsolutePath)
     )
 
     org.junit.Assert.assertEquals("Bulk Import Failed!", 1, rowCount(internalTN))
+    org.junit.Assert.assertEquals("Bulk Import function returned incorrect count!", 1, returnedCount)
   }
 
   test("Test SplitAndInsert") {

--- a/splice_spark2/src/main/scala/com/splicemachine/spark2/splicemachine/SplicemachineContext.scala
+++ b/splice_spark2/src/main/scala/com/splicemachine/spark2/splicemachine/SplicemachineContext.scala
@@ -464,6 +464,8 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
    * @param schemaTableName
    * @param statusDirectory status directory where bad records file will be created
    * @param badRecordsAllowed how many bad records are allowed. -1 for unlimited
+   *                          
+   * @return Number of records inserted
    */
   def insert(dataFrame: DataFrame, schemaTableName: String, statusDirectory: String, badRecordsAllowed: Integer): Long =
     insert(dataFrame.rdd, dataFrame.schema, schemaTableName, statusDirectory, badRecordsAllowed)
@@ -481,6 +483,8 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
    * @param statusDirectory status directory where bad records file will be created
    * @param badRecordsAllowed how many bad records are allowed. -1 for unlimited
    *
+   *
+   * @return Number of records inserted
    */
   def insert(rdd: JavaRDD[Row], schema: StructType, schemaTableName: String, statusDirectory: String, badRecordsAllowed: Integer): Long =
     insert(rdd, schema, schemaTableName, Map("insertMode"->"INSERT","statusDirectory"->statusDirectory,"badRecordsAllowed"->badRecordsAllowed.toString) )
@@ -493,6 +497,8 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
     *
     * @param dataFrame input data
     * @param schemaTableName output table
+    *
+    * @return Number of records inserted
     */
   def insert(dataFrame: DataFrame, schemaTableName: String): Long = insert(dataFrame.rdd, dataFrame.schema, schemaTableName)
 
@@ -502,6 +508,8 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
    * @param rdd input data
    * @param schema
    * @param schemaTableName
+   *
+   * @return Number of records inserted
    */
   def insert(rdd: JavaRDD[Row], schema: StructType, schemaTableName: String): Long = insert(rdd, schema, schemaTableName, Map[String,String]())
 
@@ -1060,9 +1068,11 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
    * @param dataFrame input data
    * @param schemaTableName
    * @param options options to be passed to --splice-properties; bulkImportDirectory is required
+   *
+   * @return Number of records inserted
    */
   def bulkImportHFile(dataFrame: DataFrame, schemaTableName: String,
-                      options: java.util.Map[String, String]): Unit =
+                      options: java.util.Map[String, String]): Long =
     bulkImportHFile(dataFrame, schemaTableName, options.asScala)
 
   /**
@@ -1071,9 +1081,11 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
    * @param dataFrame input data
    * @param schemaTableName
    * @param options options to be passed to --splice-properties; bulkImportDirectory is required
+   *
+   * @return Number of records inserted
    */
   def bulkImportHFile(dataFrame: DataFrame, schemaTableName: String,
-                      options: scala.collection.mutable.Map[String, String]): Unit =
+                      options: scala.collection.mutable.Map[String, String]): Long =
     bulkImportHFile(dataFrame.rdd, dataFrame.schema, schemaTableName, options)
 
   /**
@@ -1082,9 +1094,11 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
    * @param rdd input data
    * @param schemaTableName
    * @param options options to be passed to --splice-properties; bulkImportDirectory is required
+   *
+   * @return Number of records inserted
    */
   def bulkImportHFile(rdd: JavaRDD[Row], schema: StructType, schemaTableName: String,
-                      options: scala.collection.mutable.Map[String, String]): Unit = {
+                      options: scala.collection.mutable.Map[String, String]): Long = {
 
     if( ! options.contains("bulkImportDirectory") ) {
       throw new IllegalArgumentException("bulkImportDirectory cannot be null")

--- a/splice_spark2/src/test/scala/com/splicemachine/spark2/splicemachine/SplicemachineContextIT.scala
+++ b/splice_spark2/src/test/scala/com/splicemachine/spark2/splicemachine/SplicemachineContextIT.scala
@@ -269,11 +269,12 @@ class SplicemachineContextIT extends FunSuite with TestContext with Matchers {
     val bulkImportDirectory = new File( System.getProperty("java.io.tmpdir")+s"/$module-SplicemachineContextIT/bulkImport" )
     bulkImportDirectory.mkdirs()
 
-    splicemachineContext.bulkImportHFile(internalTNDF, internalTN,
+    val returnedCount = splicemachineContext.bulkImportHFile(internalTNDF, internalTN,
       collection.mutable.Map("bulkImportDirectory" -> bulkImportDirectory.getAbsolutePath)
     )
 
     org.junit.Assert.assertEquals("Bulk Import Failed!", 1, rowCount(internalTN))
+    org.junit.Assert.assertEquals("Bulk Import function returned incorrect count!", 1, returnedCount)
   }
 
   test("Test SplitAndInsert") {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
NSDS bulk import function will now return the count of imported records.  It was previously not returning anything.

## Long Description
It now returns the count returned from the JDBC Statement executeUpdate() call.

## How to test
In the DB, set up a table:
`splice> create table abc.cars(number int primary key,
                                make  varchar(20),
                                model varchar(20) );`

In Spark, bulk import a dataframe and check that bulk import returns the number of records imported.
`scala> val carsdfi = Seq(
               (1, "Toyota", "Camry"),
               (2, "Honda", "Accord"),
               (3, "Subaru", "Impreza"),
               (4, "Chevy", "Volt")
            ).toDF("NUMBER", "MAKE", "MODEL")`

`scala> spc.bulkImportHFile(carsdfi, "abc.cars", collection.mutable.Map("bulkImportDirectory" -> "/tmp/bi"))`
`res0: Long = 4`