### PR TITLE
DB-11793 global 'splice.olapParallelPartitions' property

### DIFF
--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1285,5 +1285,7 @@ public interface Property {
     String ENTERPRISE_KEY = "splicemachine.enterprise.key";
 
     String ENTERPRISE_ENABLE = "splicemachine.enterprise.enable";
+
+    String SPLICE_OLAP_PARALLEL_PARTITIONS = "splice.olapParallelPartitions";
 }
 

--- a/hbase_sql/src/main/java/com/splicemachine/stream/RemoteQueryClientImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/RemoteQueryClientImpl.java
@@ -14,6 +14,8 @@
 
 package com.splicemachine.stream;
 
+import com.splicemachine.db.iapi.reference.Property;
+import com.splicemachine.db.iapi.services.property.PropertyUtil;
 import splice.com.google.common.net.HostAndPort;
 import com.splicemachine.EngineDriver;
 import com.splicemachine.access.HConfiguration;
@@ -36,7 +38,6 @@ import org.apache.log4j.Logger;
 import splice.com.google.common.util.concurrent.ListenableFuture;
 import splice.com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
-import java.net.ConnectException;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -112,13 +113,13 @@ public class RemoteQueryClientImpl implements RemoteQueryClient {
             String userId = lcc.getCurrentUserId(activation);
             int localPort = config.getNetworkBindPort();
             int sessionId = lcc.getInstanceNumber();
-            Integer parallelPartitionsProperty = (Integer) lcc.getSessionProperties()
-                    .getProperty(SessionProperties.PROPERTYNAME.OLAPPARALLELPARTITIONS);
-            int parallelPartitions = parallelPartitionsProperty == null ? StreamableRDD.DEFAULT_PARALLEL_PARTITIONS : parallelPartitionsProperty;
+
+
             Integer shufflePartitionsProperty = (Integer) lcc.getSessionProperties()
                     .getProperty(SessionProperties.PROPERTYNAME.OLAPSHUFFLEPARTITIONS);
             String opUuid = root.getUuid() != null ? "," + root.getUuid().toString() : "";
             String session = hostname + ":" + localPort + "," + sessionId + opUuid;
+            int parallelPartitions = getParallelPartitions(lcc);
 
             RemoteQueryJob jobRequest = new RemoteQueryJob(ah, root.getResultSetNumber(), uuid, host, port, session, userId, sql,
                     streamingBatches, streamingBatchSize, parallelPartitions, shufflePartitionsProperty);
@@ -151,6 +152,36 @@ public class RemoteQueryClientImpl implements RemoteQueryClient {
         } catch (IOException e) {
             throw StandardException.newException(SQLState.OLAP_SERVER_CONNECTION, e);
         }
+    }
+
+     /**
+     * olap parallel partitions settings.
+     *  priority:
+     *  - session setting (highest prio): olapParallelPartitions session parameter
+     *  - global setting                : SYSCS_SET_GLOBAL_DATABASE_PROPERTY('splice.parallelPartitions', '20');
+     *  - default setting (lowest prio) : DEFAULT_PARALLEL_PARTITIONS = 4;
+     * @param lcc
+     * @return
+     */
+    private int getParallelPartitions(LanguageConnectionContext lcc) {
+        int parallelPartitions = StreamableRDD.DEFAULT_PARALLEL_PARTITIONS;
+        Integer sessionPartitionsProperty = (Integer) lcc.getSessionProperties()
+                .getProperty(SessionProperties.PROPERTYNAME.OLAPPARALLELPARTITIONS);
+        if(sessionPartitionsProperty != null) {
+            parallelPartitions = sessionPartitionsProperty;
+        }
+        else {
+            try {
+                String globalPartitionsProperty = PropertyUtil.
+                        getCachedDatabaseProperty(lcc, Property.SPLICE_OLAP_PARALLEL_PARTITIONS);
+                if (globalPartitionsProperty != null) {
+                    parallelPartitions = Integer.parseInt(globalPartitionsProperty);
+                }
+            } catch(Exception e) {
+                // ignore parse errors
+            }
+        }
+        return parallelPartitions;
     }
 
     private boolean hasLOBs(SpliceBaseOperation root) throws StandardException {


### PR DESCRIPTION
## Description
So far, number of OLAP parallel partitions can be changed with a session or query property olapParallelPartitions. This also adds a global database property `'splice.olapParallelPartitions'` that can be set by e.g.
```
SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY('splice.olapParallelPartitions', '16')
```

Priority of settings is
- session setting (highest prio): `olapParallelPartitions` session parameter
- global setting                : `SYSCS_SET_GLOBAL_DATABASE_PROPERTY('splice.parallelPartitions', '20');`
- default setting (lowest prio) : DEFAULT_PARALLEL_PARTITIONS = 4;

## How to test
currently only implicitly by setting the property, then running a olap query like
```
SELECT * FROM A --splice-properties useOlap=true
;
```