### PR TITLE
DB-11737 Add microbenchmarks for index lookup and join cost

### DIFF
--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
@@ -305,7 +305,7 @@ class SpliceTestPlatformConfig {
         // HFile
         //
         config.setInt("hfile.index.block.max.size", 16 * 1024); // 16KiB
-        config.setFloat("hfile.block.cache.size", 0.25f); // set block cache to 25% of heap
+        config.setFloat("hfile.block.cache.size", 0); // set block cache to 25% of heap
         config.setFloat("io.hfile.bloom.error.rate", (float) 0.005);
         config.setBoolean(CacheConfig.CACHE_BLOOM_BLOCKS_ON_WRITE_KEY, true); // hfile.block.bloom.cacheonwrite
         config.set("hbase.master.hfilecleaner.plugins", getHFileCleanerAsString());

--- a/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
+++ b/platform_it/src/test/java/com/splicemachine/test/SpliceTestPlatformConfig.java
@@ -305,7 +305,7 @@ class SpliceTestPlatformConfig {
         // HFile
         //
         config.setInt("hfile.index.block.max.size", 16 * 1024); // 16KiB
-        config.setFloat("hfile.block.cache.size", 0); // set block cache to 25% of heap
+        config.setFloat("hfile.block.cache.size", 0.25f); // set block cache to 25% of heap
         config.setFloat("io.hfile.bloom.error.rate", (float) 0.005);
         config.setBoolean(CacheConfig.CACHE_BLOOM_BLOCKS_ON_WRITE_KEY, true); // hfile.block.bloom.cacheonwrite
         config.set("hbase.master.hfilecleaner.plugins", getHFileCleanerAsString());

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
@@ -1180,7 +1180,7 @@ public class StatisticsAdmin extends BaseAdminProcedures {
                                                     dataDictionary.addColumnStatistics(statsRow, tc);
                                                 } catch (StandardException e) {
                                                     // DB-9890 Skip a column if its statistics object doesn't fit into HBase cell.
-                                                    if (e.getCause().getMessage().contains("KeyValue size too large")) {
+                                                    if (e.getCause() != null && e.getCause().getMessage() != null && e.getCause().getMessage().contains("KeyValue size too large")) {
                                                         SpliceLogUtils.warn(LOG, "Statistics object of [ConglomID=%d, ColumnID=%d] exceeds max KeyValue size. Try increase hbase.client.keyvalue.maxsize.",
                                                                 conglomId, columnId);
                                                         skippedColIds.add(columnId);
@@ -1277,7 +1277,7 @@ public class StatisticsAdmin extends BaseAdminProcedures {
                                                 dataDictionary.addColumnStatistics(nextRow, tc);
                                             } catch (StandardException e) {
                                                 // DB-9890 Skip a column if its statistics object doesn't fit into HBase cell.
-                                                if (e.getCause().getMessage().contains("KeyValue size too large")) {
+                                                if (e.getCause() != null && e.getCause().getMessage() != null && e.getCause().getMessage().contains("KeyValue size too large")) {
                                                     int columnId = nextRow.getColumn(SYSCOLUMNSTATISTICSRowFactory.COLUMNID).getInt();
                                                     SpliceLogUtils.warn(LOG, "Statistics object of [ConglomID=%d, ColumnID=%d] exceeds max KeyValue size. Try increase hbase.client.keyvalue.maxsize.",
                                                             nextRow.getColumn(SYSCOLUMNSTATISTICSRowFactory.CONGLOMID).getInt(),

--- a/splice_machine/src/test/java/com/splicemachine/benchmark/IndexLookupBenchmark.java
+++ b/splice_machine/src/test/java/com/splicemachine/benchmark/IndexLookupBenchmark.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2021 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.benchmark;
+
+import com.splicemachine.derby.test.framework.SpliceNetConnection;
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.test.Benchmark;
+import org.apache.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertTrue;
+
+@Category(Benchmark.class)
+@RunWith(Parameterized.class)
+public class IndexLookupBenchmark extends Benchmark {
+
+    private static final Logger LOG = Logger.getLogger(IndexLookupBenchmark.class);
+
+    private static final String SCHEMA = IndexLookupBenchmark.class.getSimpleName();
+    private static final String BASE_TABLE = "BASE_TABLE";
+    private static final String BASE_TABLE_IDX = "BASE_TABLE_IDX";
+    private static final String SIDE_TABLE = "SIDE_TABLE";
+    private static final int NUM_CONNECTIONS = 10;
+    private static final int NUM_EXECS = 20;
+    private static final int NUM_WARMUP_RUNS = 5;
+
+    private final int tableSize;
+    private final boolean onOlap;
+    private final int batchSize;
+
+    public IndexLookupBenchmark(int tableSize, boolean onOlap) {
+        this.tableSize = tableSize;
+        this.onOlap = onOlap;
+        this.batchSize = Math.min(tableSize, 1000);
+    }
+
+    @ClassRule
+    public static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(SCHEMA);
+
+    static Connection makeConnection() throws SQLException {
+        Connection connection = SpliceNetConnection.getDefaultConnection();
+        connection.setSchema(spliceSchemaWatcher.schemaName);
+        connection.setAutoCommit(true);
+        return connection;
+    }
+
+    static Connection testConnection;
+    static Statement testStatement;
+
+    @Before
+    public void setUp() throws Exception {
+        getInfo();
+
+        LOG.info("Create tables");
+        testConnection = makeConnection();
+        testStatement = testConnection.createStatement();
+        testStatement.execute("CREATE TABLE " + BASE_TABLE + " (col1 INTEGER NOT NULL, col2 INTEGER, col3 INTEGER, col4 INTEGER, col5 INTEGER)");
+        testStatement.execute("CREATE INDEX " + BASE_TABLE_IDX + " on " + BASE_TABLE + " (col1, col2)");
+
+        testStatement.execute("CREATE TABLE " + SIDE_TABLE + " (col1 INTEGER NOT NULL, col2 INTEGER, col3 INTEGER, col4 INTEGER, col5 INTEGER)");
+
+        curSize.set(0);
+        runBenchmark(NUM_CONNECTIONS, () -> populateTables(tableSize));
+
+        testStatement.execute(String.format("call syscs_util.syscs_flush_table('%s', '%s')", SCHEMA, BASE_TABLE));
+        LOG.info("Collect statistics");
+        try (ResultSet rs = testStatement.executeQuery("ANALYZE SCHEMA " + SCHEMA)) {
+            assertTrue(rs.next());
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        testStatement.execute("DROP TABLE " + BASE_TABLE);
+        testStatement.execute("DROP TABLE " + SIDE_TABLE);
+        testStatement.close();
+        testConnection.close();
+    }
+
+    static final String STAT_ERROR = "ERROR";
+    static final String STAT_CREATE = "CREATE";
+    static final String INDEX_LOOKUP = "INDEX_LOOKUP";
+    static final String INDEX_SCAN = "INDEX_SCAN";
+
+    static AtomicInteger curSize = new AtomicInteger(0);
+
+    private void populateTables(int size) {
+        try (Connection conn = makeConnection()) {
+            try (PreparedStatement insert1 = conn.prepareStatement("INSERT INTO " + BASE_TABLE + " VALUES (?,?,?,?,?)")) {
+                for (; ; ) {
+                    int newSize = curSize.getAndAdd(batchSize);
+                    if (newSize >= size) break;
+                    for (int i = newSize; i < newSize + batchSize; ++i) {
+                        insert1.setInt(1, i);
+                        insert1.setInt(2, i);
+                        insert1.setInt(3, i);
+                        insert1.setInt(4, i);
+                        insert1.setInt(5, i);
+                        insert1.addBatch();
+                    }
+                    long start = System.currentTimeMillis();
+                    int[] counts = insert1.executeBatch();
+                    long end = System.currentTimeMillis();
+                    int count = 0;
+                    for (int c : counts) count += c;
+                    if (count != batchSize) {
+                        updateStats(STAT_ERROR);
+                    }
+                    if (count > 0) {
+                        updateStats(STAT_CREATE, count, end - start);
+                    }
+                }
+            }
+        }
+        catch (Throwable t) {
+            LOG.error("Connection broken", t);
+        }
+    }
+
+    private static int getRowCount(ResultSet rs) throws SQLException {
+        assertTrue(rs.next());
+        return rs.getInt(1);
+    }
+
+    private void benchmark(boolean isIndexLookup, int numExec, boolean warmUp, boolean onOlap) {
+        String sqlText;
+        String dataLabel;
+        if (isIndexLookup) {
+            sqlText = String.format("select count(col3) from %s --splice-properties index=%s, useSpark=false", BASE_TABLE, BASE_TABLE_IDX);
+            dataLabel = INDEX_LOOKUP;
+        } else {
+            sqlText = String.format("select count(col1) from %s --splice-properties index=%s, useSpark=false", BASE_TABLE, BASE_TABLE_IDX);
+            dataLabel = INDEX_SCAN;
+        }
+        try (Connection conn = makeConnection()) {
+            try (PreparedStatement query = conn.prepareStatement(sqlText)) {
+                if (warmUp) {
+                    for (int i = 0; i < NUM_WARMUP_RUNS; ++i) {
+                        query.executeQuery();
+                    }
+                }
+
+                if (isIndexLookup) {
+                    rowContainsQuery(new int[]{6}, "explain " + sqlText, conn, new String[]{"IndexLookup"});
+                } else {
+                    rowContainsQuery(new int[]{6}, "explain " + sqlText, conn, new String[]{"IndexScan"});
+                }
+
+                for (int i = 0; i < numExec; ++i) {
+                    long start = System.currentTimeMillis();
+                    try (ResultSet rs = query.executeQuery()) {
+                        if (getRowCount(rs) != tableSize) {
+                            updateStats(STAT_ERROR);
+                        } else {
+                            long stop = System.currentTimeMillis();
+                            updateStats(dataLabel, stop - start);
+                        }
+                    } catch (SQLException ex) {
+                        LOG.error("ERROR execution " + i + " of indexLookup benchmark on " + BASE_TABLE + ": " + ex.getMessage());
+                        updateStats(STAT_ERROR);
+                    }
+                }
+            }
+        }
+        catch (Throwable t) {
+            LOG.error("Connection broken", t);
+        }
+    }
+
+    @Parameterized.Parameters
+    public static Collection testParams() {
+        return Arrays.asList(new Object[][] {
+                { 1000, false },
+                { 5000, false },
+                { 10000, false },
+                { 15000, false },
+                { 20000, false },
+                { 25000, false },
+                { 30000, false },
+                { 35000, false },
+                { 40000, false },
+                { 45000, false },
+                { 50000, false },
+                { 100000, false },
+                { 150000, false },
+                { 200000, false },
+                { 1000, true },
+                { 5000, true },
+                { 10000, true },
+                { 15000, true },
+                { 20000, true },
+                { 25000, true },
+                { 30000, true },
+                { 35000, true },
+                { 40000, true },
+                { 45000, true },
+                { 50000, true },
+                { 100000, true },
+                { 150000, true },
+                { 200000, true },
+        });
+    }
+
+    /* Warming up would bring data into hbase block cache. To run cold only benchmarks,
+     * hbase block cache must be disabled first:
+     * hfile.block.cache.size = 0
+     */
+
+    @Test
+    public void indexLookupWarm() throws Exception {
+        LOG.info("indexLookupWarm");
+        runBenchmark(1, () -> benchmark(true, NUM_EXECS, true, onOlap));
+    }
+
+    @Test
+    public void indexScanWarm() throws Exception {
+        LOG.info("indexScanWarm");
+        runBenchmark(1, () -> benchmark(false, NUM_EXECS, true, onOlap));
+    }
+}

--- a/splice_machine/src/test/java/com/splicemachine/benchmark/JoinBenchmark.java
+++ b/splice_machine/src/test/java/com/splicemachine/benchmark/JoinBenchmark.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2021 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.benchmark;
+
+import com.splicemachine.derby.test.framework.SpliceNetConnection;
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.test.Benchmark;
+import org.apache.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertTrue;
+
+@Category(Benchmark.class)
+@RunWith(Parameterized.class)
+public class JoinBenchmark extends Benchmark {
+
+    private static final Logger LOG = Logger.getLogger(JoinBenchmark.class);
+
+    private static final String SCHEMA = JoinBenchmark.class.getSimpleName();
+    private static final String LEFT_TABLE = "LEFT_TABLE";
+    private static final String LEFT_IDX = "LEFT_IDX";
+    private static final String RIGHT_TABLE = "RIGHT_TABLE";
+    private static final String RIGHT_IDX = "RIGHT_IDX";
+    private static final int NUM_CONNECTIONS = 10;
+    private static final int NUM_EXECS = 20;
+    private static final int NUM_WARMUP_RUNS = 5;
+
+    private static final String NESTED_LOOP = "NestedLoop";
+    private static final String BROADCAST = "Broadcast";
+    private static final String MERGE = "Merge";
+    private static final String MERGE_SORT = "SortMerge";
+    private static final String CROSS = "Cross";
+
+    private final int leftSize;
+    private final int rightSize;
+    private final boolean onOlap;
+    private final int batchSize;
+
+    public JoinBenchmark(int leftSize, int rightSize, boolean onOlap) {
+        this.leftSize = leftSize;
+        this.rightSize = rightSize;
+        this.onOlap = onOlap;
+        this.batchSize = Math.min(Math.min(leftSize, rightSize), 1000);
+    }
+
+    @ClassRule
+    public static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(SCHEMA);
+
+    static Connection makeConnection() throws SQLException {
+        Connection connection = SpliceNetConnection.getDefaultConnection();
+        connection.setSchema(spliceSchemaWatcher.schemaName);
+        connection.setAutoCommit(true);
+        return connection;
+    }
+
+    static Connection testConnection;
+    static Statement testStatement;
+
+    @Before
+    public void setUp() throws Exception {
+
+        getInfo();
+
+        LOG.info("Create tables");
+        testConnection = makeConnection();
+        testStatement = testConnection.createStatement();
+        testStatement.execute("CREATE TABLE " + LEFT_TABLE + " (col1 INTEGER, col2 INTEGER, col3 INTEGER, col4 INTEGER, col5 INTEGER)");
+        testStatement.execute("CREATE INDEX " + LEFT_IDX + " on " + LEFT_TABLE + " (col2, col3)");
+
+        testStatement.execute("CREATE TABLE " + RIGHT_TABLE + " (col1_pk INTEGER PRIMARY KEY, col2 INTEGER, col3 INTEGER, col4 INTEGER, col5 INTEGER)");
+        testStatement.execute("CREATE INDEX " + RIGHT_IDX + " on " + RIGHT_TABLE + " (col2, col3)");
+
+        curSize.set(0);
+        runBenchmark(NUM_CONNECTIONS, () -> populateTable(LEFT_TABLE, leftSize));
+
+        curSize.set(0);
+        runBenchmark(NUM_CONNECTIONS, () -> populateTable(RIGHT_TABLE, rightSize));
+
+        testStatement.execute(String.format("call syscs_util.syscs_flush_table('%s', '%s')", SCHEMA, LEFT_TABLE));
+        testStatement.execute(String.format("call syscs_util.syscs_flush_table('%s', '%s')", SCHEMA, RIGHT_TABLE));
+
+        LOG.info("Collect statistics");
+        try (ResultSet rs = testStatement.executeQuery("ANALYZE SCHEMA " + SCHEMA)) {
+            assertTrue(rs.next());
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        testStatement.execute("DROP TABLE " + LEFT_TABLE);
+        testStatement.execute("DROP TABLE " + RIGHT_TABLE);
+        testStatement.close();
+        testConnection.close();
+    }
+
+    static final String STAT_ERROR = "ERROR";
+    static final String STAT_PREP = "PREPARE ";
+    static final String KEY_JOIN = " JOIN ON KEY";
+    static AtomicInteger curSize = new AtomicInteger(0);
+
+    private void populateTable(String tableName, int size) {
+        try (Connection conn = makeConnection()) {
+            try (PreparedStatement insert = conn.prepareStatement("INSERT INTO " + tableName + " VALUES (?,?,?,?,?)")) {
+                for (; ; ) {
+                    int newSize = curSize.getAndAdd(batchSize);
+                    if (newSize >= size) break;
+                    for (int i = newSize; i < newSize + batchSize; ++i) {
+                        insert.setInt(1, i);
+                        insert.setInt(2, i);
+                        insert.setInt(3, i);
+                        insert.setInt(4, i);
+                        insert.setInt(5, i);
+                        insert.addBatch();
+                    }
+                    long start = System.currentTimeMillis();
+                    int[] counts = insert.executeBatch();
+                    long end = System.currentTimeMillis();
+                    int count = 0;
+                    for (int c : counts) count += c;
+                    if (count != batchSize) {
+                        updateStats(STAT_ERROR);
+                    }
+                    if (count > 0) {
+                        updateStats(STAT_PREP + tableName, count, end - start);
+                    }
+                }
+            }
+        }
+        catch (Throwable t) {
+            LOG.error("Connection broken", t);
+        }
+    }
+
+    private int getRowCount(ResultSet rs) throws SQLException {
+        assertTrue(rs.next());
+        return rs.getInt(1);
+    }
+
+    private void benchmark(String joinStrategy, boolean isKeyJoin, int numExec, boolean warmUp, boolean onOlap) {
+        boolean isMergeJoin = joinStrategy.equals(MERGE);
+        String sqlText = String.format("select count(L.col2) from --splice-properties joinOrder=fixed\n" +
+                "   %s L --splice-properties index=%s, useSpark=%b\n" +
+                " , %s R --splice-properties joinStrategy=%s, index=%s\n",
+                LEFT_TABLE, isKeyJoin ? LEFT_IDX : "null",
+                onOlap, RIGHT_TABLE, joinStrategy,
+                isKeyJoin ? "null" : (isMergeJoin ? RIGHT_IDX : "null"));
+        String dataLabel;
+        if (isKeyJoin) {
+            sqlText += " where L.col2 = R.col1_pk";
+            dataLabel = joinStrategy + KEY_JOIN;
+        } else {
+            sqlText += " where L.col4 = R.col4";
+            dataLabel = joinStrategy;
+        }
+        try (Connection conn = makeConnection()) {
+            try (PreparedStatement query = conn.prepareStatement(sqlText)) {
+                // validate plan
+                int[] expectedRows = {6,6,8};
+                String[] row6 = {joinStrategy + "Join"};
+                if (joinStrategy.equals(MERGE_SORT)) {
+                    row6[0] = "MergeSortJoin";
+                }
+                String[] row6or7;
+                String[] row8;
+                if (isKeyJoin) {
+                    row6or7 = new String[]{"preds=[(L.COL2[4:1] = R.COL1_PK[4:2])]"};
+                    row8 = new String[]{"IndexScan[LEFT_IDX"};
+                    if (joinStrategy.equals(NESTED_LOOP)) {
+                        expectedRows[1] = 7;
+                        row6or7[0] = "preds=[(L.COL2[1:1] = R.COL1_PK[2:1])]";
+                    }
+                } else {
+                    row6or7 = new String[]{"preds=[(L.COL4[4:2] = R.COL4[4:3])]"};
+                    row8 = new String[]{"TableScan[LEFT_TABLE"};
+                    if (joinStrategy.equals(NESTED_LOOP)) {
+                        expectedRows[1] = 7;
+                        row6or7[0] = "preds=[(L.COL4[1:2] = R.COL4[2:1])]";
+                    }
+                }
+                rowContainsQuery(expectedRows, "explain " + sqlText, conn, row6, row6or7, row8);
+
+                // warm-up runs
+                if (warmUp) {
+                    for (int i = 0; i < NUM_WARMUP_RUNS; ++i) {
+                        query.executeQuery();
+                    }
+                }
+
+                // measure and validate result row count
+                for (int i = 0; i < numExec; ++i) {
+                    long start = System.currentTimeMillis();
+                    try (ResultSet rs = query.executeQuery()) {
+                        if (getRowCount(rs) != Math.min(leftSize, rightSize)) {
+                            updateStats(STAT_ERROR);
+                        } else {
+                            long stop = System.currentTimeMillis();
+                            updateStats(dataLabel, stop - start);
+                        }
+                    } catch (SQLException ex) {
+                        LOG.error("ERROR execution " + i + " of join benchmark using " + joinStrategy + ": " + ex.getMessage());
+                        updateStats(STAT_ERROR);
+                    }
+                }
+            }
+        }
+        catch (Throwable t) {
+            LOG.error("Connection broken", t);
+        }
+    }
+
+    @Parameterized.Parameters
+    public static Collection testParams() {
+        return Arrays.asList(new Object[][] {
+                { 10, 10, false },
+                { 100, 10, false },
+                { 1000, 10, false },
+                { 10000, 10, false },
+                { 100000, 10, false },
+                { 1000000, 10, false },
+                { 10, 100, false },
+                { 100, 100, false },
+                { 1000, 100, false },
+                { 10000, 100, false },
+                { 100000, 100, false },
+                { 1000000, 100, false },
+                { 10, 1000, false },
+                { 100, 1000, false },
+                { 1000, 1000, false },
+                { 10000, 1000, false },
+                { 100000, 1000, false },
+                { 1000000, 1000, false },
+                { 10, 10000, false },
+                { 100, 10000, false },
+                { 1000, 10000, false },
+                { 10000, 10000, false },
+                { 100000, 10000, false },
+                { 1000000, 10000, false },
+                { 10, 100000, false },
+                { 100, 100000, false },
+                { 1000, 100000, false },
+                { 10000, 100000, false },
+                { 10, 1000000, false },
+                { 100, 1000000, false },
+                { 1000, 1000000, false },
+                { 10000, 1000000, false },
+                { 10, 10, true },
+                { 100, 10, true },
+                { 1000, 10, true },
+                { 10000, 10, true },
+                { 100000, 10, true },
+                { 1000000, 10, true },
+                { 10, 100, true },
+                { 100, 100, true },
+                { 1000, 100, true },
+                { 10000, 100, true },
+                { 100000, 100, true },
+                { 1000000, 100, true },
+                { 10, 1000, true },
+                { 100, 1000, true },
+                { 1000, 1000, true },
+                { 10000, 1000, true },
+                { 100000, 1000, true },
+                { 1000000, 1000, true },
+                { 10, 10000, true },
+                { 100, 10000, true },
+                { 1000, 10000, true },
+                { 10000, 10000, true },
+                { 100000, 10000, true },
+                { 1000000, 10000, true },
+                { 10, 100000, true },
+                { 100, 100000, true },
+                { 1000, 100000, true },
+                { 10000, 100000, true },
+                { 10, 1000000, true },
+                { 100, 1000000, true },
+                { 1000, 1000000, true },
+                { 10000, 1000000, true },
+        });
+    }
+
+    /* Warming up would bring data into hbase block cache. To run cold only benchmarks,
+     * hbase block cache must be disabled first:
+     * hfile.block.cache.size = 0
+     */
+
+    @Test
+    public void KeyJoinWarm() throws Exception {
+        LOG.info("KeyJoinWarm");
+        runBenchmark(1, () -> benchmark(NESTED_LOOP, true, NUM_EXECS, true, onOlap));
+        runBenchmark(1, () -> benchmark(MERGE_SORT, true, NUM_EXECS, true, onOlap));
+        runBenchmark(1, () -> benchmark(BROADCAST, true, NUM_EXECS, true, onOlap));
+        runBenchmark(1, () -> benchmark(MERGE, true, NUM_EXECS, true, onOlap));
+        if (onOlap) {
+            runBenchmark(1, () -> benchmark(CROSS, true, NUM_EXECS, true, onOlap));
+        }
+    }
+
+    @Test
+    public void NonKeyJoinWarm() throws Exception {
+        LOG.info("NonKeyJoinWarm");
+        runBenchmark(1, () -> benchmark(NESTED_LOOP, false, NUM_EXECS, true, onOlap));
+        runBenchmark(1, () -> benchmark(MERGE_SORT, false, NUM_EXECS, true, onOlap));
+        runBenchmark(1, () -> benchmark(BROADCAST, false, NUM_EXECS, true, onOlap));
+        // merge join is not feasible in this case
+        if (onOlap) {
+            runBenchmark(1, () -> benchmark(CROSS, false, NUM_EXECS, true, onOlap));
+        }
+    }
+}


### PR DESCRIPTION
## Short Description
This change adds two microbenchmarks for cost estimation tuning.

## Long Description
This change adds the following microbenchmarks:
- index lookup performance w.r.t. number of rows on OLTP/OLAP
- index scan performance w.r.t. number of rows on OLTP/OLAP
- joining on key column performance w.r.t.
    - left table size
    - right table size
    - join strategy
    - OLTP / OLAP
- joining on non-key column performance with the same set of parameters as above

## How to test
The microbenchmarks do not run by default anywhere. To run any of them against a standalone cluster, simply do the same as running an IT the way you like. To run any of them against a cluster on cloud, do the following:

1. Prepare the necessary jar files as a tarball.
```
$ mvn -Pcore,cdh6.3.0 clean install -DskipTests
$ mkdir benchmark
$ cp ./platform_it/src/main/resources/info-log4j.properties /Users/<your username>/.m2/repository/junit/junit/4.12/junit-4.12.jar /Users/<your username>/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar ./splice_machine/target/splice_machine-3.2.0.2007-SNAPSHOT-tests.jar ./platform_it/target/dependency/log4j-1.2.17.jar ./platform_it/target/dependency/db-client-3.2.0.2007-SNAPSHOT.jar benchmark
$ tar czvf benchmark.tar.gz ./benchmark
$ 
```
2. Upload the tarball to your cluster. You need to be authorized to the k8s environment before doing this step.
```
$ kubectl cp benchmark.tar.gz splicedb-hregion-0:/home/hbase/ -n <your cluster namespace>
```
3. Log into the `splicedb-hregion-0` pod of your cluster:
```
$ kubectl exec -it splicedb-hregion-0 -n <your cluster namespace> -- bash
```
4. Once in pod, run the benchmark:
```
$ cd home/hbase
$ tar zxvf benchmark.tar.gz
$ java -Dlog4j.configuration=file:./benchmark/info-log4j.properties -cp 'benchmark/*' org.junit.runner.JUnitCore com.splicemachine.benchmark.<benchmark name>
```