### PR TITLE
DB-11739 Add Hbck2 pipeline/Update Instructions

### DIFF
--- a/pipelines/hbck/Jenkinsfile
+++ b/pipelines/hbck/Jenkinsfile
@@ -1,0 +1,68 @@
+@Library('jenkins-shared-library')_
+
+// Define params
+def slackResponse = slackSend(channel: "db-automated-testing", message: "Launching $JOB_NAME pipeline")
+slackSend(channel: slackResponse.threadId, message: "Launching Jenkins node...")
+
+
+node('splice-standalone'){
+    try{
+        def artifact_values  = [
+            [$class: 'VaultSecret', path: "secret/aws/jenkins/colo_jenkins", secretValues: [
+                [$class: 'VaultSecretValue', envVar: 'ARTIFACT_USER', vaultKey: 'user'],
+                [$class: 'VaultSecretValue', envVar: 'ARTIFACT_PASSWORD', vaultKey: 'pass']]]
+        ]
+        slackSend(channel: slackResponse.threadId, message: "Assembling secrets and variables...")
+        slackSend(channel: slackResponse.threadId, message: "Checking out code...")
+            stage("Checkout") {
+                // Get some code from a GitHub repository
+                checkout([  
+                    $class: 'GitSCM', 
+                    branches: [[name: 'refs/heads/master']], 
+                    doGenerateSubmoduleConfigurations: false, 
+                    extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'hbck']], 
+                    submoduleCfg: [], 
+                    userRemoteConfigs: [[url: 'https://github.com/apache/hbase-operator-tools.git']]
+                ])
+                checkout([  
+                    $class: 'GitSCM', 
+                    branches: [[name: 'refs/heads/master']], 
+                    doGenerateSubmoduleConfigurations: false, 
+                    extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine']], 
+                    submoduleCfg: [], 
+                    userRemoteConfigs: [[credentialsId: '88647ede-744a-444b-8c08-8313cc137944', url: 'https://github.com/splicemachine/spliceengine.git']]
+                ])
+            }
+            slackSend(channel: slackResponse.threadId, message: "Deploying Latest HBCK2...")
+            stage("Deploy") {
+                dir('spliceengine'){
+                wrap([$class: 'VaultBuildWrapper', vaultSecrets: artifact_values]) {
+                    sh """
+                    mvn -Dmaven.test.failure.ignore=true -B -e --fail-at-end clean install -DskipTests
+                    cp pipelines/template/settings.xml ~/.m2/settings.xml
+                    sed  -i "s/REPLACE_USER/$ARTIFACT_USER/" ~/.m2/settings.xml
+                    sed  -i "s/REPLACE_PASS/$ARTIFACT_PASSWORD/" ~/.m2/settings.xml
+                    """
+                    }
+                }
+                dir('hbck'){
+                    sh """
+                    mvn versions:set -DnewVersion=STABLE
+                    sed -i '469 i\\ <profile><id>splicemachine-external</id><distributionManagement><repository><id>splicemachine</id><name>Splice Machine Releases</name><url>http://repository.splicemachine.com/nexus/content/repositories/releases</url><uniqueVersion>false</uniqueVersion></repository></distributionManagement></profile>' pom.xml
+                    tail pom.xml
+                    mvn -Dmaven.test.failure.ignore=true -B -e --fail-at-end clean deploy -Psplicemachine-external
+                    """
+                }
+            }
+    } catch (any) {
+        // if there was an exception thrown, the build failed
+        currentBuild.result = "FAILED"
+        throw any
+
+    } finally {
+        archiveArtifacts artifacts: 'hbck/hbase-hbck2/target/*.jar', allowEmptyArchive: true
+        slackSend(channel: slackResponse.threadId, message: "$JOB_NAME job status: $currentBuild.result $BUILD_URL")
+        // success or failure, always send notifications
+        notifyBuild(currentBuild.result)
+    }
+}

--- a/platforms/hbck/README.md
+++ b/platforms/hbck/README.md
@@ -1,0 +1,47 @@
+# Apache HBase HBCK2 Tool
+
+_HBCK2_ is the repair tool for Apache HBase clusters.
+
+hbck2 is the HBase 2.0 replacement for hbck, the HBase metadata repair tool.  This tool is used to repair `hbase:meta`, the HBase metadata table that contains the mappings from regions to regionservers. hbck/hbck2 is not used in normal operations, but is used if `hbase:meta` is damaged in some way. In some circumstances, hbck2 is the only way to recover data stored in HBase.
+
+In cases where `hbase:meta` is so corrupt that hbck2 cannot be used, HBase supports another tool, `OfflineMetaRepair`.  Again, this tool is not used for normal operations.  It is a special-purpose tool needed for particular `hbase:meta` corruption on HBase 1.0.  The 1.0 tool cannot be used against HBase 2.0 files. If it has been used, it causes data corruption which must be repaired using hbck2. There is a version of OfflineMetaRepair for hbase 2.0 that is not available in initial release of HBase 2.0.
+
+If hbase:meta is corrupt, then HBase cannot start. Data stored in HBase, including Splice Machine tables, is not accessible.
+
+## Obtaining _HBCK2_
+Releases can be found under the HBase distribution directory. See the
+[HBASE Downloads Page](http://hbase.apache.org/downloads.html).
+
+## Building _HBCK2_
+
+Run:
+```
+$ git clone https://github.com/apache/hbase-operator-tools.git
+$ cd hbase-operator-tools
+$ mvn clean install
+```
+The built _HBCK2_ jar will be in the `target` sub-directory of hbase-hbck2.
+
+## Running _HBCK2_
+
+To reassign regions with hbck, where `35cf997c258033655b74ba88e916b455` is the corrupt region
+
+`HBASE_CLASSPATH_PREFIX=/tmp/hbase-hbck2-STABLE.jar hbase org.apache.hbase.HBCK2 -skip assigns 35cf997c258033655b74ba88e916b455`
+
+You can also split the regions into a file and pass the file into the tool
+
+1. Get the list of regionservers and divided them into groups of size X. `split regionlist -l [Size of Group] regionlists`
+This results in X-row files regionlistsaa, regionlistsab...  
+2. Assign the regions from the files using hbck `hbase hbck -j hbase-hbck2-STABLE.jar assigns -i regionlistsaa`
+
+If you have corrupt metadata and need to run `OfflineMetaRepair` 
+
+1. Find the Hbase region that is corrupt i.e. `35cf997c258033655b74ba88e916b455`
+2. Shutdown the cluster
+3. Run `HBASE_CLASSPATH_PREFIX=/tmp/hbase-hbck2-STABLE.jar hbase org.apache.hbase.hbck1.OfflineMetaRepair -details`
+4. Restart the cluster
+5. Run `HBASE_CLASSPATH_PREFIX=/tmp/hbase-hbck2-STABLE.jar hbase org.apache.hbase.HBCK2 -skip assigns 35cf997c258033655b74ba88e916b455`
+6. Verify HMaster loaded and all tables are DISABLED (expected)
+7. From hbase shell ran enable_all '.*' to enable all tables 
+
+More information on how to use Hbck2 can be found at the [official hbase operator tools repository](https://github.com/apache/hbase-operator-tools/tree/master/hbase-hbck2)


### PR DESCRIPTION
## Short Description
Add README.md and add build pipeline to build hbck2.

## Long Description
Add a small readme with how to build and some quick usage. Also built a build pipeline to deploy the hbck2 at a location that we can use. Set the version to STABLE (RELEASE and LATEST is deprecated and thus can't be deployed), so that our docker images can have a static location that can pull down the jar.

## How to test
https://jenkins.build.splicemachine-dev.io/job/spliceengine-master/job/hbck/
