### PR TITLE
DB-11806 RestartOlapServer Zookeeper Port

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeSystemProcedures.java
@@ -97,7 +97,8 @@ public class UpgradeSystemProcedures {
             throw StandardException.newException(SQLState.INVALID_PARAMETER, "hbase.zookeeper.property.clientPort",
                     String.valueOf(port));
         }
-        String hostAndPort = quorum + ":" + port;
+        String portAppend = ":" + port;
+        String hostAndPort = quorum.endsWith(portAppend) ? quorum : quorum + portAppend;
         ZooKeeper zk = new ZooKeeper(hostAndPort, 120000, null);
 
         String path = SIDriver.driver().getConfiguration().getSpliceRootPath()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
https://splicemachine.atlassian.net/browse/DB-11806
In UpgradeSystemProcedures.restartOlapServer() append the port to the zookeeper address only if it's not there.

## Long Description
UpgradeSystemProcedures.restartOlapServer() was appending the port to the zookeeper address.  This was apparently needed in standalone and in on-prem envs, but the zookeeper address shown in a log from k8s has the port duplicated.  The config param `hbase.zookeeper.quorum` in k8s has the port but in the other envs it apparently doesn't.

Changed the code to check if the port is already on the end of the zookeeper quorum address before appending it.

## How to test
Before the fix, calling SYSCS_UTIL.SYSCS_ROLLBACK_DATABASE_TO_TRANSACTION() in k8s gave the error:
`KeeperErrorCode = ConnectionLoss for /splice/olapServer/restart`

To test, be sure Rollback still works as before in standalone and in on-prem envs.  In k8s, test that Rollback works normally and doesn't give the error.