### PR TITLE
DB-11815 Add JWT jars to common dependencies to enable deployment

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -129,7 +129,10 @@
             orc-protobuf,
             spark-avro_2.11,
             jython-standalone,
-            picocli
+            picocli,
+            jjwt-api,
+            jjwt-impl,
+            jjwt-jackson
         </commonArtifacts>
     </properties>
     <build>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
Add JWT jars to common dependencies to enable deployment of SSO to either onto an on-prem or cloud deployment

## Long Description
JWT jars are not currently available in a cluster, but a standalone cluster which uses maven to resolve dependencies pulls down the needed jars. This PR adds the needed JWT jars in order to add the dependencies needed to get SSO running with just the parcel.

## How to test
Was deployed on a cloud cluster and tested
