### PR TITLE
DB-11818: fix table/schema backup stats backward compatibility

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/DataInputUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/io/DataInputUtil.java
@@ -41,6 +41,7 @@ import java.io.IOException;
  */
 public final class DataInputUtil {
 
+    private static ThreadLocal<Boolean> readOldFormat = new ThreadLocal<>();
     /**
      * Skips requested number of bytes,
      * throws EOFException if there is too few bytes in the DataInput.
@@ -84,10 +85,19 @@ public final class DataInputUtil {
      * @return
      */
     public static boolean shouldReadOldFormat() {
-        return !BaseDataDictionary.READ_NEW_FORMAT;
+        return readOldFormat!= null && readOldFormat.get()!= null && readOldFormat.get()
+                || !BaseDataDictionary.READ_NEW_FORMAT;
     }
 
     public static boolean shouldWriteOldFormat() {
         return !BaseDataDictionary.WRITE_NEW_FORMAT;
+    }
+
+    public static void setReadOldFormat(Boolean b) {
+        readOldFormat.set(b);
+    }
+
+    public static void clearReadOldFormat() {
+        readOldFormat.remove();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
On a post-2003 build, restoring a backup from pre-2003 build failed

## Long Description
Build 2003 changes serialization of statistics. However, older backup still stores statistics in old serialization format. To fix this issue, bump up backup version number. For pre-2009 backup, its stats will be read using old format first. If that does not work, read using newer format. For post-2009 backup, its stats will be always stored and read using new format.

## How to test
Make table/schema backup on a pre-2003 build. Table/schema and their stats should be restored successfully.
