### PR TITLE
DB-11764 TOSCA rich client test - query complexity

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
@@ -367,7 +367,7 @@ public interface ResultSetFactory {
                                                double optimizerEstimatedRowCount,
                                                double optimizerEstimatedCost,
                                                String explainPlan,
-                                               String filterPred,
+                                               String[] filterPred,
                                                String[] expressions,
                                                boolean hasGroupingFunction,
                                                String subqueryText) throws StandardException;
@@ -386,7 +386,7 @@ public interface ResultSetFactory {
                                                double optimizerEstimatedRowCount,
                                                double optimizerEstimatedCost,
                                                String explainPlan,
-                                               String filterPred,
+                                               String[] filterPred,
                                                String[] expressions,
                                                boolean hasGroupingFunction) throws StandardException;
 
@@ -405,7 +405,7 @@ public interface ResultSetFactory {
                                                double optimizerEstimatedRowCount,
                                                double optimizerEstimatedCost,
                                                String explainPlan,
-                                               String filterPred,
+                                               String[] filterPred,
                                                String[] expressions) throws StandardException;
 
     NoPutResultSet getProjectRestrictResultSet(NoPutResultSet source,

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
@@ -49,6 +49,7 @@ import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.impl.ast.PredicateUtils;
 import com.splicemachine.db.impl.ast.RSUtils;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
+import org.apache.commons.lang3.StringUtils;
 import splice.com.google.common.base.Joiner;
 import splice.com.google.common.collect.Lists;
 
@@ -1742,7 +1743,14 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
     }
 
     private static void generateFiltersArrayOnStack(ExpressionClassBuilder acb, MethodBuilder mb, String filterPred) {
-        String filters[] = filterPred.split("(?<=\\G.{" + STRING_MAX_LENGTH + "})");
+        String filters[];
+
+        if (StringUtils.isNotEmpty(filterPred)) {
+            filters = filterPred.split("(?<=\\G.{" + STRING_MAX_LENGTH + "})");
+        } else {
+            filters = new String[0];
+        }
+
         String stringClassName = "java.lang.String";
         LocalField arrayField = acb.newFieldDeclaration(
                 Modifier.PRIVATE, stringClassName + "[]");

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
@@ -211,7 +211,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                                                       double optimizerEstimatedRowCount,
                                                       double optimizerEstimatedCost,
                                                       String explainPlan,
-                                                      String filterPred,
+                                                      String[] filterPred,
                                                       String[] expressions) throws StandardException  {
         return getProjectRestrictResultSet(source,
                                            restriction,
@@ -247,7 +247,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                                                       double optimizerEstimatedRowCount,
                                                       double optimizerEstimatedCost,
                                                       String explainPlan,
-                                                      String filterPred,
+                                                      String[] filterPred,
                                                       String[] expressions,
                                                       boolean hasGroupingFunction) throws StandardException {
         return getProjectRestrictResultSet(source,
@@ -284,7 +284,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                                                       double optimizerEstimatedRowCount,
                                                       double optimizerEstimatedCost,
                                                       String explainPlan,
-                                                      String filterPred,
+                                                      String[] filterPred,
                                                       String[] expressions,
                                                       boolean hasGroupingFunction,
                                                       String subqueryText) throws StandardException {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ProjectRestrictOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ProjectRestrictOperation.java
@@ -71,7 +71,7 @@ public class ProjectRestrictOperation extends SpliceBaseOperation {
 	public         SpliceMethod<ExecRow>             projection;
 	private        ExecRow                           execRowDefinition;
 	private        ExecRow                           projRow;
-	private        String                            filterPred                    = null;
+	private        String[]                          filterPred                    = null;
 	private        String[]                          expressions                   = null;
 	private        boolean                           hasGroupingFunction;
 	private        String                            subqueryText;
@@ -88,7 +88,7 @@ public class ProjectRestrictOperation extends SpliceBaseOperation {
 	}
 
 	public boolean hasFilterPred() {
-		return (filterPred != null && !filterPred.isEmpty());
+		return (filterPred != null && filterPred.length > 0);
 	}
 
 	public boolean hasGroupingFunction() {
@@ -97,7 +97,7 @@ public class ProjectRestrictOperation extends SpliceBaseOperation {
 
 	public String getFilterPred() {
 		if (hasFilterPred())
-			return filterPred;
+			return String.join("", filterPred);
 		else
 			return "true";
 	}
@@ -127,7 +127,7 @@ public class ProjectRestrictOperation extends SpliceBaseOperation {
 									boolean doesProjection,
 									double optimizerEstimatedRowCount,
 									double optimizerEstimatedCost,
-									String filterPred,
+									String[] filterPred,
 									String[] expressions,
 									boolean hasGroupingFunction,
 									String subqueryText) throws StandardException {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
The too complex query can cause a java.io.UTFDataFormatException.

## Long Description
if DataOutputStream.writeUTF is used, the length of the parameter cannot exceed 65535. This is due to the fact, that writeUTF uses the first two bytes to code the length of the byte array and has a check for this:
```
if (utflen > 65535)
            throw new UTFDataFormatException(
                "encoded string too long: " + utflen + " bytes");
```
In particular, in this case, the problem is with ProjectRestrictOperation.filterPred, when the query has too many values in 'in' clause, for example. CONSTANT_Utf8_info.put cannot serialize a value to ClassFormatOutput.

## How to test
Use many values for in clause in the query, like select * from [TABLE] where id in('id1','id2', .... 'idn'), that the length of the string 
```
in('id1','id2', .... 'idn')
```
is greater than 65535. It's not necessary, that all ids are presented in the database. Important only the length.
