### PR TITLE
DB-11738 Fix feasible() of HashableJoinStrategy

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizablePredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizablePredicateList.java
@@ -167,26 +167,28 @@ public interface OptimizablePredicateList {
 	/**
 	 * Is there an optimizable equijoin on the specified column?
 	 *
-	 * @param optTable		The optimizable the column comes from.
-	 * @param columnNumber	The column number within the base table.
-	 *
+	 * @param optTable        The optimizable the column comes from.
+	 * @param columnNumber    The column number within the base table.
+	 * @param joinedTableSet  The set of table numbers of the optimizables that
+	 *                        have been joined up to the current join position.
 	 * @return Whether or not there is an optimizable equijoin on the specified column.
 	 *
 	 * @exception StandardException		Thrown on error
 	 */
-	boolean hasOptimizableEquijoin(Optimizable optTable, int columnNumber) throws StandardException;
+	boolean hasOptimizableEquijoin(Optimizable optTable, int columnNumber, JBitSet joinedTableSet) throws StandardException;
 
 	/**
 	 * Is there an optimizable equijoin on the specified expression?
 	 *
-	 * @param optTable		The optimizable the expression refers to.
-	 * @param expr			The expression itself.
-	 *
+	 * @param optTable        The optimizable the expression refers to.
+	 * @param expr            The expression itself.
+	 * @param joinedTableSet  The set of table numbers of the optimizables that
+	 *                        have been joined up to the current join position.
 	 * @return Whether or not there is an optimizable equijoin on the specified expression.
 	 *
 	 * @exception StandardException		Thrown on error
 	 */
-	boolean hasOptimizableEquijoin(Optimizable optTable, ValueNode expr) throws StandardException;
+	boolean hasOptimizableEquijoin(Optimizable optTable, ValueNode expr, JBitSet joinedTableSet) throws StandardException;
 									
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizer.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizer.java
@@ -382,6 +382,10 @@ public interface Optimizer{
 
     OptimizableList getOptimizableList();
 
+    JBitSet getAssignedTableMap();
+
+    void setAssignedTableMap(JBitSet refMap);
+
     void updateBestPlanMaps(short action,Object planKey) throws StandardException;
 
     void addScopedPredicatesToList(OptimizablePredicateList predList) throws StandardException;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
@@ -35,7 +35,6 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.cache.ClassSize;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
-import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.compile.*;
 import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
@@ -44,7 +43,6 @@ import com.splicemachine.db.iapi.sql.dictionary.IndexRowGenerator;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.util.JBitSet;
 
-import javax.naming.Context;
 import java.util.Vector;
 
 /**
@@ -137,26 +135,8 @@ public abstract class HashableJoinStrategy extends BaseJoinStrategy {
             cd = innerTable.getCurrentAccessPath().getConglomerateDescriptor();
         }
 
-        /* Exclude predicates that are not useful in probing hash table built from right table.
-         * Make sure the same logic applies here and in divideUpPredicateLists(). Otherwise,
-         * this routine could return a hash-based join strategy is feasible but later in
-         * modifying access paths, no hash columns is found.
-         */
-        if (predList != null) {
-            JBitSet joinedTablesInCurrentQueryBlock = optimizer.getAssignedTableMap();
-            PredicateList predListCopy = new PredicateList();
-            PredicateList nljPreds = new PredicateList();
-            ContextManager cm = ((QueryTreeNode) innerTable).getContextManager();
-            predListCopy.setContextManager(cm);
-            nljPreds.setContextManager(cm);
-            predList.copyPredicatesToOtherList(predListCopy);
-            predListCopy.transferPredicates(nljPreds, innerTable.getReferencedTableMap(), innerTable, joinedTablesInCurrentQueryBlock);
-
-            /* Look for equijoins in the predicate list */
-            hashKeyColumns = findHashKeyColumns(innerTable, cd, predListCopy);
-        } else {
-            hashKeyColumns = null;
-        }
+        /* Look for equijoins in the predicate list */
+        hashKeyColumns = findHashKeyColumns(innerTable, cd, predList, optimizer.getAssignedTableMap());
 
         if (SanityManager.DEBUG) {
             if (hashKeyColumns == null) {
@@ -497,7 +477,7 @@ public abstract class HashableJoinStrategy extends BaseJoinStrategy {
             if (prn.getChildResult() instanceof Optimizable)
                 hashTableFor = (Optimizable) (prn.getChildResult());
         }
-        int[] hashKeyColumns = findHashKeyColumns(hashTableFor, cd, nonStoreRestrictionList);
+        int[] hashKeyColumns = findHashKeyColumns(hashTableFor, cd, nonStoreRestrictionList, joinedTableSet);
 
         if (hashKeyColumns == null) {
             if (!innerTable.getTrulyTheBestAccessPath().isMissingHashKeyOK()) {
@@ -582,15 +562,19 @@ public abstract class HashableJoinStrategy extends BaseJoinStrategy {
     /**
      * Find the hash key columns, if any, to use with this join.
      *
-     * @param innerTable	The inner table of the join
-     * @param cd			The conglomerate descriptor to use on inner table
-     * @param predList		The predicate list to look for the equijoin in
-     *
+     * @param innerTable    The inner table of the join
+     * @param cd            The conglomerate descriptor to use on inner table
+     * @param predList      The predicate list to look for the equijoin in
+     * @param joinedTableSet  The set of table numbers of the optimizables that
+     *                        have been joined up to the current join position
      * @return	the numbers of the hash key columns, or null if no hash key column
      *
      * @exception StandardException		Thrown on error
      */
-    public int[] findHashKeyColumns(Optimizable innerTable, ConglomerateDescriptor cd, OptimizablePredicateList predList) throws StandardException {
+    public int[] findHashKeyColumns(Optimizable innerTable,
+                                    ConglomerateDescriptor cd,
+                                    OptimizablePredicateList predList,
+                                    JBitSet joinedTableSet) throws StandardException {
         if (predList == null)
             return (int[]) null;
 
@@ -630,14 +614,14 @@ public abstract class HashableJoinStrategy extends BaseJoinStrategy {
 
             ValueNode[] exprAsts = irg.getParsedIndexExpressions(inner.getLanguageConnectionContext(), innerTable);
             for (int colIdx = 0; colIdx < exprAsts.length; colIdx++) {
-                if (predList.hasOptimizableEquijoin(innerTable, exprAsts[colIdx])) {
+                if (predList.hasOptimizableEquijoin(innerTable, exprAsts[colIdx], joinedTableSet)) {
                     hashKeyVector.add(colIdx);
                 }
             }
         } else {
             for (int colCtr = 0; colCtr < columns.length; colCtr++) {
                 // Is there an equijoin condition on this column?
-                if (predList.hasOptimizableEquijoin(innerTable, columns[colCtr])) {
+                if (predList.hasOptimizableEquijoin(innerTable, columns[colCtr], joinedTableSet)) {
                     hashKeyVector.add(colCtr);
                 }
             }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
@@ -142,7 +142,7 @@ public abstract class HashableJoinStrategy extends BaseJoinStrategy {
          * this routine could return a hash-based join strategy is feasible but later in
          * modifying access paths, no hash columns is found.
          */
-        if (predList != null && innerTable.isBaseTable()) {
+        if (predList != null) {
             JBitSet joinedTablesInCurrentQueryBlock = optimizer.getAssignedTableMap();
             PredicateList predListCopy = new PredicateList();
             PredicateList nljPreds = new PredicateList();
@@ -155,8 +155,7 @@ public abstract class HashableJoinStrategy extends BaseJoinStrategy {
             /* Look for equijoins in the predicate list */
             hashKeyColumns = findHashKeyColumns(innerTable, cd, predListCopy);
         } else {
-            /* Look for equijoins in the predicate list */
-            hashKeyColumns = findHashKeyColumns(innerTable, cd, predList);
+            hashKeyColumns = null;
         }
 
         if (SanityManager.DEBUG) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IntersectOrExceptNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IntersectOrExceptNode.java
@@ -239,12 +239,14 @@ public class IntersectOrExceptNode extends SetOperatorNode
                             optimizer,
                             leftResultSet,
                             (PredicateList) null,
+                            null,
                             null);
 
         rightResultSet = optimizeSource(
                             optimizer,
                             rightResultSet,
                             (PredicateList) null,
+                            null,
                             null);
 
         CostEstimate costEstimate = getCostEstimate(optimizer);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
@@ -222,7 +222,7 @@ public class JoinNode extends TableOperatorNode{
         // RESOLVE: NEED TO SET ROW ORDERING OF SOURCES IN THE ROW ORDERING
         // THAT WAS PASSED IN.
 
-        leftResultSet=optimizeSource(optimizer,leftResultSet,getLeftPredicateList(),null);
+        leftResultSet=optimizeSource(optimizer,leftResultSet,getLeftPredicateList(),null,null);
 
         /* Move all joinPredicates down to the right.
          * RESOLVE - When we consider the reverse join order then
@@ -257,7 +257,7 @@ public class JoinNode extends TableOperatorNode{
             lrsCE.setJoinType(INNERJOIN);
         double savedAccumulatedMemory = lrsCE.getAccumulatedMemory();
         lrsCE.setAccumulatedMemory(leftOptimizer.getAccumulatedMemory());
-        rightResultSet=optimizeSource(optimizer,rightResultSet,getRightPredicateList(),lrsCE);
+        rightResultSet=optimizeSource(optimizer,rightResultSet,getRightPredicateList(),leftResultSet.getReferencedTableMap(),lrsCE);
         lrsCE.setJoinType(INNERJOIN);
         lrsCE.setAccumulatedMemory(savedAccumulatedMemory);
         costEstimate=getCostEstimate(optimizer);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
@@ -1632,6 +1632,18 @@ public class OptimizerImpl implements Optimizer{
         return optimizableList;
     }
 
+    @Override
+    public JBitSet getAssignedTableMap() {
+        return assignedTableMap;
+    }
+
+    @Override
+    public void setAssignedTableMap(JBitSet refMap) {
+        if (refMap != null) {
+            assignedTableMap.setTo(refMap);
+        }
+    }
+
     private void addCost(CostEstimate addend,CostEstimate destCost){
         destCost.setRemoteCost(addend.remoteCost());
         destCost.setLocalCost(destCost.localCost()+addend.localCost());

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
@@ -50,6 +50,7 @@ import com.splicemachine.db.iapi.sql.execute.ExecutionFactory;
 import com.splicemachine.db.iapi.store.access.ScanController;
 import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.db.iapi.util.JBitSet;
+import com.splicemachine.utils.Pair;
 
 import java.lang.reflect.Modifier;
 import java.util.*;
@@ -405,18 +406,18 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
     }
 
     @Override
-    public boolean hasOptimizableEquijoin(Optimizable optTable,int columnNumber) throws StandardException{
-        return hasOptimizableEquijoinHelper(optTable, columnNumber, null, false);
+    public boolean hasOptimizableEquijoin(Optimizable optTable, int columnNumber, JBitSet joinedTableSet) throws StandardException{
+        return hasOptimizableEquijoinHelper(optTable, columnNumber, null, false, joinedTableSet);
     }
 
     @Override
-    public boolean hasOptimizableEquijoin(Optimizable optTable, ValueNode expr) throws StandardException {
-        return hasOptimizableEquijoinHelper(optTable, -1, expr, true);
+    public boolean hasOptimizableEquijoin(Optimizable optTable, ValueNode expr, JBitSet joinedTableSet) throws StandardException {
+        return hasOptimizableEquijoinHelper(optTable, -1, expr, true, joinedTableSet);
     }
 
     private boolean hasOptimizableEquijoinHelper(Optimizable optTable,
                                                  int columnNumber, ValueNode expr,
-                                                 boolean isExpr) throws StandardException {
+                                                 boolean isExpr, JBitSet joinedTableSet) throws StandardException {
         int size=size();
         for (int i = 0; i < size; i++){
             AndNode andNode;
@@ -435,8 +436,9 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                 continue;
             }
 
-            // skip non-join comparisons
-            if (predicate.getReferencedMap().hasSingleBitSet()) {
+            // Exclude single-table predicates and join predicates that
+            // are not relevant to joins within current query block.
+            if (isNotJoinPredicateForCurrentQueryBlock(predicate, joinedTableSet, optTable.getReferencedTableMap()).getFirst()) {
                 continue;
             }
 
@@ -467,6 +469,30 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
             return true;
         }
         return false;
+    }
+
+    /**
+     * Check if a predicate is not a join predicate referencing tables only in current query block.
+     * @param predicate           The predicate to be checked.
+     * @param joinedTableSet      The set of table numbers of the optimizables that have been
+     *                            joined up to the current join position. This set is always
+     *                            limited to the current query block.
+     * @param referencedTableSet  The set of table numbers the right child of the join references.
+     * @return The first boolean flag: True if the predicate is not a join predicate referencing tables
+     *                                 only in current query block. This means the predicate could be
+     *                                 a single table predicate or a join predicate that is correlated
+     *                                 to a table in an outer query block. False otherwise.
+     *         The second boolean flag: True if the predicate references a table from an outer query
+     *                                  block. False otherwise.
+     */
+    private Pair<Boolean, Boolean> isNotJoinPredicateForCurrentQueryBlock(Predicate predicate, JBitSet joinedTableSet,
+                                                                          JBitSet referencedTableSet) {
+        JBitSet maskedReferencedSet = (JBitSet)predicate.getReferencedSet().clone();
+        int numBitsSet = maskedReferencedSet.cardinality();
+        maskedReferencedSet.and(joinedTableSet);
+        int maskedNumBitsSet = maskedReferencedSet.cardinality();
+
+        return new Pair<>(referencedTableSet.contains(maskedReferencedSet), maskedNumBitsSet < numBitsSet);
     }
 
     @Override
@@ -3148,14 +3174,11 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
             // there could be nestedloop join condition pushed from outer block that should be treated as
             // single table conditions, however, they would contain table number from tables from the outer block,
             // so use joinedTableSet to mask out those table numbers
-            JBitSet maskedReferencedSet = (JBitSet)predicate.getReferencedSet().clone();
-            int numBitsSet = maskedReferencedSet.cardinality();
-            maskedReferencedSet.and(joinedTableSet);
-            int maskedNumBitsSet = maskedReferencedSet.cardinality();
+            Pair<Boolean, Boolean> result = isNotJoinPredicateForCurrentQueryBlock(predicate, joinedTableSet, referencedTableMap);
 
             // may not be fully covered by the current joined table set, however,
-            if(referencedTableMap.contains(maskedReferencedSet)){
-                if (maskedNumBitsSet < numBitsSet) {
+            if(result.getFirst()){
+                if (result.getSecond()) {
                     hasNestedLoopJoinPredicatePushedFromOuter = true;
                 }
                 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableOperatorNode.java
@@ -742,6 +742,7 @@ public abstract class TableOperatorNode extends FromTable{
     protected ResultSetNode optimizeSource(Optimizer optimizer,
                                            ResultSetNode sourceResultSet,
                                            PredicateList predList,
+                                           JBitSet otherChildReferenceMap,
                                            CostEstimate outerCost) throws StandardException{
         ResultSetNode retval;
 
@@ -767,6 +768,7 @@ public abstract class TableOperatorNode extends FromTable{
                     getCompilerContext().getMaximalPossibleTableCount(),
                     lcc);
             optimizer.prepForNextRound();
+            optimizer.setAssignedTableMap(otherChildReferenceMap);
 
             if(sourceResultSet==leftResultSet){
                 leftOptimizer=optimizer;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnionNode.java
@@ -257,9 +257,9 @@ public class UnionNode extends SetOperatorNode{
         // getNextDecoratedPermutation() method.
         updateBestPlanMap(ADD_PLAN,this);
 
-        leftResultSet=optimizeSource(optimizer, leftResultSet, getLeftOptPredicateList(), null);
+        leftResultSet=optimizeSource(optimizer, leftResultSet, getLeftOptPredicateList(), null, null);
 
-        rightResultSet=optimizeSource(optimizer, rightResultSet, getRightOptPredicateList(), null);
+        rightResultSet=optimizeSource(optimizer, rightResultSet, getRightOptPredicateList(), null, null);
 
         CostEstimate leftCost = leftResultSet.getCostEstimate();
         CostEstimate rightCost = rightResultSet.getCostEstimate();

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/HashableJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/HashableJoinIT.java
@@ -85,7 +85,7 @@ public class HashableJoinIT extends SpliceUnitTest {
     }
 
     @Test
-    public void testInfeasibleMergeSortJoin() throws Exception {
+    public void testInfeasibleHashableJoin() throws Exception {
         String sqlText = String.format("select D.c1, D.c2, G.c2 from D, G --splice-properties useSpark=%b\n " +
                 "where G.c2 = D.c2 and D.ts <= '2000-01-01' " +
                 "  and not (exists(select * from D_LZ, L " +

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/HashableJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/HashableJoinIT.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.impl.sql.execute.operations.joins;
+
+import com.splicemachine.derby.test.framework.*;
+import com.splicemachine.homeless.TestUtils;
+import com.splicemachine.test_tools.TableCreator;
+import org.junit.*;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static com.splicemachine.test_tools.Rows.row;
+import static com.splicemachine.test_tools.Rows.rows;
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class HashableJoinIT extends SpliceUnitTest {
+    private final Boolean useSpark;
+
+    @Parameterized.Parameters
+    public static Collection testParams() {
+        return Arrays.asList(new Object[][] {
+                { true },
+                { false },
+        });
+    }
+
+    public HashableJoinIT(Boolean useSpark) {
+        this.useSpark = useSpark;
+    }
+
+    public static final String SCHEMA_NAME = HashableJoinIT.class.getSimpleName().toUpperCase();
+    protected static SpliceWatcher classWatcher = new SpliceWatcher(SCHEMA_NAME);
+    protected static SpliceSchemaWatcher schemaWatcher = new SpliceSchemaWatcher(SCHEMA_NAME);
+
+    @ClassRule
+    public static TestRule chain = RuleChain.outerRule(classWatcher)
+            .around(schemaWatcher);
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher(SCHEMA_NAME);
+
+    public static void createData(Connection conn, String schemaName) throws Exception {
+
+        new TableCreator(conn)
+                .withCreate("create table D (c1 int primary key, c2 int not null, ts timestamp not null)")
+                .create();
+
+        new TableCreator(conn)
+                .withCreate("create table D_LZ (c1 int not null, lf int not null, primary key(c1, lf))")
+                .create();
+
+        new TableCreator(conn)
+                .withCreate("create table G (c2 int not null primary key)")
+                .create();
+
+        new TableCreator(conn)
+                .withCreate("create table L (c2 int not null, e char(1) not null, foreign key (c2) references G(c2))")
+                .create();
+
+        conn.commit();
+    }
+
+    @BeforeClass
+    public static void createDataSet() throws Exception {
+        createData(classWatcher.getOrCreateConnection(), schemaWatcher.toString());
+    }
+
+    @Test
+    public void testInfeasibleMergeSortJoin() throws Exception {
+        String sqlText = String.format("select D.c1, D.c2, G.c2 from D, G --splice-properties useSpark=%b\n " +
+                "where G.c2 = D.c2 and D.ts <= '2000-01-01' " +
+                "  and not (exists(select * from D_LZ, L " +
+                "                  where D_LZ.c1 = D.c1" +
+                "                    and L.c2 = D.c2" +
+                "                    and L.e = 'X'))", useSpark);
+
+        rowContainsQuery(new int[]{4, 6}, "explain " + sqlText, methodWatcher, "Subquery", useSpark ? "BroadcastJoin" : "NestedLoopJoin");
+
+        try (ResultSet rs = methodWatcher.executeQuery(sqlText)) {
+            assertFalse(rs.next());
+        }
+    }
+}


### PR DESCRIPTION
## Short Description
This change fixes an issue that some irrelevant equijoin predicates could make optimizer believes that a hashable join strategy (broadcast, merge sort, merge) is feasible but later before code generation, no hash key columns can actually be found for such a join.

## Long Description

### Problem description
The problem can be described using the following query:
```
select D.c1, D.c2, G.c2 
from D, G
where G.c2 = D.c2
  and D.ts <= '2000-01-01'
  and not (exists(select * from D_LZ, L
                  where D_LZ.c1 = D.c1
                    and L.c2 = D.c2
                    and L.e = 'X'));
```
Let's focus on the subquery. It has three predicates, but none of them is for the join between `D_LZ` and `L`. Also note that these predicates belong to the subquery at the very beginning. They are not pushed down from outer block. Also, note that the subquery cannot be flattened and `L` can only be joined with `D_LZ`.

Eventually, we want to estimate the cost of joining table `L` with predicates `L.c2 = D.c2` and `L.e = 'X'`. For hashable join strategies, we will call `feasible()` in `HashableJoinStrategy`, which does the following:
```
...
/* Look for equijoins in the predicate list */
hashKeyColumns = findHashKeyColumns(innerTable, cd, predList);
```

`predList` contains both predicates related to `L`. At this point, `findHashKeyColumns()` believes `L.c2 = D.c2` is a useful hash join predicate because it's an equijoin predicate and one side is a column in `L`, although the join is actually between `L` and `D_LZ`. In the end, the logic will see that we can find hash key columns on `L`, so a hashable join strategy like broadcast join or merge sort join is feasible.

Suppose a hashable join strategy for `L` is chosen as the best and we proceed. Later in modifying access paths, we want to find the hash key columns of `L` again for code generation. But this time, we do the following:
```
...
originalRestrictionList.transferPredicates(storeRestrictionList, innerTable.getReferencedTableMap(), innerTable, joinedTableSet);
...
originalRestrictionList.copyPredicatesToOtherList(nonStoreRestrictionList);
...
int[] hashKeyColumns = findHashKeyColumns(hashTableFor, cd, nonStoreRestrictionList);
```

The extra step `transferPredicates()` figures out that `L.c2 = D.c2` is not relevant to the join between `D_LZ` and `L`, and it removes it from `originalRestrictionList`. In the end, `nonStoreRestrictionList` is empty, and we cannot find any hash key columns for a table that was chosen to have a hashable join.

### Solution

The idea is to enhance the logic in `feasible()` so that irrelevant predicates are also excluded, just as in modifying access path.

`OptimizerImpl` has an `assignedTableMap` field tracking the set of table numbers that have been placed in current join order up to the current join position. This is exactly what we need to check if a predicate is relevant for a join in an inner query block.

There is one problem of using this field though. In our optimizing process, each query block has its own optimizer instance, which is exactly what we need. However, there are also cases in which we construct a new optimizer instance for a node that is not necessarily another query block. These cases happen in `TableOperatorNode` and `JoinNode`.

`TableOperatorNode` cases (union, intersect, except) are fine because we don't join their children. For `JoinNode`, we must manually include left child reference map when optimizing the right child using a new optimizer instance. Otherwise, there is no way to tell if a predicate referencing a table number that is not tracked by the current optimizer instance is relevant to the current join node or not.

## How to test
A new IT `testInfeasibleHashableJoin` is added. Setup tables as the way this IT does and run the query without this fix should fail with error message like the following:
```
ERROR 42Y63: Hash join requires an optimizable equijoin predicate on a column in the selected index or heap.  An optimizable equijoin predicate does not exist on any column in table or index ...
```
With this change, the query should run through.