### PR TITLE
DB-11796 Use native Spark broadcast/merge sort joins when DB2 compatibility mode is enabled

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
@@ -225,9 +225,9 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public DataSet<V> distinct(String name, boolean isLast, OperationContext context, boolean pushScope, String scopeDetail) throws StandardException {
-        String varcharDB2CompatibilityModeString =
-                PropertyUtil.getCachedDatabaseProperty(context.getActivation().getLanguageConnectionContext(), Property.SPLICE_DB2_VARCHAR_COMPATIBLE);
-        boolean varcharDB2CompatibilityMode = Boolean.parseBoolean(varcharDB2CompatibilityModeString);
+        boolean varcharDB2CompatibilityMode = PropertyUtil.getCachedDatabaseBoolean(
+                context.getActivation().getLanguageConnectionContext(),
+                Property.SPLICE_DB2_VARCHAR_COMPATIBLE);
         pushScopeIfNeeded(context, pushScope, scopeDetail);
         try {
             // Do not replace string columns using rtrimmed columns but add them as extra columns.
@@ -914,10 +914,9 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
         int[] rightJoinKeys = ((JoinOperation)context.getOperation()).getRightHashKeys();
         int[] leftJoinKeys = ((JoinOperation)context.getOperation()).getLeftHashKeys();
 
-        String varcharDB2CompatibilityModeString =
-                PropertyUtil.getCachedDatabaseProperty(context.getActivation().getLanguageConnectionContext(),
-                        Property.SPLICE_DB2_VARCHAR_COMPATIBLE);
-        boolean varcharDB2CompatibilityMode = Boolean.parseBoolean(varcharDB2CompatibilityModeString);
+        boolean varcharDB2CompatibilityMode = PropertyUtil.getCachedDatabaseBoolean(
+                context.getActivation().getLanguageConnectionContext(),
+                Property.SPLICE_DB2_VARCHAR_COMPATIBLE);
 
         List<String> extraColNamesLeft = new ArrayList<>();
         List<Column> extraColumnsLeft = new ArrayList<>();
@@ -956,9 +955,7 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
                 rightDF = NativeSparkUtils.withColumns(extraColNamesRight, extraColumnsRight, rightDF);
 
             if (!varcharDB2CompatibilityMode && sparkJoinPredicate != null) {
-                java.util.function.Function<String, DataType> convertStringToDataTypeFunction =
-                        (String s) -> { return ParserUtils.getDataTypeFromString(s); };
-                filterExpr = sparkJoinPredicate.getColumnExpression(leftDF, rightDF, convertStringToDataTypeFunction);
+                filterExpr = sparkJoinPredicate.getColumnExpression(leftDF, rightDF, ParserUtils::getDataTypeFromString);
             } else {
                 for (int i = 0; i < rightJoinKeys.length; i++) {
                     Column joinEquality = (leftDF.col(leftColNames[i]).equalTo(rightDF.col(rightColNames[i])));

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeSystemProcedures.java
@@ -97,8 +97,7 @@ public class UpgradeSystemProcedures {
             throw StandardException.newException(SQLState.INVALID_PARAMETER, "hbase.zookeeper.property.clientPort",
                     String.valueOf(port));
         }
-        String portAppend = ":" + port;
-        String hostAndPort = quorum.endsWith(portAppend) ? quorum : quorum + portAppend;
+        String hostAndPort = quorum + ":" + port;
         ZooKeeper zk = new ZooKeeper(hostAndPort, 120000, null);
 
         String path = SIDriver.driver().getConfiguration().getSpliceRootPath()

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeSystemProcedures.java
@@ -97,7 +97,8 @@ public class UpgradeSystemProcedures {
             throw StandardException.newException(SQLState.INVALID_PARAMETER, "hbase.zookeeper.property.clientPort",
                     String.valueOf(port));
         }
-        String hostAndPort = quorum + ":" + port;
+        String portAppend = ":" + port;
+        String hostAndPort = quorum.endsWith(portAppend) ? quorum : quorum + portAppend;
         ZooKeeper zk = new ZooKeeper(hostAndPort, 120000, null);
 
         String path = SIDriver.driver().getConfiguration().getSpliceRootPath()

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
@@ -15,7 +15,9 @@
 package com.splicemachine.derby.impl.sql.execute.operations;
 
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.Property;
 import com.splicemachine.db.iapi.services.loader.GeneratedMethod;
+import com.splicemachine.db.iapi.services.property.PropertyUtil;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.derby.iapi.sql.execute.SpliceOperation;
@@ -217,9 +219,11 @@ public class BroadcastJoinOperation extends JoinOperation{
                 }
                 // Adding a filter in this manner disables native spark execution,
                 // so only do it if required.
-                if (restriction != null && sparkJoinPredicate == null) {
+                boolean varcharDB2CompatibilityMode = PropertyUtil.getCachedDatabaseBoolean(
+                        operationContext.getActivation().getLanguageConnectionContext(),
+                        Property.SPLICE_DB2_VARCHAR_COMPATIBLE);
+                if (restriction != null && (varcharDB2CompatibilityMode || sparkJoinPredicate == null)) {
                     result = result.filter(new JoinRestrictionPredicateFunction(operationContext));
-                    usesNativeSparkDataSet = false;
                 }
             }
             handleSparkExplain(result, leftDataSet, rightDataSet, dsp);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
@@ -183,7 +183,6 @@ public class BroadcastJoinOperation extends JoinOperation{
 
         DataSet<ExecRow> result;
         boolean usesNativeSparkDataSet =
-           !dsp.isSparkDB2CompatibilityMode() &&
            (useDataset && dsp.getType().equals(DataSetProcessor.Type.SPARK) &&
              ((restriction == null || hasSparkJoinPredicate()) || (!isOuterJoin() && !isAntiJoin() && !isOneRowRightSide())) &&
               !containsUnsafeSQLRealComparison());

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeSortJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MergeSortJoinOperation.java
@@ -165,7 +165,6 @@ public class MergeSortJoinOperation extends JoinOperation {
         OperationContext<JoinOperation> operationContext = dsp.<JoinOperation>createOperationContext(this);
         dsp.incrementOpDepth();
         boolean useNativeSparkJoin = (dsp.getType().equals(DataSetProcessor.Type.SPARK)   &&
-                                      !dsp.isSparkDB2CompatibilityMode()               &&
                                       (restriction == null || hasSparkJoinPredicate()) &&
                                       !rightFromSSQ && !containsUnsafeSQLRealComparison());
 


### PR DESCRIPTION
## Short Description

Run broadcast joins and merge sort joins natively in spark when using db2 varchar compatibility mode

## Long Description

Up until now, broadcast joins and merge sort joins could not run natively in spark when `'splice.db2.varchar.compatible'` was set to true.
With that parameter enabled, `'a'` and `'a      '` should be evaluated to be the same varchar in a join.
If a join key is a varchar, we now rtrim it before evaluating the join predicate.

## How to test

```
create table A (a1 varchar(20), a2 varchar(20));
create table B (b1 varchar(20), b2 varchar(20));

insert into A values ('1  ', '2          '), ('1', '-2  ');
insert into B values ('1    ', '3    '), ('1 ', '-3 ');

call syscs_util.INVALIDATE_GLOBAL_DICTIONARY_CACHE();
call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', 'true');


> select * from A, B where a1 = b1;

A1                  |A2                  |B1                  |B2
-----------------------------------------------------------------------------------
1                   |2                   |1                   |3
1                   |2                   |1                   |-3
1                   |-2                  |1                   |3
1                   |-2                  |1                   |-3


> sparkexplain select a1, a2, b1, b2
from a, b --splice-properties useSpark=true, useNativeSpark=true
where a1 = b1 and (a2 = '-2' or b2 = '-3');

-> ScrollInsensitive(RS=7,totalCost=9.699, outputRows=3,outputHeapSize=13 B, partitions=1,parallelTasks=3)
  -> BroadcastJoin(RS=4, totalCost=6.899,outputRows=3, outputHeapSize=13 B,partitions=1, parallelTasks=3,preds=[((A2[4:2] = -2) or ((B2[4:4] =-3) or false)),(A1[4:1] = B1[4:3])])
    -> NativeSparkDataSet
    Scan ExistingRDD[c0#3876,c1#3877]
    -> TableScan[A(1936)](RS=0,totalCost=4.04, scannedRows=20,outputRows=20, outputHeapSize=40 B,partitions=1, parallelTasks=3)
    -> NativeSparkDataSet
         Scan ExistingRDD[c0#3894,c1#3895]
         -> TableScan[B(1952)](RS=2,totalCost=4.04, scannedRows=20,outputRows=20, outputHeapSize=13 B,partitions=1, parallelTasks=3)

> select a1, a2, b1, b2
from a, b --splice-properties useSpark=true, useNativeSpark=true
where a1 = b1 and (a2 = '-2' or b2 = '-3');

A1                  |A2                  |B1                  |B2
-----------------------------------------------------------------------------------
1                   |2                   |1                   |-3
1                   |-2                  |1                   |-3
1                   |-2                  |1                   |3


```

