### PR TITLE
DB-11766 fix VARBIT projection in db2.varchar.compatible mode

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/util/StringUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/util/StringUtil.java
@@ -31,6 +31,10 @@
 
 package com.splicemachine.db.iapi.util;
 
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.db.iapi.types.StringDataValue;
+
 import java.util.Locale;
 import java.util.StringTokenizer;
 
@@ -588,6 +592,12 @@ public class StringUtil{
             result.append(padChar);
         }
         return result.toString();
+    }
+
+    public static void setIgnoreTrailingWhitespacesInVarcharComparison(Object dvd, boolean shouldIgnore) throws StandardException {
+        if(dvd instanceof StringDataValue) {
+            ((StringDataValue)dvd).setIgnoreTrailingWhitespacesInVarcharComparison(shouldIgnore);
+        }
     }
 }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorNode.java
@@ -47,6 +47,7 @@ import com.splicemachine.db.iapi.sql.compile.Visitor;
 import com.splicemachine.db.iapi.store.access.Qualifier;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.SqlXmlUtil;
+import com.splicemachine.db.iapi.types.StringDataValue;
 import com.splicemachine.db.iapi.types.TypeId;
 
 /**
@@ -493,12 +494,13 @@ public abstract class OperatorNode extends ValueNode
         mb.callMethod(VMOpcode.INVOKEINTERFACE, resultInterfaceType, methodName, resultInterfaceType, operands.size());
     }
 
-    public void generateSetIgnoreTrailingWhitespacesInVarcharComparison(int operandIndex, MethodBuilder mb) throws StandardException {
+    public void generateSetIgnoreTrailingWhitespacesInVarcharComparison(MethodBuilder mb) throws StandardException {
         if (getCompilerContext().getVarcharDB2CompatibilityMode()) {
             mb.dup();
+            mb.upCast("java.lang.Object");
             mb.push(true);
-            mb.callMethod(VMOpcode.INVOKEINTERFACE, ClassName.StringDataValue,
-                    "setIgnoreTrailingWhitespacesInVarcharComparison", "void", 1);
+            mb.callMethod(VMOpcode.INVOKESTATIC, ClassName.StringUtil,
+                    "setIgnoreTrailingWhitespacesInVarcharComparison", "void", 2);
         }
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
@@ -270,7 +270,7 @@ public class TernaryOperatorNode extends OperatorNode
         switch (operatorType) {
             case TRIM:
             case DB2RTRIM:
-                generateSetIgnoreTrailingWhitespacesInVarcharComparison(0, mb);
+                generateSetIgnoreTrailingWhitespacesInVarcharComparison(mb);
                 mb.push(trimType);
                 getLeftOperand().generateExpression(acb, mb);
                 mb.cast(getLeftInterfaceType());
@@ -289,7 +289,7 @@ public class TernaryOperatorNode extends OperatorNode
                 receiverType = getReceiverInterfaceType();
                 break;
             case SUBSTRING:
-                generateSetIgnoreTrailingWhitespacesInVarcharComparison(0, mb);
+                generateSetIgnoreTrailingWhitespacesInVarcharComparison(mb);
                 getLeftOperand().generateExpression(acb, mb);
                 mb.upCast(getLeftInterfaceType());
                 if (getRightOperand() != null)
@@ -311,7 +311,7 @@ public class TernaryOperatorNode extends OperatorNode
                 break;
             case LEFT:
             case RIGHT:
-                generateSetIgnoreTrailingWhitespacesInVarcharComparison(0, mb);
+                generateSetIgnoreTrailingWhitespacesInVarcharComparison(mb);
                 getLeftOperand().generateExpression(acb, mb);
                 mb.upCast(getLeftInterfaceType());
                 mb.getField(field);
@@ -335,7 +335,7 @@ public class TernaryOperatorNode extends OperatorNode
                 break;
             case REPLACE:
             case SPLIT_PART:
-                generateSetIgnoreTrailingWhitespacesInVarcharComparison(0, mb);
+                generateSetIgnoreTrailingWhitespacesInVarcharComparison(mb);
                 getLeftOperand().generateExpression(acb, mb);
                 mb.upCast(getLeftInterfaceType());
                 if (getRightOperand() != null)

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TranslateFunctionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TranslateFunctionNode.java
@@ -145,7 +145,7 @@ public class TranslateFunctionNode extends OperatorNode {
         LocalField field = acb.newFieldDeclaration(Modifier.PRIVATE, resultInterfaceType);
         operands.get(0).generateExpression(acb, mb);
         mb.upCast(interfaceTypes.get(0));
-        generateSetIgnoreTrailingWhitespacesInVarcharComparison(0, mb);
+        generateSetIgnoreTrailingWhitespacesInVarcharComparison(mb);
         for (int i = 1; i < operands.size(); ++i) {
             if (operands.get(i) != null)
             {

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/ClassName.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/ClassName.java
@@ -157,4 +157,5 @@ public interface ClassName
 	String TxnUtil = "com.splicemachine.db.iapi.util.TxnUtil";
 	String SPSDescriptor = "com.splicemachine.db.iapi.sql.dictionary.SPSDescriptor";
 	String 	DecimalUtil = "com.splicemachine.db.iapi.util.DecimalUtil";
+	String 	StringUtil = "com.splicemachine.db.iapi.util.StringUtil";
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
@@ -1281,6 +1281,14 @@ public class SpliceUnitTest {
         }
     }
 
+    protected void checkVarbitExpression(String input, byte[] output, TestConnection conn) throws SQLException {
+        String sql = format("select %s", input);
+        try(ResultSet rs = conn.query(sql)) {
+            rs.next();
+            Assert.assertArrayEquals(output, rs.getBytes(1));
+        }
+    }
+
     protected void checkNullExpression(String input, TestConnection conn) throws SQLException {
         String sql = format("select %s", input);
         try (ResultSet rs = conn.query(sql)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description

In this PR we provide a fix for queries that fail to select `VARBIT` (`VARCHAR FOR BIT DATA`) when  the database is running in `splice.db2.varchar.compatible` mode.

## Long Description

A previous PR brought some fixes to trailing spaces for string types, basically a flag to set comparison with or without ignoring trailing whitespaces is added to string types, this flag is used to create either a `SQLVarchar` or a `SQLVarcharDB2Compatible`.

During code generation for some operators, e.g. `substring` the flag is always set as shown here:

```
if (getCompilerContext().getVarcharDB2CompatibilityMode()) {
            mb.dup();
            mb.push(true);
            mb.callMethod(VMOpcode.INVOKEINTERFACE, ClassName.StringDataValue,
                    "setIgnoreTrailingWhitespacesInVarcharComparison", "void", 1);
        }
```

There is a mistake in this logic, before pushing `true`, it assumes that the top of the stack is of type `StringDataValue`, and proceeds to calls that method `setIgnoreTrailingWhitespacesInVarcharComparison` on that object. Although this works fine with string types such as `StringDataValue`, it fails in case of other data types such as `Varbit` since it does not inherit from `StringDataValue` as shown in the generated code below example below:

```
public Object e2() throws StandardException, Exception {
        ExecRow var10000 = this.e2;
        BitDataValue var10002 = (BitDataValue)this.getColumnFromRow(0, 1);
        var10002.setIgnoreTrailingWhitespacesInVarcharComparison(true); // boom.
        var10000.setColumn(1, (DataValueDescriptor)var10002.substring(this.getDataValueFactory().getDataValue(37, (NumberDataValue)null), this.getDataValueFactory().getDataValue(2, (NumberDataValue)null), this.e3, 32000, true));
        var10000 = this.e2;
        var10002 = (BitDataValue)this.getColumnFromRow(0, 1);
        var10002.setIgnoreTrailingWhitespacesInVarcharComparison(true);
        var10000.setColumn(2, (DataValueDescriptor)var10002.substring(this.getDataValueFactory().getDataValue(75, (NumberDataValue)null), this.getDataValueFactory().getDataValue(26, (NumberDataValue)null), this.e4, 32000, true));
        return this.e2;
    }
```

To fix this issue, I created a bridge method `com.splicemachine.db.iapi.util.StringUtil#setIgnoreTrailingWhitespacesInVarcharComparison(Object,boolean)`, this method examines the first parameter (the top of the stack), and only calls `setIgnoreTrailingWhitespacesInVarcharComparison` on it if it is a `StringDataValue`, i.e.:

```
public static void setIgnoreTrailingWhitespacesInVarcharComparison(Object dvd, boolean shouldIgnore) throws StandardException {
    if(dvd instanceof StringDataValue) {
            ((StringDataValue)dvd).setIgnoreTrailingWhitespacesInVarcharComparison(shouldIgnore);
    }
}
```

## How to test

Here is a simple case:

```
call syscs_util.syscs_flush_table('SPLICE', 'T1');

call syscs_util.syscs_set_global_database_property('splice.db2.varchar.compatible', true);
CREATE SCHEMA TEST_SCHEMA_YH;
CREATE TABLE TEST_SCHEMA_YH.TEST_TABLE_YH ("DATEN" VARCHAR (32000) FOR BIT DATA NOT NULL DEFAULT X'');
INSERT INTO TEST_SCHEMA_YH.TEST_TABLE_YH VALUES ('abc');

-- previously:
SELECT SUBSTR(DATEN,37,2),SUBSTR(DATEN,75,26), DATEN FROM TEST_SCHEMA_YH.TEST_TABLE_YH;
ERROR SE001: Splice Engine exception: unexpected exception
ERROR XJ001: Java exception: 'java.lang.IncompatibleClassChangeError: Class com.splicemachine.db.iapi.types.SQLVarbit does not implement the requested interface com.splicemachine.db.iapi.types.StringDataValue: java.io.IOException'.
ERROR XJ001: Java exception: 'Class com.splicemachine.db.iapi.types.SQLVarbit does not implement the requested interface com.splicemachine.db.iapi.types.StringDataValue: java.lang.IncompatibleClassChangeError'.

-- after the fix:
SELECT SUBSTR(DATEN,37,2),SUBSTR(DATEN,75,26), DATEN FROM TEST_SCHEMA_YH.TEST_TABLE_YH;
1   |2                                                   |DATEN
----------------------------------------------------------------
2020|2020202020202020202020202020202020202020202020202020|616263
```
