### PR TITLE
DB-11828 Avoid bad access path when costs tie due to outdated stats

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
@@ -2483,30 +2483,28 @@ public class OptimizerImpl implements Optimizer{
         currentAccessPath.setCostEstimate(estimatedCost);
 
         /* Pick the cheapest cost for this particular optimizable. */
-        AccessPath ap=optimizable.getBestAccessPath();
-        CostEstimate bestCostEstimate=ap.getCostEstimate();
-
-        boolean memoryOK = checkPathMemoryUsage(optimizable, false);
 
         // only update the best access path if the current access path passes the memory limit check
+        boolean memoryOK = checkPathMemoryUsage(optimizable, false);
         if (memoryOK) {
-            if ((bestCostEstimate == null) || bestCostEstimate.isUninitialized() || (estimatedCost.compare(bestCostEstimate) < 0)) {
-                ap.setConglomerateDescriptor(cd);
-                ap.setCostEstimate(estimatedCost);
-                ap.setCoveringIndexScan(optimizable.isCoveringIndex(cd));
-                ap.setSpecialMaxScan(currentAccessPath.getSpecialMaxScan());
-                ap.setMissingHashKeyOK(currentAccessPath.isMissingHashKeyOK());
-                ap.setNumUnusedLeadingIndexFields(currentAccessPath.getNumUnusedLeadingIndexFields());
+            AccessPath bestAccessPath = optimizable.getBestAccessPath();
+            if (isCurrentAccessPathBetter(currentAccessPath, bestAccessPath, optimizable, predList)) {
+                bestAccessPath.setConglomerateDescriptor(cd);
+                bestAccessPath.setCostEstimate(estimatedCost);
+                bestAccessPath.setCoveringIndexScan(optimizable.isCoveringIndex(cd));
+                bestAccessPath.setSpecialMaxScan(currentAccessPath.getSpecialMaxScan());
+                bestAccessPath.setMissingHashKeyOK(currentAccessPath.isMissingHashKeyOK());
+                bestAccessPath.setNumUnusedLeadingIndexFields(currentAccessPath.getNumUnusedLeadingIndexFields());
 
             /*
             ** It's a non-matching index scan either if there is no
             ** predicate list, or nothing in the predicate list is useful
             ** for limiting the scan.
             */
-                ap.setNonMatchingIndexScan((cd == null) || (predList == null) ||
+                bestAccessPath.setNonMatchingIndexScan((cd == null) || (predList == null) ||
                                            (!(predList.useful(optimizable, currentAccessPath))));
-                ap.setLockMode(currentAccessPath.getLockMode());
-                optimizable.rememberJoinStrategyAsBest(ap);
+                bestAccessPath.setLockMode(currentAccessPath.getLockMode());
+                optimizable.rememberJoinStrategyAsBest(bestAccessPath);
             }
         }
 
@@ -2527,32 +2525,28 @@ public class OptimizerImpl implements Optimizer{
                 */
                 if(requiredRowOrdering.sortRequired(currentRowOrdering, assignedTableMap, optimizableList)
                         ==RequiredRowOrdering.NOTHING_REQUIRED){
-                    ap=optimizable.getBestSortAvoidancePath();
-                    bestCostEstimate=ap.getCostEstimate();
 
                     memoryOK = checkPathMemoryUsage(optimizable, true);
 
                     /* Is this the cheapest sort-avoidance path? */
                     if (memoryOK) {
-                        if ((bestCostEstimate == null) ||
-                                bestCostEstimate.isUninitialized() ||
-                                (estimatedCost.compare(bestCostEstimate) < 0)) {
-                            ap.setConglomerateDescriptor(cd);
-                            ap.setCostEstimate(estimatedCost);
-                            ap.setCoveringIndexScan(
-                                    optimizable.isCoveringIndex(cd));
-                            ap.setSpecialMaxScan(currentAccessPath.getSpecialMaxScan());
-                            ap.setMissingHashKeyOK(currentAccessPath.isMissingHashKeyOK());
-                            ap.setNumUnusedLeadingIndexFields(currentAccessPath.getNumUnusedLeadingIndexFields());
+                        AccessPath bestSortAvoidancePath = optimizable.getBestSortAvoidancePath();
+                        if (isCurrentAccessPathBetter(currentAccessPath, bestSortAvoidancePath, optimizable, predList)) {
+                            bestSortAvoidancePath.setConglomerateDescriptor(cd);
+                            bestSortAvoidancePath.setCostEstimate(estimatedCost);
+                            bestSortAvoidancePath.setCoveringIndexScan(optimizable.isCoveringIndex(cd));
+                            bestSortAvoidancePath.setSpecialMaxScan(currentAccessPath.getSpecialMaxScan());
+                            bestSortAvoidancePath.setMissingHashKeyOK(currentAccessPath.isMissingHashKeyOK());
+                            bestSortAvoidancePath.setNumUnusedLeadingIndexFields(currentAccessPath.getNumUnusedLeadingIndexFields());
 
                         /*
                         ** It's a non-matching index scan either if there is no
                         ** predicate list, or nothing in the predicate list is
                         ** useful for limiting the scan.
                         */
-                            ap.setNonMatchingIndexScan((predList == null) || (!(predList.useful(optimizable, currentAccessPath))));
-                            ap.setLockMode(currentAccessPath.getLockMode());
-                            optimizable.rememberJoinStrategyAsBest(ap);
+                            bestSortAvoidancePath.setNonMatchingIndexScan((predList == null) || (!(predList.useful(optimizable, currentAccessPath))));
+                            bestSortAvoidancePath.setLockMode(currentAccessPath.getLockMode());
+                            optimizable.rememberJoinStrategyAsBest(bestSortAvoidancePath);
                             optimizable.rememberSortAvoidancePath();
 
                         /*
@@ -2566,6 +2560,55 @@ public class OptimizerImpl implements Optimizer{
         }
     }
 
+    private static boolean isCurrentAccessPathBetter(AccessPath currentAccessPath, AccessPath bestAccessPath,
+                                                     Optimizable currOpt, OptimizablePredicateList predList) throws StandardException {
+        CostEstimate currentCost = currentAccessPath.getCostEstimate();
+        CostEstimate bestCost = bestAccessPath.getCostEstimate();
+
+        if ((bestCost == null) || bestCost.isUninitialized()) {
+            return true;
+        }
+
+        double compResult = currentCost.compare(bestCost);
+        if (compResult < 0) {
+            return true;
+        } else if (compResult == 0) {
+            // When current access path has the same cost as the best access path,
+            // choose the one that we know it works fine even with outdated statistics.
+            ConglomerateDescriptor currentCD = currentAccessPath.getConglomerateDescriptor();
+            if (currentCD.isIndex() || currentCD.isPrimaryKey()) {
+                // Note that we don't assert anything on best access path. Reason is
+                // that best access path can be an index scan without any start/stop
+                // keys, which could be as slow as full table scan or even worse if
+                // it's not covering. We need to make sure such an access path is not
+                // chosen as the best if we know a better access path exists.
+                // On the other hand, best access path could be a really good one and
+                // we replace it here. In that case, bottom line is that we know the
+                // current access path is not bad.
+                if (predList != null) {
+                    boolean isCurrentFullScan = true;
+                    for (int i = 0; i < predList.size(); ++i) {
+                        OptimizablePredicate pred = predList.getOptPredicate(i);
+                        if (pred.isStartKey() || pred.isStopKey()) {
+                            isCurrentFullScan = false;
+                            break;
+                        }
+                    }
+                    if (!isCurrentFullScan) {
+                        return true;
+                    }
+                }
+                // If current access path is a full scan over an index, select it
+                // only when the best access path is a full table scan and the index
+                // is covering. A covering index should still be better based on the
+                // assumption that an index typically has fewer columns.
+                ConglomerateDescriptor bestCD = bestAccessPath.getConglomerateDescriptor();
+                return !bestCD.isIndex() && !bestCD.isPrimaryKey() && currOpt.isCoveringIndex(currentCD);
+            }
+        }
+
+        return false;
+    }
 
     public boolean isSingleRow() {return singleRow;}
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
@@ -499,10 +499,12 @@ public class ExplainPlanIT extends SpliceUnitTest  {
             Assert.assertTrue("With stats, expect explain plan to pick control path", rs.getString(1).contains("engine=OLTP"));
             //skip the next step(s) to get to the IndexScan or IndexPrefixIteratorMode step
             Assert.assertTrue(rs.next());
-            if (isMemPlatform)
-                Assert.assertTrue(rs.next());
+            Assert.assertTrue(rs.next());
 
-            String indexString = isMemPlatform ? "IndexScan" : "IndexPrefixIteratorMode";
+            // PK access with IndexPrefixIteratorMode is probably better because it doesn't need a lookup.
+            // Bottom line is that if predicates are start/stop keys for an index access, it should not
+            // be too bad, either.
+            String indexString = "IndexScan";
 
             Assert.assertTrue(rs.next());
             Assert.assertTrue("Expected " + indexString, rs.getString(1).contains(indexString));
@@ -562,10 +564,9 @@ public class ExplainPlanIT extends SpliceUnitTest  {
             //skip the next step(s) to get to the IndexScan or IndexPrefixIteratorMode step
             Assert.assertTrue(rs.next());
             Assert.assertTrue(rs.next());
-            if (isMemPlatform)
-                Assert.assertTrue(rs.next());
+            Assert.assertTrue(rs.next());
 
-            String indexString = isMemPlatform ? "IndexScan" : "IndexPrefixIteratorMode";
+            String indexString ="IndexScan";
 
             Assert.assertTrue("Expected " + indexString, rs.getString(1).contains(indexString));
             Assert.assertTrue("With stats, outputRows is expected to be 1", rs.getString(1).contains("scannedRows=1"));


### PR DESCRIPTION
## Short Description
This change adds logic to avoid bad access path when statistics are outdated.

## Long Description
Root cause of this problem is that the table was empty when collecting statistics, i.e., row count of this table is 0.

This is a special case when statistics are outdated. Suppose the table was not empty back then, and we get row count = 100 from statistics. Even it’s outdated over time, optimizer would still go for the index access path for this table because it has a much lower scanned row count, hence lower cost. The two access paths' costs tie only because row count = 0 so to optimizer, it’s really doesn’t matter how to scan because according to statistics, there is nothing to scan.

Nevertheless, this change adds logic to handle such a case and also potential other cases in case costs of two access paths tie. Basic idea is that when we found the cost of current access path is the same as the cost of the best access path, the current access path is chosen when

- the current access path is an index access with start/stop keys, or
- the current access path is on a covering index while the best access path is on table conglomerate and there is no PK defined.

For detailed explanation on rationals behinds these two points, see comments in code in `isCurrentAccessPathBetter()` in `OptimizerImpl.java`.

## How to test
The newly added IT `testPreferIndexAccessEqualCosts` should fail without the fix. To see it, copy the IT only to other branches without this fix and run it on cdh6.3.0 platform. It should fail because optimizer selects the table conglomerate. With the fix, the IT should pass.

## Note
This change could decrease the chance of selecting `IndexPrefixIteratorMode` if the table has another index that doesn't require this mode. See adaptions in `testDefaultSelectivityFactorHint` for details.
