### PR TITLE
DB-11857 Short-circuit HBaseConglomerate.readExternal once the engine has started

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/hbase/HBaseConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/hbase/HBaseConglomerate.java
@@ -385,7 +385,6 @@ public class HBaseConglomerate extends SpliceConglomerate{
                 opFactory = driver.getOperationFactory();
                 if (driver.isEngineStarted()) {
                     // In that case, the upgrade must have happened, so we must have version > 1
-                    // We can skip
                     useNew = true;
                 } else {
                     String version = getConglomerateVersion(driver);


### PR DESCRIPTION
## Short Description

Redirect `HBaseConglomerate.readExternal` to `readExternalNew` once the engine has started to skip slow `getCatalogVersion`

## Long Description

3.2.0.2003 introduced a new serialization mechanism for HBaseConglomerate. On a version >= 2003, we will need the old serialization logic to upgrade, but never after that. Since `SIDriver.engineStarted` is set to true only after upgrade has completed, we don't need to check catalogVersion once `SIDriver.engineStarted == true`.


## How to test

```
git checkout 3.2.0.2000
./start-splice-cluster -k
mvn -T 4 -B clean install -Pcore,cdh6.3.0 -DskipTests
./start-splice-cluster -b -p cdh6.3.0
git checkout DB-11857
./start-splice-cluster -l -p cdh6.3.0
```

