### PR TITLE
DB-11860 Prefer indexes with more selective predicates

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/AccessPath.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/AccessPath.java
@@ -198,4 +198,7 @@ public interface AccessPath {
     void setNumUnusedLeadingIndexFields(int numUnusedLeadingIndexFields);
 
     FirstColumnOfIndexStats getFirstColumnStats();
+
+    void setNumberOfScanKeysOnSpecialColumns(int value);
+    int getNumberOfScanKeysOnSpecialColumns();
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AccessPathImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AccessPathImpl.java
@@ -56,6 +56,8 @@ class AccessPathImpl implements AccessPath{
     private boolean missingHashKeyOK = false;
     private int numUnusedLeadingIndexFields;
 
+    private int numberOfScanKeysOnSpecialColumns = 0;
+
     AccessPathImpl(Optimizer optimizer){
         this.optimizer=optimizer;
     }
@@ -182,5 +184,15 @@ class AccessPathImpl implements AccessPath{
     @Override
     public FirstColumnOfIndexStats getFirstColumnStats() {
         return getCostEstimate().getFirstColumnStats();
+    }
+
+    @Override
+    public void setNumberOfScanKeysOnSpecialColumns(int value) {
+        numberOfScanKeysOnSpecialColumns = value;
+    }
+
+    @Override
+    public int getNumberOfScanKeysOnSpecialColumns() {
+        return numberOfScanKeysOnSpecialColumns;
     }
 }


### PR DESCRIPTION
## Short Description
This change provides a temporary fix for DB-11860.

## Long Description
Main reason is again that statistics are collected when the table is empty. Long-term solution would be again automatically updated statistics.

## How to test
Check `testPreferIndexOnSpecialColumns` for details.
