### PR TITLE
DB-11839 fix selectivity estimate in case of empty stats

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/TableStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/TableStatisticsImpl.java
@@ -317,7 +317,11 @@ public class TableStatisticsImpl implements TableStatistics {
 
     @Override
     public <T extends Comparator<T>> double selectivityExcludingValueIfSkewed(T element, int positionNumber) {
-        return (double)(getEffectivePartitionStatistics().selectivityExcludingValueIfSkewed(element,positionNumber))/getEffectivePartitionStatistics().rowCount();
+        long rowCount = getEffectivePartitionStatistics().rowCount();
+        if (rowCount == 0) {
+            return 0;
+        }
+        return (double) (getEffectivePartitionStatistics().selectivityExcludingValueIfSkewed(element, positionNumber)) / rowCount;
     }
 
 }

--- a/db-engine/src/test/java/com/splicemachine/db/iapi/stats/TableStatisticsImplTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/iapi/stats/TableStatisticsImplTest.java
@@ -30,10 +30,19 @@
  */
 package com.splicemachine.db.iapi.stats;
 
-/**
- *
- * TODO
- *
- */
+import com.splicemachine.db.iapi.types.SQLChar;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
 public class TableStatisticsImplTest {
+    @Test
+    public void emptyStatsDoNotEvaluateToNaNSelectivity() {
+        List<PartitionStatistics> partitionStatistics = new ArrayList<>();
+        partitionStatistics.add(new FakePartitionStatisticsImpl("foo", "bar", 0, 0, 0.0d, 0.0d));
+        TableStatisticsImpl impl = new TableStatisticsImpl("foo", partitionStatistics, 0.0d, 0.0d);
+        Assert.assertEquals(0.0d, impl.selectivityExcludingValueIfSkewed(new SQLChar("    "), 0), 1e-15);
+    }
 }


### PR DESCRIPTION
## Short Description
In this PR we fix wrong selectivity estimation of prepared predicates when we have empty stats.

## Long Description

This bug was observed when comparing the generated plans of a statement in two flavors: prepared and non-prepared. In the prepared version, the estimates where completely off and a table scan was chosen in the RHS of NLJ instead of a much more efficient index lookup.

I thought at the beginning this is related to falling back to default selectivity estimates of prepared predicates, but even with default estimates, we should not end up with infinity selectivity / cost for any predicate / operation, which we can see clearly in the plan (the weird looking question marks in the plan, which is basically a U+FFFD REPLACEMENT CHARACTER for the non-displayable infinity character U+221E INFINITY (∞) as nicely explained here.

The main culprit was a bug in estimating selectivity excluding a skewed default value in com.splicemachine.db.iapi.stats.TableStatisticsImpl#selectivityExcludingValueIfSkewed that caused, after applying statistics on an empty table, infinity to be returned because of dividing  selection-cardinality-of-values-exclusing-skewed-default-value / total-number-of-rows [1] end up dividing 0/0 since stats are empty.

we only see this happening in case of prepared statement because estimating selectivity of prepared predicate code path ends up exactly there, the returned infinity erroneously propagates all the way to the cost estimation of the first AccessPath conglomerate (in our case, a table scan), and since we end up with the same code path when trying other conglomerates (indices), we end up with infinity as well, we end up with an awkward scenario trying to check which cost is better, i.e. if cost(conglom2) {infinity} < bestCostSoFar {infinity} which is false  since infinity < infinity == false we always prefer the first conglomerate (table scan).

With this fix, we simply return 0 instead of infinity when the total-number-of-rows is 0 in equation [1], with this fix, the selectivity estimates are much more reasonable ending up with a proper cost model in case of prepared statement.

## How to test

I added a unit test to table statistics for that corner case, please check it for more details.
