### PR TITLE
DB-11865 Enable native spark broadcast join with non-equijoin predicates

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseJoinStrategy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BaseJoinStrategy.java
@@ -40,6 +40,8 @@ import com.splicemachine.db.iapi.store.access.StaticCompiledOpenConglomInfo;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.util.PropertyUtil;
 
+import static com.splicemachine.db.impl.sql.compile.JoinNode.INNERJOIN;
+
 public abstract class BaseJoinStrategy implements JoinStrategy{
     public BaseJoinStrategy(){
     }
@@ -270,4 +272,10 @@ public abstract class BaseJoinStrategy implements JoinStrategy{
     public String getName() {
         return getJoinStrategyType().getName();
     }
+
+    protected static boolean isSingleTableScan(Optimizer optimizer) {
+        return optimizer.getJoinPosition() == 0   &&
+               optimizer.getJoinType() < INNERJOIN;
+    }
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
@@ -180,7 +180,7 @@ public abstract class HashableJoinStrategy extends BaseJoinStrategy {
                 }
             }
             else
-                ap.setMissingHashKeyOK(false);  // msirek-temp
+                ap.setMissingHashKeyOK(false);
         }
 
         return hashKeyColumns!=null;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
@@ -166,10 +166,7 @@ public abstract class HashableJoinStrategy extends BaseJoinStrategy {
                 return true;
             }
 
-            if (innerTable instanceof FromTable                               &&
-                predList != null                                              &&
-                !outerCost.isSingleRow()                                      &&
-                (innerTable.isMaterializable() ||
+            if ((innerTable.isMaterializable() ||
                  innerTable.supportsMultipleInstantiations())                 &&
                 optimizer instanceof OptimizerImpl                            &&
                 !(innerTable instanceof RowResultSetNode)                     &&
@@ -177,9 +174,13 @@ public abstract class HashableJoinStrategy extends BaseJoinStrategy {
 
                 // Consider BroadcastNestedLoopJoin for anything other
                 // than single-table scan.
-                if (!isSingleTableScan(optimizer))
+                if (!isSingleTableScan(optimizer)) {
                     ap.setMissingHashKeyOK(true);
+                    return true;
+                }
             }
+            else
+                ap.setMissingHashKeyOK(false);  // msirek-temp
         }
 
         return hashKeyColumns!=null;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
@@ -37,6 +37,7 @@ import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.sql.compile.OptimizablePredicate;
 import com.splicemachine.db.iapi.types.*;
+import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.system.SimpleSparkVersion;
 import com.splicemachine.system.SparkVersion;
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -786,7 +787,8 @@ public class OperatorToString {
                 if (!sparkSupportedType(cr.getTypeId().getTypeFormatId(), operand))
                     throwNotImplementedError();
 
-                String columnString = format("c%d", source.getVirtualColumnId()-1);
+                int columnNumber = source.getVirtualColumnId()-1;
+                String columnString = ValueRow.getNamedColumn(columnNumber);
                 if (vars.buildExpressionTree) {
                     boolean leftDataFrame;
                     int rsn =  source.getResultSetNumber();
@@ -796,7 +798,7 @@ public class OperatorToString {
                     else {
                         leftDataFrame = (rsn == vars.leftResultSetNumber);
                         vars.sparkExpressionTree =
-                        new SparkColumnReference(columnString, leftDataFrame);
+                        new SparkColumnReference(columnNumber, leftDataFrame);
                     }
                 }
                 return columnString;
@@ -814,7 +816,8 @@ public class OperatorToString {
                 if (!sparkSupportedType(operand.getTypeId().getTypeFormatId(), operand))
                     throwNotImplementedError();
 
-                String columnString = format("c%d", source.getVirtualColumnId()-1);
+                int columnNumber = source.getVirtualColumnId()-1;
+                String columnString = ValueRow.getNamedColumn(columnNumber);
                 if (vars.buildExpressionTree) {
                     boolean leftDataFrame;
                     int rsn =  source.getResultSetNumber();
@@ -824,7 +827,7 @@ public class OperatorToString {
                     else {
                         leftDataFrame = (rsn == vars.leftResultSetNumber);
                         vars.sparkExpressionTree =
-                        new SparkColumnReference(columnString, leftDataFrame);
+                        new SparkColumnReference(columnNumber, leftDataFrame);
                     }
                 }
                 return columnString;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SparkExpressionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SparkExpressionNode.java
@@ -35,8 +35,10 @@ import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.DataType;
+import scala.Tuple2;
 
 import java.io.Externalizable;
+import java.util.HashMap;
 import java.util.function.Function;
 
 /**
@@ -63,5 +65,14 @@ extends Externalizable
 
     // Is this a constant FALSE node?
     boolean isFalse();
+
+    // Transform any String columns into trimmed columns with new column names,
+    // and add the column names to the leftColMap and rightColMap (indicating if
+    // the left and/or right data frames need these new columns added, along
+    // with the column expression to add.
+    void transformToRTrimmedColumnExpression(Tuple2<String, String>[] leftColTypes,
+                                             Tuple2<String, String>[] rightColTypes,
+                                             HashMap<String, Column> leftColMap,
+                                             HashMap<String, Column> rightColMap);
 }
 

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
@@ -985,6 +985,8 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
                 }
             }
         }
+        if (!isCross && filterExpr == null && rightJoinKeys.length == 0)
+            filterExpr= lit(true);
 
         if (isBroadcast) {
             rightDF = broadcast(rightDF);

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/NativeSparkDataSet.java
@@ -907,6 +907,12 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
         }
     }
 
+    public static String getRTrimmedColumnName(String colName) {
+        if (colName == null)
+            return null;
+        return colName + "_rtrimmed";
+    }
+
     private Dataset<Row> getJoinedDataset(OperationContext context, Dataset<Row> leftDF, Dataset<Row> rightDF, boolean isCross, boolean wasRightOuter,
                                           Broadcast crossBType, boolean isBroadcast, SparkExpressionNode sparkJoinPredicate,
                                           JoinType joinType) throws StandardException {
@@ -917,6 +923,9 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
         boolean varcharDB2CompatibilityMode = PropertyUtil.getCachedDatabaseBoolean(
                 context.getActivation().getLanguageConnectionContext(),
                 Property.SPLICE_DB2_VARCHAR_COMPATIBLE);
+
+        HashMap<String, Column> leftColMap = new HashMap<>();
+        HashMap<String, Column> rightColMap = new HashMap<>();
 
         List<String> extraColNamesLeft = new ArrayList<>();
         List<Column> extraColumnsLeft = new ArrayList<>();
@@ -929,32 +938,43 @@ public class NativeSparkDataSet<V> implements DataSet<V> {
             Tuple2<String, String>[] rightColTypes = rightDF.dtypes();
             String leftColNames[] = new String[rightJoinKeys.length];
             String rightColNames[] = new String[rightJoinKeys.length];
-            boolean leftAdded = false;
-            boolean rightAdded = false;
             // Add new rtrimmed join key columns for string types
             // if using DB2 compatibility mode.
             for (int i = 0; i < rightJoinKeys.length; i++) {
                 leftColNames[i] = ValueRow.getNamedColumn(leftJoinKeys[i]);
                 if (varcharDB2CompatibilityMode && leftColTypes[leftJoinKeys[i]]._2().equals("StringType")) {
-                    extraColumnsLeft.add(rtrim(col(leftColNames[i])));
-                    leftColNames[i] = leftColNames[i] + "_rtrimmed";
-                    extraColNamesLeft.add(leftColNames[i]);
-                    leftAdded = true;
+                    String leftTrimmedColName = getRTrimmedColumnName(leftColNames[i]);
+                    leftColMap.put(leftTrimmedColName, rtrim(col(leftColNames[i])));
+                    leftColNames[i] = leftTrimmedColName;
                 }
                 rightColNames[i] = ValueRow.getNamedColumn(rightJoinKeys[i]);
                 if (varcharDB2CompatibilityMode && rightColTypes[rightJoinKeys[i]]._2().equals("StringType")) {
-                    extraColumnsRight.add(rtrim(col(rightColNames[i])));
-                    rightColNames[i] = rightColNames[i] + "_rtrimmed";
-                    extraColNamesRight.add(rightColNames[i]);
-                    rightAdded = true;
+                    String rightTrimmedColName = getRTrimmedColumnName(rightColNames[i]);
+                    rightColMap.put(rightTrimmedColName, rtrim(col(rightColNames[i])));
+                    rightColNames[i] = rightTrimmedColName;
                 }
             }
-            if (leftAdded)
+            if (sparkJoinPredicate != null && varcharDB2CompatibilityMode)
+                sparkJoinPredicate.transformToRTrimmedColumnExpression(leftColTypes,
+                                                                       rightColTypes,
+                                                                       leftColMap,
+                                                                       rightColMap);
+            if (!leftColMap.isEmpty()) {
+                for (Map.Entry<String, Column> pair : leftColMap.entrySet()) {
+                    extraColNamesLeft.add(pair.getKey());
+                    extraColumnsLeft.add(pair.getValue());
+                }
                 leftDF = NativeSparkUtils.withColumns(extraColNamesLeft, extraColumnsLeft, leftDF);
-            if (rightAdded)
+            }
+            if (!rightColMap.isEmpty()) {
+                for (Map.Entry<String, Column> pair : rightColMap.entrySet()) {
+                    extraColNamesRight.add(pair.getKey());
+                    extraColumnsRight.add(pair.getValue());
+                }
                 rightDF = NativeSparkUtils.withColumns(extraColNamesRight, extraColumnsRight, rightDF);
+            }
 
-            if (!varcharDB2CompatibilityMode && sparkJoinPredicate != null) {
+            if (sparkJoinPredicate != null) {
                 filterExpr = sparkJoinPredicate.getColumnExpression(leftDF, rightDF, ParserUtils::getDataTypeFromString);
             } else {
                 for (int i = 0; i < rightJoinKeys.length; i++) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/costing/V1NestedLoopJoinCostEstimationModel.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/costing/V1NestedLoopJoinCostEstimationModel.java
@@ -29,7 +29,7 @@ import static com.splicemachine.db.impl.sql.compile.JoinNode.INNERJOIN;
 
 public class V1NestedLoopJoinCostEstimationModel implements StrategyJoinCostEstimation {
 
-    private static final double NLJ_ON_SPARK_PENALTY = 1e15;  // msirek-temp
+    private static final double NLJ_ON_SPARK_PENALTY = 1e15;
 
     @Override
     public void estimateCost(Optimizable innerTable,

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
@@ -180,7 +180,7 @@ public class BroadcastJoinOperation extends JoinOperation{
          * so route to the rdd implementation for now for SSQ.  Also, spark join can't handle a zero length
          * hash key, so it will use rdd as well.
          */
-        if (rightFromSSQ || leftHashKeys.length == 0)
+        if (rightFromSSQ || (leftHashKeys.length == 0 && !hasSparkJoinPredicate()))
             useDataset = false;
 
         DataSet<ExecRow> result;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
@@ -180,7 +180,7 @@ public class BroadcastJoinOperation extends JoinOperation{
          * so route to the rdd implementation for now for SSQ.  Also, spark join can't handle a zero length
          * hash key, so it will use rdd as well.
          */
-        if (rightFromSSQ || (leftHashKeys.length == 0 && !hasSparkJoinPredicate()))
+        if (rightFromSSQ)
             useDataset = false;
 
         DataSet<ExecRow> result;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/BroadcastJoinOperation.java
@@ -177,8 +177,7 @@ public class BroadcastJoinOperation extends JoinOperation{
         boolean useDataset = true;
 
         /** TODO don't know how to let spark report SQLState.LANG_SCALAR_SUBQUERY_CARDINALITY_VIOLATION error,
-         * so route to the rdd implementation for now for SSQ.  Also, spark join can't handle a zero length
-         * hash key, so it will use rdd as well.
+         * so route to the rdd implementation for now for SSQ.
          */
         if (rightFromSSQ)
             useDataset = false;

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SparkExplainIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SparkExplainIT.java
@@ -874,7 +874,7 @@ public class SparkExplainIT extends SpliceUnitTest {
         String sqlText = "select * from t1 a\n" +
                          ", t2 b --splice-properties joinStrategy=broadcast\n" +
                          "where a.a1 between b.a2 and b.a2+1";
-        testQueryContains("sparkexplain " + sqlText, "+- BroadcastNestedLoopJoin", methodWatcher, true);
+        testQueryContains("sparkexplain " + sqlText, "BroadcastNestedLoopJoin", methodWatcher, true);
         String expected =
                 "A1 |B1 |C1 |A2 |B2 |C2 |\n" +
                 "------------------------\n" +
@@ -909,6 +909,7 @@ public class SparkExplainIT extends SpliceUnitTest {
                   "where not exists (select a2 from t2 b --splice-properties joinStrategy=broadcast\n" +
                   "where a.a1 between b.a2 and b.a2+1\n" +
                   ")";
+        testQueryContains("sparkexplain " + sqlText, "BroadcastNestedLoopJoin", methodWatcher, true);
         expected =
                 "A1 |B1 |C1 |\n" +
                 "------------\n" +
@@ -918,6 +919,7 @@ public class SparkExplainIT extends SpliceUnitTest {
 
         sqlText = "select * from t1 a left outer join t2 b --splice-properties joinStrategy=broadcast\n" +
                   "on a.a1 between b.a2 and b.a2+1";
+        testQueryContains("sparkexplain " + sqlText, "BroadcastNestedLoopJoin", methodWatcher, true);
         expected =
                 "A1 |B1 |C1 | A2  | B2  | C2  |\n" +
                 "------------------------------\n" +
@@ -936,6 +938,7 @@ public class SparkExplainIT extends SpliceUnitTest {
 
         sqlText = "select * from t1 a full outer join t2 b --splice-properties joinStrategy=broadcast\n" +
                   "on a.a1 between b.a2+1 and b.a2+2";
+        testQueryContains("sparkexplain " + sqlText, "BroadcastNestedLoopJoin", methodWatcher, true);
         expected =
                 "A1  | B1  | C1  | A2  | B2  | C2  |\n" +
                 "------------------------------------\n" +

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SparkExplainIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SparkExplainIT.java
@@ -826,14 +826,14 @@ public class SparkExplainIT extends SpliceUnitTest {
                 "        t1 --splice-properties useSpark=true\n" +
                 "        inner join big on 1=1";
         // BIG table should be on the left side (bigger row index)
-        String[] expectedList = {"CrossJoin", "TableScan[T1(", "TableScan[BIG("};
+        String[] expectedList = {"BroadcastJoin", "TableScan[T1(", "TableScan[BIG("};
         rowContainsQuery(new int[]{6, 7, 9}, sqlText, methodWatcher, expectedList);
 
         sqlText = "sparkexplain select count(*) from\n" +
                 "        t1 --splice-properties useSpark=true\n" +
                 "        inner join big on 1=1";
         // expecting broadcast on the right side and BIG table is on the left side
-        String[] expectedList2 = {"BroadcastNestedLoopJoin BuildRight, Cross", "Scan ExistingRDD[]", "-> TableScan[BIG("};
+        String[] expectedList2 = {"BroadcastNestedLoopJoin BuildRight", "Scan ExistingRDD[]", "-> TableScan[BIG("};
         rowContainsQuery(new int[]{5, 6, 7}, sqlText, methodWatcher, expectedList2);
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/CrossJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/CrossJoinIT.java
@@ -730,7 +730,7 @@ public class CrossJoinIT extends SpliceUnitTest {
     }
 
     @Test
-    public void testBroadcastJoinPreserveSortOrderNoJoinStrategyHint() throws Exception {
+    public void testCrossOrBroadcastJoinPreserveSortOrderNoJoinStrategyHint() throws Exception {
         String sqlText = format("select tt2.a from \n" +
                 "tab2 tt2 --splice-properties useSpark=%s\n" +
                 "inner join %s ttb\n" +
@@ -739,7 +739,7 @@ public class CrossJoinIT extends SpliceUnitTest {
         if (useSpark) {
             try (ResultSet rs = classWatcher.executeQuery("explain " + sqlText)) {
                 String matchString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
-                assertTrue("Cross join is not selected for OLAP", matchString.contains("BroadcastJoin"));
+                assertTrue("Cross or Broadcast join is not selected for OLAP", matchString.contains("BroadcastJoin") || matchString.contains("CrossJoin"));
             }
         }
 
@@ -782,7 +782,7 @@ public class CrossJoinIT extends SpliceUnitTest {
             String explainQuery = "explain " + sqlText;
             // The table with predicate "BH.A4 = 1" is smaller.
             // Make sure it is picked as the right table.
-            rowContainsQuery(new int[]{6,7,8}, explainQuery, classWatcher, "BroadcastJoin", "(BH.A4[2:1] = 1)", "(BU.B4[0:1] <> 1)])");
+            rowContainsQuery(new int[]{6,7,8}, explainQuery, classWatcher, "Join", "(BH.A4[2:1] = 1)", "(BU.B4[0:1] <> 1)])");
         }
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/CrossJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/CrossJoinIT.java
@@ -730,7 +730,7 @@ public class CrossJoinIT extends SpliceUnitTest {
     }
 
     @Test
-    public void testCrossJoinPreserveSortOrderNoJoinStrategyHint() throws Exception {
+    public void testBroadcastJoinPreserveSortOrderNoJoinStrategyHint() throws Exception {
         String sqlText = format("select tt2.a from \n" +
                 "tab2 tt2 --splice-properties useSpark=%s\n" +
                 "inner join %s ttb\n" +
@@ -739,7 +739,7 @@ public class CrossJoinIT extends SpliceUnitTest {
         if (useSpark) {
             try (ResultSet rs = classWatcher.executeQuery("explain " + sqlText)) {
                 String matchString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
-                assertTrue("Cross join is not selected for OLAP", matchString.contains("CrossJoin"));
+                assertTrue("Cross join is not selected for OLAP", matchString.contains("BroadcastJoin"));
             }
         }
 
@@ -770,7 +770,7 @@ public class CrossJoinIT extends SpliceUnitTest {
     }
 
     @Test
-    public void testCrossJoinRightTableIsSmallTable() throws Exception {
+    public void testBroadcastJoinRightTableIsSmallTable() throws Exception {
         String sqlText = format("select count(*) from \n" +
                                 "t4 BH --splice-properties useSpark=%s\n" +
                                 ",t4 BU WHERE\n" +
@@ -782,7 +782,7 @@ public class CrossJoinIT extends SpliceUnitTest {
             String explainQuery = "explain " + sqlText;
             // The table with predicate "BH.A4 = 1" is smaller.
             // Make sure it is picked as the right table.
-            rowContainsQuery(new int[]{6,7,8}, explainQuery, classWatcher, "CrossJoin", "(BH.A4[2:1] = 1)", "(BU.B4[0:1] <> 1)])");
+            rowContainsQuery(new int[]{6,7,8}, explainQuery, classWatcher, "BroadcastJoin", "(BH.A4[2:1] = 1)", "(BU.B4[0:1] <> 1)])");
         }
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/FullOuterJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/FullOuterJoinIT.java
@@ -1124,11 +1124,14 @@ public class FullOuterJoinIT extends SpliceUnitTest {
         8 rows selected
          */
         rowContainsQuery(new int[]{3,4,5,6,8}, "explain " + sqlText, methodWatcher,
-                new String[]{useSpark.equals("true")? "BroadcastJoin" : "NestedLoopJoin"},
+                new String[]{useSpark.equals("true")? "Join" : "NestedLoopJoin"},
                 new String[]{"TableScan[T3"},
                 new String[]{"LeftOuterJoin"},
                 new String[]{"TableScan[T2"},
                 new String[]{"TableScan[T1"});
+
+        if (useSpark.equals("true"))
+            queryDoesNotContainString("explain " + sqlText, "NestedLoopJoin", methodWatcher);
 
         String expected = "A1 |B1 | A2  | B2  |A3 |B3 |\n" +
                 "----------------------------\n" +

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/FullOuterJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/FullOuterJoinIT.java
@@ -1124,7 +1124,7 @@ public class FullOuterJoinIT extends SpliceUnitTest {
         8 rows selected
          */
         rowContainsQuery(new int[]{3,4,5,6,8}, "explain " + sqlText, methodWatcher,
-                new String[]{useSpark.equals("true")? "CrossJoin" : "NestedLoopJoin"},
+                new String[]{useSpark.equals("true")? "BroadcastJoin" : "NestedLoopJoin"},
                 new String[]{"TableScan[T3"},
                 new String[]{"LeftOuterJoin"},
                 new String[]{"TableScan[T2"},

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceDateFunctionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceDateFunctionsIT.java
@@ -29,6 +29,7 @@ import org.junit.runner.Description;
 
 import java.sql.*;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
 
 import static org.junit.Assert.*;
@@ -1564,9 +1565,7 @@ public class SpliceDateFunctionsIT extends SpliceUnitTest {
     @Test
     public void testBindTimezoneOperation() throws Exception {
         // See DB-11973
-        testQueryContains(
-                "select timestamp(trim('2016-08-05-07.12.59.000000')) + current timezone from sysibm.sysdummy1",
-                "2016-08-05",
-                methodWatcher);
+        testQueryContains("select timestamp(trim('2016-08-05-07.12.59.000000')) + current timezone from sysibm.sysdummy1",
+                          Arrays.asList("2016-08-04", "2016-08-05", "2016-08-06"), methodWatcher, true);
     }
 }


### PR DESCRIPTION
## Short Description
Enable native spark broadcast join with non-equijoin predicates.

## Long Description
[SPLICE-2362](https://splice.atlassian.net/browse/SPLICE-2362) added support for general expressions in native spark join predicates.  It was enabled for combinations of equijoin plus non-equijoin predicates, but not non-equijoin predicates by themselves.  This Jira enables the latter by removing the check in BroadcastJoinOperation which checks that we have at least one left hash key before choosing native spark join.

## How to test
A test case such as the following should indicate BroadcastNestedLoopJoin in the sparkexplain output:

> create table t1(a1 int not null, b1 int, c1 int, primary key(c1));
> create table t2 (a2 int not null, b2 int, c2 int, primary key(c2));
> sparkexplain select * from t1 a, t2 b --splice-properties joinStrategy=broadcast
>             where a.a1 between b.a2 and b.a2+1;
> 
> Native Spark Execution Plan
> ----------------------------
> -> NativeSparkDataSet
>     *(3) Project [c0#4365, c1#4366, c2#4367, c0#4380 AS c3#4431, c1#4381 AS c4#4432, c2#4382 AS c5#4433]
>     +- BroadcastNestedLoopJoin BuildRight, Inner, ((c0#4365 >= c0#4380) && (cast(c0#4365 as bigint) <= (cast(c0#4380 as bigint) + 1)))
>        :- *(1) Filter isnotnull(c0#4365)
>        :  +- Scan ExistingRDD[c0#4365,c1#4366,c2#4367]
>              -> TableScan[T1(7728)](RS=0,totalCost=4.04, scannedRows=20,outputRows=20, outputHeapSize=60 B,partitions=1, parallelTasks=8)
>        +- BroadcastExchange IdentityBroadcastMode
>           +- *(2) Filter isnotnull(c0#4380)
>              +- Scan ExistingRDD[c0#4380,c1#4381,c2#4382]
>                 -> TableScan[T2(7744)](RS=2,totalCost=4.04, scannedRows=20,outputRows=20, outputHeapSize=97 B,partitions=1, parallelTasks=8)
