### PR TITLE
DB-11224 Don't set exclude null/default flags of an index when they have no effect

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateIndexNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateIndexNode.java
@@ -255,6 +255,18 @@ public class CreateIndexNode extends DDLStatementNode
                 throw StandardException.newException(SQLState.LANG_COLUMN_NOT_ORDERABLE_DURING_EXECUTION,
                         columnDescriptor.getType().getTypeId().getSQLTypeName());
             }
+
+            // unset exclude flags that has no effect
+            // consider only the first index column
+            if (i == 0) {
+                if (excludeNulls && !columnDescriptor.getType().isNullable()) {
+                    excludeNulls = false;
+                }
+
+                if (excludeDefaults && columnDescriptor.getDefaultValue() == null) {
+                    excludeDefaults = false;
+                }
+            }
         }
 
         /* Check for number of key columns to be less than 16 to match DB2 */

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/IndexIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/IndexIT.java
@@ -247,6 +247,56 @@ public class IndexIT extends SpliceUnitTest{
     }
 
     @Test
+    public void createIndexExcludeNullNotApplicable() throws Exception {
+        String tableName = "TEST_IDX_EXCLUDE_NULL";
+        methodWatcher.executeUpdate(format("create table %s (c1 char(5), c2 int not null, c3 varchar(5))", tableName));
+        methodWatcher.executeUpdate(format("insert into %s values ('foo', 0, 'bar'), ('hello', 1, 'world')", tableName));
+        methodWatcher.executeUpdate(format("create index %1$s_IDX on %1$s (c2, c3) exclude null keys", tableName));
+
+        /* Old logic:
+         * Index exclude nulls, but query requires c2 is null, so index is not eligible. But it's hinted, so no valid plan.
+         * New logic:
+         * When creating the index, we see that c2 is not null. That means the "exclude null keys" on c2 has no effect.
+         * There is no need to mark this index's exclude null flag. It can be used for the following query.
+         * This is possible because for an index with multiple columns, only rows with NULL or default values on the
+         * leading index column are excluded.
+         */
+        try (ResultSet rs = methodWatcher.executeQuery(format("select c2, c3 from %1$s --splice-properties index=%1$s_IDX\n" +
+                "where c3 is not null", tableName))) {
+            String expected = "C2 | C3   |\n" +
+                    "-----------\n" +
+                    " 0 | bar  |\n" +
+                    " 1 |world |";
+            assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        }
+    }
+
+    @Test
+    public void createIndexExcludeDefaultNotApplicable() throws Exception {
+        String tableName = "TEST_IDX_EXCLUDE_DEFAULT";
+        methodWatcher.executeUpdate(format("create table %s (c1 char(3), c2 varchar(3), c3 varchar(10))", tableName));
+        methodWatcher.executeUpdate(format("insert into %s values ('zzz', 'ZzZ', 'zZz'), ('', 'EeE', 'eEe'), (null, 'NnN', 'nNn')", tableName));
+        methodWatcher.executeUpdate(format("create index %1$s_IDX on %1$s (c1, c2, c3) exclude default keys", tableName));
+
+        /* Old logic:
+         * Index exclude default values. When checking if the index is eligible or not, we try to get the default value
+         * of c1 but it's null (no default value defined), leading to NPE.
+         * New logic:
+         * Similar to exclude null case above. When defining the index, we see that c1 has no default values, so
+         * "exclude default keys" has no effect. The flag is not set and the index should qualify for the following
+         * .query
+         */
+        try (ResultSet rs = methodWatcher.executeQuery(format("select * from %s --splice-properties index=%1$s_IDX\n" +
+                "where c1 is not null", tableName))) {
+            String expected = "C1  |C2  |C3  |\n" +
+                    "---------------\n" +
+                    "    |EeE |eEe |\n" +
+                    "zzz |ZzZ |zZz |";
+            assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
+        }
+    }
+
+    @Test
     public void createIndexesOnExpressionsNoDuplicateIndex() throws Exception{
         String tableName = "TEST_IDX_DUP";
         methodWatcher.executeUpdate(format("create table %s (vc varchar(10), i int not null)", tableName));

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DefaultIndexIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DefaultIndexIT.java
@@ -158,12 +158,15 @@ public class DefaultIndexIT extends SpliceUnitTest{
 
     @Test
     public void testIndexAfterLoadNullTable() throws Exception {
-        try {
-            SpliceIndexWatcher.createIndex(conn,schemaWatcher.schemaName,INDEX_AFTER_LOAD_NULL_TABLE.tableName,"INDEX_AFTER_LOAD_NULL_TABLE_IX","(i)",false,false,true);
-            methodWatcher.executeQuery(String.format("SELECT * FROM INDEX_AFTER_LOAD_NULL_TABLE --SPLICE-PROPERTIES index=INDEX_AFTER_LOAD_NULL_TABLE_IX\n"));
-            Assert.fail("did not throw exception");
-        } catch (SQLException sqle) {
-            Assert.assertEquals("No valid execution plan was found for this statement. This is usually because an infeasible join strategy was chosen, or because an index was chosen which prevents the chosen join strategy from being used.", sqle.getMessage());
+        // Index is eligible because column i has no default value defined. Exclude default keys clause has no effect.
+        SpliceIndexWatcher.createIndex(conn,schemaWatcher.schemaName,INDEX_AFTER_LOAD_NULL_TABLE.tableName,"INDEX_AFTER_LOAD_NULL_TABLE_IX","(i)",false,false,true);
+        try (ResultSet rs = methodWatcher.executeQuery(String.format("SELECT * FROM INDEX_AFTER_LOAD_NULL_TABLE --SPLICE-PROPERTIES index=INDEX_AFTER_LOAD_NULL_TABLE_IX\n"))) {
+            String expected = "I  |  J  |\n" +
+                    "------------\n" +
+                    "NULL |NULL |\n" +
+                    "     |     |\n" +
+                    " SD  | SD  |";
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs));
         }
     }
 


### PR DESCRIPTION
## Short Description
This change improves the logic of setting `exclude null/default keys` flags of an index.

## Long Description
From splice SQL reference:
> Excluding NULL and Default Values
>
> You can include the optional EXCLUDE clause to specify that you want to exclude from the index either default values or NULL values for the column. This can be desirable for a large table in which the index column is largely populated with the same (default or NULL) value.
> Note: For an index with multiple columns, only rows with NULL or default values on the leading index column are excluded.

For the NPE issue described in Jira, root cause is that an index with `exclude default keys` clause is defined on a set of columns but the leading column has no default value defined. When optimizer checks if this index is eligible for a certain query, it tries to retrieve the default value of the leading column because the index has `excludeDefault` flag set to true. Default value returned is null, leading to NPE for the following checks on the default value.

However, in the case above, `exclude default keys` has no effect because the column has no default values, thus nothing to exclude.

A similar issue happens to `exclude null keys` clause, too. Though the symptom is less severe. Optimizer could consider the index not eligible for a query, missing an alternative access path.

In detail, we could also define an index with `exclude null keys` on a column that is `not null`. Effectively, the clause also has no effect because there is nothing to exclude.

The change fixes both problems by adding a check in binding phase of creating an index. The check applies to the leading column of the index only. The check contains two parts:

- If `exclude null keys` is specified but the leading column is `not null`, unset the `excludeNulls` flag so that the `exclude null keys` clause is effectively removed;
- If `exclude default keys` is specified but the leading column has no default value defined, unset the `excludeDefault` flag so that the `exclude default keys` clause is effectively removed.

## How to test
Two new ITs `createIndexExcludeNullNotApplicable` and `createIndexExcludeDefaultNotApplicable` are added. They should fail without the fix but pass otherwise. In particular, without the fix, 

- `createIndexExcludeNullNotApplicable` would fail with an error message that no valid plan is found;
- `createIndexExcludeDefaultNotApplicable` would fail with NPE.
