### PR TITLE
DB-9686 Introduce new auto analyze mechanism

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDescriptorGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDescriptorGenerator.java
@@ -101,6 +101,7 @@ public class DataDescriptorGenerator
      * @param schema          The descriptor for the schema the table lives in. If null, use the current (default) schema.
      * @param tableType       The type of the table: base table or view.
      * @param lockGranularity The lock granularity.
+     * @param autoAnalyze
      * @return The descriptor for the table.
      */
     public TableDescriptor newTableDescriptor(String tableName,
@@ -116,10 +117,10 @@ public class DataDescriptorGenerator
                                               String compression,
                                               boolean isPinned,
                                               boolean purgeDeletedRows,
-                                              Long minRetentionPeriod) {
+                                              Long minRetentionPeriod, Long autoAnalyze) {
         return new TableDescriptor(dataDictionary, tableName, schema, tableType, lockGranularity, columnSequence,
                         delimited, escaped, lines, storedAs, location, compression, isPinned, purgeDeletedRows,
-                        minRetentionPeriod);
+                        minRetentionPeriod, autoAnalyze);
     }{}
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/TableDescriptor.java
@@ -174,6 +174,7 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
     private boolean isPinned;
     private boolean purgeDeletedRows;
     private Long minRetentionPeriod;
+    private Long autoAnalyze;
 
     /**
      * <p>
@@ -244,7 +245,7 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
                            int tableType,
                            boolean onCommitDeleteRows,
                            boolean onRollbackDeleteRows, int numberOfColumns){
-        this(dataDictionary,tableName,schema,tableType,'\0',numberOfColumns,null,null,null,null,null,null,false,false, null);
+        this(dataDictionary,tableName,schema,tableType,'\0',numberOfColumns,null,null,null,null,null,null,false,false, null, null);
         this.onCommitDeleteRows=onCommitDeleteRows;
         this.onRollbackDeleteRows=onRollbackDeleteRows;
     }
@@ -271,7 +272,8 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
                            String compression,
                            boolean isPinned,
                            boolean purgeDeletedRows,
-                           Long minRetentionPeriod
+                           Long minRetentionPeriod,
+                           Long autoAnalyze
     ){
         super(dataDictionary);
 
@@ -294,6 +296,7 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
         this.isPinned = isPinned;
         this.purgeDeletedRows = purgeDeletedRows;
         this.minRetentionPeriod = minRetentionPeriod;
+        this.autoAnalyze = autoAnalyze;
     }
 
     //
@@ -409,8 +412,16 @@ public class TableDescriptor extends TupleDescriptor implements UniqueSQLObjectD
         return minRetentionPeriod;
     }
 
+    public Long getAutoAnalyze() {
+        return autoAnalyze;
+    }
+
     public void setMinRetentionPeriod(Long minRetentionPeriod) {
         this.minRetentionPeriod = minRetentionPeriod;
+    }
+
+    public void setAutoAnalyze(Long autoAnalyze) {
+        this.autoAnalyze = autoAnalyze;
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -7012,20 +7012,20 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
       *
       *    @exception StandardException Standard Derby error policy
       */
-        public void upgrade_addColumns( CatalogRowFactory rowFactory,
-                                        int[] newColumnIDs,
-                                        TransactionController tc )
+        public void upgradeAddColumns(CatalogRowFactory rowFactory,
+                                      int[] newColumnIDs,
+                                      TransactionController tc )
                     throws StandardException
     {
-        int            columnID;
-        SystemColumn        currentColumn;
+        int columnID;
+        SystemColumn currentColumn;
 
-        SystemColumn[]        columns = rowFactory.buildColumnList();
-                ExecRow templateRow = rowFactory.makeEmptyRowForLatestVersion();
-        int            columnCount = newColumnIDs.length;
-        SchemaDescriptor    sd = getSystemSchemaDescriptor();
-        TableDescriptor        td;
-        long                conglomID;
+        SystemColumn[] columns = rowFactory.buildColumnList();
+        ExecRow templateRow = rowFactory.makeEmptyRowForLatestVersion();
+        int columnCount = newColumnIDs.length;
+        SchemaDescriptor sd = getSystemSchemaDescriptor();
+        TableDescriptor td;
+        long conglomID;
 
         // Special case when adding a column to systables or syscolumns,
         // since we can't go to systables/syscolumns to get the
@@ -7998,6 +7998,14 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
         }
 
         return retval;
+    }
+
+    public TabInfoImpl getTabInfoByNumber(int catalogNumber) throws StandardException {
+        if (catalogNumber < coreInfo.length) {
+            return coreInfo[catalogNumber];
+        } else {
+            return getNonCoreTIByNumber(catalogNumber);
+        }
     }
 
     protected void initSystemIndexVariables(TabInfoImpl ti) throws StandardException{

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -1464,7 +1464,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
         if(SchemaDescriptor.STD_SYSTEM_DIAG_SCHEMA_NAME.equals(
                 sd.getSchemaName())){
             TableDescriptor td=new TableDescriptor(this,tableName,sd,TableDescriptor.VTI_TYPE,TableDescriptor.DEFAULT_LOCK_GRANULARITY,-1,
-                    null,null,null,null,null,null, false,false, null);
+                    null,null,null,null,null,null, false,false, null, null);
 
             // ensure a vti class exists
             if(getVTIClass(td,false)!=null)
@@ -7038,7 +7038,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
                                             TableDescriptor.BASE_TABLE_TYPE,
                                             TableDescriptor.ROW_LOCK_GRANULARITY,
                                             -1,null,null,null,
-                                            null,null,null,false,false,null);
+                                            null,null,null,false,false,null, null);
                     td.setUUID(getUUIDForCoreTable("SYSTABLES", sd.getUUID().toString(), tc));
 
                     conglomID = coreInfo[SYSTABLES_CORE_NUM].getHeapConglomerate();
@@ -7051,7 +7051,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
                                             TableDescriptor.BASE_TABLE_TYPE,
                                             TableDescriptor.ROW_LOCK_GRANULARITY,
                                             -1,null,null,null,
-                                            null,null,null,false,false,null);
+                                            null,null,null,false,false,null, null);
                     td.setUUID(getUUIDForCoreTable("SYSCOLUMNS", sd.getUUID().toString(), tc));
                     conglomID = coreInfo[SYSCOLUMNS_CORE_NUM].getHeapConglomerate();
         }
@@ -7345,7 +7345,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
         columnCount=columnList.length;
         td=ddg.newTableDescriptor(name,sd,TableDescriptor.SYSTEM_TABLE_TYPE,TableDescriptor.ROW_LOCK_GRANULARITY,-1,
                 null,null,null,null,null,null,false,false,
-                getSystablesMinRetentionPeriod());
+                getSystablesMinRetentionPeriod(), null);
         td.setUUID(crf.getCanonicalTableUUID());
         addDescriptor(td,sd,SYSTABLES_CATALOG_NUM,false,tc,false);
         toid=td.getUUID();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTABLESRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSTABLESRowFactory.java
@@ -57,7 +57,7 @@ import java.util.List;
 public class SYSTABLESRowFactory extends CatalogRowFactory {
     public static final String TABLENAME_STRING = "SYSTABLES";
 
-    public static final int SYSTABLES_COLUMN_COUNT = 16;
+    public static final int SYSTABLES_COLUMN_COUNT = 17;
 
     /* Column #s for systables (1 based) */
     public    static final int SYSTABLES_TABLEID                = 1;
@@ -79,7 +79,8 @@ public class SYSTABLESRowFactory extends CatalogRowFactory {
     @Deprecated
     protected static final int SYSTABLES_IS_PINNED              = 14;
     protected static final int SYSTABLES_PURGE_DELETED_ROWS     = 15;
-    public static final int SYSTABLES_MIN_RETENTION_PERIOD   = 16;
+    public static final int SYSTABLES_MIN_RETENTION_PERIOD      = 16;
+    public static final int SYSTABLES_AUTO_ANALYZE              = 17;
     /* End External Tables Columns */
 
     protected static final int SYSTABLES_INDEX1_ID        = 0;
@@ -106,6 +107,7 @@ public class SYSTABLESRowFactory extends CatalogRowFactory {
     public static final String TABLEID              = "TABLEID";
     public static final String PURGE_DELETED_ROWS   = "PURGE_DELETED_ROWS";
     public static final String MIN_RETENTION_PERIOD = "MIN_RETENTION_PERIOD";
+    public static final String AUTO_ANALYZE         = "AUTO_ANALYZE";
     /*
      * The first version of any tables. Use this for System tables and
      * any time that you don't know what the version is.
@@ -186,6 +188,7 @@ public class SYSTABLESRowFactory extends CatalogRowFactory {
         boolean isPinned = false;
         boolean purgeDeletedRows = false;
         Long minRetentionPeriod = null;
+        Long autoAnalyze = null;
 
         if (td != null) {
             /*
@@ -263,6 +266,7 @@ public class SYSTABLESRowFactory extends CatalogRowFactory {
             isPinned = descriptor.isPinned();
             purgeDeletedRows = descriptor.purgeDeletedRows();
             minRetentionPeriod = descriptor.getMinRetentionPeriod();
+            autoAnalyze = descriptor.getAutoAnalyze();
             tableVersion = descriptor.getVersion() == null ?
                     new SQLVarchar(CURRENT_TABLE_VERSION) :
                     new SQLVarchar(descriptor.getVersion());
@@ -279,7 +283,7 @@ public class SYSTABLESRowFactory extends CatalogRowFactory {
         row = getExecutionFactory().getValueRow(SYSTABLES_COLUMN_COUNT);
 
         setRowColumns(row, tableID, tableName, tabSType, schemaID, lockGranularity, tableVersion, columnSequence,
-                delimited, escaped, lines, storedAs, location, compression, isPinned, purgeDeletedRows, minRetentionPeriod);
+                delimited, escaped, lines, storedAs, location, compression, isPinned, purgeDeletedRows, minRetentionPeriod, autoAnalyze);
         return row;
     }
 
@@ -299,7 +303,8 @@ public class SYSTABLESRowFactory extends CatalogRowFactory {
                                      String compression,
                                      boolean isPinned,
                                      boolean purgeDeletedRows,
-                                     Long minRetentionPeriod) {
+                                     Long minRetentionPeriod,
+                                     Long autoAnalyze) {
         /* 1st column is TABLEID (UUID - char(36)) */
         row.setColumn(SYSTABLES_TABLEID, new SQLChar(tableID));
 
@@ -330,6 +335,7 @@ public class SYSTABLESRowFactory extends CatalogRowFactory {
         row.setColumn(SYSTABLES_IS_PINNED, new SQLBoolean(isPinned));
         row.setColumn(SYSTABLES_PURGE_DELETED_ROWS, new SQLBoolean(purgeDeletedRows));
         row.setColumn(SYSTABLES_MIN_RETENTION_PERIOD, new SQLLongint(minRetentionPeriod));
+        row.setColumn(SYSTABLES_AUTO_ANALYZE, new SQLLongint(autoAnalyze));
     }
 
     /**
@@ -521,6 +527,7 @@ public class SYSTABLESRowFactory extends CatalogRowFactory {
         DataValueDescriptor isPinnedDVD = row.getColumn(SYSTABLES_IS_PINNED);
         DataValueDescriptor purgeDeletedRowsDVD = row.getColumn(SYSTABLES_PURGE_DELETED_ROWS);
         DataValueDescriptor minRetentionPeriodDVD = row.getColumn(SYSTABLES_MIN_RETENTION_PERIOD);
+        DataValueDescriptor autoAnalyzeDVD = row.getColumn(SYSTABLES_AUTO_ANALYZE);
 
         // RESOLVE - Deal with lock granularity
         tabDesc = ddg.newTableDescriptor(tableName, schema, tableTypeEnum, lockGranularity.charAt(0),
@@ -533,7 +540,8 @@ public class SYSTABLESRowFactory extends CatalogRowFactory {
                 compressionDVD != null ? compressionDVD.getString() : null,
                 isPinnedDVD.getBoolean(),
                 purgeDeletedRowsDVD.getBoolean(),
-                (minRetentionPeriodDVD != null && !minRetentionPeriodDVD.isNull()) ? minRetentionPeriodDVD.getLong() : null
+                (minRetentionPeriodDVD != null && !minRetentionPeriodDVD.isNull()) ? minRetentionPeriodDVD.getLong() : null,
+                (autoAnalyzeDVD != null && !autoAnalyzeDVD.isNull()) ? autoAnalyzeDVD.getLong() : null
         );
         tabDesc.setUUID(tableUUID);
 
@@ -584,6 +592,7 @@ public class SYSTABLESRowFactory extends CatalogRowFactory {
                 SystemColumnImpl.getColumn(IS_PINNED, Types.BOOLEAN, false),
                 SystemColumnImpl.getColumn(PURGE_DELETED_ROWS, Types.BOOLEAN, false),
                 SystemColumnImpl.getColumn(MIN_RETENTION_PERIOD, Types.BIGINT, true),
+                SystemColumnImpl.getColumn(AUTO_ANALYZE, Types.BIGINT, true),
         };
     }
 
@@ -638,7 +647,10 @@ public class SYSTABLESRowFactory extends CatalogRowFactory {
                         new ColumnDescriptor(MIN_RETENTION_PERIOD, 16, 16,
                                 DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BIGINT, true),
                                 null, null, view, viewId, 0, 0, 0),
-                        new ColumnDescriptor("SCHEMANAME", 17, 17,
+                        new ColumnDescriptor(AUTO_ANALYZE, 17, 17,
+                                DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BIGINT, true),
+                                null, null, view, viewId, 0, 0, 0),
+                        new ColumnDescriptor("SCHEMANAME", 18, 18,
                                 DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.VARCHAR, false, 128),
                                 null, null, view, viewId, 0, 0, 0)
                 });

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateViewNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateViewNode.java
@@ -611,7 +611,7 @@ public class CreateViewNode extends DDLStatementNode
          * (Pass in row locking, even though meaningless for views.)
          */
         DataDescriptorGenerator ddg = dd.getDataDescriptorGenerator();
-        TableDescriptor td = ddg.newTableDescriptor(getRelativeName(),sd,TableDescriptor.WITH_TYPE,TableDescriptor.ROW_LOCK_GRANULARITY,-1,null,null,null,null,null, null,false,false,null);
+        TableDescriptor td = ddg.newTableDescriptor(getRelativeName(),sd,TableDescriptor.WITH_TYPE,TableDescriptor.ROW_LOCK_GRANULARITY,-1,null,null,null,null,null, null,false,false,null, null);
         UUID toid = td.getUUID();
 
         // No Need to add since this will be dynamic!!!

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NewInvocationNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NewInvocationNode.java
@@ -155,7 +155,7 @@ public class NewInvocationNode extends MethodCallNode
                     getSchemaDescriptor(vtiName.getSchemaName()),
                     TableDescriptor.VTI_TYPE,
                     TableDescriptor.DEFAULT_LOCK_GRANULARITY,-1,
-                    null,null,null,null,null,null, false,false, null);
+                    null,null,null,null,null,null, false,false, null,null);
         }
 
         /* Use the table descriptor to figure out what the corresponding

--- a/db-engine/src/test/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImplTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImplTest.java
@@ -133,7 +133,7 @@ public class DataDictionaryImplTest {
         DataDescriptorGenerator ddg = new DataDescriptorGenerator(dataDictionary);
         UUID schemaUuid = new BasicUUID("8000000d-00d0-fd77-3ed8-000a0a0b1900"), tableUuid = new BasicUUID("08264012-014b-c29b-a826-000003009390");
         SchemaDescriptor sd = new SchemaDescriptor(dataDictionary, "SYS", "SPLICE", schemaUuid, true);
-        TableDescriptor td = new TableDescriptor(dataDictionary, "SYSTABLESTATS", sd, 1, 'R', -1, null, null, null, null, null, null, false, false,null);
+        TableDescriptor td = new TableDescriptor(dataDictionary, "SYSTABLESTATS", sd, 1, 'R', -1, null, null, null, null, null, null, false, false,null,null);
         td.setUUID(new BasicUUID("08264012-014b-c29b-a826-000003009390"));
         td.setVersion("4.0");
         td.getColumnDescriptorList().add(new ColumnDescriptor("CONGLOMERATEID", 1 , 1 , new DataTypeDescriptor(TypeId.BIGINT_ID, true), null, null, tableUuid, null, 0, 0, 0, true,1, (byte) 0));

--- a/splice_ck/src/main/java/com/splicemachine/ck/decoder/SysTableDataDecoder.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/decoder/SysTableDataDecoder.java
@@ -28,7 +28,7 @@ public class SysTableDataDecoder extends UserDataDecoder {
         ExecRow er = new ValueRow(SYSTABLESRowFactory.SYSTABLES_COLUMN_COUNT);
         SYSTABLESRowFactory.setRowColumns(er, null, null, null, null,
                 null, null, -1, null, null, null,
-                null, null, null, false, false, null);
+                null, null, null, false, false, null, null);
         SerializerMap serializerMap = new V1SerializerMap(false);
         return new Pair<>(er, serializerMap.getSerializers(er));
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/DD_stats.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/DD_stats.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.impl.sql.catalog;
+
+import com.splicemachine.db.catalog.UUID;
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
+import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
+import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class DD_stats {
+    private ConcurrentHashMap<Long, AtomicLong> modifiedRowsCountMap = new ConcurrentHashMap<>();
+    private DataDictionary dataDictionary;
+
+    public DD_stats(DataDictionary dataDictionary) {
+        this.dataDictionary = dataDictionary;
+    }
+
+    public boolean updateModifiedRows(long heapConglom, long modifiedRowsCount) throws StandardException {
+        AtomicLong modifiedRowCount = modifiedRowsCountMap.computeIfAbsent(heapConglom, k -> new AtomicLong());
+        long count = modifiedRowCount.addAndGet(modifiedRowsCount);
+        return shouldRerunAnalyze(heapConglom, count) && modifiedRowCount.compareAndSet(count, 0);
+    }
+
+    private boolean shouldRerunAnalyze(long heapConglom, long totalModifiedRowsCount) throws StandardException {
+        ConglomerateDescriptor cd = dataDictionary.getConglomerateDescriptor(heapConglom);
+        UUID tableID = cd.getTableID();
+        TableDescriptor td = dataDictionary.getTableDescriptor(tableID);
+        return td.getAutoAnalyze() != null && totalModifiedRowsCount > td.getAutoAnalyze();
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -37,10 +37,7 @@ import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.sql.execute.ScanQualifier;
-import com.splicemachine.db.iapi.store.access.AccessFactory;
-import com.splicemachine.db.iapi.store.access.ColumnOrdering;
-import com.splicemachine.db.iapi.store.access.ScanController;
-import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.db.iapi.store.access.*;
 import com.splicemachine.db.iapi.store.access.conglomerate.Conglomerate;
 import com.splicemachine.db.iapi.store.access.conglomerate.TransactionManager;
 import com.splicemachine.db.iapi.types.*;
@@ -54,6 +51,7 @@ import com.splicemachine.derby.impl.sql.depend.SpliceDependencyManager;
 import com.splicemachine.derby.impl.sql.execute.sequence.SequenceKey;
 import com.splicemachine.derby.impl.sql.execute.sequence.SpliceSequence;
 import com.splicemachine.derby.impl.store.access.*;
+import com.splicemachine.derby.impl.store.access.hbase.HBaseController;
 import com.splicemachine.derby.lifecycle.EngineLifecycleService;
 import com.splicemachine.management.Manager;
 import com.splicemachine.pipeline.Exceptions;
@@ -1433,6 +1431,36 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
         for (int i = 0; i < n; ++i) {
             conglomerate = ti.getIndexConglomerate(i);
             tc.truncate(Long.toString(conglomerate));
+        }
+    }
+
+    @SuppressFBWarnings(value = "REC_CATCH_EXCEPTION", justification = "Intentional")
+    public void upgradeAddColumnToSystemTable(TransactionController tc, int catalogNumber, int[] colIds) throws StandardException {
+        int lastCol = colIds[colIds.length - 1];
+        TabInfoImpl tabInfo = getTabInfoByNumber(catalogNumber);
+        try {
+            TableDescriptor td = getTableDescriptor(tabInfo.getCatalogRowFactory().getCatalogName(),
+                    getSystemSchemaDescriptor(), tc );
+            long conglomID = td.getHeapConglomerateId();
+            try (ConglomerateController heapCC = tc.openConglomerate(conglomID,
+                    false,0,
+                    TransactionController.MODE_RECORD,
+                    TransactionController.ISOLATION_REPEATABLE_READ) ) {
+                // If upgrade has already been done, and we somehow got here again by
+                // mistake, don't re-add the columns to the conglomerate descriptor.
+                if (heapCC instanceof HBaseController) {
+                    HBaseController hCC = (HBaseController) heapCC;
+                    if (hCC.getConglomerate().getFormat_ids().length >= lastCol) {
+                        return;
+                    }
+                }
+            }
+            upgradeAddColumns(tabInfo.getCatalogRowFactory(), colIds, tc);
+            SpliceLogUtils.info(LOG, "Catalog upgraded: updated system table %s", tabInfo.getTableName());
+        } catch (Exception e) {
+            SpliceLogUtils.error(LOG, "Attempt to upgrade %s failed. " +
+                            "Please check if it has already been upgraded and contains the correct number of columns: %s.",
+                    tabInfo.getTableName(), lastCol);
         }
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -1314,6 +1314,16 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .build();
         procedures.add(minRetentionPeriod);
 
+        Procedure autoAnalyze = Procedure.newBuilder().name("SET_AUTO_ANALYZE")
+                .catalog("schemaName")
+                .catalog("tableName")
+                .bigint("autoAnalyze")
+                .numOutputParams(0)
+                .numResultSets(0)
+                .ownerClass(SpliceAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(autoAnalyze);
+
         Procedure snapshotSchema = Procedure.newBuilder().name("SNAPSHOT_SCHEMA")
                 .varchar("schemaName", 128)
                 .varchar("snapshotName", 128)

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -103,6 +103,7 @@ public class SpliceCatalogUpgradeScripts{
         addUpgradeScript(baseVersion4, 1989, new UpgradeScriptToAddIndexColUseViewInSYSCAT(sdd, tc));
         addUpgradeScript(baseVersion4, 1992, new UpgradeScriptForTablePriorities(sdd, tc));
         addUpgradeScript(baseVersion4, BaseDataDictionary.SERDE_UPGRADE_SPRINT, new UpgradeStoredObjects(sdd, tc));
+        addUpgradeScript(baseVersion4, 2008, new UpgradeScriptForAutoAnalyze(sdd, tc));
         // remember to add your script to SpliceCatalogUpgradeScriptsTest too, otherwise test fails
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForAutoAnalyze.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForAutoAnalyze.java
@@ -3,18 +3,16 @@ package com.splicemachine.derby.impl.sql.catalog.upgrade;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.db.impl.sql.catalog.SYSTABLESRowFactory;
 import com.splicemachine.derby.impl.sql.catalog.SpliceDataDictionary;
 
-/**
- * Created by msirek on 11/5/19.
- */
-public class UpgradeScriptForTriggerMultipleStatements extends UpgradeScriptBase {
-    public UpgradeScriptForTriggerMultipleStatements(SpliceDataDictionary sdd, TransactionController tc) {
+public class UpgradeScriptForAutoAnalyze extends UpgradeScriptBase {
+    public UpgradeScriptForAutoAnalyze(SpliceDataDictionary sdd, TransactionController tc) {
         super(sdd, tc);
     }
 
     @Override
     protected void upgradeSystemTables() throws StandardException {
-        sdd.upgradeAddColumnToSystemTable(tc, DataDictionary.SYSTRIGGERS_CATALOG_NUM, new int[]{19, 20});
+        sdd.upgradeAddColumnToSystemTable(tc, DataDictionary.SYSTABLES_CATALOG_NUM, new int[]{SYSTABLESRowFactory.SYSTABLES_AUTO_ANALYZE});
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForTriggerWhenClause.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptForTriggerWhenClause.java
@@ -1,19 +1,9 @@
 package com.splicemachine.derby.impl.sql.catalog.upgrade;
 
 import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.iapi.sql.dictionary.CatalogRowFactory;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
-import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
-import com.splicemachine.db.iapi.store.access.AccessFactory;
-import com.splicemachine.db.iapi.store.access.ConglomerateController;
 import com.splicemachine.db.iapi.store.access.TransactionController;
-import com.splicemachine.db.impl.sql.catalog.SYSTRIGGERSRowFactory;
-import com.splicemachine.db.impl.sql.catalog.TabInfoImpl;
 import com.splicemachine.derby.impl.sql.catalog.SpliceDataDictionary;
-import com.splicemachine.derby.impl.store.access.SpliceAccessManager;
-import com.splicemachine.derby.impl.store.access.hbase.HBaseController;
-import com.splicemachine.utils.SpliceLogUtils;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Created by msirek on 11/5/19.
@@ -24,33 +14,7 @@ public class UpgradeScriptForTriggerWhenClause extends UpgradeScriptBase {
     }
 
     @Override
-    @SuppressFBWarnings(value="REC_CATCH_EXCEPTION", justification="Intentional")
     protected void upgradeSystemTables() throws StandardException {
-        try {
-            TabInfoImpl tII = sdd.getNonCoreTIByNumber(DataDictionary.SYSTRIGGERS_CATALOG_NUM);
-            TableDescriptor td =
-               sdd.getTableDescriptor( tII.getCatalogRowFactory().getCatalogName(),
-                                       sdd.getSystemSchemaDescriptor(), tc );
-            long conglomID = td.getHeapConglomerateId();
-            try (ConglomerateController heapCC=tc.openConglomerate(conglomID,
-                                       false,0,
-                                       TransactionController.MODE_RECORD,
-                                       TransactionController.ISOLATION_REPEATABLE_READ)) {
-                // If upgrade has already been done, and we somehow got here again by
-                // mistake, don't re-add the WHENCLAUSETEXT column to the systriggers
-                // conglomerate descriptor.
-                if (heapCC instanceof HBaseController) {
-                    HBaseController hCC = (HBaseController) heapCC;
-                    if (hCC.getConglomerate().getFormat_ids().length >= 18) {
-                        return;
-                    }
-                }
-            }
-            sdd.upgrade_addColumns(tII.getCatalogRowFactory(), new int[]{18}, tc);
-            SpliceLogUtils.info(LOG, "Catalog upgraded: updated system table sys.systriggers");
-        }
-        catch (Exception e) {
-            SpliceLogUtils.info(LOG, "Attempt to upgrade sys.systriggers failed.  Please check if it has already been upgraded and contains the correct number of columns: 18.");
-        }
+        sdd.upgradeAddColumnToSystemTable(tc, DataDictionary.SYSTRIGGERS_CATALOG_NUM, new int[]{18});
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateAliasConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateAliasConstantOperation.java
@@ -300,7 +300,7 @@ public class CreateAliasConstantOperation extends DDLConstantOperation {
 			DataDescriptorGenerator ddg = dd.getDataDescriptorGenerator();
 			td = ddg.newTableDescriptor(aliasName, sd, TableDescriptor.SYNONYM_TYPE,
 						TableDescriptor.DEFAULT_LOCK_GRANULARITY,-1,
-					null,null,null,null,null,null,false,false,null);
+					null,null,null,null,null,null,false,false,null, null);
 			dd.addDescriptor(td, sd, DataDictionary.SYSTABLES_CATALOG_NUM, false, tc, false);
             break;
 		

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateTableConstantOperation.java
@@ -471,8 +471,8 @@ public class CreateTableConstantOperation extends DDLConstantOperation {
                     compression,
                     false,
                     false,
-                    null
-            );
+                    null,
+                    null);
         } else {
             td = ddg.newTableDescriptor(lcc.mangleTableName(tableName), sd, tableType, onCommitDeleteRows, onRollbackDeleteRows,columnInfo.length);
             td.setUUID(dd.getUUIDFactory().createUUID());

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateViewConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateViewConstantOperation.java
@@ -154,7 +154,7 @@ public class CreateViewConstantOperation extends DDLConstantOperation {
 		 * (Pass in row locking, even though meaningless for views.)
 		 */
 		DataDescriptorGenerator ddg = dd.getDataDescriptorGenerator();
-		td = ddg.newTableDescriptor(tableName,sd,tableType,TableDescriptor.ROW_LOCK_GRANULARITY,-1,null,null,null,null,null,null,false,false,null);
+		td = ddg.newTableDescriptor(tableName,sd,tableType,TableDescriptor.ROW_LOCK_GRANULARITY,-1,null,null,null,null,null,null,false,false,null, null);
 
 		dd.addDescriptor(td, sd, DataDictionary.SYSTABLES_CATALOG_NUM, false, tc, false);
 		toid = td.getUUID();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropAliasConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/DropAliasConstantOperation.java
@@ -120,7 +120,7 @@ public class DropAliasConstantOperation extends DDLConstantOperation {
             DataDescriptorGenerator ddg = dd.getDataDescriptorGenerator();
             TableDescriptor td = ddg.newTableDescriptor(aliasName, sd,
                     TableDescriptor.SYNONYM_TYPE, TableDescriptor.DEFAULT_LOCK_GRANULARITY,-1,
-                    null,null,null,null,null,null,false,false,null);
+                    null,null,null,null,null,null,false,false,null, null);
             dd.dropTableDescriptor(td, sd, tc);
         }
         else

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/InsertOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/InsertOperation.java
@@ -372,7 +372,9 @@ public class InsertOperation extends DMLWriteOperation implements HasIncrement{
                     .execRowDefinition(getExecRowDefinition())
                     .loadReplaceMode(loadReplaceMode)
                     .build();
-            return writer.write();
+
+            DataSet<ExecRow> written = writer.write();
+            return written;
 
         }
         catch (Exception e) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/serialization/SpliceObserverInstructions.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/serialization/SpliceObserverInstructions.java
@@ -243,8 +243,8 @@ public class SpliceObserverInstructions implements Externalizable{
                 /*
                  * Push the StatementContext
                  */
-                StatementContext statementContext = activation.getLanguageConnectionContext().pushStatementContext(statementAtomic,
-                        statementReadOnly,stmtText,pvs,stmtRollBackParentContext,stmtTimeout);
+                StatementContext statementContext = activation.getLanguageConnectionContext().pushStatementContext(
+                        statementAtomic,statementReadOnly,stmtText,pvs,stmtRollBackParentContext,stmtTimeout);
                 statementContext.setSQLAllowed(RoutineAliasInfo.MODIFIES_SQL_DATA, false);
 
                 return activation;

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
@@ -24,7 +24,7 @@ public class SpliceCatalogUpgradeScriptsTest {
     String s2 = "VERSION4.1989: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToAddIndexColUseViewInSYSCAT\n" +
             "VERSION4.1992: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptForTablePriorities\n" +
             "VERSION4.2003: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeStoredObjects\n" +
-            "VERSION4.2008: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeForAutoAnalyze\n";
+            "VERSION4.2008: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptForAutoAnalyze\n";
 
     // see DB-11296, UpgradeConglomerateTable must run before other upgrade scripts
     String s3 = "VERSION4.1996: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeConglomerateTable\n";

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
@@ -23,7 +23,8 @@ public class SpliceCatalogUpgradeScriptsTest {
 
     String s2 = "VERSION4.1989: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToAddIndexColUseViewInSYSCAT\n" +
             "VERSION4.1992: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptForTablePriorities\n" +
-            "VERSION4.2003: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeStoredObjects\n";
+            "VERSION4.2003: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeStoredObjects\n" +
+            "VERSION4.2008: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeForAutoAnalyze\n";
 
     // see DB-11296, UpgradeConglomerateTable must run before other upgrade scripts
     String s3 = "VERSION4.1996: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeConglomerateTable\n";


### PR DESCRIPTION
## Short Description

Introduce a new auto analyze mechanism that kicks off analyze once a table has received a certain number of updates/deletes/inserts

## Long Description

This introduces a new column in SYS.SYSTABLES: `AUTO_ANALYZE`
This can be set per table or per schema via:
```
call syscs_util.set_auto_analyze('s', 't', 20)
```

Each region server maintains a count of modified rows. Once that count exceeds the auto_analyze value set in systables, an external connection is opened to trigger analyze on that table.
For now, this will only succeed if the user who ran the insertion has analyze privilege. 



## How to test
