### PR TITLE
DB-11890 Short-circuit IndexConglomerate.readExternal once the engine has started

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/btree/IndexConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/btree/IndexConglomerate.java
@@ -522,36 +522,6 @@ public class IndexConglomerate extends SpliceConglomerate{
         }
     }
 
-    /**
-     * Restore the in-memory representation from the stream.
-     * <p/>
-     *
-     * @throws ClassNotFoundException Thrown if the stored representation
-     *                                is serialized and a class named in
-     *                                the stream could not be found.
-     * @see java.io.Externalizable#readExternal
-     **/
-    @Override
-    public void readExternal(ObjectInput in) throws IOException {
-        if (LOG.isTraceEnabled()) {
-            SpliceLogUtils.trace(LOG, "localReadExternal");
-        }
-        partitionFactory =SIDriver.driver().getTableFactory();
-        opFactory = SIDriver.driver().getOperationFactory();
-        PartitionAdmin admin = partitionFactory.getAdmin();
-        try {
-            String version = admin.getCatalogVersion(SQLConfiguration.CONGLOMERATE_TABLE_NAME);
-            if (version == null || version.equals("1")) {
-                readExternalOld(in);
-            }
-            else {
-                readExternalNew(in);
-            }
-        } catch (StandardException e) {
-            throw new IOException(e);
-        }
-    }
-
     @Override
     protected void readExternalNew(ObjectInput in) throws IOException{
         byte[] bs = ArrayUtil.readByteArray(in);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/hbase/HBaseConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/hbase/HBaseConglomerate.java
@@ -364,49 +364,6 @@ public class HBaseConglomerate extends SpliceConglomerate{
                 .build();
         return dvd;
     }
-    /**
-     * Restore the in-memory representation from the stream.
-     * <p/>
-     *
-     * @throws ClassNotFoundException Thrown if the stored representation
-     *                                is serialized and a class named in
-     *                                the stream could not be found.
-     * @see java.io.Externalizable#readExternal
-     **/
-    @Override
-    public void readExternal(ObjectInput in) throws IOException {
-
-        try {
-            SIDriver driver = SIDriver.driver();
-            boolean useNew = false;
-
-            if (driver != null) {
-                partitionFactory = driver.getTableFactory();
-                opFactory = driver.getOperationFactory();
-                if (driver.isEngineStarted()) {
-                    // In that case, the upgrade must have happened, so we must have version > 1
-                    useNew = true;
-                } else {
-                    String version = getConglomerateVersion(driver);
-                    useNew = (version != null && !version.equals("1"));
-                }
-            }
-
-            if (useNew) {
-                readExternalNew(in);
-            } else {
-                readExternalOld(in);
-            }
-        } catch (StandardException e) {
-            throw new IOException(e);
-        }
-    }
-
-    private String getConglomerateVersion(SIDriver driver) throws IOException, StandardException {
-        PartitionAdmin admin = partitionFactory.getAdmin();
-        return admin.getCatalogVersion(SQLConfiguration.CONGLOMERATE_TABLE_NAME);
-    }
-
 
     @Override
     protected void readExternalOld(ObjectInput in) throws IOException {


### PR DESCRIPTION
## Short Description

Redirect `IndexConglomerate.readExternal` to `readExternalNew` once the engine has started to skip slow `getCatalogVersion`

## Long Description

3.2.0.2003 introduced a new serialization mechanism for IndexConglomerate. On a version >= 2003, we will need the old serialization logic to upgrade, but never after that. Since `SIDriver.engineStarted` is set to true only after upgrade has completed, we don't need to check catalogVersion once `SIDriver.engineStarted == true`.
This is a clone of [DB-11857](https://github.com/splicemachine/spliceengine/pull/5387) for IndexConglomerate


## How to test

```
git checkout 3.2.0.2000
./start-splice-cluster -k
mvn -T 4 -B clean install -Pcore,cdh6.3.0 -DskipTests
./start-splice-cluster -b -p cdh6.3.0
git checkout DB-11857
./start-splice-cluster -l -p cdh6.3.0
```

