### PR TITLE
DB-11892 Avoid ctx clone on NLJ when there's only 1 row

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJAntiJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJAntiJoinFunction.java
@@ -36,9 +36,9 @@ public class NLJAntiJoinFunction<Op extends SpliceOperation> extends NLJoinFunct
 
     @Override
     public Iterator<ExecRow> call(Iterator<ExecRow> from) throws Exception {
-        if (!initialized) {
+        if (!nljInitialized) {
             init(from);
-            initialized = true;
+            nljInitialized = true;
         }
 
         return new NestedLoopJoinIterator<>(this);

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJInnerJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJInnerJoinFunction.java
@@ -35,9 +35,9 @@ public class NLJInnerJoinFunction<Op extends SpliceOperation> extends NLJoinFunc
 
     @Override
     public Iterator<ExecRow> call(Iterator<ExecRow> from) throws Exception {
-        if (!initialized) {
+        if (!nljInitialized) {
             init(from);
-            initialized = true;
+            nljInitialized = true;
         }
 
         return new NestedLoopJoinIterator<>(this);

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJOneRowInnerJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJOneRowInnerJoinFunction.java
@@ -35,9 +35,9 @@ public class NLJOneRowInnerJoinFunction <Op extends SpliceOperation> extends NLJ
 
     @Override
     public Iterator<ExecRow> call(Iterator<ExecRow> from) throws Exception {
-        if (!initialized) {
+        if (!nljInitialized) {
             init(from);
-            initialized = true;
+            nljInitialized = true;
         }
 
         return new NestedLoopJoinIterator<>(this);

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJOuterJoinFunction.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/function/NLJOuterJoinFunction.java
@@ -35,9 +35,9 @@ public class NLJOuterJoinFunction<Op extends SpliceOperation> extends NLJoinFunc
 
     @Override
     public Iterator<ExecRow> call(Iterator<ExecRow> from) throws Exception {
-        if (!initialized) {
+        if (!nljInitialized) {
             init(from);
-            initialized = true;
+            nljInitialized = true;
         }
 
         return new NestedLoopJoinIterator<>(this);


### PR DESCRIPTION
## Short Description
Avoid expensive clone operation for NestedLoopJoins that have only 1 row on the left side

## Long Description
Currently we clone the operationContext (expensive operation) in order to execute nestedLoopJoin lookups concurrently into the right table. When we only have 1 row on the left table we can avoid the expensive clone and use the operationContext directly as in any other normal operation.

## How to test
