### PR TITLE
DB-11533 Introduce parameter to change return type of count

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
@@ -55,6 +55,7 @@ import com.splicemachine.db.impl.sql.compile.subquery.aggregate.AggregateSubquer
 import com.splicemachine.system.SimpleSparkVersion;
 import com.splicemachine.system.SparkVersion;
 
+import java.sql.Types;
 import java.util.List;
 import java.util.Vector;
 import java.sql.SQLWarning;
@@ -189,6 +190,7 @@ public interface CompilerContext extends Context
     String DEFAULT_TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss.SSSSSSSSS";
     String DEFAULT_SECOND_FUNCTION_COMPATIBILITY_MODE = "splice";
     int DEFAULT_FLOATING_POINT_NOTATION = FloatingPointDataType.PLAIN;
+    int DEFAULT_COUNT_RETURN_TYPE = Types.BIGINT;
     boolean DEFAULT_OUTERJOIN_FLATTENING_DISABLED = false;
     boolean DEFAULT_SSQ_FLATTENING_FOR_UPDATE_DISABLED = false;
     NewMergeJoinExecutionType DEFAULT_SPLICE_NEW_MERGE_JOIN = NewMergeJoinExecutionType.SYSTEM;
@@ -741,6 +743,8 @@ public interface CompilerContext extends Context
 
     void setFloatingPointNotation(int floatingPointNotation);
 
+    void setCountReturnType(int countReturnType);
+
     void setCursorUntypedExpressionType(DataTypeDescriptor type);
 
     DataTypeDescriptor getCursorUntypedExpressionType();
@@ -750,6 +754,8 @@ public interface CompilerContext extends Context
     String getSecondFunctionCompatibilityMode();
 
     int getFloatingPointNotation();
+
+    int getCountReturnType();
 
     int getNextOJLevel();
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -495,6 +495,7 @@ public class GenericStatement implements Statement{
         setTimestampFormat(lcc, cc);
         setSecondFunctionCompatibilityMode(lcc, cc);
         setFloatingPointNotation(lcc, cc);
+        setCountReturnType(lcc, cc);
         setOuterJoinFlatteningDisabled(lcc, cc);
         setCursorUntypedExpressionType(lcc, cc);
 
@@ -832,6 +833,19 @@ public class GenericStatement implements Statement{
                     break;
                 default:
                     cc.setFloatingPointNotation(CompilerContext.DEFAULT_FLOATING_POINT_NOTATION);
+            }
+        }
+    }
+
+    private void setCountReturnType(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        String countReturnTypeString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.COUNT_RETURN_TYPE);
+        if(countReturnTypeString == null) {
+            cc.setCountReturnType(CompilerContext.DEFAULT_COUNT_RETURN_TYPE);
+        } else {
+            if (countReturnTypeString.toLowerCase().startsWith("int")) {
+                cc.setCountReturnType(Types.INTEGER);
+            } else {
+                cc.setCountReturnType(Types.BIGINT);
             }
         }
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AggregateNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AggregateNode.java
@@ -425,6 +425,8 @@ public class AggregateNode extends UnaryOperatorNode {
 
         setType(resultType);
 
+        addSPSPropertyDependency();
+
         return this;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AggregateNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AggregateNode.java
@@ -344,7 +344,7 @@ public class AggregateNode extends UnaryOperatorNode {
              */
             dts = getOperand().getTypeServices();
 
-            /* Convert count(nonNullableColumn) to count(*)	*/
+            /* Convert count(nonNullableColumn) to count(*)    */
             if (uad instanceof CountAggregateDefinition &&
                     !dts.isNullable()) {
                 setOperator(aggregateName);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
@@ -59,6 +59,7 @@ import com.splicemachine.utils.Pair;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.sql.SQLWarning;
+import java.sql.Types;
 import java.util.*;
 
 import static com.splicemachine.db.iapi.sql.compile.DataSetProcessorType.*;
@@ -323,6 +324,11 @@ public class CompilerContextImpl extends ContextImpl
         floatingPointNotation = value;
     }
 
+    public void setCountReturnType(int value)
+    {
+        countReturnType = value;
+    }
+
     public void setCursorUntypedExpressionType(DataTypeDescriptor type)
     {
         cursorUntypedExpressionType = type;
@@ -342,6 +348,10 @@ public class CompilerContextImpl extends ContextImpl
 
     public int getFloatingPointNotation() {
         return floatingPointNotation;
+    }
+
+    public int getCountReturnType() {
+        return countReturnType;
     }
 
     public DataTypeDescriptor getCursorUntypedExpressionType() {
@@ -1222,6 +1232,7 @@ public class CompilerContextImpl extends ContextImpl
 
     private       String                              timestampFormat                              = DEFAULT_TIMESTAMP_FORMAT;
     private       int                                 floatingPointNotation                        = DEFAULT_FLOATING_POINT_NOTATION;
+    private       int                                 countReturnType                              = DEFAULT_COUNT_RETURN_TYPE;
     private       String                              secondFunctionCompatibilityMode              = DEFAULT_SECOND_FUNCTION_COMPATIBILITY_MODE;
     private       DataTypeDescriptor                  cursorUntypedExpressionType                  = null;
     // Used to track the flattened half outer joins.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CountAggregateDefinition.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CountAggregateDefinition.java
@@ -31,7 +31,9 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
+import com.splicemachine.db.iapi.services.context.ContextService;
 import com.splicemachine.db.iapi.sql.compile.AggregateDefinition;
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 
 import com.splicemachine.db.iapi.reference.ClassName;
@@ -42,7 +44,7 @@ import com.splicemachine.db.iapi.reference.ClassName;
  *
  */
 public class CountAggregateDefinition 
-		implements AggregateDefinition
+        implements AggregateDefinition
 {
     private boolean isWindowFunction;
 
@@ -54,35 +56,37 @@ public class CountAggregateDefinition
         this.isWindowFunction = isWindowFunction;
     }
 
-	/**
-	 * Niladic constructor.  Does nothing.  For ease
-	 * Of use, only.
-	 */
-	public CountAggregateDefinition() { super(); }
+    /**
+     * Niladic constructor.  Does nothing.  For ease
+     * Of use, only.
+     */
+    public CountAggregateDefinition() { super(); }
 
-	/**
-	 * Determines the result datatype. We can run
-	 * count() on anything, and it always returns a
-	 * INTEGER (java.lang.Integer).
-	 *
-	 * @param inputType the input type, either a user type or a java.lang object
-	 *
-	 * @return the output Class (null if cannot operate on
-	 *	value expression of this type.
-	 */
-	public final DataTypeDescriptor	getAggregator(DataTypeDescriptor inputType,
-				StringBuffer aggregatorClass) 
-	{
+    /**
+     * Determines the result datatype. We can run
+     * count() on anything, and it always returns a
+     * INTEGER (java.lang.Integer).
+     *
+     * @param inputType the input type, either a user type or a java.lang object
+     *
+     * @return the output Class (null if cannot operate on
+     *    value expression of this type.
+     */
+    public final DataTypeDescriptor    getAggregator(DataTypeDescriptor inputType,
+                StringBuffer aggregatorClass)
+    {
+        CompilerContext cc = (CompilerContext) ContextService.getContext(CompilerContext.CONTEXT_ID);
+        assert cc != null;
         if (isWindowFunction) {
             aggregatorClass.append(ClassName.WindowCountAggregator);
         }
         else {
             aggregatorClass.append(ClassName.CountAggregator);
         }
-		/*
-		** COUNT never returns NULL
-		*/
-		return DataTypeDescriptor.getBuiltInDataTypeDescriptor(java.sql.Types.BIGINT, false);
-	}
+        /*
+        ** COUNT never returns NULL
+        */
+        return DataTypeDescriptor.getBuiltInDataTypeDescriptor(cc.getCountReturnType(), false);
+    }
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/SPSPropertyCountReturnType.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/SPSPropertyCountReturnType.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.db.impl.sql.execute;
+
+import com.splicemachine.db.catalog.UUID;
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.compile.CompilerContext;
+import com.splicemachine.db.iapi.sql.compile.Node;
+import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+import com.splicemachine.db.impl.sql.catalog.Aggregate;
+import com.splicemachine.db.impl.sql.compile.AggregateNode;
+import com.splicemachine.db.impl.sql.compile.CastNode;
+import com.splicemachine.db.impl.sql.compile.ValueNode;
+
+import java.sql.Types;
+
+/**
+ * An SPS property that governs timestamp field(s) in a query.
+ */
+final class SPSPropertyCountReturnType extends SPSProperty {
+
+    protected SPSPropertyCountReturnType(final UUID uuid, final String name) {
+        super(uuid, name);
+    }
+
+    protected void checkAndAddDependency(final Node node, CompilerContext cc) throws StandardException {
+        if(node instanceof AggregateNode) {
+            AggregateNode aggregateNode = (AggregateNode) node;
+            switch (aggregateNode.getType()) {
+                case COUNT_FUNCTION:
+                case COUNT_STAR_FUNCTION:
+                    cc.createDependency(this);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/SPSPropertyCountReturnType.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/SPSPropertyCountReturnType.java
@@ -35,16 +35,20 @@ final class SPSPropertyCountReturnType extends SPSProperty {
     }
 
     protected void checkAndAddDependency(final Node node, CompilerContext cc) throws StandardException {
-        if(node instanceof AggregateNode) {
-            AggregateNode aggregateNode = (AggregateNode) node;
-            switch (aggregateNode.getType()) {
-                case COUNT_FUNCTION:
-                case COUNT_STAR_FUNCTION:
-                    cc.createDependency(this);
-                    break;
-                default:
-                    break;
-            }
+        if(!(node instanceof AggregateNode)) {
+            return;
+        }
+        AggregateNode aggregateNode = (AggregateNode) node;
+        if (aggregateNode.getType() == null) {
+            return;
+        }
+        switch (aggregateNode.getType()) {
+            case COUNT_FUNCTION:
+            case COUNT_STAR_FUNCTION:
+                cc.createDependency(this);
+                break;
+            default:
+                break;
         }
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/SPSPropertyRegistry.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/SPSPropertyRegistry.java
@@ -36,6 +36,7 @@ public class SPSPropertyRegistry {
         propertySet.add(new SPSPropertyCurrentTimestampFormat(new BasicUUID("b2decb1d-acc2-4402-9278-d4aab1fc6431"), Property.SPLICE_CURRENT_TIMESTAMP_PRECISION));
         propertySet.add(new SPSPropertyFloatingpointNotation(new BasicUUID("e8027088-78d8-41aa-be8e-ede5c646ae0a"), Property.FLOATING_POINT_NOTATION));
         propertySet.add(new SPSPropertySecondFunction(new BasicUUID("01fc4415-bc53-4ac1-b829-93e0e61b0c5f"), Property.SPLICE_SECOND_FUNCTION_COMPATIBILITY_MODE));
+        propertySet.add(new SPSPropertyCountReturnType(new BasicUUID("20e3d160-b514-4e82-b8a0-3a7888c253c5"), Property.COUNT_RETURN_TYPE));
     };
 
     public static SPSProperty forName(String propertyName) {

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1161,6 +1161,8 @@ public interface Property {
     String FLOATING_POINT_NOTATION = "splice.function.floatingPointNotation";
     String PRESERVE_LINE_ENDINGS = "splice.function.preserveLineEndings";
 
+    String COUNT_RETURN_TYPE = "splice.bind.countReturnType";
+
     String CURSOR_UNTYPED_EXPRESSION_TYPE = "splice.bind.cursorUntypedExpressionType";
 
     String OUTERJOIN_FLATTENING_DISABLED = "derby.database.outerJoinFlatteningDisabled";

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/GlobalDatabasePropertyIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/GlobalDatabasePropertyIT.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.splicemachine.derby.impl.sql.execute.operations;
+
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.derby.test.framework.TestConnection;
+import com.splicemachine.test.SerialTest;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+/**
+ *
+ */
+@Category(SerialTest.class) // maybe not run in parallel since it is changing global DB configs
+public class GlobalDatabasePropertyIT extends SpliceUnitTest {
+    private static final String SCHEMA = GlobalDatabasePropertyIT.class.getSimpleName().toUpperCase();
+    protected static final SpliceWatcher spliceClassWatcher = new SpliceWatcher(SCHEMA);
+    protected static final SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(SCHEMA);
+    protected static final SpliceWatcher methodWatcher = new SpliceWatcher(SCHEMA);
+
+    @ClassRule
+    public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
+                                            .around(spliceSchemaWatcher)
+                                            .around(methodWatcher);
+
+
+    public void setProperty(String property, String value) throws Exception {
+        methodWatcher.execute(format("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( '%s', '%s')", property, value));
+    }
+
+    @Test
+    public void testCountReturnType() throws Exception {
+        try (TestConnection conn = methodWatcher.getOrCreateConnection()) {
+            setProperty("splice.bind.countReturnType", "bigint");
+            checkStringExpression("typeof(count(*)) from sysibm.sysdummy1", "BIGINT", conn);
+            checkStringExpression("typeof(count(IBMREQD)) from sysibm.sysdummy1", "BIGINT", conn);
+            setProperty("splice.bind.countReturnType", "int");
+            checkStringExpression("typeof(count(*)) from sysibm.sysdummy1", "INTEGER", conn);
+            checkStringExpression("typeof(count(IBMREQD)) from sysibm.sysdummy1", "INTEGER", conn);
+        } finally {
+            setProperty("splice.bind.countReturnType", "bigint");
+        }
+    }
+
+}


### PR DESCRIPTION
## Description

This introduces a new parameter `splice.bind.countReturnType` to toggle the return type of COUNT from big int to int.

## How to test

```
select typeof(count(*)) from sysibm.sysdummy1;
1
----------------------------------------
BIGINT

call syscs_util.syscs_set_global_database_property('splice.bind.countReturnType', 'integer');
select typeof(count(*)) from sysibm.sysdummy1;
1
----------------------------------------
INTEGER

call syscs_util.syscs_set_global_database_property('splice.bind.countReturnType', 'bigint');
select typeof(count(*)) from sysibm.sysdummy1;
1
----------------------------------------
BIGINT