### PR TITLE
DB-11534: Filter out rolled back txn during WW-conflict detection

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/BaseDataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/BaseDataDictionary.java
@@ -59,12 +59,11 @@ public abstract class BaseDataDictionary implements DataDictionary, ModuleContro
 	protected static final int		    SYSCOLUMNS_CORE_NUM = 2;
 	protected static final int		    SYSSCHEMAS_CORE_NUM = 3;
 	protected static final int          NUM_CORE = 4;
-	public static final String		CFG_CATALOG_SERIALIZATION_VERSION = "CatalogSerializationVersion";
 
-	@SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "intentional")
+	@SuppressFBWarnings(value = "MS_CANNOT_BE_FINAL", justification = "intentional")
 	public static boolean READ_NEW_FORMAT = true;
 
-	@SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "intentional")
+	@SuppressFBWarnings(value = "MS_CANNOT_BE_FINAL", justification = "intentional")
 	public static boolean WRITE_NEW_FORMAT = true;
 
 	public static int SERDE_UPGRADE_SPRINT = 2003;

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/RollbackTxnFilter.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/RollbackTxnFilter.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2012 - 2021 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.si.impl;
+
+import com.splicemachine.access.api.Durability;
+import com.splicemachine.si.api.data.OperationFactory;
+import com.splicemachine.si.api.txn.Txn;
+import com.splicemachine.si.api.txn.TxnSupplier;
+import com.splicemachine.si.api.txn.TxnView;
+import com.splicemachine.si.constants.SIConstants;
+import com.splicemachine.si.impl.driver.SIDriver;
+import com.splicemachine.storage.*;
+import com.splicemachine.utils.ByteSlice;
+import com.splicemachine.utils.SpliceLogUtils;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterBase;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.log4j.Logger;
+
+import java.util.List;
+
+public class RollbackTxnFilter extends FilterBase {
+
+    private static final Logger LOG=Logger.getLogger(RollbackTxnFilter.class);
+
+
+    private List<DataMutation> mutations;
+    private OperationFactory opFactory;
+    private TxnSupplier txnSupplier;
+
+    public RollbackTxnFilter(TxnSupplier txnSupplier, List<DataMutation> mutations) {
+        this.mutations = mutations;
+        opFactory = SIDriver.driver().baseOperationFactory();
+        this.txnSupplier = txnSupplier;
+    }
+
+    @Override
+    public Filter.ReturnCode filterCell(Cell keyValue){
+        DataCell data = new HCell(keyValue);
+        long txnId = data.version();
+        try {
+
+            if (txnSupplier != null) {
+                TxnView txn = txnSupplier.getTransaction(txnId);
+                if (txn.getEffectiveState() == Txn.State.ROLLEDBACK) {
+                    if (LOG.isDebugEnabled()) {
+                        CellType type = data.dataType();
+                        byte[] k = data.key();
+                        byte[] v = data.value();
+                        SpliceLogUtils.debug(LOG, "Filter out %s, k=%s, v=%s", type.toString(),
+                                Bytes.toStringBinary(k), Bytes.toStringBinary(v));
+
+                    }
+                    ByteSlice bs = new ByteSlice();
+                    bs.set(keyValue.getRowArray(), keyValue.getRowOffset(), keyValue.getRowLength());
+                    DataDelete delete = opFactory.newDelete(bs);
+                    delete.deleteColumn(SIConstants.DEFAULT_FAMILY_BYTES,SIConstants.FK_COUNTER_COLUMN_BYTES, keyValue.getTimestamp());
+                    delete.deleteColumn(SIConstants.DEFAULT_FAMILY_BYTES,SIConstants.FIRST_OCCURRENCE_TOKEN_COLUMN_BYTES, keyValue.getTimestamp());
+                    delete.deleteColumn(SIConstants.DEFAULT_FAMILY_BYTES,SIConstants.PACKED_COLUMN_BYTES, keyValue.getTimestamp());
+                    delete.deleteColumn(SIConstants.DEFAULT_FAMILY_BYTES,SIConstants.TOMBSTONE_COLUMN_BYTES, keyValue.getTimestamp());
+                    delete.deleteColumn(SIConstants.DEFAULT_FAMILY_BYTES,SIConstants.COMMIT_TIMESTAMP_COLUMN_BYTES, keyValue.getTimestamp());
+                    delete.addAttribute(SIConstants.SUPPRESS_INDEXING_ATTRIBUTE_NAME,SIConstants.SUPPRESS_INDEXING_ATTRIBUTE_VALUE);
+                    delete.setDurability(Durability.NONE);
+                    mutations.add(delete);
+                    return ReturnCode.SKIP;
+                }
+                else {
+                    if (LOG.isDebugEnabled()) {
+                        CellType type = data.dataType();
+                        byte[] k = data.key();
+                        byte[] v = data.value();
+                        SpliceLogUtils.debug(LOG, "Include %s, k=%s, v=%s", type.toString(),
+                                Bytes.toStringBinary(k), Bytes.toStringBinary(v));
+
+                    }
+                    return ReturnCode.INCLUDE;
+                }
+            }
+            return ReturnCode.INCLUDE;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public List<DataMutation> getMutations() {
+        return mutations;
+    }
+}

--- a/hbase_storage/src/main/java/com/splicemachine/si/impl/SIFilterPacked.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/impl/SIFilterPacked.java
@@ -40,7 +40,7 @@ public class SIFilterPacked extends FilterBase implements HasPredicateFilter{
     }
 
     @Override
-    public Filter.ReturnCode filterKeyValue(Cell keyValue){
+    public Filter.ReturnCode filterCell(Cell keyValue){
         try{
             initFilterStateIfNeeded();
             DataFilter.ReturnCode code=filterState.filterCell(new HCell(keyValue));

--- a/hbase_storage/src/main/java/com/splicemachine/storage/RangedClientPartition.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/RangedClientPartition.java
@@ -21,6 +21,7 @@ import com.splicemachine.kvpair.KVPair;
 import com.splicemachine.metrics.MetricFactory;
 import com.splicemachine.primitives.ByteComparator;
 import com.splicemachine.primitives.Bytes;
+import com.splicemachine.si.api.txn.TxnSupplier;
 import com.splicemachine.si.data.HExceptionFactory;
 import com.splicemachine.si.impl.HNotServingRegion;
 import com.splicemachine.si.impl.HRegionTooBusy;
@@ -36,6 +37,7 @@ import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.nio.charset.Charset;
 import java.util.BitSet;
 import java.util.Collections;
 import java.util.Iterator;
@@ -110,7 +112,7 @@ public class RangedClientPartition implements Partition, Comparable<RangedClient
     public void compact(boolean isMajor) throws IOException {
         Connection connection = HBaseConnectionFactory.getInstance(HConfiguration.getConfiguration()).getConnection();
         HExceptionFactory exceptionFactory = HExceptionFactory.INSTANCE;
-        byte[] encodedRegionName = regionInfo.getEncodedName().getBytes();
+        byte[] encodedRegionName = regionInfo.getEncodedName().getBytes(Charset.defaultCharset().name());
 
         try(Admin admin = connection.getAdmin()){
             if (isMajor)
@@ -150,7 +152,7 @@ public class RangedClientPartition implements Partition, Comparable<RangedClient
     @Override
     public void flush() throws IOException {
         Connection connection = HBaseConnectionFactory.getInstance(HConfiguration.getConfiguration()).getConnection();
-        byte[] encodedRegionName = regionInfo.getEncodedName().getBytes();
+        byte[] encodedRegionName = regionInfo.getEncodedName().getBytes(Charset.defaultCharset().name());
         try(Admin admin = connection.getAdmin()) {
             admin.flushRegion(encodedRegionName);
         }
@@ -297,8 +299,8 @@ public class RangedClientPartition implements Partition, Comparable<RangedClient
     }
 
     @Override
-    public DataResult getLatest(byte[] key, DataResult previous) throws IOException {
-        return delegate.getLatest(key, previous);
+    public DataResult getLatest(byte[] key, DataResult previous, Object obj) throws IOException {
+        return delegate.getLatest(key, previous, obj);
     }
 
     @Override

--- a/hbase_storage/src/main/java/com/splicemachine/storage/SkeletonHBaseClientPartition.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/SkeletonHBaseClientPartition.java
@@ -76,7 +76,7 @@ public abstract class SkeletonHBaseClientPartition implements Partition{
     }
 
     @Override
-    public DataResult getLatest(byte[] key,DataResult previous) throws IOException{
+    public DataResult getLatest(byte[] key,DataResult previous, Object obj) throws IOException{
         Get g = new Get(key);
         g.setMaxVersions(1);
 

--- a/hbase_storage/src/test/java/com/splicemachine/si/impl/SynchronousReadResolverTest.java
+++ b/hbase_storage/src/test/java/com/splicemachine/si/impl/SynchronousReadResolverTest.java
@@ -89,7 +89,7 @@ public class SynchronousReadResolverTest {
 
         Txn readTxn = ReadOnlyTxn.createReadOnlyTransaction(0x200l, Txn.ROOT_TRANSACTION, 0x200l,
                 Txn.IsolationLevel.SNAPSHOT_ISOLATION, false, mock(TxnLifecycleManager.class),HExceptionFactory.INSTANCE);
-        SimpleTxnFilter filter = new SimpleTxnFilter(null, readTxn,resolver,store);
+        SimpleTxnFilter filter = new SimpleTxnFilter(readTxn,resolver,store);
 
         Result result = region.get(new Get(rowKey));
         Assert.assertEquals("Incorrect result size", 1, result.size());
@@ -135,7 +135,7 @@ public class SynchronousReadResolverTest {
 
         Txn readTxn = ReadOnlyTxn.createReadOnlyTransaction(0x300l, Txn.ROOT_TRANSACTION, 0x300l,
                 Txn.IsolationLevel.SNAPSHOT_ISOLATION, false, mock(TxnLifecycleManager.class),HExceptionFactory.INSTANCE);
-        SimpleTxnFilter filter = new SimpleTxnFilter(null, readTxn,resolver,store);
+        SimpleTxnFilter filter = new SimpleTxnFilter(readTxn,resolver,store);
 
         Result result = region.get(new Get(rowKey));
         Assert.assertEquals("Incorrect result size", 1, result.size());
@@ -181,7 +181,7 @@ public class SynchronousReadResolverTest {
         childTxn.commit();
 
         Txn readTxn = tc.beginTransaction(); //a read-only transaction with SI semantics
-        SimpleTxnFilter filter = new SimpleTxnFilter(null, readTxn,resolver,store);
+        SimpleTxnFilter filter = new SimpleTxnFilter(readTxn,resolver,store);
 
         Result result = region.get(new Get(rowKey));
         Assert.assertEquals("Incorrect result size", 1, result.size());

--- a/mem_storage/src/main/java/com/splicemachine/si/impl/TxnPartition.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/impl/TxnPartition.java
@@ -173,8 +173,8 @@ public class TxnPartition implements Partition{
     }
 
     @Override
-    public DataResult getLatest(byte[] key,DataResult previous) throws IOException{
-        return basePartition.getLatest(key,previous);
+    public DataResult getLatest(byte[] key,DataResult previous, Object obj) throws IOException{
+        return basePartition.getLatest(key,previous,obj);
     }
 
     @Override

--- a/mem_storage/src/test/java/com/splicemachine/si/MemSITestEnv.java
+++ b/mem_storage/src/test/java/com/splicemachine/si/MemSITestEnv.java
@@ -95,7 +95,7 @@ public class MemSITestEnv implements SITestEnv{
     public void createTransactionalTable(byte[] tableNameBytes) throws IOException{
         try(PartitionAdmin pa = tableFactory.getAdmin()){
             pa.deleteTable(Bytes.toString(tableNameBytes));
-            pa.newPartition().withName(Bytes.toString(tableNameBytes)).create();
+            MPartition partition = (MPartition) pa.newPartition().withName(Bytes.toString(tableNameBytes)).create();
         }
     }
 

--- a/splice_access_api/src/main/java/com/splicemachine/storage/Partition.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/Partition.java
@@ -100,10 +100,11 @@ public interface Partition extends AutoCloseable{
      * @param previous a holder object to save storage. If {@code null} is passed in, then a new RowResult
      *                 is created. Otherwise, the previous value is used. This allows us to save on object creation
      *                 when we wish to fetch a lot of these at the same time
+     * @param obj A ConflictRollForward object to pass in active transaction cache and fetch rolled back cells
      * @return a DataResult containing the latest value of all present cells for the specified key.
      * @throws IOException if something goes wrong
      */
-    DataResult getLatest(byte[] key,DataResult previous) throws IOException;
+    DataResult getLatest(byte[] key,DataResult previous, Object obj) throws IOException;
 
     Lock getRowLock(byte[] key,int keyOff,int keyLen) throws IOException;
 

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyChildInterceptWriteHandler.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyChildInterceptWriteHandler.java
@@ -108,11 +108,11 @@ public class ForeignKeyChildInterceptWriteHandler implements WriteHandler{
             SimpleTxnFilter readUncommittedFilter;
             SimpleTxnFilter readCommittedFilter;
             if (ctx.getTxn() instanceof ActiveWriteTxn) {
-                readUncommittedFilter = new SimpleTxnFilter(Long.toString(referencedConglomerateNumber), ((ActiveWriteTxn) ctx.getTxn()).getReadUncommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
-                readCommittedFilter = new SimpleTxnFilter(Long.toString(referencedConglomerateNumber), ((ActiveWriteTxn) ctx.getTxn()).getReadCommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
+                readUncommittedFilter = new SimpleTxnFilter(((ActiveWriteTxn) ctx.getTxn()).getReadUncommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
+                readCommittedFilter = new SimpleTxnFilter(((ActiveWriteTxn) ctx.getTxn()).getReadCommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
             }else if (ctx.getTxn() instanceof WritableTxn) {
-                readUncommittedFilter = new SimpleTxnFilter(Long.toString(referencedConglomerateNumber), ((WritableTxn) ctx.getTxn()).getReadUncommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
-                readCommittedFilter = new SimpleTxnFilter(Long.toString(referencedConglomerateNumber), ((WritableTxn) ctx.getTxn()).getReadCommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
+                readUncommittedFilter = new SimpleTxnFilter(((WritableTxn) ctx.getTxn()).getReadUncommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
+                readCommittedFilter = new SimpleTxnFilter(((WritableTxn) ctx.getTxn()).getReadCommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
             }else
                 throw new IOException("invalidTxn");
 

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/actions/OnDeleteAbstractAction.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/actions/OnDeleteAbstractAction.java
@@ -110,12 +110,12 @@ public abstract class OnDeleteAbstractAction extends Action {
     private static Pair<SimpleTxnFilter, SimpleTxnFilter> prepareScanFilters(TxnView txnView, long indexConglomerateId) throws IOException {
         SimpleTxnFilter readUncommittedFilter, readCommittedFilter;
         if (txnView instanceof ActiveWriteTxn) {
-            readCommittedFilter = new SimpleTxnFilter(Long.toString(indexConglomerateId), ((ActiveWriteTxn) txnView).getReadCommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
-            readUncommittedFilter = new SimpleTxnFilter(Long.toString(indexConglomerateId), ((ActiveWriteTxn) txnView).getReadUncommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
+            readCommittedFilter = new SimpleTxnFilter(((ActiveWriteTxn) txnView).getReadCommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
+            readUncommittedFilter = new SimpleTxnFilter(((ActiveWriteTxn) txnView).getReadUncommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
 
         } else if (txnView instanceof WritableTxn) {
-            readCommittedFilter = new SimpleTxnFilter(Long.toString(indexConglomerateId), ((WritableTxn) txnView).getReadCommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
-            readUncommittedFilter = new SimpleTxnFilter(Long.toString(indexConglomerateId), ((WritableTxn) txnView).getReadUncommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
+            readCommittedFilter = new SimpleTxnFilter(((WritableTxn) txnView).getReadCommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
+            readUncommittedFilter = new SimpleTxnFilter(((WritableTxn) txnView).getReadUncommittedActiveTxn(), NoOpReadResolver.INSTANCE, SIDriver.driver().getTxnStore());
         } else {
             throw new IOException("invalidTxn,");
         }

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/SimpleTxnFilter.java
@@ -86,8 +86,7 @@ public class SimpleTxnFilter implements TxnFilter{
      */
     private final boolean ignoreNewerTransactions;
 
-    public SimpleTxnFilter(String tableName,
-                           TxnView myTxn,
+    public SimpleTxnFilter(TxnView myTxn,
                            ReadResolver readResolver,
                            TxnSupplier baseSupplier,
                            boolean ignoreNewerTransactions) {
@@ -109,11 +108,10 @@ public class SimpleTxnFilter implements TxnFilter{
     }
 
     @SuppressWarnings("unchecked")
-    public SimpleTxnFilter(String tableName,
-                           TxnView myTxn,
+    public SimpleTxnFilter(TxnView myTxn,
                            ReadResolver readResolver,
                            TxnSupplier baseSupplier){
-        this(tableName, myTxn, readResolver, baseSupplier, false);
+        this(myTxn, readResolver, baseSupplier, false);
     }
 
     @Override

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/TxnRegion.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/TxnRegion.java
@@ -67,7 +67,7 @@ public class TxnRegion<InternalScanner> implements TransactionalRegion<InternalS
 
     @Override
     public TxnFilter unpackedFilter(TxnView txn, boolean ignoreRecentTransactions) throws IOException{
-        return new SimpleTxnFilter(tableName,txn,readResolver,txnSupplier,ignoreRecentTransactions);
+        return new SimpleTxnFilter(txn,readResolver,txnSupplier,ignoreRecentTransactions);
     }
 
     @Override

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/server/ConflictRollForward.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/server/ConflictRollForward.java
@@ -94,4 +94,8 @@ public class ConflictRollForward {
     public List<DataMutation> getMutations() {
         return mutations;
     }
+
+    public TxnSupplier getTxnSupplier() {
+        return txnSupplier;
+    }
 }

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/server/SITransactor.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/server/SITransactor.java
@@ -185,7 +185,7 @@ public class SITransactor implements Transactor{
         SimpleTxnFilter constraintState=null;
         TxnSupplier supplier = null;
         if(constraintChecker!=null) {
-            constraintState = new SimpleTxnFilter(null, txn, NoOpReadResolver.INSTANCE, txnSupplier);
+            constraintState = new SimpleTxnFilter(txn, NoOpReadResolver.INSTANCE, txnSupplier);
             supplier = constraintState.getTxnSupplier();
         } else {
             SIDriver driver = SIDriver.driver();
@@ -278,6 +278,7 @@ public class SITransactor implements Transactor{
         if (rollforward) {
             toRollforward = new ArrayList<>(dataAndLocks.length);
         }
+
         for(int i = 0; i<dataAndLocks.length; i++) {
             Pair<KVPair, Lock> baseDataAndLock = dataAndLocks[i];
             if(baseDataAndLock==null) continue;
@@ -298,8 +299,19 @@ public class SITransactor implements Transactor{
                  */
                 //todo -sf remove the Row key copy here
                 checkedConflicts = true;
-                possibleConflicts=bloomInMemoryCheck==null||bloomInMemoryCheck.get(i)?table.getLatest(kvPair.getRowKey(),possibleConflicts):null;
-                if(possibleConflicts!=null && !possibleConflicts.isEmpty()){
+
+                possibleConflicts = bloomInMemoryCheck == null ||
+                        bloomInMemoryCheck.get(i) ? table.getLatest(kvPair.getRowKey(), possibleConflicts, rollForwardQueue) : null;
+                if (possibleConflicts != null && !possibleConflicts.isEmpty()) {
+                    if (LOG.isDebugEnabled()) {
+                        for (DataCell dataCell : possibleConflicts) {
+                            CellType type = dataCell.dataType();
+                            byte[] k = dataCell.key();
+                            byte[] v = dataCell.value();
+                            SpliceLogUtils.debug(LOG, "Possible conflicts: %s, k%s, v=%s",
+                                    type.toString(), Bytes.toStringBinary(k), Bytes.toStringBinary(v));
+                        }
+                    }
                     //we need to check for write conflicts
                     try {
                         conflictResults = ensureNoWriteConflict(transaction, writeType, possibleConflicts, rollForwardQueue, supplier);
@@ -309,18 +321,32 @@ public class SITransactor implements Transactor{
                             continue;
                         } else throw ioe;
                     }
-                    if(applyConstraint(constraintChecker,constraintStateFilter,i,kvPair,possibleConflicts,finalStatus,conflictResults.hasAdditiveConflicts())) //filter this row out, it fails the constraint
-                        continue;
-                }
-                //TODO -sf- if type is an UPSERT, and conflict type is ADDITIVE_CONFLICT, then we
-                //set the status on the row to ADDITIVE_CONFLICT_DURING_UPSERT
-                if(KVPair.Type.UPSERT.equals(writeType)){
-                    /*
-                     * If the type is an upsert, then we want to check for an ADDITIVE conflict. If so,
-                     * we fail this row with an ADDITIVE_UPSERT_CONFLICT.
-                     */
-                    if(conflictResults.hasAdditiveConflicts()){
-                        finalStatus[i]=operationStatusLib.failure(exceptionLib.additiveWriteConflict());
+
+                    if (constraintChecker != null) {
+                        List<DataCell> visibleColumns = filterCells(possibleConflicts, constraintStateFilter);
+                        if (visibleColumns.size() == 0 && !conflictResults.hasAdditiveConflicts()) {
+                            // Though the latest row was either committed or pending and passed RollbackTxnFilter,
+                            // it could be rolled back at this point. This is very rarely happen. For simplicity,
+                            // report a ww-conflict for this case. This could be a false positive
+                            if (isRolledBack(possibleConflicts)) {
+                                finalStatus[i] = operationStatusLib.failure("write-write conflict");
+                            }
+                        }
+                        else if (applyConstraint(visibleColumns, constraintChecker, i, kvPair, finalStatus)) {
+                            continue;
+                        }
+                    }
+
+                    //TODO -sf- if type is an UPSERT, and conflict type is ADDITIVE_CONFLICT, then we
+                    //set the status on the row to ADDITIVE_CONFLICT_DURING_UPSERT
+                    if (KVPair.Type.UPSERT.equals(writeType)) {
+                        /*
+                         * If the type is an upsert, then we want to check for an ADDITIVE conflict. If so,
+                         * we fail this row with an ADDITIVE_UPSERT_CONFLICT.
+                         */
+                        if (conflictResults.hasAdditiveConflicts()) {
+                            finalStatus[i] = operationStatusLib.failure(exceptionLib.additiveWriteConflict());
+                        }
                     }
                 }
             }
@@ -354,41 +380,48 @@ public class SITransactor implements Transactor{
         return finalMutationsToWrite;
     }
 
-    private boolean applyConstraint(ConstraintChecker constraintChecker,
-                                    TxnFilter constraintStateFilter,
-                                    int rowPosition,
-                                    KVPair mutation,
-                                    DataResult row,
-                                    MutationStatus[] finalStatus,
-                                    boolean additiveConflict) throws IOException{
-        /*
-         * Attempts to apply the constraint (if there is any). When this method returns true, the row should be filtered
-         * out.
-         */
-        if(constraintChecker==null) return false;
+    private boolean isRolledBack(DataResult result) throws IOException {
+        for (DataCell cell : result) {
+            long timestamp = cell.version();
+            TxnView txn = txnSupplier.getTransaction(timestamp);
+            if (txn.getEffectiveState() == Txn.State.ROLLEDBACK){
+                return true;
+            }
+        }
+        return false;
+    }
 
-        if(row==null || row.isEmpty()) return false;
+    private List<DataCell> filterCells(DataResult row, TxnFilter constraintStateFilter) throws IOException {
         //must reset the filter here to avoid contaminating multiple rows with tombstones and stuff
         constraintStateFilter.reset();
-
         //we need to make sure that this row is visible to the current transaction
         List<DataCell> visibleColumns=Lists.newArrayListWithExpectedSize(row.size());
-        for(DataCell data : row){
-            DataFilter.ReturnCode code=constraintStateFilter.filterCell(data);
-            switch(code){
+        for (DataCell data : row) {
+            DataFilter.ReturnCode code = constraintStateFilter.filterCell(data);
+            switch (code) {
                 case NEXT_ROW:
                 case NEXT_COL:
                 case SEEK:
-                    return false;
                 case SKIP:
+                    if (LOG.isDebugEnabled()) {
+                        SpliceLogUtils.debug(LOG, "skip k=%s, v=%s",
+                                Bytes.toStringBinary((data.key())), Bytes.toStringBinary(data.value()));
+                    }
                     continue;
                 default:
                     visibleColumns.add(data.getClone()); //TODO -sf- remove this clone
             }
         }
         constraintStateFilter.nextRow();
-        if(!additiveConflict && visibleColumns.size()<=0) return false; //no visible values to check
 
+        return visibleColumns;
+    }
+
+    private boolean applyConstraint(List<DataCell> visibleColumns,
+                                    ConstraintChecker constraintChecker,
+                                    int rowPosition,
+                                    KVPair mutation,
+                                    MutationStatus[] finalStatus) throws IOException {
         MutationStatus operationStatus=constraintChecker.checkConstraint(mutation,opFactory.newResult(visibleColumns));
         if(operationStatus!=null && !operationStatus.isSuccess()){
             finalStatus[rowPosition]=operationStatus;
@@ -396,7 +429,6 @@ public class SITransactor implements Transactor{
         }
         return false;
     }
-
 
     private void lockRows(Partition table,Collection<KVPair> mutations,Pair<KVPair, Lock>[] mutationsAndLocks,MutationStatus[] finalStatus) throws IOException{
         /*
@@ -610,6 +642,10 @@ public class SITransactor implements Transactor{
                                 +Bytes.toHex(cell.keyArray(),cell.keyOffset(),cell.keyLength()));
                     }
                     throw exceptionLib.writeWriteConflict(dataTransactionId,updateTransaction.getTxnId());
+                }
+                if(LOG.isTraceEnabled()){
+                    SpliceLogUtils.trace(LOG, "Cannot conflict with a rolled back transaction %d",
+                            dataTransaction.getEffectiveBeginTimestamp());
                 }
                 return conflictResults; //can't conflict with a rolled back transaction
             }

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/SITransactionReadController.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/SITransactionReadController.java
@@ -55,7 +55,7 @@ public class SITransactionReadController implements TransactionReadController{
 
     @Override
     public TxnFilter newFilterState(ReadResolver readResolver,TxnView txn) throws IOException{
-        return new SimpleTxnFilter(null,txn,readResolver,txnSupplier);
+        return new SimpleTxnFilter(txn,readResolver,txnSupplier);
     }
 
     @Override

--- a/splice_si_api/src/test/java/com/splicemachine/si/SITransactorTest.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/SITransactorTest.java
@@ -1465,15 +1465,15 @@ public class SITransactorTest {
     @Test
     public void rollbackUpdate() throws IOException {
         Txn t1 = control.beginTransaction(DESTINATION_TABLE);
-        testUtility.insertAge(t1, "joe43", 20);
+        testUtility.insertAge(t1, "joe48", 20);
         t1.commit();
 
         Txn t2 = control.beginTransaction(DESTINATION_TABLE);
-        testUtility.insertAge(t2, "joe43", 21);
+        testUtility.insertAge(t2, "joe48", 21);
         t2.rollback();
 
         Txn t3 = control.beginTransaction();
-        Assert.assertEquals("joe43 age=20 job=null", testUtility.read(t3, "joe43"));
+        Assert.assertEquals("joe48 age=20 job=null", testUtility.read(t3, "joe48"));
     }
 
     @Test

--- a/splice_si_api/src/test/java/com/splicemachine/si/impl/SimpleTxnFilterTest.java
+++ b/splice_si_api/src/test/java/com/splicemachine/si/impl/SimpleTxnFilterTest.java
@@ -99,7 +99,7 @@ public class SimpleTxnFilterTest{
         Assert.assertNotNull("Did not create a commit cell!",commitCell);
         assertEquals("Incorrect data type!",CellType.COMMIT_TIMESTAMP,commitCell.dataType());
 
-        SimpleTxnFilter filterState=new SimpleTxnFilter(null,myTxn,noopResolver,baseStore);
+        SimpleTxnFilter filterState=new SimpleTxnFilter(myTxn,noopResolver,baseStore);
 
         DataFilter.ReturnCode code=filterState.filterCell(commitCell);
         assertEquals("Incorrect return code for commit keyvalue!",DataFilter.ReturnCode.SKIP,code);
@@ -123,7 +123,7 @@ public class SimpleTxnFilterTest{
 
         ReadResolver noopResolver=NoOpReadResolver.INSTANCE;
         TxnView myTxn=new InheritingTxnView(Txn.ROOT_TRANSACTION,0x300L,0x300L,Txn.IsolationLevel.SNAPSHOT_ISOLATION,Txn.State.ACTIVE);
-        SimpleTxnFilter filterState=new SimpleTxnFilter(null,myTxn,noopResolver,baseStore);
+        SimpleTxnFilter filterState=new SimpleTxnFilter(myTxn,noopResolver,baseStore);
 
         DataCell userCell=getUserCell(rolledBack);
 
@@ -322,7 +322,7 @@ public class SimpleTxnFilterTest{
 
         final Pair<ByteSlice, Long> rolledBackTs=new Pair<>();
         ReadResolver resolver=getRollBackReadResolver(rolledBackTs);
-        SimpleTxnFilter filter=new SimpleTxnFilter(null,myTxn,resolver,baseStore);
+        SimpleTxnFilter filter=new SimpleTxnFilter(myTxn,resolver,baseStore);
 
         DataCell testDataKv=getUserCell(rolledBackTxn);
 
@@ -343,7 +343,7 @@ public class SimpleTxnFilterTest{
 
         final Pair<ByteSlice, Pair<Long, Long>> committedTs=new Pair<>();
         ReadResolver resolver=getCommitReadResolver(committedTs,baseStore);
-        SimpleTxnFilter filter=new SimpleTxnFilter(null,myTxn,resolver,baseStore);
+        SimpleTxnFilter filter=new SimpleTxnFilter(myTxn,resolver,baseStore);
 
         DataCell testDataKv=getUserCell(committed);
 
@@ -386,7 +386,7 @@ public class SimpleTxnFilterTest{
         data.add(baseOperationFactory.newCell(key, SIConstants.DEFAULT_FAMILY_BYTES, SIConstants.TOMBSTONE_COLUMN_BYTES,0x400L, SIConstants.TOMBSTONE_VALUE_BYTES));
         data.add(baseOperationFactory.newCell(key, SIConstants.DEFAULT_FAMILY_BYTES, SIConstants.PACKED_COLUMN_BYTES,0x200L,Bytes.toBytes(0x300L)));
 
-        SimpleTxnFilter filterState=new SimpleTxnFilter(null,myTxn,noopResolver,baseStore);
+        SimpleTxnFilter filterState=new SimpleTxnFilter(myTxn,noopResolver,baseStore);
         filterState.setIgnoreTxnSupplier(ignoreSupplier);
 
         for (DataCell cell : data) {
@@ -401,7 +401,7 @@ public class SimpleTxnFilterTest{
         // Test with committed timestamp cells
         data.add(0, baseOperationFactory.newCell(key, SIConstants.DEFAULT_FAMILY_BYTES, SIConstants.COMMIT_TIMESTAMP_COLUMN_BYTES,0x200L,Bytes.toBytes(0x300L)));
         data.add(1, baseOperationFactory.newCell(key, SIConstants.DEFAULT_FAMILY_BYTES, SIConstants.COMMIT_TIMESTAMP_COLUMN_BYTES,0x400L,Bytes.toBytes(0x500L)));
-        filterState=new SimpleTxnFilter(null,myTxn,noopResolver,baseStore);
+        filterState=new SimpleTxnFilter(myTxn,noopResolver,baseStore);
         filterState.setIgnoreTxnSupplier(ignoreSupplier);
         for (DataCell cell : data) {
             DataFilter.ReturnCode code= filterState.filterCell(cell);
@@ -436,7 +436,7 @@ public class SimpleTxnFilterTest{
         data.add(baseOperationFactory.newCell(key, SIConstants.DEFAULT_FAMILY_BYTES, SIConstants.PACKED_COLUMN_BYTES,0x400L, Bytes.toBytes("update")));
         data.add(baseOperationFactory.newCell(key, SIConstants.DEFAULT_FAMILY_BYTES, SIConstants.PACKED_COLUMN_BYTES,0x200L, Bytes.toBytes("first write")));
 
-        SimpleTxnFilter filterState=new SimpleTxnFilter(null,myTxn,noopResolver,baseStore);
+        SimpleTxnFilter filterState=new SimpleTxnFilter(myTxn,noopResolver,baseStore);
         filterState.setIgnoreTxnSupplier(ignoreSupplier);
 
         for (DataCell cell : data) {
@@ -456,7 +456,7 @@ public class SimpleTxnFilterTest{
         // Test with committed timestamp cells
         data.add(0, baseOperationFactory.newCell(key, SIConstants.DEFAULT_FAMILY_BYTES, SIConstants.COMMIT_TIMESTAMP_COLUMN_BYTES,0x200L,Bytes.toBytes(0x300L)));
         data.add(1, baseOperationFactory.newCell(key, SIConstants.DEFAULT_FAMILY_BYTES, SIConstants.COMMIT_TIMESTAMP_COLUMN_BYTES,0x400L,Bytes.toBytes(0x500L)));
-        filterState=new SimpleTxnFilter(null,myTxn,noopResolver,baseStore);
+        filterState=new SimpleTxnFilter(myTxn,noopResolver,baseStore);
         filterState.setIgnoreTxnSupplier(ignoreSupplier);
 
         for (DataCell cell : data) {
@@ -478,7 +478,7 @@ public class SimpleTxnFilterTest{
         Txn myTxn=new ReadOnlyTxn(readTs,readTs,Txn.IsolationLevel.SNAPSHOT_ISOLATION,Txn.ROOT_TRANSACTION,mock(TxnLifecycleManager.class),exceptionFactory,false);
         ReadResolver resolver=getActiveReadResolver();
 
-        SimpleTxnFilter filter=new SimpleTxnFilter(null,myTxn,resolver,baseStore);
+        SimpleTxnFilter filter=new SimpleTxnFilter(myTxn,resolver,baseStore);
 
         DataCell testDataKv=getUserCell(active);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
We only check WW-conflict with latest version. In case 

- [ ]  @latest version is rolled back, WW-conflict check can miss a conflict or constraint violation with previous version.

## Long Description
We only check WW-conflict with latest version. In case latest version is rolled back, WW-conflict check can miss a conflict or constraint violation with previous version. 

Here is an example.

        Session 0                                               Session 1
        autocommit off;                                    autocommit off;
        create table a(i int primary key, j int);   
        insert into a values (1,1);                        
        commit;                                                   
        update a set j= j+ 1;                                
        (sleep 20s)                                              
        rollback;                                                 commit;
                                                             insert into a values (1,5);
                                                             commit;
For row (1,5), splice checks WW-conflict with row (1,2) and finds it is rolled back. Splice does not try to check ww-conflict with older versions in this case, and missed PK violation between (1,5) and (1,1). 

To fix the problem, a filter is added to filter out all rolled back rows when getting latest version for the row.  

## How to test
Run previous test to confirm it is fixed. Run Jenkins elle-list test.
