### PR TITLE
DB-11897 CTRL+C exit sqlshell if no query running

### DIFF
--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijCommands.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijCommands.java
@@ -45,12 +45,16 @@ public class ijCommands {
     boolean hasServerLikeFix() {
         if(serverLikeFix == null) {
             try {
-                int[] v = parseVersion(getVersion());
-                if(v != null && v[0] >= 3 && v[3] >= 1988 ){
-                    serverLikeFix = Boolean.TRUE;
+                String strVersion = getVersion();
+                if(strVersion.equals("UNKNOWN"))
+                    serverLikeFix = Boolean.TRUE; // mem platform
+                else {
+                    int[] v = parseVersion(strVersion);
+                    if (v != null && v[0] >= 3 && v[3] >= 1988) {
+                        serverLikeFix = Boolean.TRUE;
+                    } else
+                        serverLikeFix = Boolean.FALSE;
                 }
-                else
-                    serverLikeFix = Boolean.FALSE;
             } catch (Exception e) {
                 serverLikeFix = Boolean.FALSE;
             }

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijImpl.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/ijImpl.java
@@ -40,16 +40,22 @@ public class ijImpl extends ijCommands {
     Statement currentStatement = null;
     Object currentStatementLock = new Object();
 
-    public void cancelCurrentStatement(LocalizedOutput out) {
+    public boolean
+    cancelCurrentStatement(LocalizedOutput out) {
         synchronized (currentStatementLock) {
             try {
                 if(currentStatement != null)
                 {
                     out.println("\nCTRL+C -> Canceling Statement...\n");
                     currentStatement.cancel();
+                    return true;
+                }
+                else {
+                    return false;
                 }
             } catch (Exception e) {
                 out.println("Error Canceling Statement: " + e.toString());
+                return false;
             }
         }
     }

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/utilMain.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/utilMain.java
@@ -367,7 +367,6 @@ public class utilMain implements java.security.PrivilegedAction {
                 command = null;
                 out.flush();
                 command = commandGrabber[currCE].nextStatement();
-                if(command == null) return 0;
 
                 if (doSpool) {
                     assert out.getOutputStream() instanceof ForkOutputStream;

--- a/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/utilMain.java
+++ b/db-tools-ij/src/main/java/com/splicemachine/db/impl/tools/ij/utilMain.java
@@ -166,7 +166,13 @@ public class utilMain implements java.security.PrivilegedAction {
 
         // adding Ctrl+C to cancel queries
         // to quit terminal, use 'quit;' or Ctrl+D (on Linux/Mac).
-        addSignalHandler( "INT", () -> ijParser.cancelCurrentStatement(out) );
+        addSignalHandler( "INT", this::ctrlC);
+    }
+
+    @SuppressFBWarnings("DM_EXIT")
+    public void ctrlC() {
+        if( !ijParser.cancelCurrentStatement(out) )
+            java.lang.System.exit(0);
     }
 
     /**
@@ -342,6 +348,7 @@ public class utilMain implements java.security.PrivilegedAction {
      *
      * @return The number of errors seen in the script.
      */
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
     private int runScriptGuts() {
 
         int scriptErrorCount = 0;
@@ -360,6 +367,7 @@ public class utilMain implements java.security.PrivilegedAction {
                 command = null;
                 out.flush();
                 command = commandGrabber[currCE].nextStatement();
+                if(command == null) return 0;
 
                 if (doSpool) {
                     assert out.getOutputStream() instanceof ForkOutputStream;

--- a/hbase_sql/src/test/java/com/splicemachine/derby/utils/SqlshellIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/utils/SqlshellIT.java
@@ -7,6 +7,7 @@ import com.splicemachine.db.impl.tools.ij.Main;
 import com.splicemachine.db.impl.tools.ij.ijCommands;
 import com.splicemachine.derby.test.framework.SpliceNetConnection;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.io.IOUtils;
 import org.junit.*;
@@ -415,8 +416,15 @@ public class SqlshellIT {
     }
 
     @Test
-    public void testShowVersion() {
-        Assert.assertTrue(execute("show version local;\n").contains("http://www.splicemachine.com"));
+    public void testShowVersion() throws Exception {
+        String contain;
+        if( SpliceUnitTest.isMemPlatform(new SpliceWatcher()) ) {
+            contain = "UNKNOWN";
+        }
+        else {
+            contain = "http://www.splicemachine.com";
+        }
+        Assert.assertTrue(execute("show version local;\n").contains(contain));
     }
 
     @Test


### PR DESCRIPTION
## Short Description
CTRL+C now exits sqlshell if no query is running.

## How to test
open sqlshell, enter some characters, hit Ctrl+C. sqlshell should terminate.