### PR TITLE
DB-11904 Cache transactions on commit

### DIFF
--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/WritableTxn.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/WritableTxn.java
@@ -162,8 +162,8 @@ public class WritableTxn extends AbstractTxn{
                             if (ROOT_TRANSACTION.equals(parentTxn)) {
                                 tc.unregisterActiveTransaction(getBeginTimestamp());
                                 SIDriver driver = SIDriver.driver();
-                                if (state == State.COMMITTED && driver != null && driver.isEngineStarted()) {
-                                    cacheCommittedStatus(driver.getTxnSupplier(), this);
+                                if (state == State.COMMITTED && driver != null) {
+                                    cacheCommittedStatus(driver.getTxnSupplier());
                                 }
                             }
                         }
@@ -176,14 +176,14 @@ public class WritableTxn extends AbstractTxn{
             SpliceLogUtils.trace(LOG,"After commit: txn=%s,commitTimestamp=%s",this,commitTimestamp);
     }
 
-    private void cacheCommittedStatus(TxnSupplier txnSupplier, AbstractTxn txn) {
+    private void cacheCommittedStatus(TxnSupplier txnSupplier) {
         Deque<AbstractTxn> toProcess = new ArrayDeque<>();
         toProcess.add(this);
         while(!toProcess.isEmpty()) {
-            AbstractTxn t = toProcess.pop();
-            if (t.getState() == State.COMMITTED) {
-                txnSupplier.cache(new CommittedTxn(t.getTxnId(), this.commitTimestamp));
-                for (Txn c : t.children) {
+            AbstractTxn txn = toProcess.pop();
+            if (txn.getState() == State.COMMITTED) {
+                txnSupplier.cache(new CommittedTxn(txn.getTxnId(), this.commitTimestamp));
+                for (Txn c : txn.children) {
                     if (c instanceof AbstractTxn) {
                         toProcess.add((AbstractTxn) c);
                     }

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/WritableTxn.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/WritableTxn.java
@@ -18,13 +18,17 @@ import com.splicemachine.si.api.data.ExceptionFactory;
 import com.splicemachine.si.api.txn.TaskId;
 import com.splicemachine.si.api.txn.Txn;
 import com.splicemachine.si.api.txn.TxnLifecycleManager;
+import com.splicemachine.si.api.txn.TxnSupplier;
 import com.splicemachine.si.api.txn.TxnView;
+import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.utils.ByteSlice;
 import com.splicemachine.utils.SliceIterator;
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -151,11 +155,15 @@ public class WritableTxn extends AbstractTxn{
                     case ROLLEDBACK:
                         throw exceptionFactory.cannotCommit(txnId, state);
                     case ACTIVE:
-                        if (ROOT_TRANSACTION.equals(parentTxn)) {
-                            tc.unregisterActiveTransaction(getBeginTimestamp());
-                        }
                         commitTimestamp = tc.commit(txnId);
                         state = State.COMMITTED;
+                        if (ROOT_TRANSACTION.equals(parentTxn)) {
+                            tc.unregisterActiveTransaction(getBeginTimestamp());
+                            SIDriver driver = SIDriver.driver();
+                            if (driver != null && driver.isEngineStarted()) {
+                                cacheCommittedStatus(driver.getTxnSupplier(), this);
+                            }
+                        }
                 }
             }
         } else {
@@ -163,6 +171,23 @@ public class WritableTxn extends AbstractTxn{
         }
         if(LOG.isTraceEnabled())
             SpliceLogUtils.trace(LOG,"After commit: txn=%s,commitTimestamp=%s",this,commitTimestamp);
+    }
+
+    private void cacheCommittedStatus(TxnSupplier txnSupplier, AbstractTxn txn) {
+        Deque<AbstractTxn> toProcess = new ArrayDeque<>();
+        toProcess.add(this);
+        while(!toProcess.isEmpty()) {
+            AbstractTxn t = toProcess.pop();
+            if (t.getState() == State.COMMITTED) {
+                txnSupplier.cache(new CommittedTxn(t.getTxnId(), this.commitTimestamp));
+                for (Txn c : t.children) {
+                    if (c instanceof AbstractTxn) {
+                        toProcess.add((AbstractTxn) c);
+                    }
+                }
+
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
## Short Description
When committing transactions we can update the global commit cache

## Long Description
When committing transactions we can update the global commit cache

This is specially useful for use cases where there's a single connection doing a lot of work, and most of the work happens locally on that RS
