### PR TITLE
DB-11928 Fix maxPrefixIteratorValues check of SPLICE-2399

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -4048,22 +4048,17 @@ public class FromBaseTable extends FromTable {
         if (getCompilerContext().getDisablePrefixIteratorMode())
             return false;
 
-        Optimizer optimizer = accessPath.getOptimizer();
-
-        long sparkRowThreshold = lcc.getOptimizerFactory().getDetermineSparkRowThreshold();
         long parallelism = accessPath.getCostEstimate().getParallelism();
 
         // We must have statistics collected on the base table to pick IndexPrefixIteratorMode
         // because the operation may get expensive if the number of values is underestimated.
         // Also, building of the MultiRowRangeFilter to handle the iteration may get expensive
-        // for large numbers of values, so limit it to 20000 on control and 200000 per parallel
-        // task on Spark, for now.
-        long sparkMaxPrefixIteratorValues = Long.min(MAX_ABSOLUTE_INDEX_PREFIX_VALUES,
-                                                     parallelism * MAX_PER_PARALLEL_TASK_INDEX_PREFIX_VALUES);
-        long maxPrefixIteratorValues = optimizer.isForSpark() ? sparkMaxPrefixIteratorValues :
-                                       sparkRowThreshold;
+        // for large numbers of values, so limit it to 200000 per parallel
+        // task.
+        long maxPrefixIteratorValues = Long.min(MAX_ABSOLUTE_INDEX_PREFIX_VALUES,
+                                                parallelism * MAX_PER_PARALLEL_TASK_INDEX_PREFIX_VALUES);
         return !skipStats &&
                useRealTableStats &&
-               currentIndexFirstColumnStats.getFirstIndexColumnRowsPerValue() <= maxPrefixIteratorValues;
+               currentIndexFirstColumnStats.getFirstIndexColumnCardinality() <= maxPrefixIteratorValues;
     }
 }


### PR DESCRIPTION
## Short Description
SPLICE-2399's IndexPrefixIteratorMode does not kick in for large tables.

## Long Description
The check that the special IndexPrefixIteratorMode index access is not iterating through an excessive number of leading column values was checking the rows per value statistic instead of number of values.  Fix the code to use the correct method call.  Also, there is another check which limits the first column number of values to 20000 on OLTP.  For large tables, this may be too limiting since we often hint OLTP mode for faster scans.  This limit is increased to 200000.

## How to test
Create a table with a 2-column PK and more than 20000 rows per value in the first PK column but less than 200000 values, with stats collected. EXPLAIN SELECT * FROM table WHERE 2nd_PK_Column = val;  should indicate IndexPrefixIteratorMode in the explain output.