### PR TITLE
DB-11907 Make FakeColumnStats selectivity should return rowsPerValue

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/stats/FakeColumnStatisticsImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/stats/FakeColumnStatisticsImpl.java
@@ -134,7 +134,7 @@ public class FakeColumnStatisticsImpl extends ColumnStatisticsImpl implements Ex
 
     @Override
     public long selectivityExcludingValueIfSkewed(DataValueDescriptor value) {
-        return totalCount;
+        return rpv;
     }
 
     @Override

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/JoinOrderJumpModeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/JoinOrderJumpModeIT.java
@@ -247,14 +247,14 @@ public class JoinOrderJumpModeIT extends SpliceUnitTest {
                 new String[] {"Join"},                                                        // 14
                 new String[] {"Scan["},                                                       // 16, IndexScan on mem but TableScan on cdh
                 new String[] {"Join"},                                                        // 17
-                new String[] {"TableScan[TABLE_5", "scannedRows=800,outputRows=800"},         // 18
+                new String[] {"TableScan[TABLE_5", "scannedRows=1,outputRows=1"},             // 18
                 new String[] {"Join"},                                                        // 19
                 new String[] {"TableScan[TABLE_4", "scannedRows=1,outputRows=1"},             // 20
                 new String[] {"Join"},                                                        // 21
                 new String[] {"IndexLookup"},                                                 // 23
                 new String[] {"IndexScan[IDX_3", "scannedRows=1,outputRows=1"},               // 24
                 new String[] {"Join"},                                                        // 25
-                new String[] {"IndexScan[IDX_2", "scannedRows=34609,outputRows=34609"},       // 27
+                new String[] {"IndexScan[IDX_2", "scannedRows=1,outputRows=1"},               // 27
                 new String[] {"IndexLookup"},                                                 // 28
                 new String[] {"IndexScan[IDX_1", "scannedRows=1,outputRows=1"}                // 29
                 );


### PR DESCRIPTION
## Short Description
FakeColumnStats were wrong in some cases, specifically for selectivity of columns with a default value

## How to test
- Create a table with a column with default value
- Set fake column statistics with some rowsPerValue
- Prepare statement with equality predicate on that column, the estimated scanned rows should be rowsPerValue