### PR TITLE
DB-11449 Unioned Index Scans AccessPath

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/AccessPath.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/AccessPath.java
@@ -36,6 +36,9 @@ import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.impl.sql.compile.FirstColumnOfIndexStats;
+import com.splicemachine.db.impl.sql.compile.FromTable;
+import com.splicemachine.db.impl.sql.compile.Predicate;
+import com.splicemachine.db.impl.sql.compile.ResultSetNode;
 
 /**
  * AccessPath represents a proposed access path for an Optimizable.
@@ -198,4 +201,52 @@ public interface AccessPath {
     void setNumUnusedLeadingIndexFields(int numUnusedLeadingIndexFields);
 
     FirstColumnOfIndexStats getFirstColumnStats();
+
+	/**
+	 * Store in the access path the predicate used to enable unioned index scans.
+	 */
+    void setUisPredicate(Predicate uisPredicate);
+
+	/**
+	 * The predicate used to enable unioned index scans, if any
+	 */
+    Predicate getUisPredicate();
+
+	/**
+	 * Store in the access path the RowId predicate used to join back
+	 * to the outer base table for unioned index scan query plans, when
+	 * the UIS tree has index enabling predicates which are join predicates.
+	 */
+    void setUisRowIdPredicate(Predicate uisPredicate);
+
+	/**
+	 * The RowId predicate used to join back to the outer base table
+	 * for unioned index scan query plans, when the UIS tree has
+	 * index enabling predicates which are join predicates
+	 */
+    Predicate getUisRowIdPredicate();
+
+	/**
+	 * The tree of UnionNodes that combines results of the OR'ed index scans,
+	 * for a unioned index scans access path
+	 */
+    FromTable getUnionOfIndexes();
+
+	/**
+	 * Store in the access path the tree of UnionNodes that combines results
+	 * of OR'ed index scans for a unioned index scans access path.
+	 */
+    void setUnionOfIndexes(FromTable unionOfIndexes);
+
+	/**
+	 * The entire optimized result set tree of the unioned index scans
+	 * plus the rowid join back to the base table
+	 */
+    ResultSetNode getUisRowIdJoinBackToBaseTableResultSet();
+
+	/**
+	 * Store in the access path the entire optimized result set tree of
+	 * the unioned index scans plus the rowid join back to the base table.
+	 */
+    void setUisRowIdJoinBackToBaseTableResultSet(ResultSetNode uisRowIdJoinBackToBaseTableResultSet);
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/AccessPath.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/AccessPath.java
@@ -35,10 +35,7 @@ import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.impl.sql.compile.FirstColumnOfIndexStats;
-import com.splicemachine.db.impl.sql.compile.FromTable;
-import com.splicemachine.db.impl.sql.compile.Predicate;
-import com.splicemachine.db.impl.sql.compile.ResultSetNode;
+import com.splicemachine.db.impl.sql.compile.*;
 
 /**
  * AccessPath represents a proposed access path for an Optimizable.
@@ -230,13 +227,13 @@ public interface AccessPath {
 	 * The tree of UnionNodes that combines results of the OR'ed index scans,
 	 * for a unioned index scans access path
 	 */
-    FromTable getUnionOfIndexes();
+    UnionNode getUnionOfIndexes();
 
 	/**
 	 * Store in the access path the tree of UnionNodes that combines results
 	 * of OR'ed index scans for a unioned index scans access path.
 	 */
-    void setUnionOfIndexes(FromTable unionOfIndexes);
+    void setUnionOfIndexes(UnionNode unionOfIndexes);
 
 	/**
 	 * The entire optimized result set tree of the unioned index scans

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/AccessPath.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/AccessPath.java
@@ -214,7 +214,7 @@ public interface AccessPath {
 	 * to the outer base table for unioned index scan query plans, when
 	 * the UIS tree has index enabling predicates which are join predicates.
 	 */
-    void setUisRowIdPredicate(Predicate uisPredicate);
+    void setUisRowIdPredicate(Predicate uisRowIdPredicate);
 
 	/**
 	 * The RowId predicate used to join back to the outer base table
@@ -246,4 +246,15 @@ public interface AccessPath {
 	 * the unioned index scans plus the rowid join back to the base table.
 	 */
     void setUisRowIdJoinBackToBaseTableResultSet(ResultSetNode uisRowIdJoinBackToBaseTableResultSet);
+
+	/**
+	 * Set all the fields in the access path related to Unioned Index Scans (UIS)
+	 * from the corresponding fields in the "other" access path.
+	 * This fields currently include:
+	 *    uisPredicate
+	 *    uisRowIdPredicate
+	 *    unionOfIndexes
+	 *    uisRowIdJoinBackToBaseTableResultSet
+	 */
+    void setUisFields(AccessPath copyFromAccessPath);
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
@@ -178,6 +178,8 @@ public interface CompilerContext extends Context
     int AGGREGATE_RESTRICTION = NEXT_VALUE_FOR_ILLEGAL;
     int CONDITIONAL_RESTRICTION = NEXT_VALUE_FOR_ILLEGAL;
     int GROUP_BY_RESTRICTION = NEXT_VALUE_FOR_ILLEGAL;
+    int DEFAULT_MAX_DERIVED_CNF_PREDICATES = 100;
+    int MAX_DERIVED_CNF_PREDICATES_MAX_VALUE = 10000;
     int DEFAULT_MAX_MULTICOLUMN_PROBE_VALUES = 5000;
     int MAX_MULTICOLUMN_PROBE_VALUES_MAX_VALUE = 15000;
     boolean DEFAULT_MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED = true;
@@ -195,7 +197,9 @@ public interface CompilerContext extends Context
     boolean DEFAULT_SSQ_FLATTENING_FOR_UPDATE_DISABLED = false;
     NewMergeJoinExecutionType DEFAULT_SPLICE_NEW_MERGE_JOIN = NewMergeJoinExecutionType.SYSTEM;
     boolean DEFAULT_DISABLE_PARALLEL_TASKS_JOIN_COSTING = false;
-    boolean DEFAULT_DISABLE_INDEX_PREFIX_ITERATION= false;
+    boolean DEFAULT_DISABLE_INDEX_PREFIX_ITERATION = false;
+    boolean DEFAULT_DISABLE_UNIONED_INDEX_SCANS = false;
+    boolean DEFAULT_FAVOR_UNIONED_INDEX_SCANS = false;
     boolean DEFAULT_SPLICE_DB2_VARCHAR_COMPATIBLE = false;
 
     boolean DEFAULT_PRESERVE_LINE_ENDINGS = false;
@@ -703,6 +707,10 @@ public interface CompilerContext extends Context
 
     void setProjectionPruningEnabled(boolean onOff);
 
+    int getMaxDerivedCNFPredicates();
+
+    void setMaxDerivedCNFPredicates(int newValue);
+
     int getMaxMulticolumnProbeValues();
 
     void setMaxMulticolumnProbeValues(int newValue);
@@ -778,6 +786,14 @@ public interface CompilerContext extends Context
     void setDisablePrefixIteratorMode(boolean newValue);
 
     boolean getDisablePrefixIteratorMode();
+
+    void setDisableUnionedIndexScans(boolean newValue);
+
+    boolean getDisableUnionedIndexScans();
+
+    void setFavorUnionedIndexScans(boolean newValue);
+
+    boolean getFavorUnionedIndexScans();
 
     void setVarcharDB2CompatibilityMode(boolean newValue);
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizable.java
@@ -470,4 +470,22 @@ public interface Optimizable {
      * the first index column.
      */
     default boolean indexPrefixIteratorAllowed(AccessPath accessPath) { return false; }
+
+    /**
+     * If true, this optimizable must be the outer table of a join, and
+     * join plans which use it as the inner table will not be feasible.
+     * For a given binary join involving an <code>Optimizable</code> marked as
+     * <code>outerTableOnly</code>, the optimizer will only allow that
+     * <code>Optimizable</code> to participate as the outer table of the join.
+     */
+    default boolean outerTableOnly() { return false; }
+
+    /**
+     * If true, when this <code>Optimizable</code> is joined as the inner table,
+     * only index-friendly join strategies may be used:
+     *     Merge join or Nested Loop join.
+     * Index-friendly means that join predicates involving primary
+     * key or index columns can be used to limit the scan.
+     */
+    default boolean indexFriendlyJoinsOnly() { return false; }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizable.java
@@ -477,6 +477,10 @@ public interface Optimizable {
      * For a given binary join involving an <code>Optimizable</code> marked as
      * <code>outerTableOnly</code>, the optimizer will only allow that
      * <code>Optimizable</code> to participate as the outer table of the join.
+     * This will only return true in limited scenarios when a table may
+     * only join with a single other table and no public interface to
+     * mark an optimizable as outerTableOnly is provided, on purpose,
+     * as this is an internal limited-use mechanism.
      */
     default boolean outerTableOnly() { return false; }
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizablePredicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizablePredicate.java
@@ -88,7 +88,7 @@ public interface OptimizablePredicate
 	boolean isStopKey();
 
 	/** Is this predicate a start or stop key? */
-	boolean isKey();
+	boolean isScanKey();
 
 	/**
 	 * Tell the predicate that it is to be used as a qualifier in an index
@@ -197,7 +197,7 @@ public interface OptimizablePredicate
 	boolean isFullJoinPredicate();
 
 	// Is this an OR of two or more relational operators which all are start keys or stop keys?
-	boolean isIndexEnablingORedPredicate(FromBaseTable optTable, AccessPath accessPath, Optimizer optimizer) throws StandardException;
+	boolean isDisjunctionOfScanKeys(FromBaseTable optTable, AccessPath accessPath, Optimizer optimizer) throws StandardException;
 
 	// Collect the OR'ed conditions in this Predicate into a list of PredicateLists,
 	// with each PredicateList containing a single Predicate which is the left child

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizablePredicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizablePredicate.java
@@ -37,7 +37,10 @@ import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 
 import com.splicemachine.db.iapi.util.JBitSet;
+import com.splicemachine.db.impl.sql.compile.FromBaseTable;
 import com.splicemachine.db.impl.sql.compile.SelectivityUtil;
+
+import java.util.List;
 
 /**
  * OptimizablePredicate provides services for optimizing predicates in a query.
@@ -83,6 +86,9 @@ public interface OptimizablePredicate
 
 	/** Is this predicate a stop key? */
 	boolean isStopKey();
+
+	/** Is this predicate a start or stop key? */
+	boolean isKey();
 
 	/**
 	 * Tell the predicate that it is to be used as a qualifier in an index
@@ -189,4 +195,13 @@ public interface OptimizablePredicate
 	void markFullJoinPredicate(boolean isForFullJoin);
 
 	boolean isFullJoinPredicate();
+
+	// Is this an OR of two or more relational operators which all are start keys or stop keys?
+	boolean isIndexEnablingORedPredicate(FromBaseTable optTable, AccessPath accessPath, Optimizer optimizer) throws StandardException;
+
+	// Collect the OR'ed conditions in this Predicate into a list of PredicateLists,
+	// with each PredicateList containing a single Predicate which is the left child
+	// of one of the OrNodes (OrNode chains are right-deep, with each left child being
+	// something other than an OrNode, if normalized properly).
+	List<OptimizablePredicateList> separateOredPredicates() throws StandardException;
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizablePredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizablePredicateList.java
@@ -36,7 +36,11 @@ import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.util.JBitSet;
+import com.splicemachine.db.impl.sql.compile.FromBaseTable;
+import com.splicemachine.db.impl.sql.compile.PredicateList;
 import com.splicemachine.db.impl.sql.compile.ValueNode;
+
+import java.util.List;
 
 /**
  * OptimizablePredicateList provides services for optimizing a table in a query.
@@ -388,4 +392,16 @@ public interface OptimizablePredicateList {
 	 * @return
 	 */
 	void countScanFlags();
+
+	/**
+	 *
+	 * Test if this predicate list contains a potential unioned index scans access path,
+	 * and return the predicate which enables that access path.
+	 * If accessPath is non-null, only test the index or primary key conglomerate specified
+	 * in the accessPath, otherwise test each conglomerate defined for the base table.
+	 *
+	 * @return The predicate which enables unioned index scans access path.
+	 */
+	OptimizablePredicate getUsefulPredicateForUnionedIndexScan(FromBaseTable optTable, AccessPath accessPath, Optimizer optimizer) throws StandardException;
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizer.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizer.java
@@ -39,6 +39,7 @@ import com.splicemachine.db.iapi.store.access.AggregateCostController;
 import com.splicemachine.db.iapi.store.access.SortCostController;
 import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.impl.sql.compile.AggregateNode;
+import com.splicemachine.db.impl.sql.compile.FromBaseTable;
 import com.splicemachine.db.impl.sql.compile.GroupByList;
 import com.splicemachine.db.impl.sql.compile.OrderByList;
 
@@ -425,4 +426,13 @@ public interface Optimizer{
     default boolean isMemPlatform() { return false; };
 
     CostModel getCostModel();
+
+    CostEstimate getNewCostEstimate(double theCost, double theRowCount, double theSingleScanRowCount);
+
+    OptimizablePredicateList getPredicateList();
+
+    Optimizable getOuterTable();
+
+    FromBaseTable getOuterBaseTable() throws StandardException;
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Visitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Visitor.java
@@ -123,4 +123,13 @@ public interface Visitor
 	 * in case this is an ASTVisitor.
 	 */
 	default ISpliceVisitor getBaseVisitor() { return null; }
+
+	/**
+	 * After visiting a given node, a different node may be returned.
+	 * If walkChildrenOfNewParent returns true, the children of that
+	 * new parent will be visited instead of the children of the
+	 * original parent.  Default is to visit the original parent's
+	 * children.
+	 */
+	default boolean visitChildrenOfNewParent() { return false; }
 }	

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/costing/ScanCostEstimator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/costing/ScanCostEstimator.java
@@ -14,6 +14,7 @@
 package com.splicemachine.db.iapi.sql.compile.costing;
 
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.compile.Optimizer;
 import com.splicemachine.db.impl.sql.compile.Predicate;
 
 public interface ScanCostEstimator {
@@ -21,7 +22,7 @@ public interface ScanCostEstimator {
     /**
      * Add Predicate and keep track of the selectivity.
      */
-    void addPredicate(Predicate p, double defaultSelectivityFactor) throws StandardException;
+    void addPredicate(Predicate p, double defaultSelectivityFactor, Optimizer optimizer) throws StandardException;
 
     /**
      * Compute the Base Scan Cost by utilizing the passed in StoreCostController

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -1576,4 +1576,10 @@ public interface LanguageConnectionContext extends Context {
      * @note this method has side effects.
      */
     PreparedStatement lookupStatement(GenericStatement statement) throws StandardException;
+
+    /**
+     * Get value of session-hinted joinStrategy
+     * @return value of joinStrategy
+     */
+    String getHintedJoinStrategy();
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/SessionProperties.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/SessionProperties.java
@@ -62,7 +62,8 @@ public interface SessionProperties {
         ALWAYSALLOWINDEXPREFIXITERATION(17),
         OLAPALWAYSPENALIZENLJ(18),
         FAVORINDEXPREFIXITERATION(19),
-        COSTMODEL(20);
+        COSTMODEL(20),
+        JOINSTRATEGY(21);
 
         public static final int COUNT = PROPERTYNAME.values().length;
 
@@ -96,7 +97,7 @@ public interface SessionProperties {
             property = SessionProperties.PROPERTYNAME.valueOf(propertyNameString);
         } catch (IllegalArgumentException e) {
             throw StandardException.newException(SQLState.LANG_INVALID_SESSION_PROPERTY,propertyNameString,
-                "useOLAP, useSpark (deprecated), defaultSelectivityFactor, skipStats, olapQueue, recursiveQueryIterationLimit, tableLimitForExhaustiveSearch, minPlanTimeout, currentFunctionPath, disablePredsForIndexOrPkAccessPath, alwaysAllowIndexPrefixIteration, olapAlwaysPenalizeNLJ, favorIndexPrefixIteration, costModel");
+                "useOLAP, useSpark (deprecated), defaultSelectivityFactor, skipStats, olapQueue, recursiveQueryIterationLimit, tableLimitForExhaustiveSearch, minPlanTimeout, currentFunctionPath, disablePredsForIndexOrPkAccessPath, alwaysAllowIndexPrefixIteration, olapAlwaysPenalizeNLJ, favorIndexPrefixIteration, costModel, joinStrategy");
         }
 
         String valString = pair.getSecond();

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/IndexRowGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/IndexRowGenerator.java
@@ -175,9 +175,9 @@ public class IndexRowGenerator implements IndexDescriptor, Formatable
 	 *
 	 * @return  A row template for the index row.
 	 */
-	public ExecIndexRow getIndexRowKeyTemplate()
+	public ExecIndexRow getIndexRowKeyTemplate(boolean alwaysIncludeLocation)
 	{
-		if (id.isUnique()) {
+		if (!alwaysIncludeLocation && id.isUnique()) {
 			return getExecutionFactory().getIndexableRow(id.isAscending().length);
 		} else {
 			return getIndexRowTemplate();

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataTypeDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/DataTypeDescriptor.java
@@ -1278,6 +1278,8 @@ public class DataTypeDescriptor implements Formatable{
         if(typeId.isStringTypeId()){
             if((compareWithTypeID.isDateTimeTimeStampTypeID() || compareWithTypeID.isBooleanTypeId()))
                 return true;
+            if (compareWithTypeID.getJDBCTypeId()==Types.REF && typeId.getJDBCTypeId()==Types.CHAR)
+                return true;
             //If both the types are string types, then we need to make sure
             //they have the same collation set on them
             return compareWithTypeID.isStringTypeId() && compareCollationInfo(compareWithDTD);

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLRef.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLRef.java
@@ -360,4 +360,9 @@ public class SQLRef extends DataType implements RefDataValue {
 		return value.getSparkObject();
 	}
 
+	public int hashCode()
+	{
+		return value.hashCode();
+	}
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/util/JBitSet.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/util/JBitSet.java
@@ -32,6 +32,7 @@
 package com.splicemachine.db.iapi.util;
 
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.BitSet;
 
@@ -47,7 +48,7 @@ import java.util.BitSet;
  * We want to make it look like JBitSet extends BitSet, so we need to
  * provide wrapper methods for all of BitSet's methods.
  */
-public final class JBitSet{
+public final class JBitSet implements Cloneable {
     /* The BitSet that we'd like to extend */
     private final BitSet bitSet;
     /* Cache size() of bitSet, since accessed a lot */
@@ -157,6 +158,7 @@ public final class JBitSet{
     }
 
     @Override
+    @SuppressFBWarnings(value = "EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS", justification = "intentional")
     public boolean equals(Object obj){
         if(obj instanceof BitSet){
             return bitSet.equals(obj);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/RSUtils.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/RSUtils.java
@@ -259,7 +259,7 @@ public class RSUtils {
         PredicateList storeRestrictionList = t.storeRestrictionList;
         for (int i = 0; i < storeRestrictionList.size(); ++i) {
             OptimizablePredicate pred = storeRestrictionList.getOptPredicate(i);
-            if (!pred.isKey() && !contains(pl, pred)) {
+            if (!pred.isScanKey() && !contains(pl, pred)) {
                 pl.addOptPredicate(pred);
             }
         }
@@ -280,7 +280,7 @@ public class RSUtils {
         PredicateList storeRestrictionList = t.storeRestrictionList;
         for (int i = 0; i < storeRestrictionList.size(); ++i) {
             OptimizablePredicate pred = storeRestrictionList.getOptPredicate(i);
-            if (pred.isKey() && !contains(pl, pred)) {
+            if (pred.isScanKey() && !contains(pl, pred)) {
                 pl.addOptPredicate(pred);
             }
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/RSUtils.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/RSUtils.java
@@ -248,9 +248,10 @@ public class RSUtils {
     /**
      * CAUTION: This method modifies the FromBaseTable parameter.
      */
+    // Makes a list of non-key predicates.
     public static PredicateList getPreds(FromBaseTable t) throws StandardException {
         PredicateList pl = new PredicateList();
-        t.pullOptPredicates(pl);
+        t.pullNonKeyPredicates(pl);
         for (int i = 0, s = pl.size(); i < s; i++) {
             OptimizablePredicate p = pl.getOptPredicate(i);
             t.pushOptPredicate(p);
@@ -258,7 +259,28 @@ public class RSUtils {
         PredicateList storeRestrictionList = t.storeRestrictionList;
         for (int i = 0; i < storeRestrictionList.size(); ++i) {
             OptimizablePredicate pred = storeRestrictionList.getOptPredicate(i);
-            if (!contains(pl, pred)) {
+            if (!pred.isKey() && !contains(pl, pred)) {
+                pl.addOptPredicate(pred);
+            }
+        }
+        return pl;
+    }
+
+    /**
+     * CAUTION: This method modifies the FromBaseTable parameter.
+     */
+    // Makes a list of key predicates, that allow scanning a subset of rows in the table.
+    public static PredicateList getKeyPreds(FromBaseTable t) throws StandardException {
+        PredicateList pl = new PredicateList();
+        t.pullKeyPredicates(pl);
+        for (int i = 0, s = pl.size(); i < s; i++) {
+            OptimizablePredicate p = pl.getOptPredicate(i);
+            t.pushOptPredicate(p);
+        }
+        PredicateList storeRestrictionList = t.storeRestrictionList;
+        for (int i = 0; i < storeRestrictionList.size(); ++i) {
+            OptimizablePredicate pred = storeRestrictionList.getOptPredicate(i);
+            if (pred.isKey() && !contains(pl, pred)) {
                 pl.addOptPredicate(pred);
             }
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -753,14 +753,9 @@ public class GenericStatement implements Statement{
         String disablePrefixIteratorModeString =
             PropertyUtil.getCachedDatabaseProperty(lcc, Property.DISABLE_INDEX_PREFIX_ITERATION);
         boolean disablePrefixIteratorMode = CompilerContext.DEFAULT_DISABLE_INDEX_PREFIX_ITERATION;
-        try {
-            if (disablePrefixIteratorModeString != null)
-                disablePrefixIteratorMode =
-                Boolean.parseBoolean(disablePrefixIteratorModeString);
-        } catch (Exception e) {
-            // If the property value failed to convert to a boolean, don't throw an error,
-            // just use the default setting.
-        }
+        if (disablePrefixIteratorModeString != null)
+            disablePrefixIteratorMode =
+            Boolean.parseBoolean(disablePrefixIteratorModeString);
         cc.setDisablePrefixIteratorMode(disablePrefixIteratorMode);
     }
 
@@ -768,14 +763,9 @@ public class GenericStatement implements Statement{
         String disableUnionedIndexScansString =
             PropertyUtil.getCachedDatabaseProperty(lcc, Property.DISABLE_UNIONED_INDEX_SCANS);
         boolean disableUnionedIndexScans = CompilerContext.DEFAULT_DISABLE_UNIONED_INDEX_SCANS;
-        try {
-            if (disableUnionedIndexScansString != null)
-                disableUnionedIndexScans =
-                Boolean.parseBoolean(disableUnionedIndexScansString);
-        } catch (Exception e) {
-            // If the property value failed to convert to a boolean, don't throw an error,
-            // just use the default setting.
-        }
+        if (disableUnionedIndexScansString != null)
+            disableUnionedIndexScans =
+            Boolean.parseBoolean(disableUnionedIndexScansString);
         cc.setDisableUnionedIndexScans(disableUnionedIndexScans);
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -43,14 +43,12 @@ import com.splicemachine.db.iapi.sql.compile.*;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.conn.StatementContext;
 import com.splicemachine.db.iapi.sql.depend.Dependency;
-import com.splicemachine.db.iapi.sql.depend.Provider;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
 import com.splicemachine.db.iapi.sql.execute.ExecutionContext;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.FloatingPointDataType;
 import com.splicemachine.db.iapi.types.SQLTimestamp;
-import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.util.ByteArray;
 import com.splicemachine.db.iapi.util.InterruptStatus;
 import com.splicemachine.db.impl.ast.JsonTreeBuilderVisitor;
@@ -59,7 +57,6 @@ import com.splicemachine.db.impl.sql.compile.ExplainNode;
 import com.splicemachine.db.impl.sql.compile.StatementNode;
 import com.splicemachine.db.impl.sql.compile.TriggerReferencingStruct;
 import com.splicemachine.db.impl.sql.conn.GenericLanguageConnectionContext;
-import com.splicemachine.db.impl.sql.execute.SPSPropertyRegistry;
 import com.splicemachine.db.impl.sql.misc.CommentStripper;
 import com.splicemachine.system.SimpleSparkVersion;
 import com.splicemachine.system.SparkVersion;
@@ -73,7 +70,6 @@ import java.nio.file.Paths;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.splicemachine.db.iapi.reference.Property.SPLICE_SPARK_COMPILE_VERSION;
@@ -497,7 +493,7 @@ public class GenericStatement implements Statement{
         setDisableParallelTaskJoinCosting(lcc, cc);
         setDisablePrefixIteratorMode(lcc, cc);
         setDisableUnionedIndexScans(lcc, cc);
-        setfavorUnionedIndexScans(lcc, cc);
+        setFavorUnionedIndexScans(lcc, cc);
         setCurrentTimestampPrecision(lcc, cc);
         setTimestampFormat(lcc, cc);
         setSecondFunctionCompatibilityMode(lcc, cc);
@@ -769,7 +765,7 @@ public class GenericStatement implements Statement{
         cc.setDisableUnionedIndexScans(disableUnionedIndexScans);
     }
 
-    private void setfavorUnionedIndexScans(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+    private void setFavorUnionedIndexScans(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
         String favorUnionedIndexScansString =
             PropertyUtil.getCachedDatabaseProperty(lcc, Property.FAVOR_UNIONED_INDEX_SCANS);
         boolean favorUnionedIndexScans = CompilerContext.DEFAULT_FAVOR_UNIONED_INDEX_SCANS;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -78,6 +78,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.splicemachine.db.iapi.reference.Property.SPLICE_SPARK_COMPILE_VERSION;
 import static com.splicemachine.db.iapi.reference.Property.SPLICE_SPARK_VERSION;
+import static com.splicemachine.db.iapi.sql.compile.CompilerContext.MAX_DERIVED_CNF_PREDICATES_MAX_VALUE;
 import static com.splicemachine.db.iapi.sql.compile.CompilerContext.MAX_MULTICOLUMN_PROBE_VALUES_MAX_VALUE;
 import static com.splicemachine.db.impl.sql.compile.CharTypeCompiler.getCurrentCharTypeCompiler;
 
@@ -486,6 +487,7 @@ public class GenericStatement implements Statement{
         setSelectivityEstimationIncludingSkewedDefault(lcc, cc);
         setProjectionPruningEnabled(lcc, cc);
         setMaxMulticolumnProbeValues(lcc, cc);
+        setMaxDerivedCNFPredicates(lcc, cc);
         setMulticolumnInlistProbeOnSparkEnabled(lcc, cc);
         setConvertMultiColumnDNFPredicatesToInList(lcc, cc);
         setDisablePredicateSimplification(lcc, cc);
@@ -493,6 +495,9 @@ public class GenericStatement implements Statement{
         setAllowOverflowSensitiveNativeSparkExpressions(lcc, cc);
         setNewMergeJoin(lcc, cc);
         setDisableParallelTaskJoinCosting(lcc, cc);
+        setDisablePrefixIteratorMode(lcc, cc);
+        setDisableUnionedIndexScans(lcc, cc);
+        setfavorUnionedIndexScans(lcc, cc);
         setCurrentTimestampPrecision(lcc, cc);
         setTimestampFormat(lcc, cc);
         setSecondFunctionCompatibilityMode(lcc, cc);
@@ -600,6 +605,24 @@ public class GenericStatement implements Statement{
             // just use the default setting.
         }
         cc.setProjectionPruningEnabled(!projectionPruningOptimizationDisabled);
+    }
+
+    private void setMaxDerivedCNFPredicates(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        // User can specify the maximum number of CNF predicates to derive via the distributive
+        // law.  If the calculated number of derived predicates exceeds this value, DNF to CNF
+        // conversion is skipped.
+        String maxDerivedCNFPredicatesString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.MAX_DERIVED_CNF_PREDICATES);
+        int maxDerivedCNFPredicates = CompilerContext.DEFAULT_MAX_DERIVED_CNF_PREDICATES;
+        try {
+            if (maxDerivedCNFPredicatesString != null)
+                maxDerivedCNFPredicates = Integer.parseInt(maxDerivedCNFPredicatesString);
+        } catch (Exception e) {
+            // If the property value failed to convert to an int, don't throw an error,
+            // just use the default setting.
+        }
+        if (maxDerivedCNFPredicates > MAX_DERIVED_CNF_PREDICATES_MAX_VALUE)
+            maxDerivedCNFPredicates = MAX_DERIVED_CNF_PREDICATES_MAX_VALUE;
+        cc.setMaxDerivedCNFPredicates(maxDerivedCNFPredicates);
     }
 
     private void setMaxMulticolumnProbeValues(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
@@ -739,6 +762,36 @@ public class GenericStatement implements Statement{
             // just use the default setting.
         }
         cc.setDisablePrefixIteratorMode(disablePrefixIteratorMode);
+    }
+
+    private void setDisableUnionedIndexScans(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        String disableUnionedIndexScansString =
+            PropertyUtil.getCachedDatabaseProperty(lcc, Property.DISABLE_UNIONED_INDEX_SCANS);
+        boolean disableUnionedIndexScans = CompilerContext.DEFAULT_DISABLE_UNIONED_INDEX_SCANS;
+        try {
+            if (disableUnionedIndexScansString != null)
+                disableUnionedIndexScans =
+                Boolean.parseBoolean(disableUnionedIndexScansString);
+        } catch (Exception e) {
+            // If the property value failed to convert to a boolean, don't throw an error,
+            // just use the default setting.
+        }
+        cc.setDisableUnionedIndexScans(disableUnionedIndexScans);
+    }
+
+    private void setfavorUnionedIndexScans(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        String favorUnionedIndexScansString =
+            PropertyUtil.getCachedDatabaseProperty(lcc, Property.FAVOR_UNIONED_INDEX_SCANS);
+        boolean favorUnionedIndexScans = CompilerContext.DEFAULT_FAVOR_UNIONED_INDEX_SCANS;
+        try {
+            if (favorUnionedIndexScansString != null)
+                favorUnionedIndexScans =
+                Boolean.parseBoolean(favorUnionedIndexScansString);
+        } catch (Exception e) {
+            // If the property value failed to convert to a boolean, don't throw an error,
+            // just use the default setting.
+        }
+        cc.setFavorUnionedIndexScans(favorUnionedIndexScans);
     }
 
     private void setDisableParallelTaskJoinCosting(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AccessPathImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AccessPathImpl.java
@@ -55,7 +55,6 @@ class AccessPathImpl implements AccessPath{
     private boolean isJoinStrategyHinted = false;
     private boolean missingHashKeyOK = false;
     private int numUnusedLeadingIndexFields;
-    private boolean useDNF = false;
     private Predicate uisPredicate;
     private Predicate uisRowIdPredicate;
     private FromTable unionOfIndexes = null;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AccessPathImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AccessPathImpl.java
@@ -55,6 +55,12 @@ class AccessPathImpl implements AccessPath{
     private boolean isJoinStrategyHinted = false;
     private boolean missingHashKeyOK = false;
     private int numUnusedLeadingIndexFields;
+    private boolean useDNF = false;
+    private Predicate uisPredicate;
+    private Predicate uisRowIdPredicate;
+    private FromTable unionOfIndexes = null;
+    private ResultSetNode uisRowIdJoinBackToBaseTableResultSet = null;
+
 
     AccessPathImpl(Optimizer optimizer){
         this.optimizer=optimizer;
@@ -112,6 +118,10 @@ class AccessPathImpl implements AccessPath{
         setLockMode(copyFrom.getLockMode());
         setMissingHashKeyOK(copyFrom.isMissingHashKeyOK());
         setNumUnusedLeadingIndexFields(copyFrom.getNumUnusedLeadingIndexFields());
+        setUisPredicate(copyFrom.getUisPredicate());
+        setUisRowIdPredicate(copyFrom.getUisRowIdPredicate());
+        setUnionOfIndexes(copyFrom.getUnionOfIndexes());
+        setUisRowIdJoinBackToBaseTableResultSet(copyFrom.getUisRowIdJoinBackToBaseTableResultSet());
     }
 
     @Override public Optimizer getOptimizer(){ return optimizer; }
@@ -126,9 +136,10 @@ class AccessPathImpl implements AccessPath{
                     ", specialMaxScan == "+specialMaxScan+
                     ", joinStrategy == " + (joinStrategy == null ? "null" : joinStrategy) +
                     ", lockMode == "+lockMode+
-                    ", optimizer level == "+optimizer.getLevel()+
+                    ", optimizer level == "+ (optimizer != null ? optimizer.getLevel() : -1) +
                     ", missingHashKeyOK == "+isMissingHashKeyOK()+
-                    ", numUnusedLeadingIndexFields == "+getNumUnusedLeadingIndexFields();
+                    ", numUnusedLeadingIndexFields == "+getNumUnusedLeadingIndexFields()+
+                    ", unionedIndexScan == " + Boolean.valueOf(getUisRowIdJoinBackToBaseTableResultSet() != null);
         }else{
             return "";
         }
@@ -183,4 +194,45 @@ class AccessPathImpl implements AccessPath{
     public FirstColumnOfIndexStats getFirstColumnStats() {
         return getCostEstimate().getFirstColumnStats();
     }
+
+    @Override
+    public void setUisPredicate(Predicate uisPredicate) {
+        this.uisPredicate = uisPredicate;
+    }
+
+    @Override
+    public Predicate getUisPredicate() {
+        return uisPredicate;
+    }
+
+    @Override
+    public void setUisRowIdPredicate(Predicate uisRowIdPredicate) {
+        this.uisRowIdPredicate = uisRowIdPredicate;
+    }
+
+    @Override
+    public Predicate getUisRowIdPredicate() {
+        return uisRowIdPredicate;
+    }
+
+    @Override
+    public FromTable getUnionOfIndexes() {
+        return unionOfIndexes;
+    }
+
+    @Override
+    public void setUnionOfIndexes(FromTable unionOfIndexes) {
+        this.unionOfIndexes = unionOfIndexes;
+    }
+
+    @Override
+    public ResultSetNode getUisRowIdJoinBackToBaseTableResultSet() {
+        return uisRowIdJoinBackToBaseTableResultSet;
+    }
+
+    @Override
+    public void setUisRowIdJoinBackToBaseTableResultSet(ResultSetNode uisRowIdJoinBackToBaseTableResultSet) {
+        this.uisRowIdJoinBackToBaseTableResultSet = uisRowIdJoinBackToBaseTableResultSet;
+    }
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AccessPathImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AccessPathImpl.java
@@ -57,7 +57,7 @@ class AccessPathImpl implements AccessPath{
     private int numUnusedLeadingIndexFields;
     private Predicate uisPredicate;
     private Predicate uisRowIdPredicate;
-    private FromTable unionOfIndexes = null;
+    private UnionNode unionOfIndexes = null;
     private ResultSetNode uisRowIdJoinBackToBaseTableResultSet = null;
 
 
@@ -215,12 +215,12 @@ class AccessPathImpl implements AccessPath{
     }
 
     @Override
-    public FromTable getUnionOfIndexes() {
+    public UnionNode getUnionOfIndexes() {
         return unionOfIndexes;
     }
 
     @Override
-    public void setUnionOfIndexes(FromTable unionOfIndexes) {
+    public void setUnionOfIndexes(UnionNode unionOfIndexes) {
         this.unionOfIndexes = unionOfIndexes;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AccessPathImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AccessPathImpl.java
@@ -117,10 +117,7 @@ class AccessPathImpl implements AccessPath{
         setLockMode(copyFrom.getLockMode());
         setMissingHashKeyOK(copyFrom.isMissingHashKeyOK());
         setNumUnusedLeadingIndexFields(copyFrom.getNumUnusedLeadingIndexFields());
-        setUisPredicate(copyFrom.getUisPredicate());
-        setUisRowIdPredicate(copyFrom.getUisRowIdPredicate());
-        setUnionOfIndexes(copyFrom.getUnionOfIndexes());
-        setUisRowIdJoinBackToBaseTableResultSet(copyFrom.getUisRowIdJoinBackToBaseTableResultSet());
+        setUisFields(copyFrom);
     }
 
     @Override public Optimizer getOptimizer(){ return optimizer; }
@@ -232,6 +229,14 @@ class AccessPathImpl implements AccessPath{
     @Override
     public void setUisRowIdJoinBackToBaseTableResultSet(ResultSetNode uisRowIdJoinBackToBaseTableResultSet) {
         this.uisRowIdJoinBackToBaseTableResultSet = uisRowIdJoinBackToBaseTableResultSet;
+    }
+
+    @Override
+    public void setUisFields(AccessPath copyFromAccessPath) {
+        setUisPredicate(copyFromAccessPath.getUisPredicate());
+        setUisRowIdPredicate(copyFromAccessPath.getUisRowIdPredicate());
+        setUnionOfIndexes(copyFromAccessPath.getUnionOfIndexes());
+        setUisRowIdJoinBackToBaseTableResultSet(copyFromAccessPath.getUisRowIdJoinBackToBaseTableResultSet());
     }
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AndNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AndNode.java
@@ -95,18 +95,18 @@ public class AndNode extends BinaryLogicalOperatorNode{
                                 PredicateList outerPredicateList) throws StandardException{
         /* If the left child is an OR, then mark it as the 1st OR in
          * the list.  That will allow us to consider converting the OR
-		 * to an IN list when we preprocess the 1st OR in the list.
-		 */
+         * to an IN list when we preprocess the 1st OR in the list.
+         */
         if(getLeftOperand() instanceof OrNode){
             ((OrNode)getLeftOperand()).setFirstOr();
         }
         setLeftOperand(getLeftOperand().preprocess(numTables,
                 outerFromList,outerSubqueryList,
                 outerPredicateList));
-		/* We need to rerun the changeToCNF() phase if our left operand
-		 * is an AndNode.  This can happen due to a predicate transformation,
-		 * such as the ones for LIKE and BETWEEN, underneath us.
-		 */
+        /* We need to rerun the changeToCNF() phase if our left operand
+         * is an AndNode.  This can happen due to a predicate transformation,
+         * such as the ones for LIKE and BETWEEN, underneath us.
+         */
         if(getLeftOperand() instanceof AndNode){
             // OrNode Cannot be Transformed to an AndNode.
             // This allows us to always believe we are a top AndNode...
@@ -139,7 +139,7 @@ public class AndNode extends BinaryLogicalOperatorNode{
             return this;
         }
 
-		/* Convert the AndNode to an OrNode */
+        /* Convert the AndNode to an OrNode */
         ValueNode orNode;
 
         orNode=(ValueNode)getNodeFactory().getNode(C_NodeTypes.OR_NODE,getLeftOperand(),getRightOperand(),getContextManager());
@@ -213,11 +213,11 @@ public class AndNode extends BinaryLogicalOperatorNode{
     public ValueNode changeToCNF(boolean underTopAndNode) throws StandardException{
         AndNode curAnd=this;
 
-		/* Top chain will be a chain of Ands terminated by a non-AndNode.
-		 * (putAndsOnTop() has taken care of this. If the last node in
-		 * the chain is not a true BooleanConstantNode then we need to do the
-		 * transformation to make it so.
-		 */
+        /* Top chain will be a chain of Ands terminated by a non-AndNode.
+         * (putAndsOnTop() has taken care of this. If the last node in
+         * the chain is not a true BooleanConstantNode then we need to do the
+         * transformation to make it so.
+         */
 
         /* Add the true BooleanConstantNode if not there yet */
         if (!(getRightOperand() instanceof AndNode) && !(getRightOperand().isBooleanTrue())) {
@@ -300,25 +300,25 @@ public class AndNode extends BinaryLogicalOperatorNode{
             else {
                 /* If leftOperand is an AndNode, then we modify the tree from:
                  *
-                 *				this
-                 *			   /	\
-                 *			And2	Nodex
-                 *		   /	\		...
-                 *		left2	right2
+                 *                this
+                 *               /    \
+                 *            And2    Nodex
+                 *           /    \        ...
+                 *        left2    right2
                  *
-                 *	to:
+                 *    to:
                  *
-                 *						this
-                 *					   /	\
-                 *	left2.changeToCNF()		 And2
-                 *							/	\
-                 *		right2.changeToCNF()	  Nodex.changeToCNF()
+                 *                        this
+                 *                       /    \
+                 *    left2.changeToCNF()         And2
+                 *                            /    \
+                 *        right2.changeToCNF()      Nodex.changeToCNF()
                  *
-                 *	NOTE: We could easily switch places between left2.changeToCNF() and
+                 *    NOTE: We could easily switch places between left2.changeToCNF() and
                  *  right2.changeToCNF().
                  *
                  */
-		        /* Pull up the AndNode chain to our left */
+                /* Pull up the AndNode chain to our left */
                 /* For "clarity", we first get the new and old operands */
                 ValueNode newLeft = ((AndNode) getLeftOperand()).getLeftOperand();
                 AndNode oldLeft = (AndNode) getLeftOperand();
@@ -358,7 +358,7 @@ public class AndNode extends BinaryLogicalOperatorNode{
      * Verify that changeToCNF() did its job correctly.  Verify that:
      * o  AndNode  - rightOperand is not instanceof OrNode
      * leftOperand is not instanceof AndNode
-     * o  OrNode	- rightOperand is not instanceof AndNode
+     * o  OrNode    - rightOperand is not instanceof AndNode
      * leftOperand is not instanceof OrNode
      *
      * @return Boolean which reflects validity of the tree.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryComparisonOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryComparisonOperatorNode.java
@@ -556,9 +556,9 @@ public abstract class BinaryComparisonOperatorNode extends BinaryOperatorNode
         return result;
     }
 
-    public void copy(BinaryComparisonOperatorNode other) throws StandardException
+    public void copyFrom(BinaryComparisonOperatorNode other) throws StandardException
     {
-    	super.copy(other);
+        super.copyFrom(other);
         this.forQueryRewrite = other.forQueryRewrite;
         this.betweenSelectivity = other.betweenSelectivity;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryComparisonOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryComparisonOperatorNode.java
@@ -555,4 +555,11 @@ public abstract class BinaryComparisonOperatorNode extends BinaryOperatorNode
         }
         return result;
     }
+
+    public void copy(BinaryComparisonOperatorNode other) throws StandardException
+    {
+    	super.copy(other);
+        this.forQueryRewrite = other.forQueryRewrite;
+        this.betweenSelectivity = other.betweenSelectivity;
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryOperatorNode.java
@@ -878,9 +878,11 @@ public class BinaryOperatorNode extends OperatorNode
                     return false;
                 }
             }
-            if (getRightOperand() instanceof ColumnReference) {
-                ColumnReference rcr = (ColumnReference) getRightOperand();
-                if (rcr.getSource().getExpression() instanceof CurrentRowLocationNode) {
+        }
+        if (getRightOperand() instanceof ColumnReference) {
+            ColumnReference rcr = (ColumnReference) getRightOperand();
+            if (rcr.getSource().getExpression() instanceof CurrentRowLocationNode) {
+                if (methodName.compareToIgnoreCase("NOTEQUALS") == 0) {
                     return false;
                 }
             }
@@ -976,6 +978,19 @@ public class BinaryOperatorNode extends OperatorNode
 
     public void castRightOperandAndBindCast(DataTypeDescriptor type) throws StandardException {
         castOperandAndBindCast(1, type);
+    }
+
+    public void copy(BinaryOperatorNode other) throws StandardException
+    {
+    	super.copy(other);
+        this.operatorType = other.operatorType;
+        this.leftMatchIndexExpr = other.leftMatchIndexExpr;
+        this.rightMatchIndexExpr = other.rightMatchIndexExpr;
+        this.leftMatchIndexExprConglomDesc = other.leftMatchIndexExprConglomDesc;
+        this.rightMatchIndexExprConglomDesc = other.rightMatchIndexExprConglomDesc;
+        this.leftMatchIndexExprColumnPosition = other.leftMatchIndexExprColumnPosition;
+        this.rightMatchIndexExprColumnPosition = other.rightMatchIndexExprColumnPosition;
+        this.xmlQuery = other.xmlQuery;
     }
 }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryOperatorNode.java
@@ -980,9 +980,9 @@ public class BinaryOperatorNode extends OperatorNode
         castOperandAndBindCast(1, type);
     }
 
-    public void copy(BinaryOperatorNode other) throws StandardException
+    public void copyFrom(BinaryOperatorNode other) throws StandardException
     {
-    	super.copy(other);
+        super.copyFrom(other);
         this.operatorType = other.operatorType;
         this.leftMatchIndexExpr = other.leftMatchIndexExpr;
         this.rightMatchIndexExpr = other.rightMatchIndexExpr;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
@@ -38,6 +38,7 @@ package com.splicemachine.db.impl.sql.compile;
  import com.splicemachine.db.iapi.services.sanity.SanityManager;
  import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
  import com.splicemachine.db.iapi.sql.compile.Optimizable;
+ import com.splicemachine.db.iapi.sql.compile.Visitor;
  import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
  import com.splicemachine.db.iapi.sql.dictionary.IndexRowGenerator;
  import com.splicemachine.db.iapi.store.access.ScanController;
@@ -51,6 +52,7 @@ package com.splicemachine.db.impl.sql.compile;
  import java.util.HashSet;
  import java.util.List;
 
+ import static com.splicemachine.db.impl.sql.compile.ColumnReference.isBaseRowIdOrRowId;
  import static com.splicemachine.db.impl.sql.compile.SelectivityUtil.*;
 
  /**
@@ -93,6 +95,8 @@ public class BinaryRelationalOperatorNode
     private InListOperatorNode inListProbeSource=null;
 
     private HashSet<String> noStatsColumns;
+
+    public BinaryRelationalOperatorNode() { }
 
     public void init(Object leftOperand,Object rightOperand){
         String methodName="";
@@ -336,14 +340,12 @@ public class BinaryRelationalOperatorNode
             ** Is it the correct column?
             */
             cr=(ColumnReference)getLeftOperand();
-            if(cr.getColumnName().compareToIgnoreCase("ROWID")==0){
-                return getRightOperand();
-            }
             if(valNodeReferencesOptTable(cr,ft,false,walkSubtree)){
                 /*
                 ** The table is correct, how about the column position?
                 */
-                if(cr.getSource().getColumnPosition()==columnPosition){
+                if(cr.getSource().getColumnPosition()==columnPosition ||
+                   isBaseRowIdOrRowId(cr.getColumnName())){
                     /*
                     ** We've found the correct column -
                     ** return the other side
@@ -360,14 +362,13 @@ public class BinaryRelationalOperatorNode
             ** Is it the correct column?
             */
             cr=(ColumnReference)getRightOperand();
-            if(cr.getColumnName().compareToIgnoreCase("ROWID")==0){
-                return getLeftOperand();
-            }
             if(valNodeReferencesOptTable(cr,ft,false,walkSubtree)){
                 /*
                 ** The table is correct, how about the column position?
                 */
-                if(cr.getSource().getColumnPosition()==columnPosition){
+                if(cr.getSource().getColumnPosition()==columnPosition ||
+                   isBaseRowIdOrRowId(cr.getColumnName()))
+                {
                     /*
                     ** We've found the correct column -
                     ** return the other side
@@ -2323,27 +2324,64 @@ public class BinaryRelationalOperatorNode
         boolean ret=false;
         if(getLeftOperand() instanceof ColumnReference){
             ColumnReference cr=(ColumnReference)getLeftOperand();
-            if(cr.getColumnName().compareToIgnoreCase("ROWID")==0){
+            if(isBaseRowIdOrRowId(cr.getColumnName())){
                 ret=true;
             }
         }else if(getRightOperand() instanceof ColumnReference){
             ColumnReference cr=(ColumnReference)getRightOperand();
-            if(cr.getColumnName().compareToIgnoreCase("ROWID")==0){
+            if(isBaseRowIdOrRowId(cr.getColumnName())){
                 ret=true;
             }
         }
         return ret;
     }
 
-     public int getOuterJoinLevel() {
+    public int getOuterJoinLevel() {
          return outerJoinLevel;
      }
 
-     public void setOuterJoinLevel(int level) {
+    public void setOuterJoinLevel(int level) {
          outerJoinLevel = level;
      }
 
-     public HashSet<String> getNoStatsColumns() {
+    public HashSet<String> getNoStatsColumns() {
         return noStatsColumns;
      }
+
+    public void copy(BinaryRelationalOperatorNode other) throws StandardException
+    {
+    	super.copy(other);
+        this.operatorType = other.operatorType;
+        this.outerJoinLevel = other.outerJoinLevel;
+        this.inListProbeSource = other.inListProbeSource;
+        this.noStatsColumns = other.noStatsColumns;
+        // Skip copying btnVis, optBaseTables, valNodeBaseTables.
+        // Each operator should have their own unshared copy of these.
+    }
+
+    @Override
+    public ValueNode getClone() throws StandardException
+    {
+        BinaryRelationalOperatorNode brol = new BinaryRelationalOperatorNode();
+        brol.copy(this);
+        return brol;
+    }
+
+    @Override
+    public boolean isCloneable()
+    {
+        return true;
+    }
+
+    /**
+     * Accept the visitor for all visitable children of this node.
+     *
+     * @param v the visitor
+     */
+    @Override
+    public void acceptChildren(Visitor v) throws StandardException {
+        super.acceptChildren(v);
+        if (inListProbeSource != null)
+            inListProbeSource = (InListOperatorNode)inListProbeSource.accept(v, this);
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
@@ -2370,7 +2370,9 @@ public class BinaryRelationalOperatorNode
     @Override
     public boolean isCloneable()
     {
-        return true;
+        // acceptChildren doesn't step into inListProbeSource,
+        // so if it's non-nil, we aren't cloneable.
+        return inListProbeSource == null;
     }
 
     /**
@@ -2381,7 +2383,5 @@ public class BinaryRelationalOperatorNode
     @Override
     public void acceptChildren(Visitor v) throws StandardException {
         super.acceptChildren(v);
-        if (inListProbeSource != null)
-            inListProbeSource = (InListOperatorNode)inListProbeSource.accept(v, this);
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
@@ -2348,9 +2348,9 @@ public class BinaryRelationalOperatorNode
         return noStatsColumns;
      }
 
-    public void copy(BinaryRelationalOperatorNode other) throws StandardException
+    public void copyFrom(BinaryRelationalOperatorNode other) throws StandardException
     {
-    	super.copy(other);
+        super.copyFrom(other);
         this.operatorType = other.operatorType;
         this.outerJoinLevel = other.outerJoinLevel;
         this.inListProbeSource = other.inListProbeSource;
@@ -2363,7 +2363,7 @@ public class BinaryRelationalOperatorNode
     public ValueNode getClone() throws StandardException
     {
         BinaryRelationalOperatorNode brol = new BinaryRelationalOperatorNode();
-        brol.copy(this);
+        brol.copyFrom(this);
         return brol;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CloneCRsVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CloneCRsVisitor.java
@@ -86,7 +86,21 @@ public class CloneCRsVisitor implements Visitor
 				"CloneCRsVisitor encountered unexpected SubqueryNode");
 		QueryTreeNode queryTreeNode = (QueryTreeNode)node;
 		if (queryTreeNode.isCloneable()) {
-			QueryTreeNode clone = queryTreeNode.getClone();
+			QueryTreeNode clone;
+			if (queryTreeNode instanceof OrNode) {
+				if (parent instanceof OrNode)
+					return node;
+				OrNode orNode = (OrNode)queryTreeNode;
+				clone = orNode.shallowCloneORChain();
+			}
+			else if (queryTreeNode instanceof AndNode) {
+				if (parent instanceof AndNode)
+					return node;
+				AndNode andNode = (AndNode)queryTreeNode;
+				clone = andNode.shallowCloneANDChain();
+			}
+			else
+			    clone = queryTreeNode.getClone();
 			if (isCR) {
 				ColumnReference cRef = (ColumnReference)clone;
 				// Scoped columns can do multiple levels of remapping, so let's

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CloneCRsVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CloneCRsVisitor.java
@@ -1,0 +1,132 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2021 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+import com.splicemachine.db.iapi.sql.compile.Visitable;
+import com.splicemachine.db.iapi.sql.compile.Visitor;
+import com.splicemachine.db.iapi.error.StandardException;
+
+import static com.splicemachine.db.shared.common.reference.SQLState.LANG_INTERNAL_ERROR;
+
+/**
+ * Shallow clone any ColumnReference nodes in the tree if its
+ * parent node is cloneable, and clone the parent node as well,
+ * to make sure there is no node sharing of ColumnReferences.
+ * If the parent of any ColumnReference is not cloneable,
+ * throw a StandardException.
+ * Also, clone any other cloneable nodes to prevent duplicates.
+ * One usage of this is to avoid identical copies of Predicates during DNF to CNF
+ * so that pushing and remapping one copy of the Predicate doesn't affect
+ * the other copy.
+ * Note: This is a special-purpose visitor for cloning boolean SQL expressions.
+ *       It does not currently handle SubqueryNodes.  If one is seen, a
+ *       StandardException is thrown.
+ *
+ */
+
+public class CloneCRsVisitor implements Visitor
+{
+	private boolean copySourceOfCR = false;
+	private boolean initializeSourceOfCR = false;
+
+	public CloneCRsVisitor()
+	{
+	}
+	////////////////////////////////////////////////
+	//
+	// VISITOR INTERFACE
+	//
+	////////////////////////////////////////////////
+
+	public Visitable visit(Visitable node, QueryTreeNode parent)
+		throws StandardException
+	{
+		boolean isCR = false;
+		if (node instanceof ColumnReference)
+		{
+			isCR = true;
+			if (!parent.isCloneable())
+				throw StandardException.newException(LANG_INTERNAL_ERROR,
+                    "CloneCRsVisitor encountered a ColumnReference which couldn't be cloned.");
+		}
+		else if (node instanceof ResultColumnList)
+			throw StandardException.newException(LANG_INTERNAL_ERROR,
+				"CloneCRsVisitor encountered unexpected ResultColumnList");
+		else if (node instanceof SubqueryNode)
+			throw StandardException.newException(LANG_INTERNAL_ERROR,
+				"CloneCRsVisitor encountered unexpected SubqueryNode");
+		QueryTreeNode queryTreeNode = (QueryTreeNode)node;
+		if (queryTreeNode.isCloneable()) {
+			QueryTreeNode clone = queryTreeNode.getClone();
+			if (isCR) {
+				ColumnReference cRef = (ColumnReference)clone;
+				// Scoped columns can do multiple levels of remapping, so let's
+				// use this option to be safe.
+				cRef.markAsScoped();
+				if (initializeSourceOfCR)
+					cRef.setSource(null);
+				else if (copySourceOfCR)
+					cRef.setSource(cRef.getSource().cloneMe());
+			}
+			return clone;
+		}
+
+	    return node;
+	}
+
+	public void setCopySourceOfCR(boolean copySourceOfCR) {
+		this.copySourceOfCR = copySourceOfCR;
+	}
+
+	public void setInitializeSourceOfCR(boolean initializeSourceOfCR) {
+		this.initializeSourceOfCR = initializeSourceOfCR;
+	}
+
+	public boolean skipChildren(Visitable node) { return false; }
+
+	public boolean visitChildrenFirst(Visitable node)
+	{
+		return false;
+	}
+
+	public boolean stopTraversal()
+	{
+		return false;
+	}
+
+	public boolean visitChildrenOfNewParent() { return true; }
+	////////////////////////////////////////////////
+	//
+	// CLASS INTERFACE
+	//
+	////////////////////////////////////////////////
+}	

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CollectNodesVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CollectNodesVisitor.java
@@ -45,6 +45,7 @@ public class CollectNodesVisitor implements Visitor {
     private Vector nodeList;
     private Class nodeClass;
     private Class skipOverClass;
+    private boolean skipBranchesAlreadyBoundAndOptimized = false;
 
     /**
      * Construct a visitor
@@ -103,7 +104,18 @@ public class CollectNodesVisitor implements Visitor {
      */
     @Override
     public boolean skipChildren(Visitable node) {
-        return (skipOverClass != null) && skipOverClass.isInstance(node);
+
+        boolean skipClass = (skipOverClass != null) && skipOverClass.isInstance(node);
+        if (skipClass)
+            return true;
+        if (skipBranchesAlreadyBoundAndOptimized) {
+            if (node instanceof ResultSetNode) {
+                ResultSetNode resultSetNode = (ResultSetNode) node;
+                if (resultSetNode.skipBindAndOptimize)
+                    return true;
+            }
+        }
+        return false;
     }
 
     ////////////////////////////////////////////////
@@ -117,5 +129,9 @@ public class CollectNodesVisitor implements Visitor {
      */
     public Vector getList() {
         return nodeList;
+    }
+
+    public void skipBranchesAlreadyBoundAndOptimized() {
+        this.skipBranchesAlreadyBoundAndOptimized = true;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnReference.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnReference.java
@@ -1638,18 +1638,18 @@ public class ColumnReference extends ValueNode {
         if (columnName == null)
             return false;
 
+        // These special column names for UPDATE and DELETE
+        // also refer to the RowID.
+        if (columnName.equals(UpdateNode.COLUMNNAME) ||
+            columnName.equals(DeleteNode.COLUMNNAME))
+            return true;
+
         return ROWID.equals(columnName);
     }
 
     public static boolean isBaseRowId(String columnName) {
         if (columnName == null)
             return false;
-
-        // These special column names for UPDATE and DELETE
-        // also refer to the base table RowID.
-        if (columnName.equals(UpdateNode.COLUMNNAME) ||
-            columnName.equals(DeleteNode.COLUMNNAME))
-            return true;
 
         return BASEROWID.equals(columnName);
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnReference.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnReference.java
@@ -95,6 +95,12 @@ public class ColumnReference extends ValueNode {
      */
     private ResultColumn source;
 
+    // ROWID refers to the row id of the row in the conglomerate we're reading.
+    public static final String ROWID = "ROWID";
+
+    // BASEROWID refers to the row id of the base table row.
+    public static final String BASEROWID = "BASEROWID";
+
     /* For unRemapping */
     ResultColumn    origSource;
     private String    origName;
@@ -1321,8 +1327,16 @@ public class ColumnReference extends ValueNode {
         // sourceResultSet.  The column within that sourceResultSet that
         // is referenced by this ColumnReference is also returned, via
         // the colNum parameter, and was set above.
-        if ((rcExpr != null) && (rcExpr instanceof VirtualColumnNode))
-            return ((VirtualColumnNode)rcExpr).getSourceResultSet();
+        if (rcExpr != null) {
+            if (rcExpr instanceof VirtualColumnNode)
+                return ((VirtualColumnNode)rcExpr).getSourceResultSet();
+            else if (rcExpr instanceof CurrentRowLocationNode) {
+                CurrentRowLocationNode rowLoc = (CurrentRowLocationNode)rcExpr;
+                ResultSetNode resultSet = rowLoc.getSourceResultSet();
+                if (resultSet != null)
+                    return resultSet;
+            }
+        }
 
         // If we get here then the ColumnReference doesn't reference
         // a result set, so return null.
@@ -1584,7 +1598,7 @@ public class ColumnReference extends ValueNode {
     }
 
     public boolean isRowIdColumn() {
-        return columnName.compareToIgnoreCase("ROWID")==0;
+        return isBaseRowIdOrRowId(columnName);
     }
 
     public ResultColumn getCoordinateSourceColumn() {
@@ -1611,5 +1625,33 @@ public class ColumnReference extends ValueNode {
                 this.getColumnName(),
                 this.getClone(),
                 getContextManager());
+    }
+
+    public static boolean isBaseRowIdOrRowId(String columnName) {
+        if (columnName == null)
+            return false;
+
+        return ROWID.equals(columnName) || BASEROWID.equals(columnName);
+    }
+
+    public static boolean isRowId(String columnName) {
+        if (columnName == null)
+            return false;
+
+        return ROWID.equals(columnName);
+    }
+
+    public static boolean isBaseRowId(String columnName) {
+        if (columnName == null)
+            return false;
+
+        return BASEROWID.equals(columnName);
+    }
+
+    public static void checkForDerivedColNameInDDL(String colName)
+            throws StandardException
+    {
+        if (isBaseRowIdOrRowId(colName))
+            throw StandardException.newException(SQLState.LANG_DERIVED_COLUMN_NAME_USE, colName);
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnReference.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ColumnReference.java
@@ -1631,7 +1631,7 @@ public class ColumnReference extends ValueNode {
         if (columnName == null)
             return false;
 
-        return ROWID.equals(columnName) || BASEROWID.equals(columnName);
+        return isRowId(columnName) || isBaseRowId(columnName);
     }
 
     public static boolean isRowId(String columnName) {
@@ -1644,6 +1644,12 @@ public class ColumnReference extends ValueNode {
     public static boolean isBaseRowId(String columnName) {
         if (columnName == null)
             return false;
+
+        // These special column names for UPDATE and DELETE
+        // also refer to the base table RowID.
+        if (columnName.equals(UpdateNode.COLUMNNAME) ||
+            columnName.equals(DeleteNode.COLUMNNAME))
+            return true;
 
         return BASEROWID.equals(columnName);
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
@@ -222,6 +222,14 @@ public class CompilerContextImpl extends ContextImpl
         projectionPruningEnabled = onOff;
     }
 
+    public int getMaxDerivedCNFPredicates() {
+        return maxDerivedCNFPredicates;
+    }
+
+    public void setMaxDerivedCNFPredicates(int newValue) {
+        maxDerivedCNFPredicates = newValue;
+    }
+
     public int getMaxMulticolumnProbeValues() {
         return maxMulticolumnProbeValues;
     }
@@ -300,6 +308,18 @@ public class CompilerContextImpl extends ContextImpl
     }
 
     public boolean getDisablePrefixIteratorMode() { return disablePrefixIteratorMode; }
+
+    public void setDisableUnionedIndexScans(boolean newValue) {
+        disableUnionedIndexScans = newValue;
+    }
+
+    public boolean getDisableUnionedIndexScans() { return disableUnionedIndexScans; }
+
+    public void setFavorUnionedIndexScans(boolean newValue) {
+        favorUnionedIndexScans = newValue;
+    }
+
+    public boolean getFavorUnionedIndexScans() { return favorUnionedIndexScans; }
 
     public void setVarcharDB2CompatibilityMode(boolean newValue) {
         varcharDB2CompatibilityMode = newValue;
@@ -1221,6 +1241,7 @@ public class CompilerContextImpl extends ContextImpl
     private       boolean                             selectivityEstimationIncludingSkewedDefault  = false;
     private       boolean                             projectionPruningEnabled;
     private       int                                 maxMulticolumnProbeValues                    = DEFAULT_MAX_MULTICOLUMN_PROBE_VALUES;
+    private       int                                 maxDerivedCNFPredicates                      = DEFAULT_MAX_DERIVED_CNF_PREDICATES;
     private       boolean                             multicolumnInlistProbeOnSparkEnabled         = DEFAULT_MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED;
     private       boolean                             convertMultiColumnDNFPredicatesToInList      = DEFAULT_CONVERT_MULTICOLUMN_DNF_PREDICATES_TO_INLIST;
     private       boolean                             disablePredicateSimplification               = DEFAULT_DISABLE_PREDICATE_SIMPLIFICATION;
@@ -1242,6 +1263,8 @@ public class CompilerContextImpl extends ContextImpl
     private       NewMergeJoinExecutionType           newMergeJoin                                 = DEFAULT_SPLICE_NEW_MERGE_JOIN;
     private       boolean                             disablePerParallelTaskJoinCosting            = DEFAULT_DISABLE_PARALLEL_TASKS_JOIN_COSTING;
     private       boolean                             disablePrefixIteratorMode                    = DEFAULT_DISABLE_INDEX_PREFIX_ITERATION;
+    private       boolean                             disableUnionedIndexScans                     = DEFAULT_DISABLE_UNIONED_INDEX_SCANS;
+    private       boolean                             favorUnionedIndexScans                       = DEFAULT_FAVOR_UNIONED_INDEX_SCANS;
     private       boolean                             varcharDB2CompatibilityMode                  = DEFAULT_SPLICE_DB2_VARCHAR_COMPATIBLE;
     /**
      * Saved execution time default schema, if we need to change it

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CurrentOfNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CurrentOfNode.java
@@ -245,7 +245,7 @@ public final class CurrentOfNode extends FromTable {
                                             getContextManager());
 
             /* Build the ResultColumnList to return */
-            resultColumns.addResultColumn(rc);
+            getResultColumns().addResultColumn(rc);
         }
 
         /* Assign the tableNumber */
@@ -333,7 +333,7 @@ public final class CurrentOfNode extends FromTable {
             boolean notfound = false;
 
             resultColumn =
-                resultColumns.getResultColumn(columnReference.getColumnName());
+                getResultColumns().getResultColumn(columnReference.getColumnName());
 
             if (resultColumn != null)
             {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CurrentRowLocationNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CurrentRowLocationNode.java
@@ -53,6 +53,8 @@ import java.util.List;
 
 public class CurrentRowLocationNode extends ValueNode
 {
+    protected ResultSetNode    sourceResultSet;
+
     /**
      * Binding this expression means setting the result DataTypeServices.
      * In this case, the result type is always the same.
@@ -191,6 +193,17 @@ public class CurrentRowLocationNode extends ValueNode
                 C_NodeTypes.CURRENT_ROW_LOCATION_NODE,
                 getContextManager());
         currentRowLocationNode.bindExpression(null, null, null);
+        currentRowLocationNode.sourceResultSet = sourceResultSet;
         return currentRowLocationNode;
     }
+
+    public ResultSetNode getSourceResultSet()
+    {
+        return sourceResultSet;
+    }
+
+    public void setSourceResultSet(ResultSetNode sourceResultSet) {
+        this.sourceResultSet = sourceResultSet;
+    }
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLStatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLStatementNode.java
@@ -69,6 +69,10 @@ public abstract class DMLStatementNode extends StatementNode {
     ResultSetNode resultSet;
 
     /**
+     * If this is non-null, then force spark costing if true, and OLTP costing if false;
+     */
+    private Boolean useSparkOverride = null;
+    /**
      * Initializer for a DMLStatementNode
      *
      * @param resultSet A ResultSetNode for the result set of the DML statement
@@ -248,6 +252,8 @@ public abstract class DMLStatementNode extends StatementNode {
     }
 
     private boolean shouldRunControl(ResultSetNode resultSet) throws StandardException {
+        if (useSparkOverride != null)
+            return !useSparkOverride;
         DataSetProcessorType type = getCompilerContext().getDataSetProcessorType();
         CollectNodesVisitor cnv = new CollectNodesVisitor(FromTable.class);
         resultSet.accept(cnv);
@@ -261,6 +267,8 @@ public abstract class DMLStatementNode extends StatementNode {
     }
 
     private boolean shouldRunSpark(ResultSetNode resultSet) throws StandardException {
+        if (useSparkOverride != null)
+            return useSparkOverride;
         DataSetProcessorType type = getCompilerContext().getDataSetProcessorType();
         SparkExecutionType sparkExecType = getCompilerContext().getSparkExecutionType();
         if (!type.isOlap() && (type.isHinted() || type.isForced())) {
@@ -520,5 +528,13 @@ public abstract class DMLStatementNode extends StatementNode {
         addNodeToExplainTree(tree, this, depth);
         if (resultSet != null)
             resultSet.buildTree(tree, depth + 1);
+    }
+
+    public Boolean getUseSparkOverride() {
+        return useSparkOverride;
+    }
+
+    public void setUseSparkOverride(Boolean useSparkOverride) {
+        this.useSparkOverride = useSparkOverride;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLStatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLStatementNode.java
@@ -43,6 +43,7 @@ import com.splicemachine.db.impl.ast.CollectingVisitor;
 import com.splicemachine.db.impl.ast.LimitOffsetVisitor;
 import com.splicemachine.db.impl.ast.SpliceDerbyVisitorAdapter;
 import com.splicemachine.db.impl.sql.compile.subquery.SubqueryFlattening;
+import org.apache.commons.lang3.tuple.Pair;
 import splice.com.google.common.base.Predicates;
 
 import java.util.*;
@@ -231,6 +232,7 @@ public abstract class DMLStatementNode extends StatementNode {
 
         if (shouldRunSpark(resultSet)) {
             cnv = new CollectNodesVisitor(FromTable.class);
+            cnv.skipBranchesAlreadyBoundAndOptimized();
             resultSet.accept(cnv);
             for (Object obj : cnv.getList()) {
                 FromTable ft = (FromTable) obj;
@@ -514,9 +516,8 @@ public abstract class DMLStatementNode extends StatementNode {
     }
 
     @Override
-    public void buildTree(Collection<QueryTreeNode> tree, int depth) throws StandardException {
-        setDepth(depth);
-        tree.add(this);
+    public void buildTree(Collection<Pair<QueryTreeNode,Integer>> tree, int depth) throws StandardException {
+        addNodeToExplainTree(tree, this, depth);
         if (resultSet != null)
             resultSet.buildTree(tree, depth + 1);
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DefaultPredicateSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DefaultPredicateSelectivity.java
@@ -34,7 +34,10 @@ package com.splicemachine.db.impl.sql.compile;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.compile.AccessPath;
 import com.splicemachine.db.iapi.sql.compile.Optimizable;
+import com.splicemachine.db.iapi.sql.compile.Optimizer;
 import com.splicemachine.db.impl.ast.RSUtils;
+
+import static com.splicemachine.db.impl.sql.compile.ColumnReference.isBaseRowIdOrRowId;
 
 /**
  * Predicate Selectivity Computation
@@ -43,20 +46,65 @@ import com.splicemachine.db.impl.ast.RSUtils;
 public class DefaultPredicateSelectivity extends AbstractSelectivityHolder {
     private final Optimizable baseTable;
     private final double selectivityFactor;
-    public DefaultPredicateSelectivity(Predicate p, Optimizable baseTable, QualifierPhase phase, double selectivityFactor){
+    private final Optimizer optimizer;
+    public DefaultPredicateSelectivity(Predicate p, Optimizable baseTable, QualifierPhase phase, double selectivityFactor, Optimizer optimizer){
         super(false,0,phase,p);
         this.p = p;
         this.baseTable = baseTable;
         this.selectivityFactor = selectivityFactor;
+        this.optimizer = optimizer;
     }
 
     public double getSelectivity() throws StandardException {
         if (selectivity == -1.0d) {
-            selectivity = p.selectivity(baseTable);
+            if (isRowIdBinding() && optimizer != null && optimizer.getOuterTable() != null)
+                selectivity = getRowIdPredSelectivity();
+            else
+                selectivity = p.selectivity(baseTable);
             if (selectivityFactor > 0) // we may hint to adjust selectivity by a factor
                 selectivity *= selectivityFactor;
         }
         return selectivity;
+    }
+
+    // A ROWID = ROWID join is driven from the outer table, which reduces the number of rows qualified.
+    // Find the number of qualified outer table rows to use as a reduction ratio to get the inner table selectivity.
+    private double getRowIdPredSelectivity() {
+        double outerRowCount = optimizer.getOuterTable().getCurrentAccessPath().getCostEstimate().rowCount();
+        double innerRowCount = ((FromBaseTable)baseTable).getSingleScanRowCount();
+        double lesserRowCount = Double.min(outerRowCount, innerRowCount);
+        double selectivity = lesserRowCount / innerRowCount;
+        return selectivity;
+    }
+
+    // Is this a ROWID = ROWID join predicate between 2 tables?
+    private boolean isRowIdBinding() {
+        if (!(baseTable instanceof FromBaseTable))
+            return false;
+        if (p.getReferencedSet().cardinality() != 2)
+            return false;
+        AndNode andNode = p.getAndNode();
+        if (!andNode.getRightOperand().isBooleanTrue())
+            return false;
+        ValueNode operator = andNode.getLeftOperand();
+        if (!(operator instanceof BinaryRelationalOperatorNode))
+            return false;
+        BinaryRelationalOperatorNode bron = (BinaryRelationalOperatorNode)operator;
+        if (bron.getOperator() != RelationalOperator.EQUALS_RELOP)
+            return false;
+        ValueNode left = bron.getLeftOperand();
+        ValueNode right = bron.getRightOperand();
+        if (!(left instanceof ColumnReference))
+            return false;
+        if (!(right instanceof ColumnReference))
+            return false;
+        ColumnReference leftCR = (ColumnReference)left;
+        ColumnReference rightCR = (ColumnReference)right;
+        if (!isBaseRowIdOrRowId(leftCR.getColumnName()))
+            return false;
+        if (!isBaseRowIdOrRowId(rightCR.getColumnName()))
+            return false;
+        return true;
     }
 
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DeleteNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DeleteNode.java
@@ -262,7 +262,7 @@ public class DeleteNode extends DMLModStatementNode
 
             /* Generate a select list for the ResultSetNode - CurrentRowLocation(). */
             if (SanityManager.DEBUG)
-                SanityManager.ASSERT((resultSet.resultColumns == null),
+                SanityManager.ASSERT((resultSet.getResultColumns() == null),
                               "resultColumns is expected to be null until bind time");
 
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExplainNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExplainNode.java
@@ -48,6 +48,7 @@ import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.SQLVarchar;
 import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.impl.sql.GenericColumnDescriptor;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -232,7 +233,7 @@ public class ExplainNode extends DMLStatementNode {
     }
 
     @Override
-    public void buildTree(Collection<QueryTreeNode> tree, int depth) throws StandardException {
+    public void buildTree(Collection<Pair<QueryTreeNode,Integer>> tree, int depth) throws StandardException {
         if ( node!= null)
             node.buildTree(tree,depth);
     }
@@ -251,7 +252,9 @@ public class ExplainNode extends DMLStatementNode {
             } else if (!t.getNoStatsColumnIds().isEmpty()) {
                 TableDescriptor td = t.getTableDescriptor();
                 for (int columnId : t.getNoStatsColumnIds()) {
-                    noStatsColumnSet.add(tableName + "." + td.getColumnDescriptor(columnId).getColumnName());
+                    // RowID columns may have column id of zero.
+                    if (columnId > 0)
+                        noStatsColumnSet.add(tableName + "." + td.getColumnDescriptor(columnId).getColumnName());
                 }
             }
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -2007,8 +2007,8 @@ public class FromBaseTable extends FromTable {
                     //noinspection ConstantConditions
                     SanityManager.ASSERT(vd!=null,"vd not expected to be null for "+tableName);
                 }        // make sure there's a restriction list
-        restrictionList=(PredicateList)getNodeFactory().getNode(C_NodeTypes.PREDICATE_LIST, getContextManager());
-        baseTableRestrictionList=(PredicateList)getNodeFactory().getNode(C_NodeTypes.PREDICATE_LIST, getContextManager());
+                restrictionList=(PredicateList)getNodeFactory().getNode(C_NodeTypes.PREDICATE_LIST, getContextManager());
+                baseTableRestrictionList=(PredicateList)getNodeFactory().getNode(C_NodeTypes.PREDICATE_LIST, getContextManager());
 
 
                 cvn=(CreateViewNode)parseStatement(vd.getViewText(),false);
@@ -4924,9 +4924,7 @@ public class FromBaseTable extends FromTable {
     public boolean outerTableOnly() {
         if (outerTableOnly)
             return true;
-        return (bestAccessPath != null &&
-                bestAccessPath.getUisRowIdJoinBackToBaseTableResultSet() != null) ||
-               (trulyTheBestAccessPath != null &&
+        return (trulyTheBestAccessPath != null &&
                 trulyTheBestAccessPath.getUisRowIdJoinBackToBaseTableResultSet() != null);
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -1088,6 +1088,7 @@ public class FromBaseTable extends FromTable {
                 ReuseFactory.getInteger(CursorNode.UNSPECIFIED),
                 null,
                 getContextManager());
+        stmt.setUseSparkOverride(Boolean.valueOf(optimizer.isForSpark()));
         stmt.bindStatement();
         walkAST(getLanguageConnectionContext(), stmt, CompilationPhase.AFTER_BIND);
         stmt.optimizeStatement();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -1181,7 +1181,7 @@ public class FromBaseTable extends FromTable {
         (ColumnReference) nodeFactory.getNode(
                                 C_NodeTypes.COLUMN_REFERENCE,
                                 BASEROWID,
-                                outerBaseTable.getTableName(),
+                                outerBaseTable.getExposedTableName(),
                                 getContextManager());
         ridCol2 = (ColumnReference)fromList.bindColumnReference(ridCol2);
         ridCol2.setType(new DataTypeDescriptor(TypeId.getBuiltInTypeId(TypeId.REF_NAME),
@@ -1464,7 +1464,7 @@ public class FromBaseTable extends FromTable {
         ColumnReference columnReference = (ColumnReference) getNodeFactory().getNode(
                                 C_NodeTypes.COLUMN_REFERENCE,
                                 columnName,
-                                getTableName(),
+                                getExposedTableName(),
                                 getContextManager());
 
         ResultColumn rowIdResultColumn =
@@ -1485,10 +1485,12 @@ public class FromBaseTable extends FromTable {
     // Add a BASEROWID2 column referencing the base rowid of the outer table of the current join.
     void addOuterTableRowIdToRCList(ResultColumnList resultColumnList, FromTable outerTable) throws StandardException {
         String columnName = BASEROWID;
+        TableName outerTableName = outerTable instanceof FromBaseTable ?
+                                   ((FromBaseTable) outerTable).getExposedTableName() : outerTable.getTableName();
         ColumnReference columnReference = (ColumnReference) getNodeFactory().getNode(
                                 C_NodeTypes.COLUMN_REFERENCE,
                                 columnName,
-                                outerTable.getTableName(),
+                                outerTableName,
                                 getContextManager());
         ResultColumn rowIdResultColumn =
             (ResultColumn)getNodeFactory().getNode(

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -1526,10 +1526,7 @@ public class FromBaseTable extends FromTable {
                                     C_NodeTypes.FROM_LIST,
                                     getNodeFactory().doJoinOrderOptimization(),
                                     getContextManager());
-       if (!(source instanceof FromBaseTable)) {
-           throw StandardException.newException(LANG_INTERNAL_ERROR,
-            "Unexpected inner table source result set while processing unioned index scan.");
-       }
+
        FromBaseTable innerTableCopy = ((FromBaseTable)source).shallowClone();
        innerTableCopy.setIndexFriendlyJoinsOnly(true);
 
@@ -1606,6 +1603,7 @@ public class FromBaseTable extends FromTable {
     // If the UIS access path table has join predicates, pull in the single-table predicates
     // on the outer tables so they can reduce the number of rows considered in the join of each
     // UNION branch of a UIS access path.
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", justification = "intentional")
     private boolean addPredsFromOuterRestrictionList(ProjectRestrictNode projectRestrict, ValueNode whereClause) {
        if (projectRestrict != null) {
            PredicateList restrictionList = null;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -952,7 +952,7 @@ public class FromBaseTable extends FromTable {
     // multiple index and/or PK accesses followed by a RowID join back to the
     // base table to collect all referenced columns.
     private void bindAndOptimizeUnionedIndexScansPath(AccessPath uisAccessPath, Optimizer optimizer) throws StandardException {
-        FromTable unionOfIndexes = uisAccessPath.getUnionOfIndexes();
+        UnionNode unionOfIndexes = uisAccessPath.getUnionOfIndexes();
         NodeFactory nodeFactory = getNodeFactory();
         // A copy of this base table which we can bind and optimize without
         // affecting the original.
@@ -1243,7 +1243,6 @@ public class FromBaseTable extends FromTable {
         bestAP.setJoinStrategy(bestAP.getOptimizer().getJoinStrategy(JoinStrategy.JoinStrategyType.NESTED_LOOP.ordinal()));
         trulyBestAP.setJoinStrategy(trulyBestAP.getOptimizer().getJoinStrategy(JoinStrategy.JoinStrategyType.NESTED_LOOP.ordinal()));
         fromTable.setSkipBindAndOptimize(true);
-        fromTable.setOuterTableOnly(true);
     }
 
     // A special purpose assignResultSetNumber method which gets a result set number
@@ -1455,7 +1454,7 @@ public class FromBaseTable extends FromTable {
         AccessPath uisAccessPath = new AccessPathImpl(optimizer);
         uisAccessPath.copy(currentAccessPath);
         uisAccessPath.setUisPredicate((Predicate)uisPred);
-        uisAccessPath.setUnionOfIndexes(combinedResults);
+        uisAccessPath.setUnionOfIndexes((UnionNode)combinedResults);
         return uisAccessPath;
     }
 
@@ -1644,7 +1643,7 @@ public class FromBaseTable extends FromTable {
     }
 
     // Build a UNION node between 2 branches in a Unioned Index Scans access path.
-    private FromTable getUnionNode(ResultSetNode leftSide, FromTable rightSide, Optimizer optimizer) throws StandardException {
+    private UnionNode getUnionNode(ResultSetNode leftSide, FromTable rightSide, Optimizer optimizer) throws StandardException {
        ResultSetNode leftTree = buildSelectNode(leftSide, optimizer);
        if (leftTree == null)
            return null;
@@ -1653,7 +1652,7 @@ public class FromBaseTable extends FromTable {
            return null;
 
        return
-        (FromTable) getNodeFactory().getNode(
+        (UnionNode) getNodeFactory().getNode(
                 C_NodeTypes.UNION_NODE,
                 leftTree,
                 rightTree,

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -65,6 +65,7 @@ import com.splicemachine.db.impl.ast.RSUtils;
 import com.splicemachine.db.impl.sql.catalog.SYSTOKENSRowFactory;
 import com.splicemachine.db.impl.sql.catalog.SYSUSERSRowFactory;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.lang3.tuple.Pair;
 import splice.com.google.common.base.Joiner;
 import splice.com.google.common.base.Predicates;
 import splice.com.google.common.collect.Lists;
@@ -73,6 +74,7 @@ import java.lang.reflect.Modifier;
 import java.util.*;
 
 import static com.splicemachine.db.impl.ast.RSUtils.isRSN;
+import static com.splicemachine.db.impl.sql.compile.ColumnReference.*;
 import static com.splicemachine.db.shared.common.reference.SQLState.LANG_INTERNAL_ERROR;
 
 // Temporary until user override for disposable stats has been removed.
@@ -170,6 +172,13 @@ public class FromBaseTable extends FromTable {
      */
     int numUnusedLeadingIndexFields = 0;
 
+    /* If non-null, an access path of unioned index scans was chosen
+       as truly the best access path, and this is the tree of operations
+       which performs the UNIONs of index accesses plus the final rowid
+       join back to the base table.
+     */
+    private ResultSetNode uisRowIdJoinBackToBaseTableResultSet = null;
+
     private double singleScanRowCount;
 
     private FormatableBitSet heapReferencedCols;
@@ -233,6 +242,10 @@ public class FromBaseTable extends FromTable {
 
     // expressions in whole query referencing columns in this base table
     private Set<ValueNode> referencingExpressions = null;
+
+    private boolean considerOnlyBaseConglomerate;
+
+    private static final String BASEROWID2 = "BASEROWID2";
 
     @Override
     public boolean isParallelizable(){
@@ -558,6 +571,28 @@ public class FromBaseTable extends FromTable {
         }
     }
 
+    // Collects the "preds" for the EXPLAIN text.
+    public void pullNonKeyPredicates(OptimizablePredicateList optimizablePredicates) throws StandardException{
+        for(int i=restrictionList.size()-1;i>=0;i--){
+            OptimizablePredicate pred = restrictionList.getOptPredicate(i);
+            if (pred.isKey())
+                continue;
+            optimizablePredicates.addOptPredicate(restrictionList.getOptPredicate(i));
+            restrictionList.removeOptPredicate(i);
+        }
+    }
+
+    // Collects the "keys" for the EXPLAIN text.
+    public void pullKeyPredicates(OptimizablePredicateList optimizablePredicates) throws StandardException{
+        for(int i=restrictionList.size()-1;i>=0;i--){
+            OptimizablePredicate pred = restrictionList.getOptPredicate(i);
+            if (!pred.isKey())
+                continue;
+            optimizablePredicates.addOptPredicate(restrictionList.getOptPredicate(i));
+            restrictionList.removeOptPredicate(i);
+        }
+    }
+
     @Override
     public boolean isCoveringIndex(ConglomerateDescriptor cd) throws StandardException{
         /* You can only be a covering index if you're an index */
@@ -692,6 +727,7 @@ public class FromBaseTable extends FromTable {
 
             switch (key.toLowerCase()) {
                 case "index":
+                    userSpecifiedIndexName = null;
                     // User only allowed to specify 1 of index and constraint, not both
                     if(constraintSpecified){
                         throw StandardException.newException(SQLState.LANG_BOTH_FORCE_INDEX_AND_CONSTRAINT_SPECIFIED,
@@ -838,6 +874,7 @@ public class FromBaseTable extends FromTable {
 
                 tableProperties.remove("constraint");
                 tableProperties.put("index",indexName);
+                userSpecifiedIndexName = null;
             }
         }
     }
@@ -868,6 +905,18 @@ public class FromBaseTable extends FromTable {
         ap.setMissingHashKeyOK(false);
         bestAp.setMissingHashKeyOK(false);
         bestSortAp.setMissingHashKeyOK(false);
+        ap.setUisPredicate(null);
+        bestAp.setUisPredicate(null);
+        bestSortAp.setUisPredicate(null);
+        ap.setUisRowIdPredicate(null);
+        bestAp.setUisRowIdPredicate(null);
+        bestSortAp.setUisRowIdPredicate(null);
+        ap.setUnionOfIndexes(null);
+        bestAp.setUnionOfIndexes(null);
+        bestSortAp.setUnionOfIndexes(null);
+        ap.setUisRowIdJoinBackToBaseTableResultSet(null);
+        bestAp.setUisRowIdJoinBackToBaseTableResultSet(null);
+        bestSortAp.setUisRowIdJoinBackToBaseTableResultSet(null);
         ap.setNumUnusedLeadingIndexFields(0);
         bestAp.setNumUnusedLeadingIndexFields(0);
         bestSortAp.setNumUnusedLeadingIndexFields(0);
@@ -895,6 +944,377 @@ public class FromBaseTable extends FromTable {
         return mapAbsoluteToRelativeColumnPosition(absolutePosition);
     }
 
+    // To get the cost of a Unioned Index Scans access path by building
+    // and optimizing a statement tree to be used as an altenative to the
+    // current FromBaseTable object.  If this access path is picked, we can
+    // "generate" the operation tree from this statement tree instead of
+    // generating a TableScanOperation.  The statement tree is a UNION of
+    // multiple index and/or PK accesses followed by a RowID join back to the
+    // base table to collect all referenced columns.
+    private void bindAndOptimizeUnionedIndexScansPath(AccessPath uisAccessPath, Optimizer optimizer) throws StandardException {
+        FromTable unionOfIndexes = uisAccessPath.getUnionOfIndexes();
+        NodeFactory nodeFactory = getNodeFactory();
+        // A copy of this base table which we can bind and optimize without
+        // affecting the original.
+        FromBaseTable baseTable = this.shallowClone();
+
+        // Only the base table has all table columns, so forcing the RowId join
+        // to use the base table conglomerate is guaranteed to work for all cases.
+        baseTable.setConsiderOnlyBaseConglomerate(true);
+
+        // Only consider nested loop and merge joins (though merge join does
+        // not currently support rowid join, that may be a good future enhancement).
+        baseTable.setIndexFriendlyJoinsOnly(true);
+
+        FromList fromList = (FromList) nodeFactory.getNode(
+                            C_NodeTypes.FROM_LIST,
+                            getNodeFactory().doJoinOrderOptimization(),
+                            getContextManager());
+
+        // Nested loop join (and merge join) requires the index join keys
+        // to be applied on the inner table, so force the UNION of RowIds
+        // to be the outer table of the join.  Not doing this may leave it
+        // to chance that we pick a performant join.
+        unionOfIndexes.setOuterTableOnly(true);
+        SubqueryNode    derivedTable = (SubqueryNode) nodeFactory.getNode(
+                                        C_NodeTypes.SUBQUERY_NODE,
+                                        unionOfIndexes,  // UnionNode
+                                        ReuseFactory.getInteger(SubqueryNode.FROM_SUBQUERY),
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        true,
+                                        getContextManager());
+
+        String unionAllCorrelationName = "dnfPathDT_###_" + baseTable.getExposedTableName();
+        FromTable fromSubquery = (FromTable) nodeFactory.getNode(
+                                            C_NodeTypes.FROM_SUBQUERY,
+                                            derivedTable.getResultSet(),
+                                            derivedTable.getOrderByList(),
+                                            derivedTable.getOffset(),
+                                            derivedTable.getFetchFirst(),
+                                            Boolean.valueOf( derivedTable.hasJDBClimitClause() ),
+                                            unionAllCorrelationName,
+                                            null,  // derivedRCL
+                                            (Properties) null,
+                                            getContextManager());
+        fromSubquery.setOuterTableOnly(true);
+        fromList.addFromTable(baseTable);
+        fromList.addFromTable(fromSubquery);
+
+        // Build a baseTable.BASEROWID = UIS_Statement_Tree.BASEROWID join predicate.
+        ColumnReference ridCol1 = (ColumnReference) nodeFactory.getNode(
+                                C_NodeTypes.COLUMN_REFERENCE,
+                                BASEROWID,
+                                this.getExposedTableName(),
+                                getContextManager());
+        ColumnReference ridCol2 =
+        (ColumnReference) nodeFactory.getNode(
+                                C_NodeTypes.COLUMN_REFERENCE,
+                                BASEROWID,
+                                fromSubquery.getTableName(),
+                                getContextManager());
+
+        // Set up the rowid = rowid predicate to join back to the base table.
+        BinaryRelationalOperatorNode whereClause =
+                (BinaryRelationalOperatorNode)
+                nodeFactory.getNode(
+                        C_NodeTypes.BINARY_EQUALS_OPERATOR_NODE,
+                        ridCol2,
+                        ridCol1,
+                        getContextManager());
+
+        // Include all referenced columns.
+        ResultColumnList    finalResultColumns = (ResultColumnList) nodeFactory.getNode(
+                                    C_NodeTypes.RESULT_COLUMN_LIST,
+                                    getContextManager());
+
+        for (ResultColumn rc : resultColumns) {
+            if (!rc.isReferenced())
+                continue;
+            ColumnReference newCol = (ColumnReference) nodeFactory.getNode(
+                                    C_NodeTypes.COLUMN_REFERENCE,
+                                    rc.getName(),
+                                    this.getExposedTableName(),
+                                    getContextManager());
+            ResultColumn newRC = (ResultColumn) getNodeFactory().getNode(
+                    C_NodeTypes.RESULT_COLUMN,
+                    rc.getName(),
+                    newCol,
+                    getContextManager());
+            finalResultColumns.addResultColumn(newRC);
+        }
+
+        ResultColumn baseRowId2RC = null;
+
+        // The base rowid of the outer table needs a different name in order
+        // to maintain unique column names.  This RowID refers to the outer table,
+        // not the current FromBaseTable object we're sitting in.
+        if (unionOfIndexes.resultColumns.getResultColumn(BASEROWID2) != null) {
+            ColumnReference newCol = (ColumnReference) nodeFactory.getNode(
+                                    C_NodeTypes.COLUMN_REFERENCE,
+                                    BASEROWID2,
+                                    fromSubquery.getTableName(),
+                                    getContextManager());
+            baseRowId2RC = (ResultColumn) getNodeFactory().getNode(
+                    C_NodeTypes.RESULT_COLUMN,
+                    BASEROWID2,
+                    newCol,
+                    getContextManager());
+            finalResultColumns.addResultColumn(baseRowId2RC);
+        }
+
+        SelectNode selectNode = (SelectNode) nodeFactory.getNode(
+                            C_NodeTypes.SELECT_NODE,
+                            finalResultColumns,
+                            null,         /* AGGREGATE list */
+                            fromList,
+                            whereClause,
+                            null,
+                            null,
+                            null,
+                            getContextManager());
+        DMLStatementNode
+        stmt = (CursorNode) nodeFactory.getNode(
+                C_NodeTypes.CURSOR_NODE,
+                "SELECT",
+                selectNode,
+                null,
+                null,
+                null,
+                null,
+                Boolean.valueOf( false ),
+                ReuseFactory.getInteger(CursorNode.UNSPECIFIED),
+                null,
+                getContextManager());
+        stmt.bindStatement();
+        walkAST(getLanguageConnectionContext(), stmt, CompilationPhase.AFTER_BIND);
+        stmt.optimizeStatement();
+        // The AFTER_OPTIMIZE phase call to walkAST is deferred until we commit to
+        // this access path when recordUisAccessPath is called.
+
+        ResultSetNode uisRowIdJoinBackToBaseTableResultSet = stmt.getResultSetNode();
+
+        if (uisRowIdJoinBackToBaseTableResultSet instanceof ScrollInsensitiveResultSetNode) {
+            ScrollInsensitiveResultSetNode scrollInsensitiveResultSetNode =
+            (ScrollInsensitiveResultSetNode) uisRowIdJoinBackToBaseTableResultSet;
+            uisRowIdJoinBackToBaseTableResultSet = scrollInsensitiveResultSetNode.getChildResult();
+        }
+        ResultSetNode uisJoin = uisRowIdJoinBackToBaseTableResultSet;
+
+        // If there is an outer table base rowid saved in the AST, construct a
+        // BASEROWID = BASEROWID join predicate between the outer table and the
+        // Unioned Index Scans result, and attach it to the access path.
+        if (baseRowId2RC != null) {
+            baseRowId2RC = uisRowIdJoinBackToBaseTableResultSet.getResultColumns().getResultColumn(BASEROWID2);
+            Predicate outerTableRowIdJoinPred =
+                buildRowIdPredWithOuterTable(optimizer, baseRowId2RC, fromSubquery);
+            uisAccessPath.setUisRowIdPredicate(outerTableRowIdJoinPred);
+        }
+
+        // Traverse down to the JoinNode to verify it was built.
+        // Also, set up an access path for it (for completeness).
+        while (uisJoin instanceof SingleChildResultSetNode)
+            uisJoin = ((SingleChildResultSetNode)uisJoin).getChildResult();
+
+        if (!(uisJoin instanceof JoinNode))
+            throw StandardException.newException(LANG_INTERNAL_ERROR,
+                 "Join node missing in unioned index scan query plan.");
+
+        JoinNode rowidJoin = (JoinNode)uisJoin;
+        initializeUnionedIndexScanAccessPath(rowidJoin, optimizer);
+
+        // We actually want the ProjectRestrictNode as the FromTable
+        // to use in place of this FromBaseTable because it should have the
+        // same exact resultColumnList as the base table.
+        // The JoinNode will include the RowId columns and the column numbers
+        // won't match up.
+        FromTable uisFromTable = ((FromTable) uisRowIdJoinBackToBaseTableResultSet);
+        initializeUnionedIndexScanAccessPath(uisFromTable, optimizer);
+
+        // Save the final set of statements in the access path.
+        uisAccessPath.setUisRowIdJoinBackToBaseTableResultSet(uisRowIdJoinBackToBaseTableResultSet);
+
+        // We don't want to bind or re-optimize this tree if we re-use it again.
+        unionOfIndexes.setSkipBindAndOptimize(true);
+
+        // Finally, record the cost of the UIS operations in the access path.
+        uisAccessPath.setCostEstimate(uisRowIdJoinBackToBaseTableResultSet.getCostEstimate().cloneMe());
+    }
+
+    // Build a uisResultSet.BASEROWID2 = outerTable.BASEROWID join predicate.
+    private Predicate buildRowIdPredWithOuterTable(Optimizer optimizer,
+                                                   ResultColumn baseRowId2RC,
+                                                   FromTable uisResultSet) throws StandardException {
+        if (optimizer.getJoinPosition() == 0)
+            return null;
+
+        FromList fromList = (FromList)optimizer.getOptimizableList();
+
+        FromTable outerTable = (FromTable) optimizer.getOuterTable();
+
+        // Traverse to the named table.  A FromTable is expected
+        // to be named in order to do proper binding.
+        SingleChildResultSetNode aboveResultSetNode = null;
+        while (outerTable instanceof SingleChildResultSetNode) {
+            aboveResultSetNode = (SingleChildResultSetNode) outerTable;
+            outerTable = (FromTable)aboveResultSetNode.getChildResult();
+        }
+        if (!(outerTable instanceof FromBaseTable))
+            return null;
+
+        FromBaseTable outerBaseTable = (FromBaseTable)outerTable;
+
+        NodeFactory nodeFactory = getNodeFactory();
+        ColumnReference ridCol1 = (ColumnReference) nodeFactory.getNode(
+                                C_NodeTypes.COLUMN_REFERENCE,
+                                BASEROWID2,
+                                uisResultSet.getTableName(),
+                                getContextManager());
+        ridCol1.setType(new DataTypeDescriptor(TypeId.getBuiltInTypeId(TypeId.REF_NAME),
+                                               false    /* Not nullable */
+                                               ));
+        ridCol1.setSource(baseRowId2RC);
+
+        ColumnReference ridCol2 =
+        (ColumnReference) nodeFactory.getNode(
+                                C_NodeTypes.COLUMN_REFERENCE,
+                                BASEROWID,
+                                outerBaseTable.getTableName(),
+                                getContextManager());
+        ridCol2 = (ColumnReference)fromList.bindColumnReference(ridCol2);
+        ridCol2.setType(new DataTypeDescriptor(TypeId.getBuiltInTypeId(TypeId.REF_NAME),
+                                               false    /* Not nullable */
+                                               ));
+
+        // Set up the rowid = rowid predicate to join back to the base table.
+        BinaryRelationalOperatorNode whereClause =
+                (BinaryRelationalOperatorNode)
+                nodeFactory.getNode(
+                        C_NodeTypes.BINARY_EQUALS_OPERATOR_NODE,
+                        ridCol1,
+                        ridCol2,
+                        getContextManager());
+
+        whereClause.bindComparisonOperator();
+
+        AndNode andNode = AndNode.newAndNode(whereClause, false);
+
+        JBitSet newJBitSet=new JBitSet(getCompilerContext().getNumTables());
+        Predicate
+        newPred=(Predicate)getNodeFactory().getNode(C_NodeTypes.PREDICATE,
+                  andNode, newJBitSet, getContextManager());
+        newPred.setOuterJoinLevel(whereClause.getOuterJoinLevel());
+        if (aboveResultSetNode instanceof ProjectRestrictNode) {
+            ProjectRestrictNode prn = (ProjectRestrictNode)aboveResultSetNode;
+            // Add the BASEROWID column to the ProjectRestrictNode resultColumns
+            // if it hasn't been added yet.
+            if (prn.getResultColumns().getResultColumn(BASEROWID) == null) {
+                ResultColumn rowIdResultColumn = outerBaseTable.getRowIdColumn();
+                rowIdResultColumn.setVirtualColumnId(prn.getResultColumns().size()+1);
+                rowIdResultColumn.setReferenced();
+                rowIdResultColumn.markGenerated();
+                ridCol2.setSource(rowIdResultColumn);
+
+                prn.getResultColumns().addResultColumn(rowIdResultColumn);
+                prn.assignResultSetNumber();
+            }
+        }
+        return newPred;
+    }
+
+    // In case we need to join the result to another table, since we are skipping
+    // binding and optimizing of this FromTable, we need to make sure certain items
+    // are set up that the join planner requires for proper processing.
+    void initializeUnionedIndexScanAccessPath(FromTable fromTable, Optimizer optimizer) throws StandardException {
+        fromTable.setCorrelationName(getExposedTableName().getTableName());
+        fromTable.initAccessPaths(optimizer);
+        AccessPath currentAP = fromTable.getCurrentAccessPath();
+        AccessPath bestAP = fromTable.getBestAccessPath();
+        AccessPath trulyBestAP = fromTable.getTrulyTheBestAccessPath();
+
+        CostEstimate costEstimate=getCostEstimate(optimizer);
+        currentAP.setCostEstimate(costEstimate);
+        costEstimate.setCost(Double.MAX_VALUE,Double.MAX_VALUE,Double.MAX_VALUE);
+
+        bestAP.setCostEstimate(fromTable.getCostEstimate());
+        trulyBestAP.setCostEstimate(fromTable.getCostEstimate());
+        bestAP.setJoinStrategy(bestAP.getOptimizer().getJoinStrategy(JoinStrategy.JoinStrategyType.NESTED_LOOP.ordinal()));
+        trulyBestAP.setJoinStrategy(trulyBestAP.getOptimizer().getJoinStrategy(JoinStrategy.JoinStrategyType.NESTED_LOOP.ordinal()));
+        fromTable.setSkipBindAndOptimize(true);
+        fromTable.setOuterTableOnly(true);
+    }
+
+    // A special purpose assignResultSetNumber method which gets a result set number
+    // for the FromBaseTable object which is separate from that used in the
+    // Unioned Index Scans access path, if any.
+    // The resultColumns are updated to refer to the Unioned Index Scans result columns.
+    private void assignResultSetNumber(int resultSetNumber,
+                                       ResultSetNode replacementResultSet) throws StandardException{
+        // only set if currently unset
+        if(this.resultSetNumber==-1){
+            ResultColumnList replacementResultColumns = replacementResultSet.getResultColumns();
+            this.resultSetNumber = getCompilerContext().getNextResultSetNumber();
+            resultColumns.setResultSetNumber(resultSetNumber);
+            // There may be an extra column reserved for the RowID.
+            int minColumns = Integer.min(replacementResultColumns.size(), resultColumns.size());
+            int maxColumns = Integer.max(replacementResultColumns.size(), resultColumns.size());
+            if (maxColumns != minColumns &&
+                maxColumns != minColumns + 1)
+                throw StandardException.newException(LANG_INTERNAL_ERROR,
+                     "Incorrectly built result columns for unioned index scan.");
+
+            updateResultColumnExpressions(replacementResultColumns);
+        }
+    }
+
+    public void assignResultSetNumber() throws StandardException{
+        int uisResultSetNumber = getUnionIndexScanResultSetNumber();
+        // We have the result set number of the Union Index Scans, if set.
+        if (uisResultSetNumber > -1)
+            assignResultSetNumber(uisResultSetNumber, getUnionIndexScanResultSet());
+        else if(resultSetNumber==-1){
+            // only set if currently unset
+            resultSetNumber=getCompilerContext().getNextResultSetNumber();
+            resultColumns.setResultSetNumber(resultSetNumber);
+        }
+    }
+
+    // Find the truly the best access path's Unioned Index Scans result set number.
+    public int getUnionIndexScanResultSetNumber() throws StandardException {
+        ResultSetNode uisRowIdJoinBackToBaseTableResultSet;
+        if (trulyTheBestAccessPath != null &&
+            trulyTheBestAccessPath.getUisRowIdJoinBackToBaseTableResultSet() != null) {
+            uisRowIdJoinBackToBaseTableResultSet =
+                trulyTheBestAccessPath.getUisRowIdJoinBackToBaseTableResultSet();
+            uisRowIdJoinBackToBaseTableResultSet.assignResultSetNumber();
+            return uisRowIdJoinBackToBaseTableResultSet.getResultSetNumber();
+        }
+        else
+            return -1;
+    }
+
+    // Find the truly the best access path's Unioned Index Scans result set (statements).
+    public ResultSetNode getUnionIndexScanResultSet() {
+        if (trulyTheBestAccessPath != null &&
+            trulyTheBestAccessPath.getUisRowIdJoinBackToBaseTableResultSet() != null)
+            return trulyTheBestAccessPath.getUisRowIdJoinBackToBaseTableResultSet();
+        return null;
+    }
+
+    private void walkAST(LanguageConnectionContext lcc, Visitable queryTree, CompilationPhase phase) throws StandardException {
+        ASTVisitor visitor = lcc.getASTVisitor();
+        if (visitor != null) {
+            try {
+                visitor.begin("", phase);
+                queryTree.accept(visitor);
+            } finally {
+                visitor.end(phase);
+            }
+        }
+    }
+
     @Override
     public CostEstimate estimateCost(OptimizablePredicateList predList,
                                      ConglomerateDescriptor cd,
@@ -903,18 +1323,61 @@ public class FromBaseTable extends FromTable {
                                      RowOrdering rowOrdering) throws StandardException {
         CostEstimate finalCostEstimate;
         CostEstimate firstPassCostEstimate;
+
+        // Unioned index scans access path
+        AccessPath uisAccessPath = null;
+
+        // Unioned Index Scans currently not eligible for semijoin.
+        // Build and cost the Unioned Index Scans access path.
+        OptimizablePredicate uisPred =
+            (isOneRowResultSet() || getCompilerContext().getDisableUnionedIndexScans()) ? null :
+            getUsefulPredicateForUnionedIndexScan(predList);
+        if (uisPred != null) {
+            // Using the found DNF predicate of index accesses, build the UNION
+            // statements to apply each ORed conditional expression in a separate
+            // scan, and combine all of the scans together.  The UNIONs will eliminate
+            // duplicate ROWIDs.
+            uisAccessPath =
+                buildUnionedScans(uisPred, optimizer);
+
+            // If a UIS UNION tree was built, construct the ROWID join(s) to get
+            // the final rows, optimize the tree, and cost it.
+            if (uisAccessPath != null)
+                bindAndOptimizeUnionedIndexScansPath(uisAccessPath, optimizer);
+        }
+
+        // Cost the standard base table access path.
         finalCostEstimate = firstPassCostEstimate =
             estimateCostHelper(predList, cd, outerCost, optimizer, rowOrdering);
         AccessPath currentAccessPath = getCurrentAccessPath();
 
-        // Cost accessing this conglomerate using the index with
-        // the first index column not used by any useful predicates
-        // versus scanning all rows in the conglomerate.
-        // Choose the cheapest of the two access paths.
         LanguageConnectionContext lcc = getLanguageConnectionContext();
-        if (lcc.favorIndexPrefixIteration())
-            return finalCostEstimate;
-        if (currentAccessPath.getNumUnusedLeadingIndexFields() > 0) {
+        currentAccessPath.setUisPredicate(null);
+        currentAccessPath.setUisRowIdPredicate(null);
+        currentAccessPath.setUnionOfIndexes(null);
+        currentAccessPath.setUisRowIdJoinBackToBaseTableResultSet(null);
+
+        boolean hintedUISAccessPath = false;
+
+        // Cost accessing this conglomerate using a Unioned Index Scans
+        // access path vs. standard access path.
+        if (uisAccessPath != null &&
+            (getCompilerContext().getFavorUnionedIndexScans() ||
+            uisAccessPath.getCostEstimate().compare(firstPassCostEstimate) < 0)) {
+
+            hintedUISAccessPath = getCompilerContext().getFavorUnionedIndexScans();
+            if (hintedUISAccessPath)
+                reduceEstimatedCosts(uisAccessPath);
+            currentAccessPath.copy(uisAccessPath);
+            finalCostEstimate = firstPassCostEstimate = uisAccessPath.getCostEstimate();
+        }
+
+        // Cost index access where the first index column is not present
+        // in any useful predicates the best cost currentAccessPath from above.
+        if (currentAccessPath.getNumUnusedLeadingIndexFields() > 0 &&
+            !hintedUISAccessPath &&
+            !lcc.favorIndexPrefixIteration()) {
+
             finalCostEstimate = firstPassCostEstimate = firstPassCostEstimate.cloneMe();
             AccessPath firstPassAccessPath = new AccessPathImpl(optimizer);
             firstPassAccessPath.copy(currentAccessPath);
@@ -927,11 +1390,281 @@ public class FromBaseTable extends FromTable {
             else
                 finalCostEstimate = secondPassCostEstimate;
         }
+
         return finalCostEstimate;
     }
 
+    private void reduceEstimatedCosts(AccessPath accessPath) {
+        accessPath.setCostEstimate(accessPath.getCostEstimate().cloneMe());
 
-    private
+        double costScaleFactor = 1e-9;
+        CostEstimate estimate = accessPath.getCostEstimate();
+
+        estimate.setLocalCost(estimate.getLocalCost() * costScaleFactor);
+        estimate.setRemoteCost(estimate.getRemoteCost() * costScaleFactor);
+        estimate.setLocalCostPerParallelTask(estimate.getLocalCostPerParallelTask() * costScaleFactor);
+        estimate.setRemoteCostPerParallelTask(estimate.getRemoteCostPerParallelTask() * costScaleFactor);
+    }
+
+    private OptimizablePredicate getUsefulPredicateForUnionedIndexScan(OptimizablePredicateList predicateList) throws StandardException {
+        // Only consider the unioned index scan path once per table,
+        // on the first conglomerate, or on the current, user-specified one.
+        boolean hintedIndex = getUserSpecifiedIndexName() != null;
+        if (currentAccessPath.getConglomerateDescriptor().isIndex() &&
+            !hintedIndex)
+            return null;
+        if (currentAccessPath.getUisRowIdJoinBackToBaseTableResultSet() != null)
+            return null;
+        if (predicateList == null)
+            return null;
+        AccessPath accessPath = hintedIndex ? currentAccessPath : null;
+        return predicateList.getUsefulPredicateForUnionedIndexScan(this, accessPath, currentAccessPath.getOptimizer());
+    }
+
+    // Generate a new AccessPath with its unionOfIndexes field populated
+    // with a UnionNode of the PK or index accesses to perform, if legal.
+    // Otherwise, return null.
+    private AccessPath buildUnionedScans(OptimizablePredicate uisPred,
+                                         Optimizer optimizer) throws StandardException {
+        List<OptimizablePredicateList> predicateLists;
+        FromTable combinedResults = null;
+        predicateLists = uisPred.separateOredPredicates();
+        if (predicateLists == null || predicateLists.size() == 0)
+            return null;
+
+        FromBaseTable baseTable;
+        for (OptimizablePredicateList predList:predicateLists) {
+            baseTable = shallowClone();
+            baseTable.setIndexFriendlyJoinsOnly(true);
+            if (predList.size() != 1)
+                return null;
+
+            AccessPath currentAccessPath = getCurrentAccessPath();
+            JoinStrategy currentJoinStrategy=currentAccessPath.getJoinStrategy();
+            currentJoinStrategy.getBasePredicates(predList, baseTable.baseTableRestrictionList, this);
+            if (combinedResults != null) {
+                combinedResults = getUnionNode(combinedResults, baseTable, optimizer);
+                if (combinedResults == null)
+                    return null;
+            }
+            else
+                combinedResults = baseTable;
+        }
+
+        combinedResults.setOuterTableOnly(true);
+        AccessPath uisAccessPath = new AccessPathImpl(optimizer);
+        uisAccessPath.copy(currentAccessPath);
+        uisAccessPath.setUisPredicate((Predicate)uisPred);
+        uisAccessPath.setUnionOfIndexes(combinedResults);
+        return uisAccessPath;
+    }
+
+    // RCL with a single BASEROWID.
+    ResultColumnList singleRowIdColumnResultColumnList() throws StandardException {
+        String columnName = BASEROWID;
+        ColumnReference columnReference = (ColumnReference) getNodeFactory().getNode(
+                                C_NodeTypes.COLUMN_REFERENCE,
+                                columnName,
+                                getTableName(),
+                                getContextManager());
+
+        ResultColumn rowIdResultColumn =
+            (ResultColumn)getNodeFactory().getNode(
+                C_NodeTypes.RESULT_COLUMN,
+                columnName,
+                columnReference,
+                getContextManager());
+        ResultColumnList
+            newList=(ResultColumnList)getNodeFactory().getNode(
+                    C_NodeTypes.RESULT_COLUMN_LIST,
+                    getContextManager());
+
+        newList.addResultColumn(rowIdResultColumn);
+        return newList;
+    }
+
+    // Add a BASEROWID2 column referencing the base rowid of the outer table of the current join.
+    void addOuterTableRowIdToRCList(ResultColumnList resultColumnList, FromTable outerTable) throws StandardException {
+        String columnName = BASEROWID;
+        ColumnReference columnReference = (ColumnReference) getNodeFactory().getNode(
+                                C_NodeTypes.COLUMN_REFERENCE,
+                                columnName,
+                                outerTable.getTableName(),
+                                getContextManager());
+        ResultColumn rowIdResultColumn =
+            (ResultColumn)getNodeFactory().getNode(
+                C_NodeTypes.RESULT_COLUMN,
+                BASEROWID2,
+                columnReference,
+                getContextManager());
+
+        resultColumnList.addResultColumn(rowIdResultColumn);
+    }
+
+    // Build one branch of the UNION tree for UIS access path.
+    ResultSetNode buildSelectNode(ResultSetNode source, Optimizer optimizer) throws StandardException {
+        if (source instanceof UnionNode)
+            return source;
+        PredicateList predList;
+        ValueNode whereClause = null;
+        Predicate pred = null;
+        if (source instanceof FromBaseTable) {
+            predList = new PredicateList();
+            FromBaseTable baseTable = (FromBaseTable)source;
+            optimizer.getJoinStrategy(0).putBasePredicates(predList, baseTable.baseTableRestrictionList);
+            if (predList.size() > 1)
+                throw StandardException.newException(LANG_INTERNAL_ERROR,
+                    "Improperly built internal predicate list while processing unioned index scan.");
+            pred = (Predicate)predList.getOptPredicate(0);
+            whereClause = pred.getAndNode();
+       }
+       else
+           throw StandardException.newException(LANG_INTERNAL_ERROR,
+                "Expected a base table source while processing unioned index scan.");
+
+       FromList fromList = (FromList) getNodeFactory().getNode(
+                                    C_NodeTypes.FROM_LIST,
+                                    getNodeFactory().doJoinOrderOptimization(),
+                                    getContextManager());
+       if (!(source instanceof FromBaseTable)) {
+           throw StandardException.newException(LANG_INTERNAL_ERROR,
+            "Unexpected inner table source result set while processing unioned index scan.");
+       }
+       FromBaseTable innerTableCopy = ((FromBaseTable)source).shallowClone();
+       innerTableCopy.setIndexFriendlyJoinsOnly(true);
+
+       fromList.addFromTable(innerTableCopy);
+       ResultColumnList resultColumnList = singleRowIdColumnResultColumnList();
+
+       if (pred.getReferencedSet().cardinality() > 1) {
+           int joinPosition = optimizer.getJoinPosition();
+           if (joinPosition > 0) {
+               FromTable outerTable = (FromTable) optimizer.getOuterTable();
+               ProjectRestrictNode
+                   projectRestrict = outerTable instanceof ProjectRestrictNode ?
+                                     (ProjectRestrictNode) outerTable : null;
+
+               // Traverse to the named table.  A FromTable is expected
+               // to be named in order to do proper binding.
+               while (outerTable instanceof SingleChildResultSetNode) {
+                   if (outerTable.getTableName() != null)
+                       break;
+
+                   SingleChildResultSetNode resultSetNode = (SingleChildResultSetNode) outerTable;
+                   outerTable = (FromTable)resultSetNode.getChildResult();
+               }
+               FromBaseTable outerBaseTable = null;
+               ResultSetNode unionIndexScanResultSet = null;
+               if (!(outerTable instanceof FromBaseTable)) {
+                   if (outerTable.getCorrelationName() == null)
+                       throw StandardException.newException(LANG_INTERNAL_ERROR,
+                        "Unexpected outer table source result set while processing unioned index scan.");
+               }
+               else {
+                   outerBaseTable = (FromBaseTable) outerTable;
+                   unionIndexScanResultSet = outerBaseTable.getUnionIndexScanResultSet();
+               }
+               FromTable outerRelation;
+               if (unionIndexScanResultSet != null)
+                   outerRelation = (FromTable) unionIndexScanResultSet;
+               else {
+                   outerRelation = outerBaseTable.shallowClone();
+                   boolean noError =
+                       addPredsFromOuterRestrictionList(projectRestrict, whereClause);
+                   // If an error occurred in constructing the UNIONs, abandon the
+                   // attempt at this access path.
+                   if (!noError)
+                       return null;
+
+                   // Need to correlate each reference to an outer table row in the inner
+                   // result set with the matching outer table row in the join back to the
+                   // outer table.  Save the base rowid to facilitate this join back.
+                   addOuterTableRowIdToRCList(resultColumnList, outerRelation);
+               }
+
+               // Join predicates that enable the union index scans require
+               // that current optimizable be planned as the inner table,
+               // so mark the other table as outer table only.
+               outerRelation.setOuterTableOnly(true);
+               fromList.addFromTable(outerRelation);
+           }
+       }
+
+       SelectNode selectNode = (SelectNode) getNodeFactory().getNode(
+                            C_NodeTypes.SELECT_NODE,
+                            resultColumnList,
+                            null,
+                            fromList,
+                            whereClause,
+                            null,
+                            null,
+                            null,
+                            getContextManager());
+       return selectNode;
+    }
+
+    // If the UIS access path table has join predicates, pull in the single-table predicates
+    // on the outer tables so they can reduce the number of rows considered in the join of each
+    // UNION branch of a UIS access path.
+    private boolean addPredsFromOuterRestrictionList(ProjectRestrictNode projectRestrict, ValueNode whereClause) {
+       if (projectRestrict != null) {
+           PredicateList restrictionList = null;
+           restrictionList = projectRestrict.getRestrictionList();
+           // Applying Unioned Index Scan join predicates is typically only effective
+           // if the outer table has predicates limiting the scan.
+           // Avoid costly plans with no such predicates for now, unless we can find
+           // some reason to use them in the future.
+           if (restrictionList == null || restrictionList.isEmpty())
+               return false;
+           if (restrictionList != null) {
+               CloneCRsVisitor cloneCRsVisitor = new CloneCRsVisitor();
+               cloneCRsVisitor.setInitializeSourceOfCR(true);
+               AndNode tempAnd = (AndNode)whereClause;
+   nextPred:   for(int i=0; i < restrictionList.size(); i++) {
+                   Predicate predicate = restrictionList.elementAt(i);
+                   AndNode andNodeToAdd = predicate.getAndNode();
+                   if (tempAnd == andNodeToAdd)
+                       continue nextPred;
+                   while (!tempAnd.getRightOperand().isBooleanTrue()) {
+                       tempAnd = (AndNode) tempAnd.getRightOperand();
+                       if (tempAnd == andNodeToAdd)
+                           continue nextPred;
+                   }
+                   try {
+                       andNodeToAdd = (AndNode)andNodeToAdd.accept(cloneCRsVisitor);
+                   }
+                   catch (StandardException e) {
+                       // If unable to clone all ColumnReferences, it is
+                       // unsafe to use this predicate tree.
+                       return false;
+                   }
+                   tempAnd.setRightOperand(andNodeToAdd);
+               }
+           }
+       }
+       return true;
+    }
+
+    // Build a UNION node between 2 branches in a Unioned Index Scans access path.
+    private FromTable getUnionNode(ResultSetNode leftSide, FromTable rightSide, Optimizer optimizer) throws StandardException {
+       ResultSetNode leftTree = buildSelectNode(leftSide, optimizer);
+       if (leftTree == null)
+           return null;
+       ResultSetNode rightTree = buildSelectNode(rightSide, optimizer);
+       if (rightTree == null)
+           return null;
+
+       return
+        (FromTable) getNodeFactory().getNode(
+                C_NodeTypes.UNION_NODE,
+                leftTree,
+                rightTree,
+                Boolean.FALSE,
+                Boolean.FALSE,
+                null,
+                getContextManager());
+    }
+
     CostEstimate estimateCostHelper(OptimizablePredicateList predList,
                                     ConglomerateDescriptor cd,
                                     CostEstimate outerCost,
@@ -1050,7 +1783,7 @@ public class FromBaseTable extends FromTable {
 
                 //skip join predicates unless they support predicate pushdown
                 if(!p.isHashableJoinPredicate()&& !p.isFullJoinPredicate() || currentJoinStrategy.allowsJoinPredicatePushdown()) {
-                    scf.addPredicate(p, defaultSelectivityFactor);
+                    scf.addPredicate(p, defaultSelectivityFactor, optimizer);
                     numUnusedLeadingIndexFields = currentAccessPath.getNumUnusedLeadingIndexFields();
                 }
             }
@@ -1196,6 +1929,8 @@ public class FromBaseTable extends FromTable {
     @Override
     public ResultSetNode bindNonVTITables(DataDictionary dataDictionary,
                                           FromList fromListParam)throws StandardException{
+        if (skipBindAndOptimize)
+            return this;
         TableDescriptor tableDescriptor=bindTableDescriptor();
 
         int tableType = tableDescriptor.getTableType();
@@ -1273,7 +2008,10 @@ public class FromBaseTable extends FromTable {
                 if(SanityManager.DEBUG){
                     //noinspection ConstantConditions
                     SanityManager.ASSERT(vd!=null,"vd not expected to be null for "+tableName);
-                }
+                }        // make sure there's a restriction list
+        restrictionList=(PredicateList)getNodeFactory().getNode(C_NodeTypes.PREDICATE_LIST, getContextManager());
+        baseTableRestrictionList=(PredicateList)getNodeFactory().getNode(C_NodeTypes.PREDICATE_LIST, getContextManager());
+
 
                 cvn=(CreateViewNode)parseStatement(vd.getViewText(),false);
 
@@ -1634,6 +2372,35 @@ public class FromBaseTable extends FromTable {
         /* Nothing to do, since RCL bound in bindNonVTITables() */
     }
 
+    private void buildRowIdColumn(boolean isRowId) throws StandardException {
+        String colName = isRowId ? ROWID : BASEROWID;
+
+        if(rowIdColumn==null){
+            ResultColumn match = resultColumns.getResultColumn(colName);
+            if (match != null) {
+                rowIdColumn = match;
+                return;
+            }
+
+            ValueNode rowLocationNode=(ValueNode)getNodeFactory().getNode(
+                    C_NodeTypes.CURRENT_ROW_LOCATION_NODE,
+                    getContextManager());
+
+            rowLocationNode.setType(new DataTypeDescriptor(TypeId.getBuiltInTypeId(TypeId.REF_NAME),
+                            false        /* Not nullable */
+                    )
+            );
+
+            rowIdColumn=(ResultColumn)getNodeFactory().getNode(
+                    C_NodeTypes.RESULT_COLUMN,
+                    colName,
+                    rowLocationNode,
+                    getContextManager());
+
+            rowIdColumn.markGenerated();
+        }
+    }
+
     /**
      * Try to find a ResultColumn in the table represented by this FromBaseTable
      * that matches the name in the given ColumnReference.
@@ -1693,23 +2460,8 @@ public class FromBaseTable extends FromTable {
                     referencedColumnMap.set(resultColumn.getColumnPosition());
                     tableDescriptor.setReferencedColumnMap(referencedColumnMap);
                 }
-            }else if(columnReference.columnName.compareTo("ROWID")==0){
-                if(rowIdColumn==null){
-                    ValueNode rowLocationNode=(ValueNode)getNodeFactory().getNode(
-                            C_NodeTypes.CURRENT_ROW_LOCATION_NODE,
-                            getContextManager());
-
-                    rowLocationNode.setType(new DataTypeDescriptor(TypeId.getBuiltInTypeId(TypeId.REF_NAME),
-                                    false        /* Not nullable */
-                            )
-                    );
-
-                    rowIdColumn=(ResultColumn)getNodeFactory().getNode(
-                            C_NodeTypes.RESULT_COLUMN,
-                            columnReference.columnName,
-                            rowLocationNode,
-                            getContextManager());
-                }
+            }else if(isBaseRowIdOrRowId(columnReference.columnName)){
+                buildRowIdColumn(isRowId(columnReference.columnName));
                 columnReference.setTableNumber(tableNumber);
                 resultColumn=rowIdColumn;
             }
@@ -1788,13 +2540,9 @@ public class FromBaseTable extends FromTable {
          */
         prRCList.doProjection(true);
 
-        // Add rowId column to prRCList
-        if(rowIdColumn!=null){
-            prRCList.addResultColumn(rowIdColumn);
-        }
-
         /* Finally, we create the new ProjectRestrictNode */
-        return (ResultSetNode)getNodeFactory().getNode(
+        ResultSetNode projectRestrict =
+            (ResultSetNode)getNodeFactory().getNode(
                 C_NodeTypes.PROJECT_RESTRICT_NODE,
                 this,
                 prRCList,
@@ -1804,6 +2552,13 @@ public class FromBaseTable extends FromTable {
                 null,    /* Restrict subquery list */
                 null,
                 getContextManager());
+
+        // Add rowId column to prRCList
+        if(rowIdColumn!=null){
+            ((CurrentRowLocationNode)rowIdColumn.getExpression()).setSourceResultSet(projectRestrict);
+            prRCList.addResultColumn(rowIdColumn);
+        }
+        return projectRestrict;
     }
 
     private void markFirstColumnReferencedForIndexIteratorMode() throws StandardException {
@@ -2016,6 +2771,11 @@ public class FromBaseTable extends FromTable {
                     baseConglomerateDescriptor,
                     false);
             templateColumns.addRCForRID();
+            // Resolve the row id column to the last column in the index
+            // instead of the index row's CurrentRowLocation (key) if the
+            // base row id is requested.
+            if (rowIdColumn != null && isBaseRowId(rowIdColumn.getName()))
+                resultColumns.addRCForRID();
 
             // If this is for update then we need to get the RID in the result row
             if(forUpdate()){
@@ -2336,7 +3096,10 @@ public class FromBaseTable extends FromTable {
             }
         }
 
-        generateResultSet(acb,mb);
+        if (getTrulyTheBestAccessPath().getUisRowIdJoinBackToBaseTableResultSet() != null)
+            getTrulyTheBestAccessPath().getUisRowIdJoinBackToBaseTableResultSet().generate(acb, mb);
+        else
+            generateResultSet(acb,mb);
 
         /*
         ** Remember if this base table is the cursor target table, so we can
@@ -3625,9 +4388,11 @@ public class FromBaseTable extends FromTable {
 
     private String getUserSpecifiedIndexName(){
         String retval=null;
+        if (userSpecifiedIndexName != null)
+            return userSpecifiedIndexName;
 
         if(tableProperties!=null){
-            retval=tableProperties.getProperty("index");
+            retval=tableProperties.getProperty(INDEX_PROPERTY_NAME);
         }
 
         return retval;
@@ -3685,6 +4450,9 @@ public class FromBaseTable extends FromTable {
         int index=-1;
 
         if (currCD != null){
+            if (considerOnlyBaseConglomerate)
+                return null;
+
             for (index=0; index < conglomDescs.length; index++) {
                 if (currCD == conglomDescs[index]) {
                     break;
@@ -3694,6 +4462,12 @@ public class FromBaseTable extends FromTable {
 
         index ++;
         while (index<conglomDescs.length) {
+            if (considerOnlyBaseConglomerate) {
+                if (!conglomDescs[index].isIndex())
+                    return conglomDescs[index];
+                index ++;
+                continue;
+            }
             if (isIndexEligible(conglomDescs[index], predList))
                 return conglomDescs[index];
             tracer.trace(OptimizerFlag.SPARSE_INDEX_NOT_ELIGIBLE,0,0,0.0,conglomDescs[index]);
@@ -3752,6 +4526,10 @@ public class FromBaseTable extends FromTable {
         if(requalificationRestrictionList!=null){
             requalificationRestrictionList.accept(v, this);
         }
+
+        if (uisRowIdJoinBackToBaseTableResultSet!=null) {
+            uisRowIdJoinBackToBaseTableResultSet.accept(v, this);
+        }
     }
 
     @Override
@@ -3790,6 +4568,9 @@ public class FromBaseTable extends FromTable {
                 .append(",").append(getFinalCostEstimate(false).prettyFromBaseTableString());
         if (indexName != null)
             sb.append(",baseTable=").append(getPrettyTableName());
+        List<String> keys =  Lists.transform(PredicateUtils.PLtoList(RSUtils.getKeyPreds(this)), PredicateUtils.predToString);
+        if(keys!=null && !keys.isEmpty()) //add
+            sb.append(",keys=[").append(Joiner.on(",").skipNulls().join(keys)).append("]");
         List<String> qualifiers =  Lists.transform(PredicateUtils.PLtoList(RSUtils.getPreds(this)), PredicateUtils.predToString);
         if(qualifiers!=null && !qualifiers.isEmpty()) //add
             sb.append(",preds=[").append(Joiner.on(",").skipNulls().join(qualifiers)).append("]");
@@ -3807,6 +4588,9 @@ public class FromBaseTable extends FromTable {
         sb.append(getFinalCostEstimate(false).prettyFromBaseTableString(attrDelim));
         if (indexName != null)
             sb.append(attrDelim).append("baseTable=").append(getPrettyTableName());
+        List<String> keys =  Lists.transform(PredicateUtils.PLtoList(RSUtils.getKeyPreds(this)), PredicateUtils.predToString);
+        if (keys != null && !keys.isEmpty())
+            sb.append(attrDelim).append("keys=[").append(Joiner.on(",").skipNulls().join(keys)).append("]");
         List<String> qualifiers = Lists.transform(PredicateUtils.PLtoList(RSUtils.getPreds(this)), PredicateUtils.predToString);
         if (qualifiers != null && !qualifiers.isEmpty())
             sb.append(attrDelim).append("preds=[").append(Joiner.on(",").skipNulls().join(qualifiers)).append("]");
@@ -3846,9 +4630,12 @@ public class FromBaseTable extends FromTable {
     }
 
     @Override
-    public void buildTree(Collection<QueryTreeNode> tree, int depth) throws StandardException {
-        setDepth(depth);
-        tree.add(this);
+    public void buildTree(Collection<Pair<QueryTreeNode,Integer>> tree, int depth) throws StandardException {
+        if (getTrulyTheBestAccessPath().getUisRowIdJoinBackToBaseTableResultSet() != null) {
+            getTrulyTheBestAccessPath().getUisRowIdJoinBackToBaseTableResultSet().buildTree(tree, depth);
+            return;
+        }
+        addNodeToExplainTree(tree, this, depth);
         /* predicates in restrictionList after post-opt stage should be redundant, as all the predicates
            should have been either in storeRestrictionList or nonStoreRestrictionList.
            When searching the current FromBaseTable node for subqueries, we may get duplicate SubqueryNodes.
@@ -3950,6 +4737,10 @@ public class FromBaseTable extends FromTable {
 
     public void setReferencingExpressions(Map<Integer, Set<ValueNode>> exprMap) {
         referencingExpressions = exprMap.get(tableNumber);
+    }
+
+    public void setReferencingExpressionsFromOther(Set<ValueNode> referencingExpressions) {
+        this.referencingExpressions = referencingExpressions;
     }
 
     @Override
@@ -4061,5 +4852,101 @@ public class FromBaseTable extends FromTable {
         return !skipStats &&
                useRealTableStats &&
                currentIndexFirstColumnStats.getFirstIndexColumnCardinality() <= maxPrefixIteratorValues;
+    }
+
+    public void setMinRetentionPeriod(long minRetentionPeriod) {
+        this.minRetentionPeriod = minRetentionPeriod;
+    }
+
+    public void setColumnNames(String [] columnNames) {
+        this.columnNames = columnNames;
+    }
+
+    public FromBaseTable shallowClone() throws StandardException {
+        FromBaseTable
+           fromBaseTable = (FromBaseTable) getNodeFactory().getNode(
+                                        C_NodeTypes.FROM_BASE_TABLE,
+                                        tableName,
+                                        correlationName,
+                                        resultColumns,
+                                        null,
+                                        isBulkDelete,
+                                        pastTxIdExpression,
+                                        getContextManager());
+        // make sure there's a restriction list
+        fromBaseTable.restrictionList=(PredicateList)getNodeFactory().getNode(C_NodeTypes.PREDICATE_LIST, getContextManager());
+        fromBaseTable.baseTableRestrictionList=(PredicateList)getNodeFactory().getNode(C_NodeTypes.PREDICATE_LIST, getContextManager());
+
+        fromBaseTable.shallowCopy(this);
+        return fromBaseTable;
+    }
+
+    @Override
+    protected void shallowCopy(ResultSetNode otherResultSet) throws StandardException {
+        super.shallowCopy(otherResultSet);
+        if (!(otherResultSet instanceof FromBaseTable))
+            return;
+
+        FromBaseTable other = (FromBaseTable)otherResultSet;
+
+        tableDescriptor            = other.tableDescriptor;
+        baseConglomerateDescriptor = other.baseConglomerateDescriptor;
+        conglomDescs               = other.conglomDescs;
+        updateOrDelete             = other.updateOrDelete;
+        skipStats                  = other.skipStats;
+        useRealTableStats          = other.useRealTableStats;
+        splits                     = other.splits;
+        defaultRowCount            = other.defaultRowCount;
+        defaultSelectivityFactor   = other.defaultSelectivityFactor;
+        bulkFetch                  = other.bulkFetch;
+        bulkFetchTurnedOff         = other.bulkFetchTurnedOff;
+        setColumnNames(other.columnNames);
+        if (other.distinctScan)
+            markForDistinctScan();
+
+        // The following items are intentionally not copied.
+        // Each table must have its own unshared predicates.
+        // baseTableRestrictionList       = other.baseTableRestrictionList;
+        // nonBaseTableRestrictionList    = other.nonBaseTableRestrictionList;
+        // storeRestrictionList           = other.storeRestrictionList;
+        // nonStoreRestrictionList        = other.nonStoreRestrictionList;
+        // requalificationRestrictionList = other.requalificationRestrictionList;
+
+        setAntiJoin(other.isAntiJoin);
+        setAggregateForSpecialMaxScan(other.aggrForSpecialMaxScan);
+        setMinRetentionPeriod(other.minRetentionPeriod);
+        setReferencingExpressionsFromOther(other.referencingExpressions);
+    }
+
+    public void setConsiderOnlyBaseConglomerate(boolean considerOnlyBaseConglomerate) {
+        this.considerOnlyBaseConglomerate = considerOnlyBaseConglomerate;
+    }
+
+    @Override
+    public boolean outerTableOnly() {
+        if (outerTableOnly)
+            return true;
+        return (bestAccessPath != null &&
+                bestAccessPath.getUisRowIdJoinBackToBaseTableResultSet() != null) ||
+               (trulyTheBestAccessPath != null &&
+                trulyTheBestAccessPath.getUisRowIdJoinBackToBaseTableResultSet() != null);
+    }
+
+    // Save the Unioned Index Scans statement tree from the access path into the base table,
+    // and finalize the tree by doing the AFTER_OPTIMIZE walking of the AST.
+    @Override
+    protected void recordUisAccessPath(AccessPath ap) throws StandardException {
+        super.recordUisAccessPath(ap);
+        uisRowIdJoinBackToBaseTableResultSet = ap.getUisRowIdJoinBackToBaseTableResultSet();
+        if (uisRowIdJoinBackToBaseTableResultSet != null) {
+            walkAST(getLanguageConnectionContext(),
+                    uisRowIdJoinBackToBaseTableResultSet,
+                    CompilationPhase.AFTER_OPTIMIZE);
+            uisRowIdJoinBackToBaseTableResultSet.assignResultSetNumber();
+        }
+    }
+
+    public double getSingleScanRowCount() {
+        return singleScanRowCount;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -1586,6 +1586,8 @@ public class FromBaseTable extends FromTable {
                outerRelation.setOuterTableOnly(true);
                fromList.addFromTable(outerRelation);
            }
+           else  // Must be joining to a table if the UIS predicate is a join predicate
+               return null;
        }
 
        SelectNode selectNode = (SelectNode) getNodeFactory().getNode(

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromSubquery.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromSubquery.java
@@ -419,7 +419,7 @@ public class FromSubquery extends FromTable
     {
 
         if(subquery != null && subquery instanceof SelectNode){
-            ResultColumnList rcl = subquery.resultColumns;
+            ResultColumnList rcl = subquery.getResultColumns();
             HashMap<String, ResultColumn> hs = new HashMap<>();
 
             for(ResultColumn rc : rcl){

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
@@ -368,10 +368,7 @@ public abstract class FromTable extends ResultSetNode implements Optimizable{
         JoinStrategy joinStrategy=currentAccessPath.getJoinStrategy();
         ap.setJoinStrategy(joinStrategy);
         ap.setHintedJoinStrategy(currentAccessPath.isHintedJoinStrategy());
-        ap.setUisPredicate(currentAccessPath.getUisPredicate());
-        ap.setUisRowIdPredicate(currentAccessPath.getUisRowIdPredicate());
-        ap.setUnionOfIndexes(currentAccessPath.getUnionOfIndexes());
-        ap.setUisRowIdJoinBackToBaseTableResultSet(currentAccessPath.getUisRowIdJoinBackToBaseTableResultSet());
+        ap.setUisFields(currentAccessPath);
         if (joinStrategy.getJoinStrategyType() == JoinStrategy.JoinStrategyType.BROADCAST)
             ap.setMissingHashKeyOK(currentAccessPath.isMissingHashKeyOK());
         else

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
@@ -1589,7 +1589,12 @@ public abstract class FromTable extends ResultSetNode implements Optimizable{
         return outerTableOnly;
     }
 
-    public void setOuterTableOnly(boolean outerTableOnly) {
+    // This is a special-purpose method for tagging an optimizable to be used
+    // as the outer table of a join in very limited scenarios, usually when
+    // we are planning only a single join between it and another table.
+    // Please do not use this for queries of all forms, and only
+    // use it if you have a targeted, specific and limited use case.
+    protected void setOuterTableOnly(boolean outerTableOnly) {
         this.outerTableOnly = outerTableOnly;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
@@ -294,6 +294,13 @@ public abstract class FromTable extends ResultSetNode implements Optimizable{
                     correlationName);
             }
         }
+        // Reset Unioned Index Scans access path in case the
+        // previous path chose to use it.
+        ap.setUisPredicate(null);
+        ap.setUisRowIdPredicate(null);
+        ap.setUnionOfIndexes(null);
+        ap.setUisRowIdJoinBackToBaseTableResultSet(null);
+
         ap.setMissingHashKeyOK(false);
 
         // Tell the RowOrdering about columns that are equal to constant

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromVTI.java
@@ -35,7 +35,6 @@ import com.splicemachine.db.catalog.TypeDescriptor;
 import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.catalog.types.RoutineAliasInfo;
 import com.splicemachine.db.iapi.error.StandardException;
-import com.splicemachine.db.iapi.jdbc.ConnectionContext;
 import com.splicemachine.db.iapi.reference.ClassName;
 import com.splicemachine.db.iapi.reference.Property;
 import com.splicemachine.db.iapi.reference.SQLState;
@@ -61,6 +60,7 @@ import com.splicemachine.db.impl.sql.execute.*;
 import com.splicemachine.db.vti.*;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.SerializationUtils;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -201,6 +201,18 @@ public class FromVTI extends FromTable implements VTIEnvironment {
         ap.setMissingHashKeyOK(false);
         bestAp.setMissingHashKeyOK(false);
         bestSortAp.setMissingHashKeyOK(false);
+        ap.setUisPredicate(null);
+        bestAp.setUisPredicate(null);
+        bestSortAp.setUisPredicate(null);
+        ap.setUisRowIdPredicate(null);
+        bestAp.setUisRowIdPredicate(null);
+        bestSortAp.setUisRowIdPredicate(null);
+        ap.setUnionOfIndexes(null);
+        bestAp.setUnionOfIndexes(null);
+        bestSortAp.setUnionOfIndexes(null);
+        ap.setUisRowIdJoinBackToBaseTableResultSet(null);
+        bestAp.setUisRowIdJoinBackToBaseTableResultSet(null);
+        bestSortAp.setUisRowIdJoinBackToBaseTableResultSet(null);
         ap.setNumUnusedLeadingIndexFields(0);
         bestAp.setNumUnusedLeadingIndexFields(0);
         bestSortAp.setNumUnusedLeadingIndexFields(0);
@@ -296,14 +308,7 @@ public class FromVTI extends FromTable implements VTIEnvironment {
                 estimatedCost = vtic.getEstimatedCostPerInstantiation(this);
                 estimatedRowCount = vtic.getEstimatedRowCount(this);
                 supportsMultipleInstantiations = vtic.supportsMultipleInstantiations(this);
-                costEstimate.setEstimatedCost(estimatedCost);
-                costEstimate.setRowCount(estimatedRowCount);
-                costEstimate.setSingleScanRowCount(estimatedRowCount);
-                costEstimate.setLocalCost(estimatedCost);
-                costEstimate.setRemoteCost(estimatedCost);
-                costEstimate.setLocalCostPerParallelTask(estimatedCost, costEstimate.getParallelism());
-                costEstimate.setRemoteCostPerParallelTask(estimatedCost, costEstimate.getParallelism());
-
+                updateCostEstimate();
             }
             catch (SQLException sqle)
             {
@@ -311,6 +316,11 @@ public class FromVTI extends FromTable implements VTIEnvironment {
             }
             vtiCosted = true;
         }
+        else {
+            // Copy the defaults into the CostEstimate.
+            updateCostEstimate();
+        }
+
 
         AccessPath currentAccessPath=getCurrentAccessPath();
         JoinStrategy currentJoinStrategy=currentAccessPath.getJoinStrategy();
@@ -322,6 +332,16 @@ public class FromVTI extends FromTable implements VTIEnvironment {
         tracer.trace(OptimizerFlag.COST_OF_N_SCANS,tableNumber,0,outerCost.rowCount(),costEstimate, correlationName);
 
         return costEstimate;
+    }
+
+    private void updateCostEstimate() {
+        costEstimate.setEstimatedCost(estimatedCost);
+        costEstimate.setRowCount(estimatedRowCount);
+        costEstimate.setSingleScanRowCount(estimatedRowCount);
+        costEstimate.setLocalCost(estimatedCost);
+        costEstimate.setRemoteCost(estimatedCost);
+        costEstimate.setLocalCostPerParallelTask(estimatedCost, costEstimate.getParallelism());
+        costEstimate.setRemoteCostPerParallelTask(estimatedCost, costEstimate.getParallelism());
     }
 
     /**
@@ -2023,9 +2043,8 @@ public class FromVTI extends FromTable implements VTIEnvironment {
         }
     }
 
-    public void buildTree(Collection<QueryTreeNode> tree, int depth) {
-        setDepth(depth);
-        tree.add(this);
+    public void buildTree(Collection<Pair<QueryTreeNode,Integer>> tree, int depth) {
+        addNodeToExplainTree(tree, this, depth);
     }
 
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashTableNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashTableNode.java
@@ -73,7 +73,7 @@ public class HashTableNode extends SingleChildResultSetNode
 	 * @param searchPredicateList	Single table clauses
 	 * @param joinPredicateList		Multi table clauses
 	 * @param accessPath			The access path
-	 * @param costEstimate			The cost estimate
+	 * @param costEstimate			The cost estimateuisRowIdJoinBackToBaseTableResultSet
 	 * @param pSubqueryList			List of subqueries in RCL
 	 * @param rSubqueryList			List of subqueries in Predicate lists
 	 * @param hashKeyColumns		Hash key columns

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HashableJoinStrategy.java
@@ -61,6 +61,8 @@ public abstract class HashableJoinStrategy extends BaseJoinStrategy {
                             CostEstimate outerCost,
                             boolean wasHinted,
                             boolean skipKeyCheck) throws StandardException {
+        if (optimizer.getJoinPosition() > 0 && innerTable.outerTableOnly())
+            return false;
         int[] hashKeyColumns;
         ConglomerateDescriptor cd = null;
         OptimizerTrace tracer = optimizer.tracer();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
@@ -523,10 +523,13 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 			rightBCO.bindComparisonOperator();
 
 			/* Create the AND */
+			// leftSide comes from leftOperand, but we want the AND nodes
+			// to be normalized (right-linked), so leftSide is passed as the
+			// right operand of the new AND.
 			newAnd = (AndNode) getNodeFactory().getNode(
 												C_NodeTypes.AND_NODE,
-												leftSide,
 												rightBCO,
+												leftSide,
 												getContextManager());
 			newAnd.postBindFixup();
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IndexToBaseRowNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IndexToBaseRowNode.java
@@ -43,6 +43,7 @@ import com.splicemachine.db.iapi.sql.compile.RequiredRowOrdering;
 import com.splicemachine.db.iapi.sql.compile.Visitor;
 import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.store.access.StaticCompiledOpenConglomInfo;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Collection;
 import java.util.Vector;
@@ -395,9 +396,8 @@ public class IndexToBaseRowNode extends FromTable{
         }
     }
     @Override
-    public void buildTree(Collection<QueryTreeNode> tree, int depth) throws StandardException{
-        setDepth(depth);
-        tree.add(this);
+    public void buildTree(Collection<Pair<QueryTreeNode,Integer>> tree, int depth) throws StandardException{
+        addNodeToExplainTree(tree, this, depth);
         source.buildTree(tree,depth+1);
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IsNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IsNode.java
@@ -37,6 +37,7 @@ import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 
 import com.splicemachine.db.iapi.reference.ClassName;
 import com.splicemachine.db.iapi.services.classfile.VMOpcode;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 
 import java.util.List;
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
@@ -190,6 +190,8 @@ public class JoinNode extends TableOperatorNode{
                                    OptimizablePredicateList predList,
                                    CostEstimate outerCost,
                                    RowOrdering rowOrdering) throws StandardException{
+        if (skipBindAndOptimize)
+            return costEstimate;
         optimizer.tracer().trace(OptimizerFlag.CALLING_ON_JOIN_NODE,0,0,0.0,null);
 
         // It's possible that a call to optimize the left/right will cause
@@ -534,6 +536,14 @@ public class JoinNode extends TableOperatorNode{
      */
     @Override
     public ResultColumn getMatchingColumn(ColumnReference columnReference) throws StandardException{
+        if (skipBindAndOptimize) {
+            if (getTableName() != null &&
+                getTableName().getTableName() != null &&
+                getTableName().getTableName().equals(columnReference.getTableName()))
+                return resultColumns.getResultColumn(columnReference.getColumnName(), true);
+            else
+                return null;
+        }
         /* Get the logical left and right sides of the join.
          * (For RIGHT OUTER JOIN, the left is the right
          * and the right is the left and the JOIN is the NIOJ).
@@ -627,6 +637,8 @@ public class JoinNode extends TableOperatorNode{
      */
     @Override
     public void bindExpressions(FromList fromListParam) throws StandardException{
+        if (skipBindAndOptimize)
+            return;
         super.bindExpressions(fromListParam);
 
         // Now that both the left and the right side of the join have been
@@ -648,6 +660,8 @@ public class JoinNode extends TableOperatorNode{
      */
     @Override
     public void bindResultColumns(FromList fromListParam) throws StandardException{
+        if (skipBindAndOptimize)
+            return;
         super.bindResultColumns(fromListParam);
 
         /* Now we build our RCL */
@@ -696,6 +710,8 @@ public class JoinNode extends TableOperatorNode{
                                   ResultColumnList targetColumnList,
                                   DMLStatementNode statement,
                                   FromList fromListParam) throws StandardException{
+        if (skipBindAndOptimize)
+            return;
         super.bindResultColumns(targetTableDescriptor,targetVTI,targetColumnList,statement,fromListParam);
 
         /* Now we build our RCL */
@@ -737,6 +753,8 @@ public class JoinNode extends TableOperatorNode{
      */
     @Override
     public ResultSetNode preprocess(int numTables, GroupByList gbl, FromList fromList) throws StandardException{
+        if (skipBindAndOptimize)
+            return this;
         ResultSetNode newTreeTop;
 
         newTreeTop=super.preprocess(numTables,gbl,fromList);
@@ -765,6 +783,8 @@ public class JoinNode extends TableOperatorNode{
                                       FromList outerFromList,
                                       SubqueryList outerSubqueryList,
                                       PredicateList outerPredicateList) throws StandardException{
+        if (skipBindAndOptimize)
+            return;
         /* Put the expression trees in conjunctive normal form.
          * NOTE - This needs to occur before we preprocess the subqueries
          * because the subquery transformations assume that any subquery operator
@@ -1951,7 +1971,7 @@ public class JoinNode extends TableOperatorNode{
         int numArgs=getNumJoinArguments();
 
         leftResultSet.generate(acb,mb); // arg 1
-        mb.push(leftResultSet.resultColumns.size()); // arg 2
+        mb.push(leftResultSet.getResultColumns().size()); // arg 2
 
         if(isNestedLoopOverHashableJoin()){
 
@@ -1987,7 +2007,7 @@ public class JoinNode extends TableOperatorNode{
         }
 
         rightResultSet.generate(acb,mb); // arg 3
-        mb.push(rightResultSet.resultColumns.size()); // arg 4
+        mb.push(rightResultSet.getResultColumns().size()); // arg 4
 
         if(rightResultSet instanceof Optimizable &&
                 (isHashableJoin(rightResultSet) || isCrossJoin())){
@@ -2303,8 +2323,8 @@ public class JoinNode extends TableOperatorNode{
         List<QueryTreeNode> refedcolmnList = collectReferencedColumns();
 
         // clear the referenced fields for both source tables
-        leftResultSet.resultColumns.setColumnReferences(false, true);
-        rightResultSet.resultColumns.setColumnReferences(false, true);
+        leftResultSet.getResultColumns().setColumnReferences(false, true);
+        rightResultSet.getResultColumns().setColumnReferences(false, true);
 
         markReferencedResultColumns(refedcolmnList);
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinPredicateSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinPredicateSelectivity.java
@@ -32,6 +32,7 @@
 package com.splicemachine.db.impl.sql.compile;
 
 import com.splicemachine.db.iapi.sql.compile.Optimizable;
+import com.splicemachine.db.iapi.sql.compile.Optimizer;
 
 /**
  * Join Predicate Selectivity Holder
@@ -39,7 +40,7 @@ import com.splicemachine.db.iapi.sql.compile.Optimizable;
  */
 public class JoinPredicateSelectivity extends DefaultPredicateSelectivity {
     public JoinPredicateSelectivity(Predicate p, Optimizable baseTable, QualifierPhase phase, double selectivity){
-        super(p, baseTable, phase, 1.0);
+        super(p, baseTable, phase, 1.0, null);
         this.selectivity = selectivity;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NotNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NotNode.java
@@ -39,6 +39,7 @@ import com.splicemachine.db.iapi.reference.ClassName;
 import com.splicemachine.db.iapi.error.StandardException;
 
 import com.splicemachine.db.iapi.services.classfile.VMOpcode;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 
 import java.lang.reflect.Modifier;
 
@@ -131,5 +132,27 @@ public final class NotNode extends UnaryLogicalOperatorNode
         mb.upCast(ClassName.DataValueDescriptor);
 
         mb.callMethod(VMOpcode.INVOKEINTERFACE, (String) null, "equals", interfaceName, 2);
+    }
+
+    @Override
+    public boolean isCloneable()
+    {
+        return true;
+    }
+
+    @Override
+    public ValueNode getClone() throws StandardException
+    {
+        ValueNode left = getOperand();
+        NotNode notNode = (NotNode) left.getNodeFactory().getNode(
+                                                    C_NodeTypes.NOT_NODE,
+                                                    left,
+                                                    left.getContextManager());
+        notNode.postBindFixup();
+        return notNode;
+    }
+
+    void postBindFixup() throws StandardException{
+        setType(getOperand().getTypeServices());
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorNode.java
@@ -505,9 +505,9 @@ public abstract class OperatorNode extends ValueNode
         }
     }
 
-    public void copy(OperatorNode other) throws StandardException
+    public void copyFrom(OperatorNode other) throws StandardException
     {
-        super.copy(other);
+        super.copyFrom(other);
         this.operator = other.operator;
         this.methodName = other.methodName;
         this.operands = new ArrayList<>(other.operands);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorNode.java
@@ -32,6 +32,7 @@
 package com.splicemachine.db.impl.sql.compile;
 
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -502,5 +503,15 @@ public abstract class OperatorNode extends ValueNode
             mb.callMethod(VMOpcode.INVOKESTATIC, ClassName.StringUtil,
                     "setIgnoreTrailingWhitespacesInVarcharComparison", "void", 2);
         }
+    }
+
+    public void copy(OperatorNode other) throws StandardException
+    {
+        super.copy(other);
+        this.operator = other.operator;
+        this.methodName = other.methodName;
+        this.operands = new ArrayList<>(other.operands);
+        this.interfaceTypes = new ArrayList<>(other.interfaceTypes);
+        this.resultInterfaceType = other.resultInterfaceType;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
@@ -2860,8 +2860,6 @@ public class OptimizerImpl implements Optimizer{
                break;
 
            SingleChildResultSetNode resultSetNode = (SingleChildResultSetNode) outerTable;
-           if (!(resultSetNode instanceof FromTable))
-               return null;
            outerTable = (FromTable)resultSetNode.getChildResult();
        }
        FromBaseTable outerBaseTable = null;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
@@ -895,6 +895,12 @@ public class OptimizerImpl implements Optimizer{
             }
 
             // If we want to re-use this Optimizable without re-planning it, return now.
+            // This is the case where nextOptimizable uses a Unioned Index Scans access path,
+            // and it is being joined with another table which itself might use a UIS access path.
+            // We want to set the join cost estimate to an uninitialized state and set assignedTableMap
+            // to include the proper tables, but we don't want to push any new predicates to this
+            // table because it has already been materialized into a sequence of statements that
+            // can't be modified.
             ResultSetNode optimizableResultSet = (ResultSetNode) optimizableList.getOptimizable(nextOptimizable);
             if (optimizableResultSet.skipBindAndOptimize) {
                 if (optimizableResultSet instanceof FromTable) {
@@ -2426,10 +2432,7 @@ public class OptimizerImpl implements Optimizer{
                 bestAp.setLockMode(currentAccessPath.getLockMode());
                 bestAp.setMissingHashKeyOK(currentAccessPath.isMissingHashKeyOK());
                 bestAp.setNumUnusedLeadingIndexFields(currentAccessPath.getNumUnusedLeadingIndexFields());
-                bestAp.setUisPredicate(currentAccessPath.getUisPredicate());
-                bestAp.setUisRowIdPredicate(currentAccessPath.getUisRowIdPredicate());
-                bestAp.setUnionOfIndexes(currentAccessPath.getUnionOfIndexes());
-                bestAp.setUisRowIdJoinBackToBaseTableResultSet(currentAccessPath.getUisRowIdJoinBackToBaseTableResultSet());
+                bestAp.setUisFields(currentAccessPath);
                 optimizable.rememberJoinStrategyAsBest(bestAp);
             }
 
@@ -2449,10 +2452,7 @@ public class OptimizerImpl implements Optimizer{
             bestAp.setLockMode(currentAccessPath.getLockMode());
             bestAp.setMissingHashKeyOK(currentAccessPath.isMissingHashKeyOK());
             bestAp.setNumUnusedLeadingIndexFields(currentAccessPath.getNumUnusedLeadingIndexFields());
-            bestAp.setUisPredicate(currentAccessPath.getUisPredicate());
-            bestAp.setUisRowIdPredicate(currentAccessPath.getUisRowIdPredicate());
-            bestAp.setUnionOfIndexes(currentAccessPath.getUnionOfIndexes());
-            bestAp.setUisRowIdJoinBackToBaseTableResultSet(currentAccessPath.getUisRowIdJoinBackToBaseTableResultSet());
+            bestAp.setUisFields(currentAccessPath);
             optimizable.rememberJoinStrategyAsBest(bestAp);
             return;
         }
@@ -2469,10 +2469,7 @@ public class OptimizerImpl implements Optimizer{
             bestAp.setLockMode(currentAccessPath.getLockMode());
             bestAp.setMissingHashKeyOK(currentAccessPath.isMissingHashKeyOK());
             bestAp.setNumUnusedLeadingIndexFields(currentAccessPath.getNumUnusedLeadingIndexFields());
-            bestAp.setUisPredicate(currentAccessPath.getUisPredicate());
-            bestAp.setUisRowIdPredicate(currentAccessPath.getUisRowIdPredicate());
-            bestAp.setUnionOfIndexes(currentAccessPath.getUnionOfIndexes());
-            bestAp.setUisRowIdJoinBackToBaseTableResultSet(currentAccessPath.getUisRowIdJoinBackToBaseTableResultSet());
+            bestAp.setUisFields(currentAccessPath);
             optimizable.rememberJoinStrategyAsBest(bestAp);
 
             /*
@@ -2503,10 +2500,7 @@ public class OptimizerImpl implements Optimizer{
             bestAp.setLockMode(currentAccessPath.getLockMode());
             bestAp.setMissingHashKeyOK(currentAccessPath.isMissingHashKeyOK());
             bestAp.setNumUnusedLeadingIndexFields(currentAccessPath.getNumUnusedLeadingIndexFields());
-            bestAp.setUisPredicate(currentAccessPath.getUisPredicate());
-            bestAp.setUisRowIdPredicate(currentAccessPath.getUisRowIdPredicate());
-            bestAp.setUnionOfIndexes(currentAccessPath.getUnionOfIndexes());
-            bestAp.setUisRowIdJoinBackToBaseTableResultSet(currentAccessPath.getUisRowIdJoinBackToBaseTableResultSet());
+            bestAp.setUisFields(currentAccessPath);
             optimizable.rememberJoinStrategyAsBest(bestAp);
         }
 
@@ -2549,10 +2543,7 @@ public class OptimizerImpl implements Optimizer{
                 ap.setSpecialMaxScan(currentAccessPath.getSpecialMaxScan());
                 ap.setMissingHashKeyOK(currentAccessPath.isMissingHashKeyOK());
                 ap.setNumUnusedLeadingIndexFields(currentAccessPath.getNumUnusedLeadingIndexFields());
-                ap.setUisPredicate(currentAccessPath.getUisPredicate());
-                ap.setUisRowIdPredicate(currentAccessPath.getUisRowIdPredicate());
-                ap.setUnionOfIndexes(currentAccessPath.getUnionOfIndexes());
-                ap.setUisRowIdJoinBackToBaseTableResultSet(currentAccessPath.getUisRowIdJoinBackToBaseTableResultSet());
+                ap.setUisFields(currentAccessPath);
 
             /*
             ** It's a non-matching index scan either if there is no
@@ -2600,10 +2591,7 @@ public class OptimizerImpl implements Optimizer{
                             ap.setSpecialMaxScan(currentAccessPath.getSpecialMaxScan());
                             ap.setMissingHashKeyOK(currentAccessPath.isMissingHashKeyOK());
                             ap.setNumUnusedLeadingIndexFields(currentAccessPath.getNumUnusedLeadingIndexFields());
-                            ap.setUisPredicate(currentAccessPath.getUisPredicate());
-                            ap.setUisRowIdPredicate(currentAccessPath.getUisRowIdPredicate());
-                            ap.setUnionOfIndexes(currentAccessPath.getUnionOfIndexes());
-                            ap.setUisRowIdJoinBackToBaseTableResultSet(currentAccessPath.getUisRowIdJoinBackToBaseTableResultSet());
+                            ap.setUisFields(currentAccessPath);
 
                         /*
                         ** It's a non-matching index scan either if there is no

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrNode.java
@@ -37,10 +37,13 @@ import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableInt;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+
+import static com.splicemachine.db.impl.sql.compile.AndNode.newAndNode;
 
 public class OrNode extends BinaryLogicalOperatorNode {
     /* Is this the 1st OR in the OR chain? */
@@ -547,6 +550,23 @@ public class OrNode extends BinaryLogicalOperatorNode {
             ((OrNode) curOr.getRightOperand()).postBindFixup();
         }
 
+        normalize();
+
+        /* Finally, we continue to normalize the left and right subtrees. */
+        setLeftOperand(getLeftOperand().changeToCNF(false));
+        setRightOperand(getRightOperand().changeToCNF(false));
+
+        // See if we can convert this OR into an AND for
+        // a more complete conversion to CNF.
+        if (underTopAndNode) {
+            ValueNode newOperator = dnfToCNF();
+            if (newOperator != null)
+                return newOperator;
+        }
+        return this;
+    }
+
+    public void normalize() {
         /* If leftOperand is an OrNode, then we modify the tree from:
          *
          *                this
@@ -586,12 +606,155 @@ public class OrNode extends BinaryLogicalOperatorNode {
             newRight.setLeftOperand(oldLeft.getRightOperand());
             newRight.setRightOperand(oldRight);
         }
+    }
 
-        /* Finally, we continue to normalize the left and right subtrees. */
-        setLeftOperand(getLeftOperand().changeToCNF(false));
-        setRightOperand(getRightOperand().changeToCNF(false));
+    private ValueNode dnfToCNF() throws StandardException {
+        // Collect the children in the chain of linked OR nodes.
+        // Any child AND nodes can be combined via the distributive property.
+        List<List<ValueNode>> linkedChildren = new ArrayList<>();
+        collectChildLists(getLeftOperand(), true, linkedChildren);
+        collectChildLists(getRightOperand(), true, linkedChildren);
+        long numDerivedPredicates = getNumDerivedPredicates(linkedChildren);
 
-        return this;
+        // If number of derived predicates we would build is 1 or less (means there are no ANDs),
+        // or larger than the maximum allowed, don't perform the expansion.
+        long maxPredicates = getCompilerContext().getMaxDerivedCNFPredicates();
+        if (numDerivedPredicates <= 1 ||
+            numDerivedPredicates > maxPredicates)
+            return null;
+        return buildCNFPredicates(linkedChildren, null, 0, null, null);
+    }
+
+    private long getNumDerivedPredicates(List<List<ValueNode>> linkedChildren) {
+        long runningCount = 1;
+        for (List<ValueNode> andedPreds:linkedChildren) {
+            runningCount *= andedPreds.size();
+            // Try to avoid overflow of runningCount.
+            if (runningCount > Integer.MAX_VALUE)
+                return runningCount;
+        }
+        return runningCount;
+    }
+
+    private ValueNode buildCNFPredicates(List<List<ValueNode>> linkedChildren,
+                                         List<OrNode> disjuncts,
+                                         int depth,
+                                         OrNode currentOrNode,
+                                         OrNode firstOrNode) throws StandardException {
+        int numberOfOrs = linkedChildren.size() - 1;
+        List<ValueNode> predicates = linkedChildren.get(depth);
+        OrNode newOrNode;
+
+        if (depth == 0)
+            disjuncts = new ArrayList<>();
+        for (ValueNode pred:predicates) {
+            newOrNode = newOrNode(pred);
+            if (depth == 0)
+                firstOrNode = newOrNode;
+            else // Build a right-linked chain of OR nodes
+                currentOrNode.setRightOperand(newOrNode);
+            if (depth < numberOfOrs) {
+                buildCNFPredicates(linkedChildren, disjuncts, depth + 1, newOrNode, firstOrNode);
+            }
+            else {
+                OrNode newOrChain =
+                    firstOrNode.shallowCloneORChain();
+                disjuncts.add(newOrChain);
+            }
+        }
+
+        // Now combine the disjunctions.
+        if (depth == 0) {
+            AndNode firstAnd = null;
+            AndNode newAndNode, currentAnd = null;
+            for (OrNode orNode:disjuncts) {
+                newAndNode = newAndNode(orNode, true);
+                if (firstAnd == null)
+                    firstAnd = newAndNode;
+                else
+                    currentAnd.setRightOperand(newAndNode);
+                currentAnd = newAndNode;
+            }
+            try {
+                CloneCRsVisitor cloneCRsVisitor = new CloneCRsVisitor();
+                firstAnd.accept(cloneCRsVisitor);
+            }
+            catch (StandardException e) {
+                // If unable to clone all ColumnReferences, it is
+                // unsafe to use this predicate tree.
+                return null;
+            }
+            return firstAnd;
+        }
+        return null;
+    }
+
+    public static OrNode newOrNode(ValueNode left) throws StandardException {
+        ValueNode falseNode=(ValueNode)left.getNodeFactory().getNode(
+                C_NodeTypes.BOOLEAN_CONSTANT_NODE,
+                Boolean.FALSE,
+                left.getContextManager());
+        OrNode    orNode;
+        orNode = (OrNode) left.getNodeFactory().getNode(
+                                                    C_NodeTypes.OR_NODE,
+                                                    left,
+                                                    falseNode,
+                                                    left.getContextManager());
+        orNode.postBindFixup();
+        return orNode;
+    }
+
+    private List<ValueNode> linkNewList(List<List<ValueNode>> linkedChildren) {
+        List<ValueNode> andNodeLinkedChildren = new ArrayList<>();
+        linkedChildren.add(andNodeLinkedChildren);
+        return andNodeLinkedChildren;
+    }
+
+    private void collectChildLists(ValueNode node,
+                                   boolean underOrNode,
+                                   List<List<ValueNode>> linkedChildren) {
+        if (underOrNode) {
+            if (node instanceof AndNode) {
+                collectAndLinkedChildren((AndNode) node, linkNewList(linkedChildren));
+            }
+            else if (node instanceof OrNode) {
+                collectChildLists(((OrNode) node).getLeftOperand(), true, linkedChildren);
+                collectChildLists(((OrNode) node).getRightOperand(), true, linkedChildren);
+            }
+            else {
+                // OR'ing a FALSE does not change the outcome, so do not
+                // include boolean FALSE.
+                if (node instanceof BooleanConstantNode) {
+                    BooleanConstantNode bcn = (BooleanConstantNode) node;
+                    if (bcn.isBooleanFalse())
+                        return;
+                }
+                linkNewList(linkedChildren).add(node);
+            }
+        }
+    }
+
+    private void collectAndLinkedChildren(AndNode node,
+                                          List<ValueNode> andNodeLinkedChildren) {
+        if (node.getLeftOperand() instanceof AndNode)
+            collectAndLinkedChildren((AndNode)node.getLeftOperand(), andNodeLinkedChildren);
+        else
+            addAndedPredicate(node.getLeftOperand(), andNodeLinkedChildren);
+        if (node.getRightOperand() instanceof AndNode)
+            collectAndLinkedChildren((AndNode)node.getRightOperand(), andNodeLinkedChildren);
+        else
+            addAndedPredicate(node.getRightOperand(), andNodeLinkedChildren);
+    }
+
+    private void addAndedPredicate(ValueNode node, List<ValueNode> andNodeLinkedChildren) {
+        // AND'ing a TRUE does not change the outcome, so do not
+        // include boolean TRUE.
+        if (node instanceof BooleanConstantNode) {
+            BooleanConstantNode bcn = (BooleanConstantNode) node;
+            if (bcn.isBooleanTrue())
+                return;
+        }
+        andNodeLinkedChildren.add(node);
     }
 
     /**
@@ -633,5 +796,44 @@ public class OrNode extends BinaryLogicalOperatorNode {
                             getRightOperand().getTypeServices()
                                             )
                 );
+    }
+
+    public OrNode shallowCloneORChain() throws StandardException {
+        ValueNode node = this;
+        OrNode nextOrNode, currentOr = null;
+        OrNode firstNode = null;
+        while (node instanceof OrNode) {
+            OrNode orNode = (OrNode) node;
+            nextOrNode = newOrNode(orNode.getLeftOperand());
+            if (firstNode == null)
+                firstNode = nextOrNode;
+            else
+                currentOr.setRightOperand(nextOrNode);
+
+            currentOr = nextOrNode;
+            node = orNode.getRightOperand();
+        }
+        return firstNode;
+    }
+
+    @Override
+    public boolean isCloneable()
+    {
+        return true;
+    }
+
+    @Override
+    public ValueNode getClone() throws StandardException
+    {
+        ValueNode left = getLeftOperand();
+        ValueNode right = getRightOperand();
+        OrNode    orNode;
+        orNode = (OrNode) left.getNodeFactory().getNode(
+                                                    C_NodeTypes.OR_NODE,
+                                                    left,
+                                                    right,
+                                                    left.getContextManager());
+        orNode.postBindFixup();
+        return orNode;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OrNode.java
@@ -648,7 +648,10 @@ public class OrNode extends BinaryLogicalOperatorNode {
         if (depth == 0)
             disjuncts = new ArrayList<>();
         for (ValueNode pred:predicates) {
-            newOrNode = newOrNode(pred);
+            if (pred instanceof OrNode)
+                newOrNode = (OrNode)pred;
+            else
+                newOrNode = newOrNode(pred);
             if (depth == 0)
                 firstOrNode = newOrNode;
             else // Build a right-linked chain of OR nodes
@@ -677,7 +680,7 @@ public class OrNode extends BinaryLogicalOperatorNode {
             }
             try {
                 CloneCRsVisitor cloneCRsVisitor = new CloneCRsVisitor();
-                firstAnd.accept(cloneCRsVisitor);
+                firstAnd = (AndNode)firstAnd.accept(cloneCRsVisitor);
             }
             catch (StandardException e) {
                 // If unable to clone all ColumnReferences, it is

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
@@ -192,7 +192,7 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
     }
 
     @Override
-    public boolean isKey(){
+    public boolean isScanKey(){
         return startKey || stopKey;
     }
 
@@ -1679,7 +1679,7 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
             tempAccessPath.setConglomerateDescriptor(conglomDescs[i]);
             predicateList.categorize();
             predicateList.classify(optTable, tempAccessPath, true);
-            foundKey = predicate.isKey();
+            foundKey = predicate.isScanKey();
             predicate.clearScanFlags();
             if (foundKey) {
                 if (predicate.getReferencedSet().cardinality() < 2)
@@ -1699,7 +1699,7 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
         return foundKey;
     }
 
-    public boolean isIndexEnablingORedPredicate(FromBaseTable optTable, AccessPath accessPath, Optimizer optimizer) throws StandardException {
+    public boolean isDisjunctionOfScanKeys(FromBaseTable optTable, AccessPath accessPath, Optimizer optimizer) throws StandardException {
         if (andNode.getLeftOperand() instanceof OrNode) {
             OrNode orNode = (OrNode) andNode.getLeftOperand();
             if (orNode.getLeftOperand() instanceof AndNode ||

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
@@ -46,6 +46,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.*;
 
+import static com.splicemachine.db.impl.sql.compile.PredicateSimplificationVisitor.isBooleanFalse;
+import static com.splicemachine.db.impl.sql.compile.PredicateSimplificationVisitor.isBooleanTrue;
 import static com.splicemachine.db.shared.common.reference.SQLState.LANG_INTERNAL_ERROR;
 
 /**
@@ -187,6 +189,11 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
     @Override
     public boolean isStopKey(){
         return stopKey;
+    }
+
+    @Override
+    public boolean isKey(){
+        return startKey || stopKey;
     }
 
     @Override
@@ -707,6 +714,7 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
         startKey=false;
         stopKey=false;
         isQualifier=false;
+        rowId=false;
         // indexPosition of -1 is used by rowId, so use -2 to indicate that it has been set
         indexPosition = -2;
         matchIndexExpression = false;
@@ -1627,5 +1635,158 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
         BinaryRelationalOperatorNode bron = (BinaryRelationalOperatorNode) relOp;
         return bron.getLeftOperand().getTypeServices().
                                      getTypeName().equals(TypeId.VARCHAR_NAME);
+    }
+
+    // Build a raw AndNode boolean expression into a Predicate.
+    private Predicate getNewPredicate(ValueNode booleanExpression) throws StandardException {
+        int numTables = getCompilerContext().getMaximalPossibleTableCount();
+        JBitSet tableMap=new JBitSet(numTables);
+        ReferencedColumnsMap columnsMap = new ReferencedColumnsMap();
+        booleanExpression.categorize(tableMap, columnsMap, false);
+
+        JBitSet newJBitSet = new JBitSet(getReferencedSet().size());
+        AndNode andNode = booleanExpression instanceof AndNode ?
+                          (AndNode) booleanExpression :
+                          AndNode.newAndNode(booleanExpression, true);
+        Predicate newPred =
+            (Predicate) getNodeFactory().getNode(C_NodeTypes.PREDICATE,
+                                         andNode, newJBitSet, getContextManager());
+        return newPred;
+    }
+
+    // For a given predicate, check the heap conglomerate and all index
+    // conglomerates to see if it can be used as a start key or stop key
+    // for any of those indexes.
+    private boolean predicateEnablesKeyedIndexAccess(Predicate predicate,
+                                                     FromBaseTable optTable,
+                                                     AccessPath accessPath,
+                                                     Optimizer optimizer) throws StandardException {
+        ConglomerateDescriptor[] conglomDescs;
+        if (accessPath != null) {
+            conglomDescs = new ConglomerateDescriptor[1];
+            conglomDescs[0] = accessPath.getConglomerateDescriptor();
+        }
+        else
+            conglomDescs = optTable.conglomDescs;
+
+        int numConglomerates = conglomDescs.length;
+        PredicateList predicateList = getNewPredList();
+        predicateList.addOptPredicate(predicate);
+        AccessPath tempAccessPath = optTable.getCurrentAccessPath();
+        ConglomerateDescriptor savedConglomerateDescriptor = tempAccessPath.getConglomerateDescriptor();
+        boolean foundKey = false;
+        for (int i = 0; i < numConglomerates; i++) {
+            tempAccessPath.setConglomerateDescriptor(conglomDescs[i]);
+            predicateList.categorize();
+            predicateList.classify(optTable, tempAccessPath, true);
+            foundKey = predicate.isKey();
+            predicate.clearScanFlags();
+            if (foundKey) {
+                if (predicate.getReferencedSet().cardinality() < 2)
+                    break;
+                FromBaseTable outerBaseTable = optimizer.getOuterBaseTable();
+                if (outerBaseTable == null) {
+                    break;
+                }
+                if (predicate.getReferencedSet().contains(outerBaseTable.getReferencedTableMap())) {
+                    break;
+                }
+                foundKey = false;
+            }
+        }
+        predicateList.removeOptPredicate(0);
+        tempAccessPath.setConglomerateDescriptor(savedConglomerateDescriptor);
+        return foundKey;
+    }
+
+    public boolean isIndexEnablingORedPredicate(FromBaseTable optTable, AccessPath accessPath, Optimizer optimizer) throws StandardException {
+        if (andNode.getLeftOperand() instanceof OrNode) {
+            OrNode orNode = (OrNode) andNode.getLeftOperand();
+            if (orNode.getLeftOperand() instanceof AndNode ||
+                orNode.getRightOperand() instanceof AndNode)
+                return false;
+            ValueNode node = andNode.getLeftOperand();
+            OrNode tmpOrNode;
+            while (node instanceof OrNode) {
+                tmpOrNode = (OrNode)node;
+                Predicate newPred = getNewPredicate(tmpOrNode.getLeftOperand());
+                if (!predicateEnablesKeyedIndexAccess(newPred, optTable, accessPath, optimizer))
+                    return false;
+                node = tmpOrNode.getRightOperand();
+            }
+            if (node instanceof BinaryRelationalOperatorNode) {
+                Predicate newPred = getNewPredicate(node);
+                if (!predicateEnablesKeyedIndexAccess(newPred, optTable, accessPath, optimizer))
+                    return false;
+            }
+            else if (!(node instanceof BooleanConstantNode))
+                return false;
+
+            return true;
+        }
+        return false;
+    }
+
+    public List<OptimizablePredicateList> separateOredPredicates() throws StandardException {
+        List<OptimizablePredicateList> predicateLists = new ArrayList<>();
+        if (andNode.getLeftOperand() instanceof OrNode)
+            walkOredTerms(andNode.getLeftOperand(), predicateLists);
+        if (predicateLists.isEmpty())
+            return null;
+        else
+            return predicateLists;
+    }
+
+    private void walkOredTerms(ValueNode node, List<OptimizablePredicateList> predicateLists) throws StandardException {
+        if (!(node instanceof OrNode)) {
+            PredicateList predList = getNewPredList();
+            AndNode andNodeToAdd;
+            CloneCRsVisitor cloneCRsVisitor = new CloneCRsVisitor();
+            // Break the link between ColumnReferences in the new predicate
+            // and ColumnReferences in the PredicateList this was extracted from.
+            node = (ValueNode)node.accept(cloneCRsVisitor);
+            if (node instanceof AndNode)
+                andNodeToAdd = (AndNode) node;
+            else
+                andNodeToAdd = getNewAndWithBooleanExpression(node);
+            Predicate predicateToAdd = getNewAndedPredicate(andNodeToAdd);
+            predList.addPredicate(predicateToAdd);
+            predicateLists.add(predList);
+            return;
+        }
+        OrNode orNode = (OrNode)node;
+        if (isBooleanTrue(orNode.getLeftOperand()) || isBooleanTrue(orNode.getRightOperand()))
+            return;
+        if (!isBooleanFalse(orNode.getLeftOperand()))
+            walkOredTerms(orNode.getLeftOperand(), predicateLists);
+        if (!isBooleanFalse(orNode.getRightOperand()))
+            walkOredTerms(orNode.getRightOperand(), predicateLists);
+    }
+
+    private PredicateList getNewPredList() throws StandardException {
+        return (PredicateList)getNodeFactory().getNode(C_NodeTypes.PREDICATE_LIST,getContextManager());
+    }
+
+    private AndNode getNewAndWithBooleanExpression(ValueNode booleanExpression) throws StandardException {
+        BooleanConstantNode trueNode;
+        trueNode = (BooleanConstantNode) getNodeFactory().getNode(
+                C_NodeTypes.BOOLEAN_CONSTANT_NODE,
+                Boolean.TRUE,
+                getContextManager());
+        AndNode newAnd = (AndNode) getNodeFactory().getNode(
+				C_NodeTypes.AND_NODE,
+				booleanExpression,
+				trueNode,
+				getContextManager());
+        return newAnd;
+     }
+
+    private Predicate getNewAndedPredicate(AndNode andNode) throws StandardException {
+        Predicate newPred = (Predicate)getNodeFactory().getNode(
+            C_NodeTypes.PREDICATE,
+            andNode,
+            getReferencedSet(),
+            getContextManager());
+        return newPred;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
@@ -1729,8 +1729,16 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
 
     public List<OptimizablePredicateList> separateOredPredicates() throws StandardException {
         List<OptimizablePredicateList> predicateLists = new ArrayList<>();
-        if (andNode.getLeftOperand() instanceof OrNode)
-            walkOredTerms(andNode.getLeftOperand(), predicateLists);
+        if (andNode.getLeftOperand() instanceof OrNode) {
+            try {
+                walkOredTerms(andNode.getLeftOperand(), predicateLists);
+            }
+            catch (StandardException e) {
+                // If we failed due to a cloning error in CloneCRsVisitor, don't error
+                // out, just disable UIS access path.
+                return null;
+            }
+        }
         if (predicateLists.isEmpty())
             return null;
         else

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
@@ -714,6 +714,13 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                 }
             }
         }
+        if (relop instanceof BinaryRelationalOperatorNode) {
+            BinaryRelationalOperatorNode brelop = (BinaryRelationalOperatorNode)relop;
+            if (brelop.hasRowId()) {
+                pred.markRowId();
+                return -1;
+            }
+        }
         /*
         ** Skip over it if there is no index column on one side of the
         ** operand.
@@ -727,13 +734,6 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
              * restrictions.  That "revert" operation happens in
              * the generateExpression() method of BinaryOperatorNode.
              */
-            if (relop instanceof BinaryRelationalOperatorNode) {
-                BinaryRelationalOperatorNode brelop = (BinaryRelationalOperatorNode)relop;
-                if (brelop.hasRowId()) {
-                    pred.markRowId();
-                    return -1;
-                }
-            }
             return null;
         }
         return indexPosition;
@@ -901,6 +901,27 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
         newPred.setOriginalInListPredList(origList);
     }
 
+    private void handleRowIdJoinPredicateForUnionedIndexScans(AccessPath accessPath) throws StandardException {
+        Predicate uisPredicate = accessPath.getUisPredicate();
+        // Remove the predicate which enabled unioned index scans so
+        // it is not applied a second time.
+        if (uisPredicate != null)
+            removeOptPredicate(uisPredicate);
+        accessPath.setUisPredicate(null);
+        Predicate uisRowIdPredicate = accessPath.getUisRowIdPredicate();
+
+        // Add the RowId = RowId join back to base table predicate.
+        if (uisRowIdPredicate != null) {
+            CloneCRsVisitor cloneCRsVisitor = new CloneCRsVisitor();
+            cloneCRsVisitor.setCopySourceOfCR(true);
+            AndNode andNode = uisRowIdPredicate.getAndNode();
+            andNode = (AndNode)andNode.accept(cloneCRsVisitor);
+            uisRowIdPredicate.setAndNode(andNode);
+            addOptPredicate(uisRowIdPredicate);
+        }
+        accessPath.setUisRowIdPredicate(null);
+    }
+
     private void orderUsefulPredicates(Optimizable optTable,
                                        AccessPath accessPath,
                                        boolean pushPreds,
@@ -908,6 +929,14 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                                        boolean coveringIndexScan,
                                        boolean considerJoinPredicateAsKey,
                                        boolean rewriteList) throws StandardException{
+
+        if (pushPreds) {
+            handleRowIdJoinPredicateForUnionedIndexScans(accessPath);
+            // We can't push any predicates down to a base table with a Unioned Index Scans
+            // access path because the statement tree has already been built.
+            if (optTable.getTrulyTheBestAccessPath().getUisRowIdJoinBackToBaseTableResultSet() != null)
+                return;
+        }
 
         ConglomerateDescriptor cd = accessPath.getConglomerateDescriptor();
         boolean primaryKey=false;
@@ -923,6 +952,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
         int varcharRangeKeyPos = Integer.MAX_VALUE;
         if (getLanguageConnectionContext().isPredicateUsageForIndexOrPkAccessDisabled())
             return;
+
         // If pushPreds or rewriteList is true, the accessPath is trulyTheBestAccessPath
         // and tells us whether IndexPrefixIteratorMode was picked during
         // costing.  Repeat the same decision when pushing predicates.
@@ -973,6 +1003,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
         ** if the row still qualifies (there is a new method in ScanController
         ** for this.
         */
+        Predicate[] preds = null;
 
         /* Is a heap scan or a non-matching index scan on a covering index? */
         if(!rowIdScan && ((cd==null) || (!cd.isIndex() && !primaryKey) || (nonMatchingIndexScan && coveringIndexScan))){
@@ -992,7 +1023,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
             ** delete while looping and then delete them
             ** in reverse order after completing the loop.
             */
-            Predicate[] preds=new Predicate[size];
+            preds=new Predicate[size];
             for(int index=0;index<size;index++){
                 Predicate pred=elementAt(index);
 
@@ -1075,6 +1106,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
 
         TreeMap<Integer, Predicate> inlistPreds = new TreeMap<>();
         List<Predicate> predicates=new ArrayList<>();
+        int k = 0;
         for(int index=0;index<size;index++){
             Predicate pred=elementAt(index);
 
@@ -1569,6 +1601,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
              * otherwise we may match on (2, 0, 3).
              */
             if((!isIn) &&    // store can never treat "in" as qualifier
+               !thisPred.isRowId()  &&
                     ((!thisPredMarked) || (seenNonEquals && thisIndexPosition!=firstNonEqualsPosition))){
                 thisPred.markQualifier();
             }
@@ -3847,13 +3880,18 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
             //     2nd OR predicate -> qual[2][0.. number of OR terms]
             //     ...
             //
-            int and_idx=1;
+            int and_idx=0;
 
             // The remaining qualifiers must all be OR predicates, which
             // are pushed slightly differently than the leading AND qualifiers.
 
-            for(int index=qualNum;index<size;index++,and_idx++){
+            for(int index=qualNum;index<size;index++){
                 Predicate pred=elementAt(index);
+
+                if (!pred.isQualifier())
+                    continue;
+
+                and_idx++;
 
                 if(SanityManager.DEBUG){
                     SanityManager.ASSERT(pred.isOrList());
@@ -5032,6 +5070,17 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
             result = result && pred.collectExpressions(exprMap);
         }
         return result;
+    }
+
+    public OptimizablePredicate getUsefulPredicateForUnionedIndexScan(FromBaseTable optTable, AccessPath accessPath, Optimizer optimizer) throws StandardException {
+        if (size() == 0)
+            return null;
+        for (int i = 0; i < size(); i++) {
+            OptimizablePredicate pred = getOptPredicate(i);
+            if (pred.isIndexEnablingORedPredicate(optTable, accessPath, optimizer))
+                return pred;
+        }
+        return null;
     }
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
@@ -932,11 +932,11 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
 
         if (pushPreds) {
             handleRowIdJoinPredicateForUnionedIndexScans(accessPath);
-            // We can't push any predicates down to a base table with a Unioned Index Scans
-            // access path because the statement tree has already been built.
-            if (optTable.getTrulyTheBestAccessPath().getUisRowIdJoinBackToBaseTableResultSet() != null)
-                return;
         }
+        // We can't push any predicates down to a base table with a Unioned Index Scans
+        // access path because the statement tree has already been built.
+        if (accessPath.getUisRowIdJoinBackToBaseTableResultSet() != null)
+            return;
 
         ConglomerateDescriptor cd = accessPath.getConglomerateDescriptor();
         boolean primaryKey=false;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
@@ -40,6 +40,7 @@ import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.compile.*;
+import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.sql.dictionary.IndexRowGenerator;
@@ -50,6 +51,7 @@ import com.splicemachine.db.impl.ast.PredicateUtils;
 import com.splicemachine.db.impl.ast.RSUtils;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import splice.com.google.common.base.Joiner;
 import splice.com.google.common.collect.Lists;
 
@@ -57,6 +59,7 @@ import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.splicemachine.db.shared.common.reference.SQLState.LANG_INTERNAL_ERROR;
 import static java.lang.String.format;
 
 /**
@@ -683,6 +686,8 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
                 resultColumns.genVirtualColumnNodes(newPRNode, newPrRCList, false);
 
                 for (ColumnReference cr: rowIdReferenceList) {
+                    if (!(cr.getSource().getExpression() instanceof VirtualColumnNode))
+                        continue;
                     VirtualColumnNode virtualColumNode = (VirtualColumnNode)cr.getSource().getExpression();
                     cr.setSource(virtualColumNode.getSourceResultColumn() );
                 }
@@ -703,7 +708,7 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
          * be non-empty.  Multiple calls to modify the access path can
          * occur when there is a non-flattenable FromSubquery (or view).
          */
-        if(accessPathModified){
+        if(accessPathModified || skipBindAndOptimize){
             return this;
         }
 
@@ -1122,6 +1127,8 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
      */
     @Override
     public ResultSetNode preprocess(int numTables, GroupByList gbl, FromList fromList) throws StandardException{
+        if (skipBindAndOptimize)
+            return this;
         childResult=childResult.preprocess(numTables,gbl,fromList);
 
         /* Build the referenced table map */
@@ -1729,8 +1736,8 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
         mb.push(cloneMapItem);
         mb.push(resultColumns.reusableResult());
         mb.push(doesProjection);
-        mb.push(costEstimate.rowCount());
-        mb.push(costEstimate.getEstimatedCost());
+        mb.push(getCostEstimate().rowCount());
+        mb.push(getCostEstimate().getEstimatedCost());
         mb.push(printExplainInformationForActivation());
 
         String filterPred = OperatorToString.opToSparkString(restriction);
@@ -1779,6 +1786,16 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
         */
         if((restriction!=null) || (constantRestriction!=null) || (restrictionList!=null && !restrictionList.isEmpty())){
             return false;
+        }
+
+        // The source of a Unioned Index Scans result set may have a different number of columns
+        // projected than the base table.  Do not eliminate the projection for these cases because
+        // if we are the source of a JoinNode, the way joins build output rows requires the entire
+        // source row be copied into the merged row as-is.
+        FromBaseTable childBaseTable = childResult instanceof FromBaseTable ? (FromBaseTable) childResult : null;
+        if (childBaseTable != null && childBaseTable.getTrulyTheBestAccessPath() != null) {
+            if (childBaseTable.getTrulyTheBestAccessPath().getUisRowIdJoinBackToBaseTableResultSet() != null)
+                return false;
         }
 
         ResultColumnList childColumns=childResult.getResultColumns();
@@ -2056,11 +2073,10 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
         sb.append(")");
         return sb.toString();
     }
-    @Override
-    public void buildTree(Collection<QueryTreeNode> tree, int depth) throws StandardException {
+    public void buildTree(Collection<Pair<QueryTreeNode,Integer>> tree, int depth) throws StandardException {
         if (!nopProjectRestrict()) {
-            setDepth(depth);
-            tree.add(this);
+            addNodeToExplainTree(tree, this, depth);
+
             // look for subqueries in projection and restrictions, print if any
             for (SubqueryNode sub: RSUtils.collectExpressionNodes(this, SubqueryNode.class))
                 sub.buildTree(tree,depth+1);
@@ -2164,5 +2180,30 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
             return false;
         FromTable child = (FromTable) childResult;
         return child.isTargetTable();
+    }
+
+    public void setSkipBindAndOptimize(boolean skipBindAndOptimize) {
+        this.skipBindAndOptimize = skipBindAndOptimize;
+    }
+
+    @Override
+    public String getExposedName() throws StandardException {
+        return correlationName;
+    }
+
+    @Override
+    protected void recordUisAccessPath(AccessPath ap) throws StandardException {
+        super.recordUisAccessPath(ap);
+        if (childResult instanceof FromTable) {
+            FromTable childFromTable = (FromTable)childResult;
+            childFromTable.recordUisAccessPath(ap);
+        }
+    }
+
+   @Override
+    public boolean skipBindAndOptimize() {
+        if (skipBindAndOptimize)
+            return true;
+        return childResult.skipBindAndOptimize();
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
@@ -1492,18 +1492,18 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
         }
         if (subqueryNode != null) {
             subqueryText = subqueryNode.printExplainInformation(",");
-            subqueryText = subqueryText.substring(subqueryText.indexOf("->") + 2).trim();
+            subqueryText = subqueryText.substring(subqueryText.indexOf("->") + 1).trim();
             if (subqueryNode.getResultSet() instanceof ProjectRestrictNode) {
                 ProjectRestrictNode prn = (ProjectRestrictNode) subqueryNode.getResultSet();
                 String prnExplainText = prn.printExplainInformation(",");
-                prnExplainText = prnExplainText.substring(prnExplainText.indexOf("->") + 2).trim();
+                prnExplainText = prnExplainText.substring(prnExplainText.indexOf("->") + 1).trim();
                 subqueryText = subqueryText + "\n" + prnExplainText;
                 while (prn.getChildResult() instanceof ProjectRestrictNode)
                     prn = (ProjectRestrictNode) prn.getChildResult();
                 if (prn.getChildResult() instanceof FromTable) {
                     FromTable table = (FromTable) prn.getChildResult();
                     String tableExplainText = table.printExplainInformation(",");
-                    tableExplainText = tableExplainText.substring(tableExplainText.indexOf("->") + 2).trim();
+                    tableExplainText = tableExplainText.substring(tableExplainText.indexOf("->") + 1).trim();
                     subqueryText = subqueryText + "\n" + tableExplainText;
                 }
             }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QueryTreeNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QueryTreeNode.java
@@ -2137,7 +2137,7 @@ public abstract class QueryTreeNode implements Node, Visitable{
         return null;
     }
 
-    public void copy(OperatorNode other) throws StandardException
+    public void copyFrom(OperatorNode other) throws StandardException
     {
         // Do not copy this.depth, it is instance-dependent.
         this.isPrivilegeCollectionRequired = other.isPrivilegeCollectionRequired;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QueryTreeNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QueryTreeNode.java
@@ -69,6 +69,8 @@ import com.splicemachine.db.impl.sql.execute.GenericConstantActionFactory;
 import com.splicemachine.db.impl.sql.execute.GenericExecutionFactory;
 import com.splicemachine.db.impl.sql.execute.SPSPropertyRegistry;
 import org.apache.commons.lang3.SystemUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import splice.com.google.common.base.Predicates;
 import splice.com.google.common.base.Strings;
 
@@ -591,7 +593,13 @@ public abstract class QueryTreeNode implements Node, Visitable{
         final Visitable ret = visitor.stopTraversal() ? this : visitor.visit(this, parent);
 
         if(!childrenFirst && !skipChildren && !visitor.stopTraversal()){
-            acceptChildren(visitor);
+            if (visitor.visitChildrenOfNewParent()) {
+                if (ret != null) {
+                    ((QueryTreeNode) ret).acceptChildren(visitor);
+                }
+            }
+            else
+                acceptChildren(visitor);
         }
 
         return ret;
@@ -1746,7 +1754,7 @@ public abstract class QueryTreeNode implements Node, Visitable{
         throw StandardException.newException(sqlState,fragmentType);
     }
 
-    protected void setDepth(int depth) {
+    public void setDepth(int depth) {
         this.depth = depth;
     }
 
@@ -1768,9 +1776,8 @@ public abstract class QueryTreeNode implements Node, Visitable{
 
     private static final String spaces="  ";
 
-    public void buildTree(Collection<QueryTreeNode> tree, int depth) throws StandardException {
-        setDepth(depth);
-        tree.add(this);
+    public void buildTree(Collection<Pair<QueryTreeNode,Integer>> tree, int depth) throws StandardException {
+        addNodeToExplainTree(tree, this, depth);
     }
 
     public String printExplainInformation(boolean printHeader, DataSetProcessorType type, boolean fromPlanPrinter) throws StandardException {
@@ -2100,5 +2107,49 @@ public abstract class QueryTreeNode implements Node, Visitable{
 
     protected void addSPSPropertyDependency(final Node node) throws StandardException {
         SPSPropertyRegistry.checkAndAddDependency(node, getCompilerContext());
+    }
+
+    /**
+     * Return whether or not this expression tree is cloneable.
+     *
+     * @return boolean    Whether or not this expression tree is cloneable.
+     */
+    public boolean isCloneable()
+    {
+        return false;
+    }
+
+    /**
+     * Return a clone of this node.
+     *
+     * @return ValueNode    A clone of this node.
+     *
+     * @exception StandardException            Thrown on error
+     */
+    public ValueNode getClone() throws StandardException
+    {
+        if (SanityManager.DEBUG)
+        {
+            SanityManager.ASSERT(false,
+                "getClone() not expected to be called for " +
+                getClass().getName());
+        }
+        return null;
+    }
+
+    public void copy(OperatorNode other) throws StandardException
+    {
+        // Do not copy this.depth, it is instance-dependent.
+        this.isPrivilegeCollectionRequired = other.isPrivilegeCollectionRequired;
+        this.beginOffset = other.getBeginOffset();
+        this.endOffset = other.getEndOffset();
+        this.nodeType = other.getNodeType();
+        this.cm = other.getContextManager();
+        this.lcc = other.getLanguageConnectionContext();
+        this.constantActionFactory = other.getGenericConstantActionFactory();
+    }
+
+    protected void addNodeToExplainTree(Collection<Pair<QueryTreeNode,Integer>> tree, QueryTreeNode node, int depth) {
+        tree.add(new ImmutablePair<QueryTreeNode, Integer>(node, depth));
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RemapCRsForJoinVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RemapCRsForJoinVisitor.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2021 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+import com.splicemachine.db.iapi.sql.compile.Visitable;
+import com.splicemachine.db.iapi.sql.compile.Visitor;
+import com.splicemachine.db.iapi.error.StandardException;
+
+import static com.splicemachine.db.impl.sql.compile.ColumnReference.isBaseRowIdOrRowId;
+
+/**
+ * Remap ROWID or BASEROWID ColumnReference nodes in ResultColumnLists
+ * if they refer to a JoinNode, so they refer to the original source column.
+ *
+ */
+
+public class RemapCRsForJoinVisitor implements Visitor
+{
+	public RemapCRsForJoinVisitor()
+	{
+	}
+
+	public Visitable visit(Visitable node, QueryTreeNode parent)
+		throws StandardException
+	{
+            if (node instanceof ColumnReference)
+            {
+                ColumnReference cr = (ColumnReference)node;
+                if (!isBaseRowIdOrRowId(cr.getColumnName()))
+                	return node;
+                ResultColumn resultColumn = cr.getSource();
+                if (resultColumn != null) {
+                    if (resultColumn.getExpression() instanceof VirtualColumnNode) {
+						VirtualColumnNode vcn = (VirtualColumnNode) resultColumn.getExpression();
+                        if (vcn.getSourceResultSet() instanceof JoinNode) {
+                        	// Remap twice to get to the left or right source of
+							// the join.
+							cr.remapColumnReferences();
+							cr.remapColumnReferences();
+						}
+					}
+                }
+            }
+	    return node;
+	}
+	/**
+	 * No need to go below a SubqueryNode.
+	 *
+	 * @return Whether or not to go below the node.
+	 */
+	public boolean skipChildren(Visitable node)
+	{
+		return (node instanceof SubqueryNode);
+	}
+	public boolean visitChildrenFirst(Visitable node)
+	{
+		return false;
+	}
+	public boolean stopTraversal()
+	{
+		return false;
+	}
+	////////////////////////////////////////////////
+	//
+	// CLASS INTERFACE
+	//
+	////////////////////////////////////////////////
+}	

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RemapCRsForJoinVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RemapCRsForJoinVisitor.java
@@ -79,7 +79,8 @@ public class RemapCRsForJoinVisitor implements Visitor
      */
     public boolean skipChildren(Visitable node)
     {
-        return (node instanceof SubqueryNode);
+        return ((node instanceof ColumnReference) ||
+                (node instanceof SubqueryNode));
     }
     public boolean visitChildrenFirst(Visitable node)
     {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RemapCRsForJoinVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RemapCRsForJoinVisitor.java
@@ -45,53 +45,53 @@ import static com.splicemachine.db.impl.sql.compile.ColumnReference.isBaseRowIdO
 
 public class RemapCRsForJoinVisitor implements Visitor
 {
-	public RemapCRsForJoinVisitor()
-	{
-	}
+    public RemapCRsForJoinVisitor()
+    {
+    }
 
-	public Visitable visit(Visitable node, QueryTreeNode parent)
-		throws StandardException
-	{
+    public Visitable visit(Visitable node, QueryTreeNode parent)
+        throws StandardException
+    {
             if (node instanceof ColumnReference)
             {
                 ColumnReference cr = (ColumnReference)node;
                 if (!isBaseRowIdOrRowId(cr.getColumnName()))
-                	return node;
+                    return node;
                 ResultColumn resultColumn = cr.getSource();
                 if (resultColumn != null) {
                     if (resultColumn.getExpression() instanceof VirtualColumnNode) {
-						VirtualColumnNode vcn = (VirtualColumnNode) resultColumn.getExpression();
+                        VirtualColumnNode vcn = (VirtualColumnNode) resultColumn.getExpression();
                         if (vcn.getSourceResultSet() instanceof JoinNode) {
-                        	// Remap twice to get to the left or right source of
-							// the join.
-							cr.remapColumnReferences();
-							cr.remapColumnReferences();
-						}
-					}
+                            // Remap twice to get to the left or right source of
+                            // the join.
+                            cr.remapColumnReferences();
+                            cr.remapColumnReferences();
+                        }
+                    }
                 }
             }
-	    return node;
-	}
-	/**
-	 * No need to go below a SubqueryNode.
-	 *
-	 * @return Whether or not to go below the node.
-	 */
-	public boolean skipChildren(Visitable node)
-	{
-		return (node instanceof SubqueryNode);
-	}
-	public boolean visitChildrenFirst(Visitable node)
-	{
-		return false;
-	}
-	public boolean stopTraversal()
-	{
-		return false;
-	}
-	////////////////////////////////////////////////
-	//
-	// CLASS INTERFACE
-	//
-	////////////////////////////////////////////////
-}	
+        return node;
+    }
+    /**
+     * No need to go below a SubqueryNode.
+     *
+     * @return Whether or not to go below the node.
+     */
+    public boolean skipChildren(Visitable node)
+    {
+        return (node instanceof SubqueryNode);
+    }
+    public boolean visitChildrenFirst(Visitable node)
+    {
+        return false;
+    }
+    public boolean stopTraversal()
+    {
+        return false;
+    }
+    ////////////////////////////////////////////////
+    //
+    // CLASS INTERFACE
+    //
+    ////////////////////////////////////////////////
+}    

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RenameNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RenameNode.java
@@ -51,6 +51,8 @@ import com.splicemachine.db.iapi.services.sanity.SanityManager;
 
 import com.splicemachine.db.iapi.sql.StatementType;
 
+import static com.splicemachine.db.impl.sql.compile.ColumnReference.checkForDerivedColNameInDDL;
+
 /**
  * A RenameNode is the root of a QueryTree that represents a
  * RENAME TABLE/COLUMN/INDEX statement.
@@ -378,6 +380,7 @@ public class RenameNode extends DDLStatementNode
 	private void renameColumnBind(DataDictionary dd)
 		throws StandardException
 	{
+		checkForDerivedColNameInDDL(newObjectName);
 		ColumnDescriptor columnDescriptor = td.getColumnDescriptor(oldObjectName);
 
 		/* Verify that old column name does exist in the table */

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
@@ -2240,9 +2240,7 @@ public class ResultColumn extends ValueNode
         if (!(getExpression() instanceof ColumnReference))
             return false;
         ColumnReference columnReference = (ColumnReference)getExpression();
-        if (columnReference.getSource() instanceof ResultColumn)
-            return immutableVirtualColumn(columnReference.getSource());
-        return false;
+        return immutableVirtualColumn(columnReference.getSource());
     }
 }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumn.java
@@ -2223,5 +2223,26 @@ public class ResultColumn extends ValueNode
         }
         return this;
     }
+
+    private static boolean immutableVirtualColumn(ResultColumn rc) {
+        if (rc == null)
+            return false;
+        if (rc.getExpression() instanceof VirtualColumnNode) {
+            VirtualColumnNode vc = (VirtualColumnNode)rc.getExpression();
+            return vc.immutable();
+        }
+        return false;
+    }
+
+    public boolean sourceResultSetForbidsColumnRemoval() {
+        if (immutableVirtualColumn(this))
+            return true;
+        if (!(getExpression() instanceof ColumnReference))
+            return false;
+        ColumnReference columnReference = (ColumnReference)getExpression();
+        if (columnReference.getSource() instanceof ResultColumn)
+            return immutableVirtualColumn(columnReference.getSource());
+        return false;
+    }
 }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultSetNode.java
@@ -71,6 +71,7 @@ public abstract class ResultSetNode extends QueryTreeNode{
     protected CostEstimate costEstimate;
     protected CostEstimate scratchCostEstimate;
     protected Optimizer optimizer;
+    protected boolean skipBindAndOptimize;
 
     // Final cost estimate for this result set node, which is the estimate
     // for this node with respect to the best join order for the top-level
@@ -183,7 +184,7 @@ public abstract class ResultSetNode extends QueryTreeNode{
      */
     public CostEstimate getCostEstimate(){
         if(SanityManager.DEBUG){
-            if(costEstimate==null){
+            if(costEstimate==null && optimizer != null){
                 SanityManager.THROWASSERT(
                         "costEstimate is not expected to be null for "+
                                 getClass().getName());
@@ -263,6 +264,8 @@ public abstract class ResultSetNode extends QueryTreeNode{
      * @throws StandardException Thrown on error
      */
     public void bindExpressions(FromList fromListParam) throws StandardException{
+        if (skipBindAndOptimize)
+            return;
         if(SanityManager.DEBUG)
             SanityManager.ASSERT(false,
                     "bindExpressions() is not expected to be called for "+
@@ -279,6 +282,8 @@ public abstract class ResultSetNode extends QueryTreeNode{
      */
     public void bindExpressionsWithTables(FromList fromListParam)
             throws StandardException{
+        if (skipBindAndOptimize)
+            return;
         if(SanityManager.DEBUG)
             SanityManager.ASSERT(false,
                     "bindExpressionsWithTables() is not expected to be called for "+
@@ -297,6 +302,8 @@ public abstract class ResultSetNode extends QueryTreeNode{
 
     public void bindTargetExpressions(FromList fromListParam, boolean checkFromSubquery)
             throws StandardException{
+        if (skipBindAndOptimize)
+            return;
         if(SanityManager.DEBUG)
             SanityManager.ASSERT(false,
                     "bindTargetExpressions() is not expected to be called for "+
@@ -539,6 +546,8 @@ public abstract class ResultSetNode extends QueryTreeNode{
      */
 
     public ResultSetNode preprocess(int numTables, GroupByList gbl, FromList fromList) throws StandardException{
+        if (skipBindAndOptimize)
+            return this;
         if(SanityManager.DEBUG)
             SanityManager.THROWASSERT(
                     "preprocess() not expected to be called for "+getClass().toString());
@@ -1191,6 +1200,31 @@ public abstract class ResultSetNode extends QueryTreeNode{
         return null;
     }
 
+    // shallowCopy is a special-purpose function that is not meant
+    // to copy all items in a ResultSetNode, but only those items
+    // that allow the copy to perform the same operations as the
+    // original after being bound and optimized.  Only add fields
+    // here if they are primitives that affect the behavior of the
+    // operations, or they are objects that are OK to be shared.
+    // The same applies to overridden subclass methods.
+    protected void shallowCopy(ResultSetNode other) throws StandardException {
+        /* Skip the following, which should not be shared.:
+            protected int resultSetNumber;
+            ResultColumnList resultColumns;
+        */
+
+        referencedTableMap   = other.referencedTableMap;
+        statementResultSet    = other.statementResultSet;
+        cursorTargetTable     = other.cursorTargetTable;
+        insertSource          = other.insertSource;
+        costEstimate          = other.costEstimate;
+        scratchCostEstimate   = other.scratchCostEstimate;
+        optimizer             = other.optimizer;
+        finalCostEstimate     = other.finalCostEstimate;
+        sat                   = other.sat;
+        containsSelfReference = other.containsSelfReference;
+    }
+
     /**
      * Set the type of each parameter in the result column list for this
      * table constructor.
@@ -1779,5 +1813,13 @@ public abstract class ResultSetNode extends QueryTreeNode{
 
     public boolean collectExpressions(Map<Integer, Set<ValueNode>> exprMap) {
         return true;
+    }
+
+    public void setSkipBindAndOptimize(boolean skipBindAndOptimize) {
+        this.skipBindAndOptimize = skipBindAndOptimize;
+    }
+
+    public boolean skipBindAndOptimize() {
+        return skipBindAndOptimize;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RowResultSetNode.java
@@ -46,6 +46,7 @@ import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.impl.ast.RSUtils;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -906,9 +907,8 @@ public class RowResultSetNode extends FromTable {
     }
 
     @Override
-    public void buildTree(Collection<QueryTreeNode> tree, int depth) throws StandardException {
-        setDepth(depth);
-        tree.add(this);
+    public void buildTree(Collection<Pair<QueryTreeNode,Integer>> tree, int depth) throws StandardException {
+        addNodeToExplainTree(tree, this, depth);
         if (subqueries != null && !subqueries.isEmpty()) {
             for (SubqueryNode node: subqueries) {
                 node.buildTree(tree,depth+1);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
@@ -1903,6 +1903,10 @@ public class SelectNode extends ResultSetNode {
         ResultSetNode leftResultSet;
         ResultSetNode rightResultSet;
 
+        PredicateList predicateList = (PredicateList)getNodeFactory().getNode(C_NodeTypes.PREDICATE_LIST,getContextManager());;
+        if (optimizer.getPredicateList() != null)
+            optimizer.getPredicateList().copyPredicatesToOtherList(predicateList);
+
         /*
          ** Modify the access path for each Optimizable, as necessary
          **
@@ -2060,8 +2064,29 @@ public class SelectNode extends ResultSetNode {
                 getContextManager()
                 );
             }
+            joinNode.setCostEstimate(rightResultSet.getCostEstimate());
 
             ResultSetNode newPRNode = joinNode.genProjectRestrict();
+
+            // Remap ResultColumns present in ROWID = ROWID predicates.
+            // We want the predicates to be applied as join predicates
+            // instead of after the join.
+            JBitSet referencedTableMap = joinNode.getReferencedTableMap();
+            for(int index=predicateList.size()-1;index>=0;index--){
+                Predicate predicate=predicateList.elementAt(index);
+                if(!predicate.getPushable()){
+                    continue;
+                }
+                JBitSet curBitSet=predicate.getReferencedSet();
+                /* Do we have a match? */
+                if(referencedTableMap.contains(curBitSet)){
+                    /* Remap all of the ROWID ColumnReferences to point to the
+                     * source ProjectRestrictNode on the right or left of the join.
+                     */
+                    RemapCRsForJoinVisitor decoupleCRsVisitor = new RemapCRsForJoinVisitor();
+                    predicate.getAndNode().accept(decoupleCRsVisitor);
+                }
+            }
 
             // apply post outer join conditions
             if (((FromTable) rightResultSet).getOuterJoinLevel() > 0) {
@@ -2795,9 +2820,11 @@ public class SelectNode extends ResultSetNode {
             if (rc.getTypeId() == null)
                 throw StandardException.newException("Type in Result Column is not specified");
             if (rc.getTypeId().getJDBCTypeId() == Types.REF) {
-                ValueNode rowLocationNode = (ValueNode) getNodeFactory().getNode(
-                C_NodeTypes.CURRENT_ROW_LOCATION_NODE,
-                getContextManager());
+                ValueNode rowLocationNode =
+                    (ValueNode) getNodeFactory().getNode(
+                        C_NodeTypes.CURRENT_ROW_LOCATION_NODE,
+                        getContextManager());
+                rowLocationNode.bindExpression(null, null, null);
                 rc.setExpression(rowLocationNode);
 
             } else {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelfReferenceNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelfReferenceNode.java
@@ -41,6 +41,7 @@ import com.splicemachine.db.iapi.sql.compile.*;
 import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.iapi.util.StringUtil;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.lang.reflect.Modifier;
 import java.util.*;
@@ -244,9 +245,8 @@ public class SelfReferenceNode extends FromTable {
     }
 
     @Override
-    public void buildTree(Collection<QueryTreeNode> tree, int depth) throws StandardException {
-        setDepth(depth);
-        tree.add(this);
+    public void buildTree(Collection<Pair<QueryTreeNode,Integer>> tree, int depth) throws StandardException {
+        addNodeToExplainTree(tree, this, depth);
     }
 
     public String getExposedName(){

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SetOperatorNode.java
@@ -580,6 +580,8 @@ public abstract class SetOperatorNode extends TableOperatorNode
     public void bindResultColumns(FromList fromListParam)
                     throws StandardException
     {
+        if (skipBindAndOptimize)
+            return;
         super.bindResultColumns(fromListParam);
 
         if (TriggerReferencingStruct.fromTableTriggerDescriptor.get() != null)
@@ -592,6 +594,8 @@ public abstract class SetOperatorNode extends TableOperatorNode
     public void bindResultColumns(FromList fromListParam, boolean bindRightOnly)
             throws StandardException
     {
+        if (skipBindAndOptimize)
+            return;
         super.bindResultColumns(fromListParam, bindRightOnly);
 
         /* Now we build our RCL */
@@ -1155,8 +1159,8 @@ public abstract class SetOperatorNode extends TableOperatorNode
         for (int i=0; i<resultColumns.size(); i++) {
             ResultColumn rc = resultColumns.elementAt(i);
             if (rc.isReferenced()) {
-                leftResultSet.resultColumns.elementAt(i).setReferenced();
-                rightResultSet.resultColumns.elementAt(i).setReferenced();
+                leftResultSet.getResultColumns().elementAt(i).setReferenced();
+                rightResultSet.getResultColumns().elementAt(i).setReferenced();
             }
         }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SingleChildResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SingleChildResultSetNode.java
@@ -37,6 +37,7 @@ import com.splicemachine.db.iapi.sql.compile.*;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.sql.execute.ConstantAction;
 import com.splicemachine.db.iapi.util.JBitSet;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Collection;
 import java.util.Vector;
@@ -140,6 +141,8 @@ public abstract class SingleChildResultSetNode extends FromTable{
 
     @Override
     public void initAccessPaths(Optimizer optimizer){
+        if (skipBindAndOptimize)
+            return;
         super.initAccessPaths(optimizer);
         if(childResult instanceof Optimizable){
             ((Optimizable)childResult).initAccessPaths(optimizer);
@@ -148,6 +151,8 @@ public abstract class SingleChildResultSetNode extends FromTable{
 
     @Override
     public void resetAccessPaths() {
+        if (skipBindAndOptimize)
+            return;
         super.resetAccessPaths();
         if (childResult instanceof Optimizable) {
             ((Optimizable)childResult).resetAccessPaths();
@@ -554,9 +559,19 @@ public abstract class SingleChildResultSetNode extends FromTable{
         return null;
     }
     @Override
-    public void buildTree(Collection<QueryTreeNode> tree, int depth) throws StandardException {
-        setDepth(depth);
-        tree.add(this);
+    public void buildTree(Collection<Pair<QueryTreeNode,Integer>> tree, int depth) throws StandardException {
+        addNodeToExplainTree(tree, this, depth);
         childResult.buildTree(tree,depth+1);
+    }
+
+    @Override
+    public boolean outerTableOnly() {
+        if (outerTableOnly)
+            return true;
+        if(childResult instanceof Optimizable){
+            return ((Optimizable)childResult).outerTableOnly();
+        }
+        else
+            return outerTableOnly;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SubqueryNode.java
@@ -48,6 +48,7 @@ import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.iapi.util.ReuseFactory;
 import com.splicemachine.db.iapi.util.StringUtil;
 import com.splicemachine.db.impl.sql.execute.OnceResultSet;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.lang.reflect.Modifier;
 import java.util.*;
@@ -2862,9 +2863,8 @@ public class SubqueryNode extends ValueNode{
         setType(dts.getNullabilityType(true));
     }
     @Override
-    public void buildTree(Collection<QueryTreeNode> tree, int depth) throws StandardException {
-        setDepth(depth);
-        tree.add(this);
+    public void buildTree(Collection<Pair<QueryTreeNode,Integer>> tree, int depth) throws StandardException {
+        addNodeToExplainTree(tree, this, depth);
         resultSet.buildTree(tree,depth+1);
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableElementList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableElementList.java
@@ -59,6 +59,7 @@ import splice.com.google.common.collect.Lists;
 import java.util.*;
 
 import static com.splicemachine.db.iapi.sql.compile.C_NodeTypes.TABLE_ELEMENT_LIST;
+import static com.splicemachine.db.impl.sql.compile.ColumnReference.checkForDerivedColNameInDDL;
 
 /**
  * A TableElementList represents the list of columns and other table elements
@@ -208,6 +209,7 @@ public class TableElementList extends QueryTreeNodeVector {
                 {
                     throw StandardException.newException(SQLState.LANG_LONG_DATA_TYPE_NOT_ALLOWED, cdn.getColumnName());
                 }
+                checkForDerivedColNameInDDL(cdn.getColumnName());
                 checkForDuplicateColumns(ddlStmt, columnHT, cdn.getColumnName());
                 cdn.checkUserType(td);
                 cdn.bindAndValidateDefault(dd, td);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableOperatorNode.java
@@ -38,6 +38,7 @@ import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.util.JBitSet;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Collection;
 import java.util.Map;
@@ -314,6 +315,8 @@ public abstract class TableOperatorNode extends FromTable{
     }
 
     public ResultSetNode bindNonVTITables(DataDictionary dataDictionary,FromList fromListParam, boolean bindRightOnly)throws StandardException{
+        if (skipBindAndOptimize)
+            return this;
         if (!bindRightOnly)
             leftResultSet=leftResultSet.bindNonVTITables(dataDictionary,fromListParam);
         rightResultSet=rightResultSet.bindNonVTITables(dataDictionary,fromListParam);
@@ -341,6 +344,8 @@ public abstract class TableOperatorNode extends FromTable{
     }
 
     public ResultSetNode bindVTITables(FromList fromListParam, boolean bindRightOnly) throws StandardException{
+        if (skipBindAndOptimize)
+            return this;
         if (!bindRightOnly)
             leftResultSet=leftResultSet.bindVTITables(fromListParam);
         rightResultSet=rightResultSet.bindVTITables(fromListParam);
@@ -360,6 +365,8 @@ public abstract class TableOperatorNode extends FromTable{
     }
 
     public void bindExpressions(FromList fromListParam, boolean bindRightOnly) throws StandardException{
+        if (skipBindAndOptimize)
+            return;
         if (!bindRightOnly) {
             if (!(this instanceof UnionNode)) {
                 leftResultSet.rejectParameters();
@@ -394,6 +401,8 @@ public abstract class TableOperatorNode extends FromTable{
      */
     @Override
     public void bindExpressionsWithTables(FromList fromListParam) throws StandardException{
+        if (skipBindAndOptimize)
+            return;
         /*
         ** Parameters not allowed in select list of either side of a set operator,
         ** except when the set operator is for a table constructor.
@@ -422,6 +431,8 @@ public abstract class TableOperatorNode extends FromTable{
     }
 
     public void bindResultColumns(FromList fromListParam, boolean bindRightOnly) throws StandardException{
+        if (skipBindAndOptimize)
+            return;
         if (!bindRightOnly)
             leftResultSet.bindResultColumns(fromListParam);
         rightResultSet.bindResultColumns(fromListParam);
@@ -467,6 +478,8 @@ public abstract class TableOperatorNode extends FromTable{
                                   ResultColumnList targetColumnList,
                                   DMLStatementNode statement,
                                   FromList fromListParam) throws StandardException{
+        if (skipBindAndOptimize)
+            return;
         leftResultSet.bindResultColumns(targetTableDescriptor,
                 targetVTI,
                 targetColumnList,
@@ -525,6 +538,8 @@ public abstract class TableOperatorNode extends FromTable{
      */
     @Override
     public ResultSetNode preprocess(int numTables, GroupByList gbl, FromList fromList) throws StandardException{
+        if (skipBindAndOptimize)
+            return this;
         /* DB-10817 note
          * For a non-flattenable join, set the non-flattenable flag to all nested joins.
          * This has nothing to do with flattening, but to build a PRN on top of each
@@ -851,9 +866,8 @@ public abstract class TableOperatorNode extends FromTable{
     }
 
     @Override
-    public void buildTree(Collection<QueryTreeNode> tree, int depth) throws StandardException {
-        setDepth(depth);
-        tree.add(this);
+    public void buildTree(Collection<Pair<QueryTreeNode,Integer>> tree, int depth) throws StandardException {
+        addNodeToExplainTree(tree, this, depth);
         rightResultSet.buildTree(tree,depth+1);
         leftResultSet.buildTree(tree,depth+1);
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnionNode.java
@@ -212,6 +212,8 @@ public class UnionNode extends SetOperatorNode{
                                    OptimizablePredicateList predList,
                                    CostEstimate outerCost,
                                    RowOrdering rowOrdering) throws StandardException{
+        if (skipBindAndOptimize)
+            return costEstimate;
         /*
         ** RESOLVE: Most types of Optimizables only implement estimateCost(),
         ** and leave it up to optimizeIt() in FromTable to figure out the
@@ -514,6 +516,8 @@ public class UnionNode extends SetOperatorNode{
      */
     @Override
     public void bindExpressions(FromList fromListParam) throws StandardException{
+        if (skipBindAndOptimize)
+            return;
         super.bindExpressions(fromListParam);
 
         if (TriggerReferencingStruct.fromTableTriggerDescriptor.get() != null)

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UpdateNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UpdateNode.java
@@ -409,7 +409,7 @@ public final class UpdateNode extends DMLModStatementNode
 
         /* Prepend CurrentRowLocation() to the select's result column list. */
         if (SanityManager.DEBUG)
-        SanityManager.ASSERT((resultSet.resultColumns != null),
+        SanityManager.ASSERT((resultSet.getResultColumns() != null),
                               "resultColumns is expected not to be null at bind time");
 
         /*
@@ -427,15 +427,15 @@ public final class UpdateNode extends DMLModStatementNode
 
         /* Normalize the SET clause's result column list for synonym */
         if (synonymTableName != null)
-            normalizeSynonymColumns( resultSet.resultColumns, targetTable );
+            normalizeSynonymColumns( resultSet.getResultColumns(), targetTable );
 
         /* Bind the original result columns by column name */
-        normalizeCorrelatedColumns( resultSet.resultColumns, targetTable );
+        normalizeCorrelatedColumns( resultSet.getResultColumns(), targetTable );
 
         getCompilerContext().pushCurrentPrivType(getPrivType()); // Update privilege
         resultSet.bindResultColumns(targetTableDescriptor,
                     targetVTI,
-                    resultSet.resultColumns, this,
+                    resultSet.getResultColumns(), this,
                     fromList);
         getCompilerContext().popCurrentPrivType();
 
@@ -581,6 +581,7 @@ public final class UpdateNode extends DMLModStatementNode
             rowLocationNode = (ValueNode) getNodeFactory().getNode(
                                         C_NodeTypes.CURRENT_ROW_LOCATION_NODE,
                                         getContextManager());
+            rowLocationNode.bindExpression(null, null, null);
         }
         else
         {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNode.java
@@ -1642,9 +1642,9 @@ public abstract class ValueNode extends QueryTreeNode implements ParentNode
 
     public double getBaseOperationCost() throws StandardException { return 0.0; }
 
-    public void copy(OperatorNode other) throws StandardException
+    public void copyFrom(OperatorNode other) throws StandardException
     {
-        super.copy(other);
+        super.copyFrom(other);
         this.dataTypeServices = other.dataTypeServices;
         this.transformed = other.transformed;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNode.java
@@ -810,34 +810,6 @@ public abstract class ValueNode extends QueryTreeNode implements ParentNode
     }
 
     /**
-     * Return whether or not this expression tree is cloneable.
-     *
-     * @return boolean    Whether or not this expression tree is cloneable.
-     */
-    public boolean isCloneable()
-    {
-        return false;
-    }
-
-    /**
-     * Return a clone of this node.
-     *
-     * @return ValueNode    A clone of this node.
-     *
-     * @exception StandardException            Thrown on error
-     */
-    public ValueNode getClone() throws StandardException
-    {
-        if (SanityManager.DEBUG)
-        {
-            SanityManager.ASSERT(false,
-                "getClone() not expected to be called for " +
-                getClass().getName());
-        }
-        return null;
-    }
-
-    /**
      * Copy all of the "appropriate fields" for a shallow copy.
      *
      * @param oldVN        The ValueNode to copy from.
@@ -1669,4 +1641,11 @@ public abstract class ValueNode extends QueryTreeNode implements ParentNode
     protected static final double ALLOC_COST_FACTOR = 350;
 
     public double getBaseOperationCost() throws StandardException { return 0.0; }
+
+    public void copy(OperatorNode other) throws StandardException
+    {
+        super.copy(other);
+        this.dataTypeServices = other.dataTypeServices;
+        this.transformed = other.transformed;
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/VirtualColumnNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/VirtualColumnNode.java
@@ -33,7 +33,9 @@ package com.splicemachine.db.impl.sql.compile;
 
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.context.ContextService;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
+import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 
 import java.util.Collections;
@@ -365,5 +367,27 @@ public class VirtualColumnNode extends ValueNode
 
     public int getColumnId() {
         return columnId;
+    }
+
+    public boolean immutable() {
+        return (getSourceResultSet() != null && getSourceResultSet().skipBindAndOptimize);
+    }
+
+    // By convention VirtualColumnNode's isCloneable method returns true, but
+    // it did not provide a getClone() method.
+    // It is not desirable to clone the entire VirtualColumnNode tree because
+    // Splice relies on node sharing of ResultColumn nodes so the proper source
+    // result set is always referenced.  Therefore VirtualColumnNode's getClone
+    // will do a shallow clone.
+    @Override
+    public ValueNode getClone() throws StandardException
+    {
+        VirtualColumnNode shallowClone =
+           (VirtualColumnNode) getNodeFactory().getNode(C_NodeTypes.VIRTUAL_COLUMN_NODE,
+                sourceResultSet, // source result set.
+                sourceColumn,
+                columnId,
+                getContextManager());
+        return shallowClone;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -490,6 +490,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             setSessionFromConnectionProperty(connectionProperties, Property.CONNECTION_MIN_PLAN_TIMEOUT, SessionProperties.PROPERTYNAME.MINPLANTIMEOUT);
             setSessionFromConnectionProperty(connectionProperties, Property.CURRENT_FUNCTION_PATH, SessionProperties.PROPERTYNAME.CURRENTFUNCTIONPATH);
             setSessionFromConnectionProperty(connectionProperties, Property.OLAP_ALWAYS_PENALIZE_NLJ, SessionProperties.PROPERTYNAME.OLAPALWAYSPENALIZENLJ);
+            setSessionFromConnectionProperty(connectionProperties, Property.CONNECTION_JOIN_STRATEGY, SessionProperties.PROPERTYNAME.JOINSTRATEGY);
 
             String disableAdvancedTC = connectionProperties.getProperty(Property.CONNECTION_DISABLE_TC_PUSHED_DOWN_INTO_VIEWS);
             if (disableAdvancedTC != null && disableAdvancedTC.equalsIgnoreCase("true")) {
@@ -4289,4 +4290,9 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         return activeStateTxId;
     }
 
+    @Override
+    public String getHintedJoinStrategy() {
+        return (String) sessionProperties.getProperty(
+            SessionProperties.PROPERTYNAME.JOINSTRATEGY);
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/SessionPropertiesImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/SessionPropertiesImpl.java
@@ -145,6 +145,8 @@ public class SessionPropertiesImpl implements SessionProperties {
                     case "BROADCAST":
                         properties[JOINSTRATEGY.getId()] = joinStrategy;
                         break;
+                    default:
+                        break;
                 }
                 break;
             default:

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/SessionPropertiesImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/SessionPropertiesImpl.java
@@ -135,6 +135,18 @@ public class SessionPropertiesImpl implements SessionProperties {
             case COSTMODEL:
                 properties[COSTMODEL.getId()] = valString;
                 break;
+            case JOINSTRATEGY:
+                String joinStrategy = StringUtil.SQLToUpperCase(valString);
+                switch (joinStrategy) {
+                    case "CROSS":
+                    case "NESTEDLOOP":
+                    case "MERGE":
+                    case "SORTMERGE":
+                    case "BROADCAST":
+                        properties[JOINSTRATEGY.getId()] = joinStrategy;
+                        break;
+                }
+                break;
             default:
                 assert false;
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexChanger.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/IndexChanger.java
@@ -180,7 +180,7 @@ public class IndexChanger
                                 RowLocation baseRowLoc)
          throws StandardException
     {
-            ourIndexRow = irg.getIndexRowKeyTemplate();
+            ourIndexRow = irg.getIndexRowKeyTemplate(false);
 
             irg.getIndexRowKey(baseRow, baseRowLoc, ourIndexRow, baseRowReadMap);
     }
@@ -197,7 +197,7 @@ public class IndexChanger
                                 RowLocation baseRowLoc)
         throws StandardException
     {
-        ourUpdatedIndexRow = irg.getIndexRowKeyTemplate();
+        ourUpdatedIndexRow = irg.getIndexRowKeyTemplate(false);
 
         irg.getIndexRowKey(baseRow, baseRowLoc, ourUpdatedIndexRow, baseRowReadMap);
     }

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1194,6 +1194,11 @@ public interface Property {
     String CONNECTION_USE_NATIVE_SPARK = "useNativeSpark";
 
     /**
+     * Hint join strategy at the session level.
+     */
+    String CONNECTION_JOIN_STRATEGY = "joinStrategy";
+
+    /**
      * True ignores statistics for this connection
      */
     String CONNECTION_SKIP_STATS = "skipStats";
@@ -1293,5 +1298,28 @@ public interface Property {
     String SPLICE_OLAP_PARALLEL_PARTITIONS = "splice.olapParallelPartitions";
 
     String COST_MODEL = "costModel";
+
+    /**
+     * The maximum number of predicates the optimizer is allowed to derive in
+     * DNF to CNF predicate expansion.
+     * Default value is 100.  The maximum value for this parameter is 10000.
+     */
+    String MAX_DERIVED_CNF_PREDICATES =
+            "splice.optimizer.maxDerivedCNFPredicates";
+
+    /**
+     * If true, disable Unioned Index Scans access paths.
+     * The default value is false.
+     */
+    String DISABLE_UNIONED_INDEX_SCANS =
+            "splice.optimizer.disableUnionedIndexScans";
+
+    /**
+     * If true, favor Unioned Index Scans access paths by making the
+     * estimated cost artificially low.
+     * The default values is false.
+     */
+    String FAVOR_UNIONED_INDEX_SCANS =
+            "splice.optimizer.favorUnionedIndexScans";
 }
 

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -878,6 +878,7 @@ public interface SQLState {
     String LANG_NOT_COMPARABLE                                             = "42818";
     String LANG_NON_BOOLEAN_WHERE_CLAUSE                                   = "42X19";
     String LANG_INTEGER_LITERAL_EXPECTED                                   = "42X20";
+    String LANG_DERIVED_COLUMN_NAME_USE                                    = "42X21";
     String LANG_CURSOR_NOT_UPDATABLE                                       = "42X23";
     String LANG_INVALID_COL_HAVING_CLAUSE                                  = "42X24";
     String LANG_UNARY_FUNCTION_BAD_TYPE                                    = "42X25";

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -1842,6 +1842,12 @@ Guide.
             </msg>
 
             <msg>
+                <name>42X21</name>
+                <text>'{0}' is a special derived column which may not be defined in DDL statements.  Please rename the column.</text>
+                <arg>colName</arg>
+            </msg>
+
+            <msg>
                 <name>42X23</name>
                 <text>Cursor {0} is not updatable.</text>
                 <arg>cursorName</arg>

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkLeanOperationContext.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/SparkLeanOperationContext.java
@@ -453,4 +453,7 @@ public class SparkLeanOperationContext<Op extends SpliceOperation> implements Op
 
     @Override
     public String getImportFileName() { return importFileName; }
+
+    @Override
+    public boolean isSpark() { return true; };
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/BroadcastJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/BroadcastJoinStrategy.java
@@ -71,6 +71,9 @@ public class BroadcastJoinStrategy extends HashableJoinStrategy {
         if (JoinStrategyUtil.isNonCoveringIndex(innerTable))
             return false;
 
+        if (innerTable.indexFriendlyJoinsOnly())
+            return false;
+
         return super.feasible(innerTable, predList, optimizer, outerCost, wasHinted, true);
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/BroadcastJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/BroadcastJoinStrategy.java
@@ -74,7 +74,9 @@ public class BroadcastJoinStrategy extends HashableJoinStrategy {
         if (innerTable.indexFriendlyJoinsOnly())
             return false;
 
-        return super.feasible(innerTable, predList, optimizer, outerCost, wasHinted, true);
+        boolean feasible =
+            super.feasible(innerTable, predList, optimizer, outerCost, wasHinted, true);
+        return feasible;
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/CrossJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/CrossJoinStrategy.java
@@ -185,6 +185,11 @@ public class CrossJoinStrategy extends BaseJoinStrategy {
                             CostEstimate outerCost,
                             boolean wasHinted,
                             boolean skipKeyCheck) throws StandardException {
+        if (innerTable.indexFriendlyJoinsOnly())
+            return false;
+
+        if (optimizer.getJoinPosition() > 0 && innerTable.outerTableOnly())
+            return false;
 
         // cross join strategy cannot be applied to the very left table as it is not a join but just a scan
         if(outerCost.isUninitialized() ||(outerCost.localCost()==0d)) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
@@ -34,6 +34,8 @@ public class MergeSortJoinStrategy extends HashableJoinStrategy {
                             Optimizer optimizer,
                             CostEstimate outerCost,boolean wasHinted,
                             boolean skipKeyCheck) throws StandardException {
+        if (innerTable.indexFriendlyJoinsOnly())
+            return false;
 		return super.feasible(innerTable, predList, optimizer,outerCost,wasHinted,skipKeyCheck);
 	}
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
@@ -14,23 +14,15 @@
 
 package com.splicemachine.derby.impl.sql.compile;
 
-import com.splicemachine.EngineDriver;
-import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.compile.*;
-import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
-import com.splicemachine.db.iapi.sql.conn.SessionProperties;
-import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.impl.sql.compile.*;
-import com.splicemachine.utils.SpliceLogUtils;
-import org.apache.log4j.Logger;
 
-import static com.splicemachine.db.impl.sql.compile.JoinNode.INNERJOIN;
 
 public class NestedLoopJoinStrategy extends BaseJoinStrategy{
 
@@ -44,6 +36,10 @@ public class NestedLoopJoinStrategy extends BaseJoinStrategy{
                             CostEstimate outerCost,
                             boolean wasHinted,
                             boolean skipKeyCheck) throws StandardException{
+
+        if (optimizer.getJoinPosition() > 0 && innerTable.outerTableOnly())
+            return false;
+
         /* Nested loop is feasible, except in the corner case
          * where innerTable is a VTI that cannot be materialized
          * (because it has a join column as a parameter) and

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SimpleCostEstimate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SimpleCostEstimate.java
@@ -98,6 +98,7 @@ public class SimpleCostEstimate implements CostEstimate{
     @Override
     public void setCost(double cost,double rowCount,double singleScanRowCount,int numPartitions,int parallelism){
         this.localCost = cost;
+        this.remoteCost = 0.0d;  // This may hold a leftover value from a scratch cost estimate
         this.numRows = rowCount > 1 ? rowCount : 1;
         this.singleScanRowCount = singleScanRowCount;
         this.numPartitions = numPartitions;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/costing/V1ScanCostEstimator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/costing/V1ScanCostEstimator.java
@@ -16,6 +16,7 @@ package com.splicemachine.derby.impl.sql.compile.costing;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.compile.CostEstimate;
 import com.splicemachine.db.iapi.sql.compile.Optimizable;
+import com.splicemachine.db.iapi.sql.compile.Optimizer;
 import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.store.access.StoreCostController;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
@@ -44,7 +45,7 @@ public class V1ScanCostEstimator extends AbstractScanCostEstimator {
     /**
      * {@inheritDoc}
      */
-    public void addPredicate(Predicate p, double defaultSelectivityFactor) throws StandardException{
+    public void addPredicate(Predicate p, double defaultSelectivityFactor, Optimizer optimizer) throws StandardException{
         if (p.isMultiProbeQualifier(indexColumns)) {// MultiProbeQualifier against keys (BASE)
             addSelectivity(new InListSelectivity(scc, p, isIndexOnExpression ? indexColumns : null, QualifierPhase.BASE, defaultSelectivityFactor), SCAN);
             collectNoStatsColumnsFromInListPred(p);
@@ -59,22 +60,22 @@ public class V1ScanCostEstimator extends AbstractScanCostEstimator {
             collectNoStatsColumnsFromInListPred(p);
         }
         else if ( (p.isStartKey() || p.isStopKey()) && scanPredicatePossible) { // Range Qualifier on Start/Stop Keys (BASE)
-            performQualifierSelectivity(p, QualifierPhase.BASE, isIndexOnExpression, defaultSelectivityFactor, SCAN);
+            performQualifierSelectivity(p, QualifierPhase.BASE, isIndexOnExpression, defaultSelectivityFactor, SCAN, optimizer);
             if (!p.isStartKey() || !p.isStopKey()) // Only allows = to further restrict BASE scan numbers
                 scanPredicatePossible = false;
             collectNoStatsColumnsFromUnaryAndBinaryPred(p);
         }
         else if (p.isQualifier()) { // Qualifier in Base Table (FILTER_BASE)
-            performQualifierSelectivity(p, QualifierPhase.FILTER_BASE, isIndexOnExpression, defaultSelectivityFactor, SCAN);
+            performQualifierSelectivity(p, QualifierPhase.FILTER_BASE, isIndexOnExpression, defaultSelectivityFactor, SCAN, optimizer);
             collectNoStatsColumnsFromUnaryAndBinaryPred(p);
         }
         else if (PredicateList.isQualifier(p,baseTable,cd,false)) { // Qualifier on Base Table After Index Lookup (FILTER_PROJECTION)
-            performQualifierSelectivity(p, QualifierPhase.FILTER_PROJECTION, isIndexOnExpression, defaultSelectivityFactor, TOP);
+            performQualifierSelectivity(p, QualifierPhase.FILTER_PROJECTION, isIndexOnExpression, defaultSelectivityFactor, TOP, optimizer);
             accumulateExprEvalCost(p);
             collectNoStatsColumnsFromUnaryAndBinaryPred(p);
         }
         else { // Project Restrict Selectivity Filter
-            addSelectivity(new DefaultPredicateSelectivity(p, baseTable, QualifierPhase.FILTER_PROJECTION, defaultSelectivityFactor), TOP);
+            addSelectivity(new DefaultPredicateSelectivity(p, baseTable, QualifierPhase.FILTER_PROJECTION, defaultSelectivityFactor, optimizer), TOP);
             accumulateExprEvalCost(p);
         }
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/CreateIndexConstantOperation.java
@@ -624,7 +624,7 @@ public class CreateIndexConstantOperation extends IndexConstantOperation impleme
             FormatableBitSet zeroBasedBitSet = RowUtil.shift(bitSet, 1);
 
             ExecRow baseRow = activation.getExecutionFactory().getValueRow(maxBaseColumnPosition);
-            ExecIndexRow indexRow = indexRowGenerator.getIndexRowKeyTemplate();
+            ExecIndexRow indexRow = indexRowGenerator.getIndexRowKeyTemplate(true);
             ExecRow compactBaseRow = activation.getExecutionFactory().getValueRow(baseColumnPositions.length);
 
             indexTemplateRow = indexRow;//indexRows[0];

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainOperation.java
@@ -32,6 +32,7 @@ import com.splicemachine.derby.iapi.sql.execute.SpliceOperationContext;
 import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
 import com.splicemachine.derby.stream.iapi.OperationContext;
+import org.apache.commons.lang3.tuple.Pair;
 import splice.com.google.common.base.Function;
 import splice.com.google.common.collect.Iterators;
 
@@ -153,7 +154,7 @@ public class ExplainOperation extends SpliceBaseOperation {
     }
 
     protected void clearState() {
-        Map<String, Collection<QueryTreeNode>> m = PlanPrinter.planMap.get();
+        Map<String, Collection<Pair<QueryTreeNode,Integer>>> m = PlanPrinter.planMap.get();
         String sql = activation.getPreparedStatement().getSource();
         m.remove(sql);
     }
@@ -190,10 +191,10 @@ public class ExplainOperation extends SpliceBaseOperation {
 
     @SuppressWarnings("unchecked")
     private void getPlanInformation() throws StandardException {
-        Map<String, Collection<QueryTreeNode>> m = PlanPrinter.planMap.get();
+        Map<String, Collection<Pair<QueryTreeNode,Integer>>> m = PlanPrinter.planMap.get();
         String sql = activation.getPreparedStatement().getSource();
         Iterator<String> explainStringIter;
-        Collection<QueryTreeNode> opPlanMap = m.get(sql);
+        Collection<Pair<QueryTreeNode,Integer>> opPlanMap = m.get(sql);
         if (opPlanMap != null) {
             DataSetProcessorType type = activation.datasetProcessorType();
             explainStringIter = PlanPrinter.planToIterator(opPlanMap, type);

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/OperationContext.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/OperationContext.java
@@ -94,4 +94,5 @@ public interface OperationContext<Op extends SpliceOperation> extends Externaliz
     ActivationHolder getActivationHolder();
     long getBadRecordThreshold();
     String getImportFileName();
+    default boolean isSpark() { return false; };
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/Scans.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/Scans.java
@@ -279,8 +279,8 @@ public class Scans extends SpliceUtils {
 
                     // we just rely on key table positions
                     if (!isEmpty(keyDecodingMap) && keyDecodingMap[i] >= 0 && !isEmpty(keyTablePositionMap)) {
-                        DataValueDescriptor targetDesc = scannedRow.getColumn(keyTablePositionMap[keyDecodingMap[i]] + 1); // the maps are 0-based, get Column is 1-based
                         if (!rowIdKey) {
+                            DataValueDescriptor targetDesc = scannedRow.getColumn(keyTablePositionMap[keyDecodingMap[i]] + 1); // the maps are 0-based, get Column is 1-based
                             startKeyValue[i] = QualifierUtils.adjustDataValueDescriptor(startDesc, targetDesc, dataValueFactory, true);
                         }
                     }
@@ -300,8 +300,8 @@ public class Scans extends SpliceUtils {
 
                     //  we just rely on key table positions
                     if (!isEmpty(keyDecodingMap) && !isEmpty(keyTablePositionMap)) {
-                        DataValueDescriptor targetDesc = scannedRow.getColumn(keyTablePositionMap[keyDecodingMap[i]] + 1);
                         if (!rowIdKey) {
+                            DataValueDescriptor targetDesc = scannedRow.getColumn(keyTablePositionMap[keyDecodingMap[i]] + 1);
                             stop[i] = QualifierUtils.adjustDataValueDescriptor(stopDesc, targetDesc, dataValueFactory, false);
                         }
                     }
@@ -479,9 +479,8 @@ public class Scans extends SpliceUtils {
 
                     // we just rely on key table positions
                     if (!isEmpty(keyDecodingMap) && keyDecodingMap[i] >= 0 && !isEmpty(keyTablePositionMap)) {
-                        int targetColFormatId = columnTypes[keyTablePositionMap[keyDecodingMap[i]]];
-                        DataValueDescriptor targetDesc = templateRow.getColumn(keyTablePositionMap[keyDecodingMap[i]] + 1); // the maps are 0-based, get Column is 1-based
                         if (!rowIdKey) {
+                            DataValueDescriptor targetDesc = templateRow.getColumn(keyTablePositionMap[keyDecodingMap[i]] + 1); // the maps are 0-based, get Column is 1-based
                             startKeyValue[i] = QualifierUtils.adjustDataValueDescriptor(startDesc, targetDesc, dataValueFactory, true);
                         }
                     }
@@ -511,9 +510,8 @@ public class Scans extends SpliceUtils {
 
                     //  we just rely on key table positions
                     if (!isEmpty(keyDecodingMap) && !isEmpty(keyTablePositionMap)) {
-                        int targetColFormatId = columnTypes[keyTablePositionMap[keyDecodingMap[i]]];
-                        DataValueDescriptor targetDesc = templateRow.getColumn(keyTablePositionMap[keyDecodingMap[i]] + 1); // the maps are 0-based, get Column is 1-based
                         if (!rowIdKey) {
+                            DataValueDescriptor targetDesc = templateRow.getColumn(keyTablePositionMap[keyDecodingMap[i]] + 1); // the maps are 0-based, get Column is 1-based
                             stop[i] = QualifierUtils.adjustDataValueDescriptor(stopDesc, targetDesc, dataValueFactory, false);
                         }
                     }

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/InListMultiprobeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/InListMultiprobeIT.java
@@ -470,9 +470,9 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
         rs = methodWatcher.executeQuery("explain " + sqlText);
 
         resultString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
-        Assert.assertFalse("MultiProbeTableScan is not expected", resultString.contains("MultiProbeTableScan"));
+        Assert.assertTrue("MultiProbeTableScan is expected", resultString.contains("MultiProbeTableScan"));
 
-        Assert.assertTrue("Multicolumn IN list should be built", resultString.contains("[((A1[0:1],B1[0:2]) IN ((A         ,1),(D         ,4)))]"));
+        Assert.assertTrue("Multicolumn IN list should be built", resultString.contains("[((A1[0:1],B1[0:2]) IN "));
 
         rs = methodWatcher.executeQuery(sqlText);
 
@@ -726,10 +726,8 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
         level = 1;
         while (rs.next()) {
             String resultString = rs.getString(1);
-            if (level == 6) {
-                Assert.assertTrue("MultiProbeIndexScan is not expected", !resultString.contains("MultiProbeIndexScan"));
-                Assert.assertTrue("MultiProbeTableScan is not expected", !resultString.contains("MultiProbeTableScan"));
-                Assert.assertTrue("Should have converted the OR'ed conditions to IN.", resultString.contains("(F[0:1],R[0:2]) IN "));
+            if (level == 7) {
+                Assert.assertTrue("MultiProbeIndexScan is expected", resultString.contains("MultiProbeIndexScan"));
             }
             level++;
         }
@@ -1443,7 +1441,7 @@ public class InListMultiprobeIT  extends SpliceUnitTest {
                 if (!multiProbeFound)
                     multiProbeFound = resultString.contains("MultiProbeTableScan");
                 if (!multiColINFound)
-                    multiColINFound = resultString.contains("preds=[((B1[0:2],A1[0:1]) IN ");
+                    multiColINFound = resultString.contains("keys=[((B1[0:2],A1[0:1]) IN ");
             }
             if (level > 4) {
                 Assert.assertTrue("MultiProbeTableScan is expected", multiProbeFound);

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NLJPredicatePushedToDerivedTableIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NLJPredicatePushedToDerivedTableIT.java
@@ -229,7 +229,7 @@ public class NLJPredicatePushedToDerivedTableIT extends SpliceUnitTest {
         if (!useSpark)
             rowContainsQuery(new int[]{4, 8, 9, 10}, "explain " + sqlText, methodWatcher,
                     new String[]{"NestedLoopJoin", "outputRows=3"},
-                    new String[]{"TableScan[T2", "scannedRows=1,outputRows=1", "preds=[(A1[1:1] = A2[2:1])]"},
+                    new String[]{"TableScan[T2", "scannedRows=1,outputRows=1", "keys=[(A1[1:1] = A2[2:1])]"},
                     new String[]{"ProjectRestrict", "outputRows=3", "preds=[(B1[0:2] IN (1,2,3))]"},
                     new String[]{"TableScan[T1", "scannedRows=3,outputRows=3"}
                     );
@@ -320,7 +320,7 @@ public class NLJPredicatePushedToDerivedTableIT extends SpliceUnitTest {
          */
         rowContainsQuery(new int[]{4, 8, 9, 10}, "explain " + sqlText, methodWatcher,
                 new String[]{"NestedLoopJoin", "outputRows=3"},
-                new String[]{"TableScan[T2", "scannedRows=1,outputRows=1", "preds=[(A1[1:1] = A2[2:1])]"},
+                new String[]{"TableScan[T2", "scannedRows=1,outputRows=1", "keys=[(A1[1:1] = A2[2:1])]"},
                 new String[]{"ProjectRestrict", "outputRows=3", "preds=[(B1[0:2] IN (1,2,3))]"},
                 new String[]{"TableScan[T1", "scannedRows=3,outputRows=3"}
         );
@@ -363,10 +363,10 @@ public class NLJPredicatePushedToDerivedTableIT extends SpliceUnitTest {
         rowContainsQuery(new int[]{3, 5, 6, 8, 9, 10, 11}, "explain " + sqlText, methodWatcher,
                 new String[]{"NestedLoopJoin", "outputRows=3"},
                 new String[]{"NestedLoopJoin", "outputRows=1"},
-                new String[]{"TableScan[T2", "scannedRows=1,outputRows=1", "preds=[(A2[10:1] = DT.A3[9:1])]"},
+                new String[]{"TableScan[T2", "scannedRows=1,outputRows=1", "keys=[(A2[10:1] = DT.A3[9:1])]"},
                 new String[]{"NestedLoopJoin", "outputRows=1"},
                 new String[]{"TableScan[T3", "scannedRows=10000,outputRows=1", "preds=[(X.B3[3:2] = Y.B3[4:1])]"},
-                new String[]{"TableScan[T3", "scannedRows=1,outputRows=1", "preds=[(A1[1:1] = X.A3[2:1])]"},
+                new String[]{"TableScan[T3", "scannedRows=1,outputRows=1", "keys=[(A1[1:1] = X.A3[2:1])]"},
                 new String[]{"TableScan[T1", "scannedRows=3,outputRows=3"}
         );
 
@@ -453,7 +453,7 @@ public class NLJPredicatePushedToDerivedTableIT extends SpliceUnitTest {
         rowContainsQuery(new int[]{4, 6, 7, 8, 9, 10}, "explain " + sqlText, methodWatcher,
                 new String[]{"NestedLoopJoin", "outputRows=3000"},
                 new String[]{"BroadcastJoin", "outputRows=1000", "preds=[(A2[6:2] = A4[6:1])]"},
-                new String[]{"TableScan[T2", "scannedRows=10000,outputRows=10000", "preds=[(A1[1:1] = T2.A2[4:1])]"},
+                new String[]{"TableScan[T2", "scannedRows=10000,outputRows=10000", "keys=[(A1[1:1] = T2.A2[4:1])]"},
                 new String[]{"TableScan[T4", "scannedRows=1000,outputRows=1000"},
                 new String[]{"ProjectRestrict", "outputRows=3", "preds=[(B1[0:2] IN (1,2,3))]"},
                 new String[]{"TableScan[T1", "scannedRows=3,outputRows=3"}

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/PredicatePushToUnionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/PredicatePushToUnionIT.java
@@ -230,8 +230,8 @@ public class PredicatePushToUnionIT extends SpliceUnitTest {
          */
         rowContainsQuery(new int[]{5, 8, 10}, "explain " + sqlText, methodWatcher,
                 new String[]{"TableScan", "preds=[(C3[7:2] = 1),(B3[7:1] = 1)]"},
-                new String[]{"IndexScan", "preds=[(C2[3:1] = 1),(B2[3:2] = 1)]"},
-                new String[]{"IndexScan", "preds=[(C1[0:1] = 1),(B1[0:2] = 1)]"});
+                new String[]{"IndexScan", "keys=[(C2[3:1] = 1),(B2[3:2] = 1)]"},
+                new String[]{"IndexScan", "keys=[(C1[0:1] = 1),(B1[0:2] = 1)]"});
 
         ResultSet rs = methodWatcher.executeQuery(sqlText);
         String expected =
@@ -273,8 +273,8 @@ public class PredicatePushToUnionIT extends SpliceUnitTest {
          */
         rowContainsQuery(new int[]{5, 8, 10}, "explain " + sqlText, methodWatcher,
                 new String[]{"TableScan", "preds=[(C3[7:2] = 1),(B3[7:1] = 1)]"},
-                new String[]{"IndexScan", "preds=[(C2[3:1] = 1),(B2[3:2] = 1)]"},
-                new String[]{"IndexScan", "preds=[(C1[0:1] = 1)]"});
+                new String[]{"IndexScan", "keys=[(C2[3:1] = 1),(B2[3:2] = 1)]"},
+                new String[]{"IndexScan", "keys=[(C1[0:1] = 1)]"});
 
         ResultSet rs = methodWatcher.executeQuery(sqlText);
         String expected =
@@ -313,9 +313,9 @@ public class PredicatePushToUnionIT extends SpliceUnitTest {
         10 rows selected
          */
         rowContainsQuery(new int[]{6, 9, 10}, "explain " + sqlText, methodWatcher,
-                new String[]{"MultiProbeTableScan", "preds=[(A3[9:1] IN (A         ,B         ,C         ))]"},
-                new String[]{"MultiProbeTableScan", "preds=[(A2[3:1] IN (A         ,B         ,C         ))]"},
-                new String[]{"MultiProbeTableScan", "preds=[(A1[0:1] IN (A         ,B         ,C         ))]"});
+                new String[]{"MultiProbeTableScan", "keys=[(A3[9:1] IN (A         ,B         ,C         ))]"},
+                new String[]{"MultiProbeTableScan", "keys=[(A2[3:1] IN (A         ,B         ,C         ))]"},
+                new String[]{"MultiProbeTableScan", "keys=[(A1[0:1] IN (A         ,B         ,C         ))]"});
 
         ResultSet rs = methodWatcher.executeQuery(sqlText);
         String expected =
@@ -372,7 +372,7 @@ public class PredicatePushToUnionIT extends SpliceUnitTest {
          */
         rowContainsQuery(new int[]{8, 10}, "explain " + sqlText, methodWatcher,
                 new String[]{"preds=[(C3[3:2] = 1),(B3[3:1] = 1)]"},
-                new String[]{"IndexScan", "preds=[(C2[0:1] = 1),(B2[0:2] = 1)]"});
+                new String[]{"IndexScan", "keys=[(C2[0:1] = 1),(B2[0:2] = 1)]"});
 
         ResultSet rs = methodWatcher.executeQuery(sqlText);
         String expected =
@@ -427,8 +427,8 @@ public class PredicatePushToUnionIT extends SpliceUnitTest {
          */
 
         rowContainsQuery(new int[]{7, 9}, "explain " + sqlText, methodWatcher,
-                new String[]{"MultiProbeTableScan", "preds=[((A6[3:1],B6[3:2],C6[3:3]) IN ((abcde,2,2018-12-01),(abcde,2,2018-12-05),(splice,2,2018-12-01),(splice,2,2018-12-05)))]"},
-                new String[]{"MultiProbeTableScan", "preds=[((A5[0:1],B5[0:2],C5[0:3]) IN ((abcde,2,2018-12-01),(abcde,2,2018-12-05),(splice,2,2018-12-01),(splice,2,2018-12-05)))]"});
+                new String[]{"MultiProbeTableScan", "keys=[((A6[3:1],B6[3:2],C6[3:3]) IN ((abcde,2,2018-12-01),(abcde,2,2018-12-05),(splice,2,2018-12-01),(splice,2,2018-12-05)))]"},
+                new String[]{"MultiProbeTableScan", "keys=[((A5[0:1],B5[0:2],C5[0:3]) IN ((abcde,2,2018-12-01),(abcde,2,2018-12-05),(splice,2,2018-12-01),(splice,2,2018-12-05)))]"});
 
 
 
@@ -489,8 +489,8 @@ public class PredicatePushToUnionIT extends SpliceUnitTest {
         11 rows selected
          */
         rowContainsQuery(new int[]{7, 9}, "explain " + sqlText, methodWatcher,
-                new String[]{"MultiProbeTableScan", "preds=[((A6[3:1],B6[3:2],C6[3:3]) IN ((substring(abcdeNNN, 1, 5) ,2,dataTypeServices: DATE ),(substring(abcdeNNN, 1, 5) ,2,dataTypeServices: DATE ),(splice,2,dataTypeServices: DATE ),(splice,2,dataTypeServices: DATE )))]"},
-                new String[]{"MultiProbeTableScan", "preds=[((A5[0:1],B5[0:2],C5[0:3]) IN ((substring(abcdeNNN, 1, 5) ,2,dataTypeServices: DATE ),(substring(abcdeNNN, 1, 5) ,2,dataTypeServices: DATE ),(splice,2,dataTypeServices: DATE ),(splice,2,dataTypeServices: DATE )))]"});
+                new String[]{"MultiProbeTableScan", "keys=[((A6[3:1],B6[3:2],C6[3:3]) IN ((substring(abcdeNNN, 1, 5) ,2,dataTypeServices: DATE ),(substring(abcdeNNN, 1, 5) ,2,dataTypeServices: DATE ),(splice,2,dataTypeServices: DATE ),(splice,2,dataTypeServices: DATE )))]"},
+                new String[]{"MultiProbeTableScan", "keys=[((A5[0:1],B5[0:2],C5[0:3]) IN ((substring(abcdeNNN, 1, 5) ,2,dataTypeServices: DATE ),(substring(abcdeNNN, 1, 5) ,2,dataTypeServices: DATE ),(splice,2,dataTypeServices: DATE ),(splice,2,dataTypeServices: DATE )))]"});
 
         ResultSet rs = methodWatcher.executeQuery(sqlText);
         String expected =
@@ -543,12 +543,12 @@ public class PredicatePushToUnionIT extends SpliceUnitTest {
          */
 
         rowContainsQuery(new int[]{7, 8, 12, 14, 17, 19}, "explain " + sqlText, methodWatcher,
-                new String[]{"TableScan", "preds=[(T11.A1[17:1] = C         ),(T11.B1[17:2] = 3)]"},
+                new String[]{"TableScan", "keys=[(T11.A1[17:1] = C         ),(T11.B1[17:2] = 3)]"},
                 new String[]{"TableScan", "preds=[(T3.C3[15:2] = 3),(T3.B3[15:1] = 3)]"},
-                new String[]{"TableScan", "preds=[(T11.A1[9:1] = C         ),(T11.B1[9:2] = 3)]"},
-                new String[]{"IndexScan", "preds=[(T2.C2[7:1] = 3),(T2.B2[7:2] = 3)]"},
-                new String[]{"TableScan", "preds=[(T11.A1[2:1] = C         ),(T11.B1[2:2] = 3)]"},
-                new String[]{"IndexScan", "preds=[(T1.C1[0:1] = 3),(T1.B1[0:2] = 3)]"});
+                new String[]{"TableScan", "keys=[(T11.A1[9:1] = C         ),(T11.B1[9:2] = 3)]"},
+                new String[]{"IndexScan", "keys=[(T2.C2[7:1] = 3),(T2.B2[7:2] = 3)]"},
+                new String[]{"TableScan", "keys=[(T11.A1[2:1] = C         ),(T11.B1[2:2] = 3)]"},
+                new String[]{"IndexScan", "keys=[(T1.C1[0:1] = 3),(T1.B1[0:2] = 3)]"});
 
         ResultSet rs = methodWatcher.executeQuery(sqlText);
         String expected =
@@ -603,12 +603,12 @@ public class PredicatePushToUnionIT extends SpliceUnitTest {
          */
 
         rowContainsQuery(new int[]{7, 8, 12, 14, 17, 19}, "explain " + sqlText, conn,
-                new String[]{"TableScan", "preds=[(T11.A1[17:1] = C         )]"},
+                new String[]{"TableScan", "keys=[(T11.A1[17:1] = C         )]"},
                 new String[]{"TableScan", "preds=[(T3.C3[15:2] = 3),(T3.B3[15:1] = 3)]"},
-                new String[]{"TableScan", "preds=[(T11.A1[9:1] = C         )]"},
-                new String[]{"IndexScan", "preds=[(T2.C2[7:1] = 3),(T2.B2[7:2] = 3)]"},
-                new String[]{"TableScan", "preds=[(T11.A1[2:1] = C         )]"},
-                new String[]{"IndexScan", "preds=[(T1.C1[0:1] = 3),(T1.B1[0:2] = 3)]"});
+                new String[]{"TableScan", "keys=[(T11.A1[9:1] = C         )]"},
+                new String[]{"IndexScan", "keys=[(T2.C2[7:1] = 3),(T2.B2[7:2] = 3)]"},
+                new String[]{"TableScan", "keys=[(T11.A1[2:1] = C         )]"},
+                new String[]{"IndexScan", "keys=[(T1.C1[0:1] = 3),(T1.B1[0:2] = 3)]"});
 
 
         ResultSet rs = conn.query(sqlText);
@@ -651,8 +651,8 @@ public class PredicatePushToUnionIT extends SpliceUnitTest {
         */
 
         rowContainsQuery(new int[]{7, 9}, "explain " + sqlText, methodWatcher,
-                new String[]{"TableScan", "preds=[(A6[3:1] = substring(abcdeNNN, 1, 5) ),(B6[3:2] = 2),(C6[3:3] = dataTypeServices: DATE )]"},
-                new String[]{"TableScan", "preds=[(A5[0:1] = substring(abcdeNNN, 1, 5) ),(B5[0:2] = 2),(C5[0:3] = dataTypeServices: DATE )]"});
+                new String[]{"TableScan", "keys=[(A6[3:1] = substring(abcdeNNN, 1, 5) ),(B6[3:2] = 2),(C6[3:3] = dataTypeServices: DATE )]"},
+                new String[]{"TableScan", "keys=[(A5[0:1] = substring(abcdeNNN, 1, 5) ),(B5[0:2] = 2),(C5[0:3] = dataTypeServices: DATE )]"});
 
         ResultSet rs = methodWatcher.executeQuery(sqlText);
         String expected =

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/UnionedIndexScansIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/UnionedIndexScansIT.java
@@ -1,0 +1,401 @@
+/*
+ * Copyright (c) 2012 - 2021 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.homeless.TestUtils;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import splice.com.google.common.collect.Lists;
+
+import java.sql.ResultSet;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+
+/**
+ * Test Unioned Index Scans Access Path
+ */
+@RunWith(Parameterized.class)
+public class UnionedIndexScansIT  extends SpliceUnitTest {
+    
+    private Boolean useSpark;
+    private static boolean isMemPlatform = false;
+    
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        Collection<Object[]> params = Lists.newArrayListWithCapacity(2);
+        params.add(new Object[]{true});
+        params.add(new Object[]{false});
+        return params;
+    }
+    private static final String SCHEMA = UnionedIndexScansIT.class.getSimpleName();
+
+    @ClassRule
+    public static SpliceSchemaWatcher schemaWatcher = new SpliceSchemaWatcher(SCHEMA);
+
+    @ClassRule
+    public static SpliceWatcher classWatcher = new SpliceWatcher(SCHEMA);
+
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher(SCHEMA);
+
+    @BeforeClass
+    public static void createSharedTables() throws Exception {
+        isMemPlatform = isMemPlatform();
+        TestUtils.executeSqlFile(classWatcher.getOrCreateConnection(), "subquery/UnionedIndexScansTestTables.sql", "");
+    }
+
+    @AfterClass
+    public static void cleanup() throws Exception {
+        try {
+            TestUtils.executeSqlFile(classWatcher.getOrCreateConnection(), "subquery/UnionedIndexScansTestCleanup.sql", "");
+        }
+        catch (Exception e) {
+
+        }
+    }
+
+    public UnionedIndexScansIT(Boolean useSpark) throws Exception {
+        this.useSpark = useSpark;
+        try (ResultSet rs = classWatcher.executeQuery("call syscs_util.syscs_set_global_database_property('splice.optimizer.favorUnionedIndexScans', 'true')")) {
+        }
+    }
+
+    public static boolean
+    isMemPlatform() throws Exception{
+        try (ResultSet rs = classWatcher.executeQuery("CALL SYSCS_UTIL.SYSCS_IS_MEM_PLATFORM()")) {
+            rs.next();
+            return ((Boolean)rs.getObject(1));
+        }
+    }
+
+    @Test
+    public void testSingleTableScan() throws Exception {
+        String expected =
+            "A | B | C |\n" +
+            "------------\n" +
+            " 1 | 1 | 1 |\n" +
+            " 1 | 2 | 1 |\n" +
+            " 1 | 3 | 1 |\n" +
+            " 1 | 4 | 1 |\n" +
+            " 2 | 1 | 2 |\n" +
+            " 2 | 2 | 2 |\n" +
+            " 2 | 3 | 2 |\n" +
+            " 2 | 4 | 2 |\n" +
+            " 3 | 1 | 3 |\n" +
+            " 3 | 2 | 3 |\n" +
+            " 3 | 3 | 3 |\n" +
+            " 3 | 4 | 3 |";
+
+        String query = format("select * from t1 --SPLICE-PROPERTIES useSpark=%s\n" +
+                                "where (a = 1 or a = 2 or c = 3)", useSpark);
+
+        List<String> containedStrings = Arrays.asList("BASEROWID");
+        List<String> notContainedStrings = null;
+        testQuery(query, expected, methodWatcher);
+        testExplainContains(query, methodWatcher, containedStrings, notContainedStrings);
+
+    }
+
+    @Test
+    public void testManyORedPredicates() throws Exception {
+        String expected =
+            "A | B | C |\n" +
+            "------------\n" +
+            " 1 | 1 | 1 |\n" +
+            " 1 | 2 | 1 |\n" +
+            " 1 | 3 | 1 |\n" +
+            " 1 | 4 | 1 |\n" +
+            " 3 | 1 | 3 |\n" +
+            " 3 | 2 | 3 |\n" +
+            " 3 | 3 | 3 |\n" +
+            " 3 | 4 | 3 |";
+
+        String query = format("select * from t1 --SPLICE-PROPERTIES useSpark=%s\n" +
+                                "where (a = 1 and c = 1) or (a = 2 and c = 1) or (a = 3 and c = 3) or (a = 5 and c = 4)", useSpark);
+
+        List<String> containedStrings = Arrays.asList("BASEROWID");
+        List<String> notContainedStrings = null;
+        testQuery(query, expected, methodWatcher);
+        testExplainContains(query, methodWatcher, containedStrings, notContainedStrings);
+
+        query = format("select * from t1 --SPLICE-PROPERTIES useSpark=%s\n" +
+                                "where (a = 1 or c = 1) and (a = 2 or c = 2) and (a = 3 or c = 3) and (a = 4 and c = 4)", useSpark);
+        expected =
+            "";
+        testQuery(query, expected, methodWatcher);
+        testExplainContains(query, methodWatcher, containedStrings, notContainedStrings);
+
+        query = format("select * from t1 --SPLICE-PROPERTIES useSpark=%s\n" +
+                                "where (a > 1 or c > 1) and (a = 2 or c = 2 or c =3)", useSpark);
+        expected =
+            "A | B | C |\n" +
+            "------------\n" +
+            " 2 | 1 | 2 |\n" +
+            " 2 | 2 | 2 |\n" +
+            " 2 | 3 | 2 |\n" +
+            " 2 | 4 | 2 |\n" +
+            " 3 | 1 | 3 |\n" +
+            " 3 | 2 | 3 |\n" +
+            " 3 | 3 | 3 |\n" +
+            " 3 | 4 | 3 |";
+        testQuery(query, expected, methodWatcher);
+        testExplainContains(query, methodWatcher, containedStrings, notContainedStrings);
+    }
+
+    @Test
+    public void testJoins() throws Exception {
+        String query = format("select count(*) from t2 --SPLICE-PROPERTIES useSpark=%s\n" +
+                                ", t1 where (t2.b = 1 or t2.a = 2 or t2.a = 3) and (t2.a = t1.a or t2.a = t1.c)", useSpark);
+
+        String expected =
+            "1 |\n" +
+            "----\n" +
+            "40 |";
+        List<String> containedStrings = Arrays.asList("BASEROWID");
+        List<String> notContainedStrings = null;
+        testExplainContains(query, methodWatcher, containedStrings, notContainedStrings);
+        testQuery(query, expected, methodWatcher);
+
+
+        query = format("select count(*) from t2 --SPLICE-PROPERTIES useSpark=%s\n" +
+                                ", t1 where (t2.a = 1 or t2.a = 2 or t2.a = 3) and (t2.a = t1.a or t2.a = t1.c)", useSpark);
+
+        expected =
+            "1 |\n" +
+            "----\n" +
+            "48 |";
+        notContainedStrings = Arrays.asList("BASEROWID");
+        containedStrings = null;
+        testQuery(query, expected, methodWatcher);
+        // This query cannot currently use UIS access path.
+        testExplainContains(query, methodWatcher, containedStrings, notContainedStrings);
+
+        query = format("select count(*) from t2 a --SPLICE-PROPERTIES useSpark=%s\n" +
+                                ",t2, t1 where (t2.a = 1 or t2.a = 2 or t2.a = 3) and (t2.a = t1.a or t2.a = t1.c)", useSpark);
+        expected =
+            "1  |\n" +
+            "-----\n" +
+            "768 |";
+        testQuery(query, expected, methodWatcher);
+        // This query cannot currently use UIS access path.
+        testExplainContains(query, methodWatcher, containedStrings, notContainedStrings);
+
+        query = format("select count(*) from t2 a --SPLICE-PROPERTIES useSpark=%s\n" +
+                                ",t2, t1 where (t2.b = 1 or t2.a = 2 or t2.a = 3) and (t2.a = t1.a or t2.a = t1.c)", useSpark);
+        expected =
+            "1  |\n" +
+            "-----\n" +
+            "640 |";
+        testQuery(query, expected, methodWatcher);
+        containedStrings = Arrays.asList("BASEROWID");
+        notContainedStrings = null;
+        testExplainContains(query, methodWatcher, containedStrings, notContainedStrings);
+
+        // A simplified customer-like query.
+        query = format("select * from t1 BH --SPLICE-PROPERTIES useSpark=%s\n" +
+                              ", t1 BU where\n" +
+                              "( BH.a = 1 AND BH.b = BU.a )\n" +
+                              "          OR ( BH.a = BU.a\n" +
+                              "               AND BH.b = 1 )", useSpark);
+        // The explain should look something like:
+        // Plan
+        //----
+        //Cursor(n=75,rows=36864,updateMode=READ_ONLY (1),engine=OLTP (session hint))
+        //  ->  ScrollInsensitive(n=75,totalCost=0,outputRows=36864,outputHeapSize=1.453 MB,partitions=1,parallelTasks=1)
+        //    ->  ProjectRestrict(n=74,totalCost=0,outputRows=36864,outputHeapSize=1.453 MB,partitions=1,parallelTasks=1)
+        //      ->  NestedLoopJoin(n=72,totalCost=0,outputRows=36864,outputHeapSize=1.453 MB,partitions=1,parallelTasks=1)
+        //        ->  ProjectRestrict(n=71,totalCost=4.036,outputRows=32,outputHeapSize=1.453 MB,partitions=1,parallelTasks=1,preds=[((BH.B[30:2] = BU.A[68:1]) or ((BH.B[30:2] = 1) or false)),((BH.A[30:1] = 1) or ((BH.A[30:1] = BU.A[68:1]) or false)),(dnfPathDT_###_BU.BASEROWID2[68:4] = BH.BASEROWID[30:4])])
+        //          ->  ProjectRestrict(n=68,totalCost=15481.567,outputRows=36864,outputHeapSize=1.453 MB,partitions=1,parallelTasks=1)
+        //            ->  NestedLoopJoin(n=66,totalCost=15481.567,outputRows=36864,outputHeapSize=1.453 MB,partitions=1,parallelTasks=1)
+        //              ->  ProjectRestrict(n=65,totalCost=4.036,outputRows=32,outputHeapSize=1.453 MB,partitions=1,parallelTasks=1)
+        //                ->  TableScan[T1(4272)](n=64,totalCost=4.036,scannedRows=32,outputRows=32,outputHeapSize=1.453 MB,partitions=1,parallelTasks=1,keys=[(dnfPathDT_###_BU.BASEROWID[63:1] = BU.BASEROWID[65:4])])
+        //              ->  Distinct(n=62,totalCost=1158.935,outputRows=1152,outputHeapSize=28.5 KB,partitions=1,parallelTasks=1)
+        //                ->  Union(n=60,totalCost=1158.935,outputRows=1152,outputHeapSize=28.5 KB,partitions=2,parallelTasks=1)
+        //                  ->  ProjectRestrict(n=59,totalCost=1158.935,outputRows=576,outputHeapSize=14.25 KB,partitions=1,parallelTasks=1)
+        //                    ->  NestedLoopJoin(n=57,totalCost=1158.935,outputRows=576,outputHeapSize=14.25 KB,partitions=1,parallelTasks=1)
+        //                      ->  ProjectRestrict(n=56,totalCost=4.004,outputRows=4,outputHeapSize=14.25 KB,partitions=1,parallelTasks=1)
+        //                        ->  IndexScan[IDX1(4305)](n=55,totalCost=4.004,scannedRows=4,outputRows=4,outputHeapSize=14.25 KB,partitions=1,parallelTasks=1,baseTable=T1(4272),keys=[(BH.A[54:1] = BU.A[55:1])])
+        //                      ->  ProjectRestrict(n=54,totalCost=4.013,outputRows=12,outputHeapSize=2.438 KB,partitions=1,parallelTasks=1)
+        //                        ->  ProjectRestrict(n=29,totalCost=150.726,outputRows=144,outputHeapSize=2.438 KB,partitions=1,parallelTasks=1)
+        //                          ->  NestedLoopJoin(n=27,totalCost=150.726,outputRows=144,outputHeapSize=2.438 KB,partitions=1,parallelTasks=1)
+        //                            ->  ProjectRestrict(n=26,totalCost=4.013,outputRows=12,outputHeapSize=2.438 KB,partitions=1,parallelTasks=1)
+        //                              ->  TableScan[T1(4272)](n=25,totalCost=4.013,scannedRows=12,outputRows=12,outputHeapSize=2.438 KB,partitions=1,parallelTasks=1,keys=[(dnfPathDT_###_BH.BASEROWID[24:1] = BH.BASEROWID[26:3])])
+        //                            ->  Distinct(n=23,totalCost=4.009,outputRows=12,outputHeapSize=64 B,partitions=1,parallelTasks=1)
+        //                              ->  Union(n=21,totalCost=4.009,outputRows=12,outputHeapSize=64 B,partitions=2,parallelTasks=1)
+        //                                ->  ProjectRestrict(n=20,totalCost=4.009,outputRows=8,outputHeapSize=32 B,partitions=1,parallelTasks=1)
+        //                                  ->  ProjectRestrict(n=19,totalCost=4.009,outputRows=8,outputHeapSize=32 B,partitions=1,parallelTasks=1)
+        //                                    ->  TableScan[T1(4272)](n=18,totalCost=4.009,scannedRows=8,outputRows=8,outputHeapSize=32 B,partitions=1,parallelTasks=1,keys=[(BH.B[18:1] = 1)])
+        //                                ->  ProjectRestrict(n=17,totalCost=4.004,outputRows=4,outputHeapSize=32 B,partitions=1,parallelTasks=1)
+        //                                  ->  ProjectRestrict(n=16,totalCost=4.004,outputRows=4,outputHeapSize=32 B,partitions=1,parallelTasks=1)
+        //                                    ->  IndexScan[IDX1(4305)](n=15,totalCost=4.004,scannedRows=4,outputRows=4,outputHeapSize=32 B,partitions=1,parallelTasks=1,baseTable=T1(4272),keys=[(BH.A[15:1] = 1)])
+        //                  ->  ProjectRestrict(n=52,totalCost=1158.935,outputRows=576,outputHeapSize=14.25 KB,partitions=1,parallelTasks=1)
+        //                    ->  NestedLoopJoin(n=50,totalCost=1158.935,outputRows=576,outputHeapSize=14.25 KB,partitions=1,parallelTasks=1)
+        //                      ->  ProjectRestrict(n=49,totalCost=4.004,outputRows=4,outputHeapSize=14.25 KB,partitions=1,parallelTasks=1)
+        //                        ->  IndexScan[IDX1(4305)](n=48,totalCost=4.004,scannedRows=4,outputRows=4,outputHeapSize=14.25 KB,partitions=1,parallelTasks=1,baseTable=T1(4272),keys=[(BH.B[47:2] = BU.A[48:1])])
+        //                      ->  ProjectRestrict(n=47,totalCost=4.013,outputRows=12,outputHeapSize=2.438 KB,partitions=1,parallelTasks=1)
+        //                        ->  ProjectRestrict(n=14,totalCost=150.726,outputRows=144,outputHeapSize=2.438 KB,partitions=1,parallelTasks=1)
+        //                          ->  NestedLoopJoin(n=12,totalCost=150.726,outputRows=144,outputHeapSize=2.438 KB,partitions=1,parallelTasks=1)
+        //                            ->  ProjectRestrict(n=11,totalCost=4.013,outputRows=12,outputHeapSize=2.438 KB,partitions=1,parallelTasks=1)
+        //                              ->  TableScan[T1(4272)](n=10,totalCost=4.013,scannedRows=12,outputRows=12,outputHeapSize=2.438 KB,partitions=1,parallelTasks=1,keys=[(dnfPathDT_###_BH.BASEROWID[9:1] = BH.BASEROWID[11:3])])
+        //                            ->  Distinct(n=8,totalCost=4.009,outputRows=12,outputHeapSize=64 B,partitions=1,parallelTasks=1)
+        //                              ->  Union(n=6,totalCost=4.009,outputRows=12,outputHeapSize=64 B,partitions=2,parallelTasks=1)
+        //                                ->  ProjectRestrict(n=5,totalCost=4.009,outputRows=8,outputHeapSize=32 B,partitions=1,parallelTasks=1)
+        //                                  ->  ProjectRestrict(n=4,totalCost=4.009,outputRows=8,outputHeapSize=32 B,partitions=1,parallelTasks=1)
+        //                                    ->  TableScan[T1(4272)](n=3,totalCost=4.009,scannedRows=8,outputRows=8,outputHeapSize=32 B,partitions=1,parallelTasks=1,keys=[(BH.B[3:1] = 1)])
+        //                                ->  ProjectRestrict(n=2,totalCost=4.004,outputRows=4,outputHeapSize=32 B,partitions=1,parallelTasks=1)
+        //                                  ->  ProjectRestrict(n=1,totalCost=4.004,outputRows=4,outputHeapSize=32 B,partitions=1,parallelTasks=1)
+        //                                    ->  IndexScan[IDX1(4305)](n=0,totalCost=4.004,scannedRows=4,outputRows=4,outputHeapSize=32 B,partitions=1,parallelTasks=1,baseTable=T1(4272),keys=[(BH.A[0:1] = 1)])
+        //        ->  ProjectRestrict(n=30,totalCost=4.013,outputRows=12,outputHeapSize=3 KB,partitions=1,parallelTasks=1)
+        //          ->  ProjectRestrict(n=45,totalCost=150.726,outputRows=144,outputHeapSize=3 KB,partitions=1,parallelTasks=1)
+        //            ->  NestedLoopJoin(n=43,totalCost=150.726,outputRows=144,outputHeapSize=3 KB,partitions=1,parallelTasks=1)
+        //              ->  ProjectRestrict(n=42,totalCost=4.013,outputRows=12,outputHeapSize=3 KB,partitions=1,parallelTasks=1)
+        //                ->  TableScan[T1(4272)](n=41,totalCost=4.013,scannedRows=12,outputRows=12,outputHeapSize=3 KB,partitions=1,parallelTasks=1,keys=[(dnfPathDT_###_BH.BASEROWID[40:1] = BH.BASEROWID[42:4])])
+        //              ->  Distinct(n=39,totalCost=4.009,outputRows=12,outputHeapSize=64 B,partitions=1,parallelTasks=1)
+        //                ->  Union(n=37,totalCost=4.009,outputRows=12,outputHeapSize=64 B,partitions=2,parallelTasks=1)
+        //                  ->  ProjectRestrict(n=36,totalCost=4.009,outputRows=8,outputHeapSize=32 B,partitions=1,parallelTasks=1)
+        //                    ->  ProjectRestrict(n=35,totalCost=4.009,outputRows=8,outputHeapSize=32 B,partitions=1,parallelTasks=1)
+        //                      ->  TableScan[T1(4272)](n=34,totalCost=4.009,scannedRows=8,outputRows=8,outputHeapSize=32 B,partitions=1,parallelTasks=1,keys=[(BH.B[34:1] = 1)])
+        //                  ->  ProjectRestrict(n=33,totalCost=4.004,outputRows=4,outputHeapSize=32 B,partitions=1,parallelTasks=1)
+        //                    ->  ProjectRestrict(n=32,totalCost=4.004,outputRows=4,outputHeapSize=32 B,partitions=1,parallelTasks=1)
+        //                      ->  IndexScan[IDX1(4305)](n=31,totalCost=4.004,scannedRows=4,outputRows=4,outputHeapSize=32 B,partitions=1,parallelTasks=1,baseTable=T1(4272),keys=[(BH.A[31:1] = 1)])
+        expected =
+            "A | B | C | A | B | C |\n" +
+            "------------------------\n" +
+            " 1 | 1 | 1 | 1 | 1 | 1 |\n" +
+            " 1 | 1 | 1 | 1 | 2 | 1 |\n" +
+            " 1 | 1 | 1 | 1 | 3 | 1 |\n" +
+            " 1 | 1 | 1 | 1 | 4 | 1 |\n" +
+            " 1 | 2 | 1 | 2 | 1 | 2 |\n" +
+            " 1 | 2 | 1 | 2 | 2 | 2 |\n" +
+            " 1 | 2 | 1 | 2 | 3 | 2 |\n" +
+            " 1 | 2 | 1 | 2 | 4 | 2 |\n" +
+            " 1 | 3 | 1 | 3 | 1 | 3 |\n" +
+            " 1 | 3 | 1 | 3 | 2 | 3 |\n" +
+            " 1 | 3 | 1 | 3 | 3 | 3 |\n" +
+            " 1 | 3 | 1 | 3 | 4 | 3 |\n" +
+            " 1 | 4 | 1 | 4 | 1 | 4 |\n" +
+            " 1 | 4 | 1 | 4 | 2 | 4 |\n" +
+            " 1 | 4 | 1 | 4 | 3 | 4 |\n" +
+            " 1 | 4 | 1 | 4 | 4 | 4 |\n" +
+            " 2 | 1 | 2 | 2 | 1 | 2 |\n" +
+            " 2 | 1 | 2 | 2 | 2 | 2 |\n" +
+            " 2 | 1 | 2 | 2 | 3 | 2 |\n" +
+            " 2 | 1 | 2 | 2 | 4 | 2 |\n" +
+            " 3 | 1 | 3 | 3 | 1 | 3 |\n" +
+            " 3 | 1 | 3 | 3 | 2 | 3 |\n" +
+            " 3 | 1 | 3 | 3 | 3 | 3 |\n" +
+            " 3 | 1 | 3 | 3 | 4 | 3 |\n" +
+            " 4 | 1 | 4 | 4 | 1 | 4 |\n" +
+            " 4 | 1 | 4 | 4 | 2 | 4 |\n" +
+            " 4 | 1 | 4 | 4 | 3 | 4 |\n" +
+            " 4 | 1 | 4 | 4 | 4 | 4 |\n" +
+            " 5 | 1 | 5 | 5 | 1 | 5 |\n" +
+            " 5 | 1 | 5 | 5 | 2 | 5 |\n" +
+            " 5 | 1 | 5 | 5 | 3 | 5 |\n" +
+            " 5 | 1 | 5 | 5 | 4 | 5 |\n" +
+            " 6 | 1 | 6 | 6 | 1 | 6 |\n" +
+            " 6 | 1 | 6 | 6 | 2 | 6 |\n" +
+            " 6 | 1 | 6 | 6 | 3 | 6 |\n" +
+            " 6 | 1 | 6 | 6 | 4 | 6 |\n" +
+            " 7 | 1 | 7 | 7 | 1 | 7 |\n" +
+            " 7 | 1 | 7 | 7 | 2 | 7 |\n" +
+            " 7 | 1 | 7 | 7 | 3 | 7 |\n" +
+            " 7 | 1 | 7 | 7 | 4 | 7 |\n" +
+            " 8 | 1 | 8 | 8 | 1 | 8 |\n" +
+            " 8 | 1 | 8 | 8 | 2 | 8 |\n" +
+            " 8 | 1 | 8 | 8 | 3 | 8 |\n" +
+            " 8 | 1 | 8 | 8 | 4 | 8 |";
+        testQuery(query, expected, methodWatcher);
+        testExplainContains(query, methodWatcher, containedStrings, notContainedStrings);
+
+    }
+
+
+    @Test
+    public void testParameterized() throws Exception {
+        String expected =
+            "A | B | C |\n" +
+            "------------\n" +
+            " 1 | 1 | 1 |\n" +
+            " 2 | 1 | 2 |\n" +
+            " 3 | 1 | 3 |\n" +
+            " 4 | 1 | 4 |\n" +
+            " 1 | 2 | 1 |\n" +
+            " 2 | 2 | 2 |\n" +
+            " 3 | 2 | 3 |\n" +
+            " 4 | 2 | 4 |\n" +
+            " 1 | 3 | 1 |\n" +
+            " 2 | 3 | 2 |\n" +
+            " 3 | 3 | 3 |\n" +
+            " 4 | 3 | 4 |\n" +
+            " 1 | 4 | 1 |\n" +
+            " 2 | 4 | 2 |\n" +
+            " 3 | 4 | 3 |\n" +
+            " 4 | 4 | 4 |";
+        String query = format("select * from t1 --SPLICE-PROPERTIES useSpark=%s\n" +
+                                "where\n" +
+                                "a  = ? or\n" +
+                                "a  = ? or\n" +
+                                "c  = ? or\n" +
+                                "c  = ?\n", useSpark);
+
+        List<String> containedStrings = Arrays.asList("BASEROWID");
+        List<String> notContainedStrings = null;
+        List<Integer> paramList = Arrays.asList(1,2,3,4);
+        testPreparedQuery(query, methodWatcher, expected, paramList);
+        testParameterizedExplainContains(query, methodWatcher, containedStrings, notContainedStrings, paramList);
+
+    }
+
+    @Test
+    public void testIllegalCreate() throws Exception {
+
+        String query = "create table t3 (baserowid int, a int)";
+        List<String> expectedErrors =
+        Arrays.asList("'BASEROWID' is a special derived column which may not be defined in DDL statements.  Please rename the column.");
+
+        testUpdateFail(query, expectedErrors, methodWatcher);
+
+        query = "create table t3 (rowid int, a int)";
+        expectedErrors =
+        Arrays.asList("'ROWID' is a special derived column which may not be defined in DDL statements.  Please rename the column.");
+        testUpdateFail(query, expectedErrors, methodWatcher);
+    }
+
+    @Test
+    public void testIllegalRename() throws Exception {
+
+        String query = "create table t3 (a int, b int)";
+        methodWatcher.executeUpdate(query);
+        List<String> expectedErrors =
+        Arrays.asList("'BASEROWID' is a special derived column which may not be defined in DDL statements.  Please rename the column.");
+        query = "RENAME COLUMN T3.a TO baserowid";
+        testUpdateFail(query, expectedErrors, methodWatcher);
+
+        query = "RENAME COLUMN T3.a TO rowid";
+        expectedErrors =
+        Arrays.asList("'ROWID' is a special derived column which may not be defined in DDL statements.  Please rename the column.");
+        testUpdateFail(query, expectedErrors, methodWatcher);
+
+        methodWatcher.executeUpdate("drop table t3");
+    }
+}

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/UnionedIndexScansIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/UnionedIndexScansIT.java
@@ -19,7 +19,9 @@ import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
 import com.splicemachine.homeless.TestUtils;
+import com.splicemachine.test.SerialTest;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import splice.com.google.common.collect.Lists;
@@ -33,6 +35,7 @@ import java.util.List;
 /**
  * Test Unioned Index Scans Access Path
  */
+@Category({SerialTest.class})
 @RunWith(Parameterized.class)
 public class UnionedIndexScansIT  extends SpliceUnitTest {
     

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/JoinOrderIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/JoinOrderIT.java
@@ -273,6 +273,6 @@ public class JoinOrderIT extends SpliceUnitTest {
                 new String[] {"NestedLoopJoin"},
                 new String[] {"TableScan[T33", "scannedRows=1,outputRows=1"},
                 new String[] {"IndexLookup", "outputRows=1"},
-                new String[] {"IndexScan[IDX_T44", "scannedRows=1,outputRows=1", "preds=[(C4[1:3] = 10)]"});
+                new String[] {"IndexScan[IDX_T44", "scannedRows=1,outputRows=1", "keys=[(C4[1:3] = 10)]"});
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/JoinOrderJumpModeIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/compile/JoinOrderJumpModeIT.java
@@ -258,5 +258,5 @@ public class JoinOrderJumpModeIT extends SpliceUnitTest {
                 new String[] {"IndexLookup"},                                                 // 28
                 new String[] {"IndexScan[IDX_1", "scannedRows=1,outputRows=1"}                // 29
                 );
-    }
+        }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/JoinSelectionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/JoinSelectionIT.java
@@ -474,7 +474,7 @@ public class JoinSelectionIT extends SpliceUnitTest  {
 
         fourthRowContainsQuery(
                 "explain select * from a, b where (a.i = b.i and a.j=1) or (a.i = b.i and a.j=2) or (b.j=1)",
-                "preds=[(((A.I[1:1] = B.I[2:1]) and ((A.J[1:2] = 1) and true)) or (((A.I[1:1] = B.I[2:1]) and ((A.J[1:2] = 2) and true)) or ((B.J[2:2] = 1) or false)))]", methodWatcher);
+                "preds=[((A.I[1:1] = B.I[2:1]) or ((A.J[1:2] = 2) or ((B.J[2:2] = 1) or false))),((A.J[1:2] = 1) or ((A.I[1:1] = B.I[2:1]) or ((B.J[2:2] = 1) or false))),((A.J[1:2] = 1) or ((A.J[1:2] = 2) or ((B.J[2:2] = 1) or false)))]", methodWatcher);
 
         thirdRowContainsQuery(
                 "explain select * from a, b where (a.i = b.i and a.j=1) or (a.i = b.i+1 and a.j=2)",
@@ -491,7 +491,7 @@ public class JoinSelectionIT extends SpliceUnitTest  {
 
         fourthRowContainsQuery(
                 "explain select * from a, b where (a.i = b.i and a.j=1) or (not(a.i = b.i) and a.j=2)",
-                "preds=[(((A.I[1:1] = B.I[2:1]) and ((A.J[1:2] = 1) and true)) or (((A.I[1:1] <> B.I[2:1]) and ((A.J[1:2] = 2) and true)) or false))]", methodWatcher);
+                "preds=[((A.I[1:1] = B.I[2:1]) or ((A.J[1:2] = 2) or false)),((A.J[1:2] = 1) or ((A.I[1:1] <> B.I[2:1]) or false))]", methodWatcher);
 
         // Negative test: Clause is not in a DNF form and not subject to optimization
         thirdRowContainsQuery(
@@ -500,7 +500,7 @@ public class JoinSelectionIT extends SpliceUnitTest  {
 
         fourthRowContainsQuery(
                 "explain select * from a, b where (a.i = b.i and a.j=1) or ((a.i = b.i or a.j=2) and a.i=1)",
-                "preds=[(((A.I[1:1] = B.I[2:1]) and ((A.J[1:2] = 1) and true)) or ((((A.I[1:1] = B.I[2:1]) or ((A.J[1:2] = 2) or false)) and ((A.I[1:1] = 1) and true)) or false))]", methodWatcher);
+                "preds=[((A.I[1:1] = B.I[2:1]) or ((A.I[1:1] = B.I[2:1]) or ((A.J[1:2] = 2) or false))),((A.I[1:1] = B.I[2:1]) or ((A.I[1:1] = 1) or false)),((A.J[1:2] = 1) or ((A.I[1:1] = B.I[2:1]) or ((A.J[1:2] = 2) or false)))]", methodWatcher);
 
     }
 
@@ -574,7 +574,7 @@ public class JoinSelectionIT extends SpliceUnitTest  {
 
         fourthRowContainsQuery(
                 "explain select * from a, b where (a.i = b.i and a.j=1) or (a.i = b.i and a.j=2) or (b.j=1)",
-                "preds=[(((A.I[1:1] = B.I[2:1]) and ((A.J[1:2] = 1) and true)) or (((A.I[1:1] = B.I[2:1]) and ((A.J[1:2] = 2) and true)) or ((B.J[2:2] = 1) or false)))]", methodWatcher);
+                "preds=[((A.I[1:1] = B.I[2:1]) or ((A.J[1:2] = 2) or ((B.J[2:2] = 1) or false))),((A.J[1:2] = 1) or ((A.I[1:1] = B.I[2:1]) or ((B.J[2:2] = 1) or false))),((A.J[1:2] = 1) or ((A.J[1:2] = 2) or ((B.J[2:2] = 1) or false)))]", methodWatcher);
 
         thirdRowContainsQuery(
                 "explain select * from a, b where ((a.i = b.i and a.j=1) or (a.i = b.i+1 and a.j=2)) and a.k=3",

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperatonIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperatonIT.java
@@ -242,7 +242,7 @@ public class MultiProbeTableScanOperatonIT extends SpliceUnitTest {
     @Test
     public void testMultiProbeWithComputations() throws Exception {
         this.thirdRowContainsQuery("explain select * from a --splice-properties index=i\n" +
-                " where d in (10.0+10, 11.0+10)","preds=[(D[0:1] IN ((10.0 + 10),(11.0 + 10)))]",methodWatcher);
+                " where d in (10.0+10, 11.0+10)","keys=[(D[0:1] IN ((10.0 + 10),(11.0 + 10)))]",methodWatcher);
     }
 
     // DB-1323

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/FullOuterJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/FullOuterJoinIT.java
@@ -710,7 +710,7 @@ public class FullOuterJoinIT extends SpliceUnitTest {
                 "select a5 as X from t5) dt where X in (1,3,5,7)", useSpark, joinStrategy);
 
         rowContainsQuery(new int[]{5, 7, 8}, "explain " + sqlText, methodWatcher,
-                new String[]{"MultiProbeTableScan", "preds=[(A5[7:1] IN (1,3,5,7))]"},
+                new String[]{"MultiProbeTableScan", "keys=[(A5[7:1] IN (1,3,5,7))]"},
                 new String[]{"ProjectRestrict", "preds=[(A1[4:1] IN (1,3,5,7))]"},
                 new String[]{"FullOuterJoin", "preds=[(A1[4:1] = A2[4:2])]"});
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/NestedLoopJoinOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/NestedLoopJoinOperationIT.java
@@ -541,7 +541,7 @@ public class NestedLoopJoinOperationIT extends SpliceUnitTest {
 
         rowContainsQuery(new int[]{3, 4, 5}, "explain " + sql, methodWatcher,
                 new String[]{"NestedLoopJoin"},
-                new String[]{"TableScan[T1", "preds=[(CTX.SQLCol1[1:1] = T1.A1[2:1])]"},
+                new String[]{"TableScan[T1", "keys=[(CTX.SQLCol1[1:1] = T1.A1[2:1])]"},
                 new String[]{"Values", "outputRows=1"});
 
         ResultSet rs = methodWatcher.executeQuery(sql);

--- a/splice_machine/src/test/test-data/subquery/UnionedIndexScansTestCleanup.sql
+++ b/splice_machine/src/test/test-data/subquery/UnionedIndexScansTestCleanup.sql
@@ -1,0 +1,4 @@
+DROP TABLE T1;
+DROP TABLE T2;
+call syscs_util.syscs_set_global_database_property('splice.optimizer.favorUnionedIndexScans', null);
+CALL SYSCS_UTIL.SYSCS_EMPTY_GLOBAL_STATEMENT_CACHE();

--- a/splice_machine/src/test/test-data/subquery/UnionedIndexScansTestTables.sql
+++ b/splice_machine/src/test/test-data/subquery/UnionedIndexScansTestTables.sql
@@ -1,0 +1,26 @@
+CALL SYSCS_UTIL.SYSCS_EMPTY_GLOBAL_STATEMENT_CACHE();
+drop table if exists t1;
+drop table if exists t2;
+create table t1 (a int, b int, c int, primary key(b,a));
+create table t2 (a int, b int);
+create index idx1 on t1(a);
+create index idx3 on t1(c);
+create index idx2 on t2(a, b);
+create index idx4 on t2(b);
+
+insert into t1 values (1,1,1);
+insert into t1 select a+1,1,c+1 from t1;
+insert into t1 select a+2,1,c+2 from t1;
+insert into t1 select a+4,1,c+4 from t1;
+
+insert into t2 select a,b from t1 where a <= 4;
+insert into t2 select a,b+2 from t2;
+insert into t2 select a,b+4 from t2;
+
+insert into t1 select a, b+1,c from t1;
+insert into t1 select a, b+2,c from t1;
+
+analyze table t1;
+analyze table t2;
+
+


### PR DESCRIPTION
## Short Description
Optimize queries of the form:
`select * from t1 where index1_col1 = 1 or index2_col1 = 'a' or index3_col1 >= 99.0;`

by scanning index1, index2 and index3 in separate scans, one predicate per scan, then UNIONing the matching base table RowIDs together and joining the result back to the base table to get the final result set.  This is called a Unioned Index Scans access path, because we are unioning different scans against different indexes (or the primary key).  If the predicates are highly selective and the base table is large, we bypass reading many rows.

## Long Description
Consider a table, t1:
```
create table t1 (a int, b int, primary key(a,b));
create index t1_idx2 on t1(b);
```

... and a query,
` select * from t1 where a=1 or b=2;`

Column a is the leading column of the primary key and column b is the leading column of the index.  So, considering a=1 alone, we could do a keyed PK access, and considering b=2 alone we could do a keyed index access.  The Unioned Index Scans plan for this query is:

```
Cursor(n=18,rows=720,updateMode=READ_ONLY (1),engine=OLTP (default))
  ->  ScrollInsensitive(n=18,totalCost=0,outputRows=720,outputHeapSize=3.164 KB,partitions=1,parallelTasks=1)
    ->  ProjectRestrict(n=16,totalCost=4.04,outputRows=20,outputHeapSize=3.164 KB,partitions=1,parallelTasks=1)
      ->  ProjectRestrict(n=14,totalCost=451.876,outputRows=720,outputHeapSize=3.164 KB,partitions=1,parallelTasks=1)
        ->  NestedLoopJoin(n=12,totalCost=451.876,outputRows=720,outputHeapSize=3.164 KB,partitions=1,parallelTasks=1)
          ->  ProjectRestrict(n=11,totalCost=4.04,outputRows=20,outputHeapSize=3.164 KB,partitions=1,parallelTasks=1)
            ->  TableScan[T1(2096)](n=10,totalCost=4.04,scannedRows=20,outputRows=20,outputHeapSize=3.164 KB,partitions=1,parallelTasks=1,keys=[(dnfPathDT_###_T1.BASEROWID[9:1] = T1.BASEROWID[11:3])])
          ->  Distinct(n=8,totalCost=4.036,outputRows=36,outputHeapSize=54 B,partitions=1,parallelTasks=1)
            ->  Union(n=6,totalCost=4.036,outputRows=36,outputHeapSize=54 B,partitions=2,parallelTasks=1)
              ->  ProjectRestrict(n=5,totalCost=4.027,outputRows=18,outputHeapSize=18 B,partitions=1,parallelTasks=1)
                ->  ProjectRestrict(n=4,totalCost=4.027,outputRows=18,outputHeapSize=18 B,partitions=1,parallelTasks=1)
                  ->  IndexScan[T1_IDX2(2113)](n=3,totalCost=4.027,scannedRows=18,outputRows=18,outputHeapSize=18 B,partitions=1,parallelTasks=1,baseTable=T1(2096),keys=[(B[3:1] = 2)])
              ->  ProjectRestrict(n=2,totalCost=4.036,outputRows=18,outputHeapSize=36 B,partitions=1,parallelTasks=1)
                ->  ProjectRestrict(n=1,totalCost=4.036,outputRows=18,outputHeapSize=36 B,partitions=1,parallelTasks=1)
                  ->  TableScan[T1(2096)](n=0,totalCost=4.036,scannedRows=18,outputRows=18,outputHeapSize=36 B,partitions=1,parallelTasks=1,keys=[(A[0:1] = 1)])
```

This feature modifies the explain text to indicate 'keys=' to signify any predicates which cause an index access which skips over rows.  Normal qualifier predicates are still indicated as 'preds='.
It also adds the BASEROWID derived column name.  If you query a table, 'select BASEROWID from t1;' this will return back the rowids of the base table rows, whether or not the scan uses an index to satisfy the query (the base table rowids are stored in the index).  Derived column name ROWID is pre-existing, but it may return back the rowid of the base table row, or the index row, depending on whether the base table or index was scanned (or if an IndexLookup operation was done).
Note in the explain the BASEROWID = BASEROWID join between the UNION derived table and the base table T1.  This predicate is also indicated as a key, meaning the join back to T1 looks up those base rowids directly instead of scanning the entire T1.

This is a cost-based optimization, meaning when costing table T1 as a single-table scan, or as the inner table of a join, we will first cost the scan/join using the normal method, then we look for any OR'ed predicates that may enable UIS (Unioned Index Scans) access path, and cost the scan/join with UIS access path.  The cheaper of the two is selected.  

DNF to CNF conversion of predicates previously does not apply the distributive property to derive new terms.  This is being added by this PR.  For example, given the query:

```
select * from BH, BU where ( BH.a = 1 AND BH.b = BU.a ) 
                     OR ( BH.a = BU.a AND BH.b = 1);
```

We can convert to CNF as follows:

```
(BH.a = 1 OR BH.a = BU.a)   AND 
(BH.a = 1 OR BH.b = 1)     AND 
(BH.b = BU.a OR BH.a = BU.a) AND 
(BH.b = BU.a OR BH.b = 1)
```

This conversion enables two separate UIS access paths on the two middle terms.  
First, (BH.a = 1 OR BH.b = 1)  can be applied to table BH in two scans.
Next, (BH.b = BU.a OR BH.a = BU.a)  can be applied between the result from above in 2 unioned joins with these index-enabling join predicates.

The number of predicate we can derive in this manner is limited to 100, by default, but may be tuned lower or higher (as high as 10000) using a new database property, splice.optimizer.maxDerivedCNFPredicates:

> call syscs_util.syscs_set_global_database_property('splice.optimizer.maxDerivedCNFPredicates', '200');

A CloneCRsVisitor is added to clone any BinaryRelationalOperatorNodes and underlying ColumnReferences during DNF to CNF term expansion.  This is required because we don't want remapping of a ColumnReference in one predicate to also remap a ColumnReference in a copied operator in another predicate.  Each predicate can be pushed separately so must not share memory.  If this cloning operation fails, so does DNF to CNF conversion because it is unsafe to proceed using shared memory in separate predicates.  Currently not many operators support cloning, so building up cloning support could extend CNF conversion potential to the full range of boolean expressions Splice supports.

UIS access paths can be disabled via database property splice.optimizer.disableUnionedIndexScans:
> call syscs_util.syscs_set_global_database_property('splice.optimizer.disableUnionedIndexScans', true);

UIS access paths can be favored by the optimizer for testing purposes via database property splice.optimizer.favorUnionedIndexScans:
> call syscs_util.syscs_set_global_database_property('splice.optimizer.favorUnionedIndexScans', true);

ROWID and BASEROWID cannot be column names in CREATE TABLE or RENAME statements, and will result in an error.

When costing UIS access paths, we first separate OR'ed predicates into separate lists and categorize them one-at-a-time.  If each separate predicate is either a start key or stop key, we attempt UIS access path.  The UNION tree which collects rowids and removes any duplicates is built up by function buildUnionedScans.  The FromBaseTable cloned objects in this tree are marked as indexFriendlyJoinsOnly, so that only nested loop join or merge join are used, to skip over unqualified join rows.
If there are no errors, an AccessPath object is returned from buildUnionedScans with the UNION derived table to optimize.  bindAndOptimizeUnionedIndexScansPath is then called, which builds a BASEROWID = BASEROWID join predicate between the base table and the UNION derived table and constructs a new SELECT statement:  

> SELECT (original_T1_projection_list) from T1, UNION_derived_table where T1.BASEROWID = UNION_derived_table.BASEROWID;

This statement is then bound and optimized (bindStatement and optimizeStatement are called).  
If the table is being joined with an outer table, the UNION_derived_table will include that join, but also we need to join the entire result back to the outer table in the main join.  buildRowIdPredWithOuterTable is called to generate a UNION_derived_table_plus_RowID_Join.BASEROWID2 = outer_table.BASEROWID predicate to match the proper rows.  It is possible to eliminate this join entirely by manually manipulating the list of optimizables at the end of join planning, but this may be a high-risk change, so is not being done in the first pass of this feature.  The UIS derived table plus rowid join result set is marked as skipBindAndOptimize, which is a new flag to indicate no more binding or optimization should be done on the result set if it is joined or referenced elsewhere in the AST.  It is also marked as outerTableOnly so it is only considered as the outer table of any join it participates in (since it has a reduced set of RowIDs, we want to drive the join from these instead of scan all RowIDs in the base table).

## How to test
```
create table t1 (a int, b int, primary key(a,b));
create index t1_idx2 on t1(b);
call syscs_util.syscs_set_global_database_property('splice.optimizer.favorUnionedIndexScans', 'true');
// The following should contain 'BASEROWID' in the explain output:
explain select * from t1 where a=1 or b=2;
```