### PR TITLE
DB-11926: add system procedures to move region

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/hbase/SpliceRegionAdminIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/SpliceRegionAdminIT.java
@@ -616,8 +616,22 @@ public class SpliceRegionAdminIT {
     }
 
     @Test
-    public void testMoveRegion() throws Exception {
+    public void testLocalizeIndexForTable() throws Exception {
 
+        separateIndexAndTable();
+        String sql = String.format("call syscs_util.localize_indexes_for_table('%s', 'T')", SCHEMA_NAME);
+        try (ResultSet rs = methodWatcher.executeQuery(sql)) {
+            int count = 0;
+            while(rs.next()) {
+                count++;
+                String result = rs.getString(1);
+                Assert.assertTrue(result.contains("Moved"));
+            }
+            Assert.assertTrue(count > 0);
+        }
+    }
+
+    private void separateIndexAndTable() throws Exception {
         Map<String, List<String>> serverUsage = new HashMap();
         String sql = "call syscs_util.syscs_get_active_servers()";
         try (ResultSet rs = methodWatcher.executeQuery(sql)) {
@@ -668,19 +682,7 @@ public class SpliceRegionAdminIT {
                 }
             }
         }
-
-        sql = String.format("call syscs_util.localize_indexes_for_table('%s', 'T')", SCHEMA_NAME);
-        try (ResultSet rs = methodWatcher.executeQuery(sql)) {
-            int count = 0;
-            while(rs.next()) {
-                count++;
-                String result = rs.getString(1);
-                Assert.assertTrue(result.contains("Moved"));
-            }
-            Assert.assertTrue(count > 0);
-        }
     }
-
     private String getAnotherServer(Map<String, List<String>> serverUsage , String server) {
         String result = null;
         for (String s : serverUsage.keySet()) {
@@ -690,5 +692,20 @@ public class SpliceRegionAdminIT {
             }
         }
         return result;
+    }
+
+    @Test
+    public void testLocalizeIndexForSchema() throws Exception {
+        separateIndexAndTable();
+        String sql = String.format("call syscs_util.localize_indexes_for_schema('%s')", SCHEMA_NAME);
+        try (ResultSet rs = methodWatcher.executeQuery(sql)) {
+            int count = 0;
+            while(rs.next()) {
+                count++;
+                String result = rs.getString(1);
+                Assert.assertTrue(result.contains("Moved"));
+            }
+            Assert.assertTrue(count > 0);
+        }
     }
 }

--- a/hbase_sql/src/test/java/com/splicemachine/hbase/SpliceRegionAdminIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/hbase/SpliceRegionAdminIT.java
@@ -37,9 +37,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static com.splicemachine.test_tools.Rows.row;
 import static com.splicemachine.test_tools.Rows.rows;
@@ -151,6 +149,11 @@ public class SpliceRegionAdminIT {
             String split = String.format("call syscs_util.syscs_split_table_or_index_at_points('SPLICEREGIONADMINIT', 'D', null,'\\x%d')", i);
             spliceClassWatcher.execute(split);
         }
+
+        new TableCreator(conn)
+                .withCreate("create table T (i int, j int unique)")
+                .withIndex("create index ti on t(i)")
+                .create();
     }
 
     @Test
@@ -610,5 +613,82 @@ public class SpliceRegionAdminIT {
 
     private static String getResource(String name) {
         return SpliceUnitTest.getResourceDirectory() + "tcph/data/" + name;
+    }
+
+    @Test
+    public void testMoveRegion() throws Exception {
+
+        Map<String, List<String>> serverUsage = new HashMap();
+        String sql = "call syscs_util.syscs_get_active_servers()";
+        try (ResultSet rs = methodWatcher.executeQuery(sql)) {
+            while(rs.next()) {
+                String server = rs.getString(1) + "," + rs.getLong(2) + "," + rs.getLong(3);
+                serverUsage.put(server, Lists.newArrayList());
+            }
+        }
+
+        sql = String.format("call syscs_util.get_region_locations('%s', 'T')", SCHEMA_NAME);
+        try (ResultSet rs = methodWatcher.executeQuery(sql)) {
+            rs.next();
+            String s = rs.getString("OWNING_SERVER");
+            List<String> objects = serverUsage.get(s);
+            objects.add("T");
+        }
+
+        sql = String.format("select conglomeratename from sys.sysconglomerates c, sys.sysschemas s, sys.systables t " +
+                "where t.tableid=c.tableid and " +
+                "s.schemaid=t.schemaid and " +
+                "schemaname='%s' and " +
+                "tablename='T' and c.isindex", SCHEMA_NAME);
+        try (ResultSet resultSet = methodWatcher.executeQuery(sql)) {
+            while (resultSet.next()) {
+                String indexName = resultSet.getString(1);
+                sql = String.format("call syscs_util.get_region_locations('%s', '%s')", SCHEMA_NAME, indexName);
+                try (ResultSet rs = methodWatcher.executeQuery(sql)) {
+                    rs.next();
+                    String s = rs.getString("OWNING_SERVER");
+                    List<String> objects = serverUsage.get(s);
+                    objects.add(indexName);
+                }
+            }
+        }
+
+        for (String server : serverUsage.keySet()) {
+            List<String> objects = serverUsage.get(server);
+            if (objects.size() == 0)
+                continue;
+            else if (objects.size() == 3) {
+                // If all table and indexes are in the same server, move table to the other server
+                String otherServer = getAnotherServer(serverUsage, server);
+                sql = String.format("call syscs_util.assign_to_server('%s', 'T', '%s')", SCHEMA_NAME, otherServer);
+                try (ResultSet rs = methodWatcher.executeQuery(sql)) {
+                    rs.next();
+                    String result = rs.getString(1);
+                    Assert.assertTrue(result.contains("Moved"));
+                }
+            }
+        }
+
+        sql = String.format("call syscs_util.localize_indexes_for_table('%s', 'T')", SCHEMA_NAME);
+        try (ResultSet rs = methodWatcher.executeQuery(sql)) {
+            int count = 0;
+            while(rs.next()) {
+                count++;
+                String result = rs.getString(1);
+                Assert.assertTrue(result.contains("Moved"));
+            }
+            Assert.assertTrue(count > 0);
+        }
+    }
+
+    private String getAnotherServer(Map<String, List<String>> serverUsage , String server) {
+        String result = null;
+        for (String s : serverUsage.keySet()) {
+            if (!s.equals(server)) {
+                result = s;
+                break;
+            }
+        }
+        return result;
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -874,6 +874,42 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
                 .build();
         procedures.add(deleteRegion);
 
+        Procedure getRegionLocations = Procedure.newBuilder().name("GET_REGION_LOCATIONS")
+                .catalog("schemaName")
+                .catalog("objectName")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(getRegionLocations);
+
+        Procedure assignRegionToServer = Procedure.newBuilder().name("ASSIGN_TO_SERVER")
+                .catalog("schemaName")
+                .catalog("objectName")
+                .varchar("server", 32672)
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(assignRegionToServer);
+
+        Procedure  localizeIndexesForTable = Procedure.newBuilder().name("LOCALIZE_INDEXES_FOR_TABLE")
+                .catalog("schemaName")
+                .catalog("tableName")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(localizeIndexesForTable);
+
+        Procedure  localizeIndexesForSchema = Procedure.newBuilder().name("LOCALIZE_INDEXES_FOR_SCHEMA")
+                .catalog("schemaName")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(SpliceRegionAdmin.class.getCanonicalName())
+                .build();
+        procedures.add(localizeIndexesForSchema);
+
         Procedure invalidateLocalCache = Procedure.newBuilder().name("INVALIDATE_DICTIONARY_CACHE")
                 .numOutputParams(0)
                 .numResultSets(0)

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/ProcedureUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/ProcedureUnitTest.java
@@ -204,7 +204,7 @@ public class ProcedureUnitTest {
     public void testCheckSpliceSystemProcedures() {
         List<Procedure> proc = new ArrayList<>();
         SpliceSystemProcedures.createSysUtilProcedures(proc);
-        Assert.assertEquals(-630442100, proc.stream().map( procedure -> procedure.getName() ).sorted()
+        Assert.assertEquals(-421655730, proc.stream().map( procedure -> procedure.getName() ).sorted()
                 .map( s -> s.hashCode()).reduce(0, (subtotal, element) -> subtotal + element).longValue() );
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
Implemented system procedures to move index to the same region as base table. Currently only support table with a single region.

## Long Description
Please checkout DB-11926 for system procedure interface and use cases.

## How to test
(e.g. if bugfix: how to reproduce bug / impact)
(if feature: a easy example of how to check the feature)
(if feature is a configuration: an example to see different behavior with different configuration)
