### PR TITLE
DB-10494 DDL coordination timed out when analyze schema with many tables (3.1)

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
@@ -308,7 +308,6 @@ public class StatisticsAdmin extends BaseAdminProcedures {
             TransactionController transactionExecute = lcc.getTransactionExecute();
             transactionExecute.elevate("statistics");
             dropTableStatistics(tds, dd, tc);
-            ddlNotification(tc, tds);
             TxnView txn = ((SpliceTransactionManager) transactionExecute).getRawTransaction().getActiveStateTxn();
 
             HashMap<Long, Pair<String, String>> display = new HashMap<>();

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/StatisticsAdmin.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.derby.utils;
 
+import splice.com.google.common.collect.Iterables;
 import com.splicemachine.EngineDriver;
 import com.splicemachine.db.iapi.error.PublicAPI;
 import com.splicemachine.db.iapi.error.StandardException;
@@ -83,6 +84,8 @@ import static com.splicemachine.derby.utils.EngineUtils.verifyTableExists;
  */
 public class StatisticsAdmin extends BaseAdminProcedures {
     private static final Logger LOG = Logger.getLogger(StatisticsAdmin.class);
+    private static final int DDL_NOTIFICATION_PARTITION_SIZE = 512;
+
     public static final String TABLEID_FROM_SCHEMA = "select tableid from sysvw.systablesView t where t.schemaid = ?";
 
     @SuppressWarnings("UnusedDeclaration")
@@ -316,6 +319,7 @@ public class StatisticsAdmin extends BaseAdminProcedures {
 
             IteratorNoPutResultSet resultsToWrap = wrapResults(conn,
                     displayTableStatistics(statisticsOperations,true, dd, transactionExecute, display), COLLECTED_STATS_OUTPUT_COLUMNS);
+            ddlNotificationInPartitions(tc, tds, DDL_NOTIFICATION_PARTITION_SIZE);
             outputResults[0] = new EmbedResultSet40(conn, resultsToWrap, false, null, true);
         } catch (StandardException se) {
             throw PublicAPI.wrapStandardException(se);
@@ -561,6 +565,25 @@ public class StatisticsAdmin extends BaseAdminProcedures {
     private static void ddlNotification(TransactionController tc,  List<TableDescriptor> tds) throws StandardException {
         DDLChange ddlChange = ProtoUtil.alterStats(((SpliceTransactionManager) tc).getActiveStateTxn().getTxnId(),tds);
         tc.prepareDataDictionaryChange(DDLUtils.notifyMetadataChange(ddlChange));
+    }
+
+    /**
+     * When COLLECT_SCHEMA_STATISTICS analyzes a big schema with many tables, it could cause a DDL coordination timeout.
+     * The problem happens when the massage with ddlChangeType: ALTER_STATS has many table descriptor ids.
+     * To avoid this issue, the method splits the list of table descriptors into smaller partitions with the size given
+     * in partitionSize.
+     *
+     * @param tc
+     * @param tds
+     * @param partitionSize
+     * @throws StandardException
+     */
+    private static void ddlNotificationInPartitions(TransactionController tc,  List<TableDescriptor> tds, int partitionSize) throws StandardException {
+        Iterable<List<TableDescriptor>> tdPartitions = Iterables.partition(tds, partitionSize);
+        for (List<TableDescriptor> tdPartition : tdPartitions) {
+            DDLChange ddlChange = ProtoUtil.alterStats(((SpliceTransactionManager) tc).getActiveStateTxn().getTxnId(), tdPartition);
+            tc.prepareDataDictionaryChange(DDLUtils.notifyMetadataChange(ddlChange));
+        }
     }
 
     /* ****************************************************************************************************************/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
ddl notifications are partitioned during COLLECT_SCHEMA_STATISTICS. Previously, a large list of table descriptor ids was sent in one call. 

## Long Description
When COLLECT_SCHEMA_STATISTICS analyzes a big schema with many tables, it could cause a DDL coordination timeout. The problem happens when the massage with ddlChangeType: ALTER_STATS has many table descriptor ids. To avoid this issue, the new method ddlNotificationInPartitions splits the list of table descriptors into smaller partitions with the size given in partitionSize.

## How to test
Create a schema with big amount of tables, some thousands, and call  COLLECT_SCHEMA_STATISTICS. It's also possible to decrease the environment variable splice.ddl.maxWaitSeconds to have a higher probability to get a timeout.
